### PR TITLE
feat(a2a): promote context IDs for classifier routing

### DIFF
--- a/docs/filters/a2a.md
+++ b/docs/filters/a2a.md
@@ -10,6 +10,7 @@ Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method,
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
 | `headers` | A2aHeaders | no | Header names for A2A metadata promotion. |
+| `headers.context_id` | string | no | Header name for the extracted context ID (e.g. `x-praxis-a2a-context-id`). |
 | `headers.family` | string | no | Header name for the A2A family (e.g. `x-praxis-a2a-family`). |
 | `headers.kind` | string | no | Header name for the JSON-RPC kind (e.g. `x-praxis-a2a-kind`). |
 | `headers.method` | string | no | Header name for the canonical A2A method (e.g. `x-praxis-a2a-method`). |

--- a/examples/configs/a2a-classifier-routing.yaml
+++ b/examples/configs/a2a-classifier-routing.yaml
@@ -1,6 +1,6 @@
 # A2A Classifier Routing
 #
-# Routes A2A requests by body-derived method, family, task ID, and streaming detection.
+# Routes A2A requests by body-derived method, family, context ID, task ID, and streaming detection.
 # The `a2a` filter parses JSON-RPC bodies and promotes internal routing headers
 # (x-praxis-a2a-*) for router matching. These internal headers are stripped
 # before upstream by header hygiene.
@@ -8,6 +8,7 @@
 # This example demonstrates static A2A routing based on:
 # - Method classification (SendMessage, SendStreamingMessage, GetTask, etc.)
 # - Streaming detection for SendStreamingMessage and SubscribeToTask
+# - Context ID extraction from params.message.contextId
 # - Task ID extraction from params.id and params.taskId
 # - Method alias support for compatibility (slash-delimited → PascalCase)
 #
@@ -33,6 +34,7 @@ filter_chains:
         headers:
           method: x-praxis-a2a-method
           family: x-praxis-a2a-family
+          context_id: x-praxis-a2a-context-id
           task_id: x-praxis-a2a-task-id
           kind: x-praxis-a2a-kind
           streaming: x-praxis-a2a-streaming
@@ -40,6 +42,12 @@ filter_chains:
 
       - filter: router
         routes:
+          # First-match routing requires specific context rules before broader method/family rules.
+          - path_prefix: "/"
+            headers:
+              x-praxis-a2a-context-id: "ctx-123"
+            cluster: "message-backend"
+
           # Route SendMessage to agent backend
           - path_prefix: "/"
             headers:

--- a/examples/configs/a2a-classifier-routing.yaml
+++ b/examples/configs/a2a-classifier-routing.yaml
@@ -8,7 +8,7 @@
 # This example demonstrates static A2A routing based on:
 # - Method classification (SendMessage, SendStreamingMessage, GetTask, etc.)
 # - Streaming detection for SendStreamingMessage and SubscribeToTask
-# - Context ID extraction from params.message.contextId
+# - Context ID extraction from params.message.contextId and ListTasks params.contextId
 # - Task ID extraction from params.id and params.taskId
 # - Method alias support for compatibility (slash-delimited → PascalCase)
 #

--- a/filters/src/agentic/a2a/config.rs
+++ b/filters/src/agentic/a2a/config.rs
@@ -136,6 +136,10 @@ fn default_max_response_body_bytes() -> usize {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct A2aHeaders {
+    /// Header name for the extracted context ID (e.g. `x-praxis-a2a-context-id`).
+    #[serde(default = "default_context_id_header")]
+    pub context_id: Option<String>,
+
     /// Header name for the A2A family (e.g. `x-praxis-a2a-family`).
     #[serde(default = "default_family_header")]
     pub family: Option<String>,
@@ -164,6 +168,7 @@ pub(crate) struct A2aHeaders {
 impl Default for A2aHeaders {
     fn default() -> Self {
         Self {
+            context_id: default_context_id_header(),
             family: default_family_header(),
             kind: default_kind_header(),
             method: default_method_header(),
@@ -172,6 +177,15 @@ impl Default for A2aHeaders {
             version: default_version_header(),
         }
     }
+}
+
+/// Default context ID header name.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_context_id_header() -> Option<String> {
+    Some("x-praxis-a2a-context-id".to_owned())
 }
 
 /// Default method header name.
@@ -270,6 +284,7 @@ fn default_max_body_bytes() -> usize {
 pub(crate) fn build_config(cfg: A2aConfig) -> Result<A2aConfig, FilterError> {
     validate_max_body_bytes("a2a", cfg.max_body_bytes)?;
 
+    validate_header_name("a2a", "context_id", cfg.headers.context_id.as_deref())?;
     validate_header_name("a2a", "method", cfg.headers.method.as_deref())?;
     validate_header_name("a2a", "family", cfg.headers.family.as_deref())?;
     validate_header_name("a2a", "task_id", cfg.headers.task_id.as_deref())?;

--- a/filters/src/agentic/a2a/envelope.rs
+++ b/filters/src/agentic/a2a/envelope.rs
@@ -185,6 +185,8 @@ impl A2aFamily {
 /// Extracted A2A envelope metadata.
 #[derive(Debug, Clone)]
 pub(crate) struct A2aEnvelope {
+    /// Context ID from the request, when present.
+    pub context_id: Option<String>,
     /// Method family classification.
     pub family: A2aFamily,
     /// Classified A2A method (canonical after alias resolution).
@@ -218,9 +220,11 @@ pub(crate) fn extract_a2a_envelope(
     let family = method.family();
     let streaming = method.is_streaming();
     let task_id = extract_task_id(value, &method);
+    let context_id = extract_context_id(value, &method);
     let version = extract_version(request_headers);
 
     A2aEnvelope {
+        context_id,
         family,
         method,
         original_method,
@@ -243,6 +247,22 @@ fn extract_task_id(value: &Value, method: &A2aMethod) -> Option<String> {
     } else {
         // No task ID extraction for other methods
         None
+    }
+}
+
+/// A2A places context IDs at different JSON depths depending on the
+/// method, so extraction must be method-aware.
+fn extract_context_id(value: &Value, method: &A2aMethod) -> Option<String> {
+    let params = value.get("params")?;
+
+    match method {
+        A2aMethod::SendMessage | A2aMethod::SendStreamingMessage => params
+            .get("message")
+            .and_then(|m| m.get("contextId"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        A2aMethod::ListTasks => params.get("contextId").and_then(Value::as_str).map(str::to_owned),
+        _ => None,
     }
 }
 

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -70,6 +70,7 @@ use self::{
 /// headers:
 ///   method: x-praxis-a2a-method
 ///   family: x-praxis-a2a-family
+///   context_id: x-praxis-a2a-context-id
 ///   task_id: x-praxis-a2a-task-id
 ///   kind: x-praxis-a2a-kind
 ///   streaming: x-praxis-a2a-streaming

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -198,6 +198,7 @@ impl HttpFilter for A2aFilter {
             a2a_method = a2a_envelope.method.as_str(),
             a2a_family = a2a_envelope.family.as_str(),
             streaming = a2a_envelope.streaming,
+            context_id = ?a2a_envelope.context_id,
             task_id = ?a2a_envelope.task_id,
             version = ?a2a_envelope.version,
             "extracted A2A envelope metadata"
@@ -646,6 +647,7 @@ fn write_metadata(
     set_safe_metadata(ctx, "a2a.original_method", a2a.original_method.as_deref());
     ctx.set_metadata("a2a.family", a2a.family.as_str());
     ctx.set_metadata("a2a.streaming", if a2a.streaming { "true" } else { "false" });
+    set_safe_metadata(ctx, "a2a.context_id", a2a.context_id.as_deref());
     set_safe_metadata(ctx, "a2a.task_id", a2a.task_id.as_deref());
     set_safe_metadata(ctx, "a2a.version", a2a.version.as_deref());
 }
@@ -682,6 +684,7 @@ fn promote_a2a_headers(
         headers.push((Cow::Owned(header_name.clone()), a2a.family.as_str().to_owned()));
     }
 
+    promote_optional_header(&config.headers.context_id, a2a.context_id.as_deref(), headers);
     promote_optional_header(&config.headers.task_id, a2a.task_id.as_deref(), headers);
 
     if let Some(header_name) = &config.headers.kind {
@@ -727,6 +730,7 @@ fn promote_filter_results(
     results.set("streaming", if a2a.streaming { "true" } else { "false" })?;
     results.set("kind", envelope.kind.as_str())?;
 
+    set_optional_result(results, "context_id", a2a.context_id.as_deref())?;
     set_optional_result(results, "task_id", a2a.task_id.as_deref())?;
     set_optional_result(results, "version", a2a.version.as_deref())?;
 

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -510,6 +510,19 @@ fn send_message_context_id_extracted_from_message() {
 }
 
 #[test]
+fn send_message_without_context_id_leaves_context_unset() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "SendMessage",
+        "params": { "message": { "role": "ROLE_USER", "parts": [] } }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(&json, "SendMessage", &BTreeMap::new(), &HeaderMap::new());
+    assert_eq!(
+        envelope.context_id, None,
+        "missing params.message.contextId should leave context_id unset"
+    );
+}
+
+#[test]
 fn send_streaming_message_context_id_extracted_from_message() {
     let json = serde_json::json!({
         "jsonrpc": "2.0", "method": "SendStreamingMessage",
@@ -551,8 +564,30 @@ fn non_string_context_id_left_unset() {
 }
 
 #[test]
+fn list_tasks_non_string_context_id_left_unset() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "ListTasks",
+        "params": { "contextId": 42 }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(&json, "ListTasks", &BTreeMap::new(), &HeaderMap::new());
+    assert_eq!(
+        envelope.context_id, None,
+        "non-string params.contextId should leave context_id unset"
+    );
+}
+
+#[test]
 fn methods_without_context_id_do_not_extract_context() {
-    for method in ["GetTask", "CancelTask", "SubscribeToTask", "GetExtendedAgentCard"] {
+    for method in [
+        "GetTask",
+        "CancelTask",
+        "SubscribeToTask",
+        "CreateTaskPushNotificationConfig",
+        "GetTaskPushNotificationConfig",
+        "ListTaskPushNotificationConfigs",
+        "DeleteTaskPushNotificationConfig",
+        "GetExtendedAgentCard",
+    ] {
         let json = serde_json::json!({
             "jsonrpc": "2.0", "method": method,
             "params": { "id": "task-1", "contextId": "ctx-should-not-extract" }, "id": 1

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -149,6 +149,98 @@ fn reject_invalid_header_name() {
     );
 }
 
+#[test]
+fn default_context_id_header_config() {
+    let cfg: A2aConfig = serde_yaml::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.headers.context_id,
+        Some("x-praxis-a2a-context-id".to_owned()),
+        "default context_id header should be x-praxis-a2a-context-id"
+    );
+}
+
+#[test]
+fn custom_context_id_header_config() {
+    let cfg: A2aConfig = serde_yaml::from_str(
+        r#"
+        headers:
+          context_id: x-custom-ctx
+        "#,
+    )
+    .unwrap();
+    let validated = build_config(cfg).unwrap();
+    assert_eq!(
+        validated.headers.context_id,
+        Some("x-custom-ctx".to_owned()),
+        "custom context_id header should be accepted"
+    );
+}
+
+#[test]
+fn null_context_id_header_config_disables_header() {
+    let cfg: A2aConfig = serde_yaml::from_str(
+        r#"
+        headers:
+          context_id: ~
+        "#,
+    )
+    .unwrap();
+    let validated = build_config(cfg).unwrap();
+    assert!(
+        validated.headers.context_id.is_none(),
+        "null context_id header should disable header promotion"
+    );
+}
+
+#[test]
+fn invalid_context_id_header_name_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        headers:
+          context_id: "invalid header with spaces"
+        "#,
+    )
+    .unwrap();
+    let err = A2aFilter::from_config(&yaml).err().expect("should fail");
+    assert!(
+        err.to_string().contains("not a valid HTTP header name"),
+        "invalid context_id header name should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn null_context_id_header_disables_header_but_promotes_metadata_and_results() {
+    let filter = make_filter(r#"{"headers": {"context_id": null}}"#);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"contextId":"ctx-null-hdr","role":"ROLE_USER","parts":[]}}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release), "should release");
+    assert_eq!(
+        ctx.get_metadata("a2a.context_id"),
+        Some("ctx-null-hdr"),
+        "metadata should still promote context_id when header is null"
+    );
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-a2a-context-id"),
+        "null header config should suppress header promotion"
+    );
+    let results = ctx.filter_results.get("a2a").unwrap();
+    assert_eq!(
+        results.get("context_id"),
+        Some("ctx-null-hdr"),
+        "filter results should still promote context_id when header is null"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Method Classification Tests
 // -----------------------------------------------------------------------------
@@ -404,6 +496,73 @@ fn version_extraction() {
 }
 
 #[test]
+fn send_message_context_id_extracted_from_message() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "SendMessage",
+        "params": { "message": { "contextId": "ctx-42", "role": "ROLE_USER", "parts": [] } }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(&json, "SendMessage", &BTreeMap::new(), &HeaderMap::new());
+    assert_eq!(
+        envelope.context_id,
+        Some("ctx-42".to_owned()),
+        "SendMessage should extract contextId from params.message.contextId"
+    );
+}
+
+#[test]
+fn send_streaming_message_context_id_extracted_from_message() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "SendStreamingMessage",
+        "params": { "message": { "contextId": "ctx-stream", "role": "ROLE_USER", "parts": [] } }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(&json, "SendStreamingMessage", &BTreeMap::new(), &HeaderMap::new());
+    assert_eq!(
+        envelope.context_id,
+        Some("ctx-stream".to_owned()),
+        "SendStreamingMessage should extract contextId from params.message.contextId"
+    );
+}
+
+#[test]
+fn list_tasks_context_id_extracted_from_params() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "ListTasks",
+        "params": { "contextId": "ctx-list" }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(&json, "ListTasks", &BTreeMap::new(), &HeaderMap::new());
+    assert_eq!(
+        envelope.context_id,
+        Some("ctx-list".to_owned()),
+        "ListTasks should extract contextId from params.contextId"
+    );
+}
+
+#[test]
+fn non_string_context_id_left_unset() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "SendMessage",
+        "params": { "message": { "contextId": 42, "role": "ROLE_USER", "parts": [] } }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(&json, "SendMessage", &BTreeMap::new(), &HeaderMap::new());
+    assert_eq!(
+        envelope.context_id, None,
+        "non-string params.message.contextId should leave context_id unset"
+    );
+}
+
+#[test]
+fn methods_without_context_id_do_not_extract_context() {
+    for method in ["GetTask", "CancelTask", "SubscribeToTask", "GetExtendedAgentCard"] {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0", "method": method,
+            "params": { "id": "task-1", "contextId": "ctx-should-not-extract" }, "id": 1
+        });
+        let envelope = extract_a2a_envelope(&json, method, &BTreeMap::new(), &HeaderMap::new());
+        assert_eq!(envelope.context_id, None, "{method} should not extract contextId");
+    }
+}
+
+#[test]
 fn original_method_tracking() {
     let mut aliases = BTreeMap::new();
     aliases.insert("message/send".to_owned(), "SendMessage".to_owned());
@@ -485,6 +644,42 @@ async fn send_message_extracts_metadata() {
     assert_eq!(ctx.get_metadata("a2a.method"), Some("SendMessage"));
     assert_eq!(ctx.get_metadata("a2a.family"), Some("message"));
     assert_eq!(ctx.get_metadata("a2a.streaming"), Some("false"));
+}
+
+#[tokio::test]
+async fn send_message_context_id_promoted_to_metadata_headers_results() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"contextId":"ctx-promo","role":"ROLE_USER","parts":[]}}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release), "should release");
+    assert_eq!(
+        ctx.get_metadata("a2a.context_id"),
+        Some("ctx-promo"),
+        "context_id should be in durable metadata"
+    );
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert_eq!(
+        headers.get("x-praxis-a2a-context-id"),
+        Some(&"ctx-promo"),
+        "context_id should be promoted to header"
+    );
+
+    let results = ctx.filter_results.get("a2a").unwrap();
+    assert_eq!(
+        results.get("context_id"),
+        Some("ctx-promo"),
+        "context_id should be in filter results"
+    );
 }
 
 #[tokio::test]
@@ -1006,6 +1201,82 @@ async fn too_long_task_id_not_promoted() {
     assert!(
         !headers.contains_key("x-praxis-a2a-task-id"),
         "too-long task ID should not be promoted to header"
+    );
+}
+
+#[tokio::test]
+async fn context_id_control_chars_not_promoted() {
+    let filter = make_default_filter();
+    let body_str = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"SendMessage\",\"params\":{\"message\":{\"contextId\":\"ctx\\n123\",\"role\":\"ROLE_USER\",\"parts\":[]}}}";
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Release),
+        "control char context ID should still release"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.context_id"),
+        None,
+        "context ID with control chars should not be promoted to metadata"
+    );
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-a2a-context-id"),
+        "context ID with control chars should not be promoted to header"
+    );
+    let results = ctx.filter_results.get("a2a").unwrap();
+    assert_eq!(
+        results.get("context_id"),
+        None,
+        "context ID with control chars should not be in filter results"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "exhaustive safety assertions")]
+async fn context_id_too_long_not_promoted() {
+    let filter = make_default_filter();
+    let long_ctx = "c".repeat(257);
+    let body_str = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{{"message":{{"contextId":"{long_ctx}","role":"ROLE_USER","parts":[]}}}}}}"#
+    );
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Release),
+        "too-long context ID should still release"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.context_id"),
+        None,
+        "context ID exceeding 256 bytes should not be promoted"
+    );
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-a2a-context-id"),
+        "too-long context ID should not be promoted to header"
+    );
+    let results = ctx.filter_results.get("a2a").unwrap();
+    assert_eq!(
+        results.get("context_id"),
+        None,
+        "too-long context ID should not be in filter results"
     );
 }
 

--- a/tests/integration/tests/suite/a2a.rs
+++ b/tests/integration/tests/suite/a2a.rs
@@ -713,8 +713,103 @@ fn a2a_subscribe_to_task_sse_captures_task_route() {
 }
 
 // -----------------------------------------------------------------------------
+// Context ID Routing Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn a2a_context_id_routes_to_context_specific_backend() {
+    let context_guard = start_backend_with_shutdown("context-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = a2a_context_routing_yaml(proxy_port, context_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"contextId":"ctx-123","role":"ROLE_USER","parts":[{"text":"hello"}]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "context-backend",
+        "SendMessage with contextId=ctx-123 should route to context-specific backend"
+    );
+
+    let body_no_ctx = r#"{"jsonrpc":"2.0","id":2,"method":"SendMessage","params":{"message":{"role":"ROLE_USER","parts":[{"text":"hello"}]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", body_no_ctx, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "default-backend",
+        "SendMessage without contextId should route to default backend"
+    );
+}
+
+#[test]
+fn a2a_spoofed_context_id_header_rejected() {
+    let context_guard = start_backend_with_shutdown("context-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = a2a_context_routing_yaml(proxy_port, context_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body =
+        r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"role":"ROLE_USER","parts":[]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", body, &[("x-praxis-a2a-context-id", "ctx-123")]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "client-supplied x-praxis-a2a-context-id should be rejected by reserved-header guard"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
+
+fn a2a_context_routing_yaml(proxy_port: u16, context_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          context_id: x-praxis-a2a-context-id
+      - filter: router
+        routes:
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-context-id: "ctx-123"
+            cluster: "context"
+          - path_prefix: "/a2a/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "context"
+            endpoints:
+              - "127.0.0.1:{context_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#,
+    )
+}
 
 fn json_post_with_a2a_headers(path: &str, body: &str, headers: &[(&str, &str)]) -> String {
     let mut extra = String::new();

--- a/tests/integration/tests/suite/examples/agentic_routing.rs
+++ b/tests/integration/tests/suite/examples/agentic_routing.rs
@@ -298,6 +298,46 @@ fn a2a_classifier_routing_routes_send_message() {
 }
 
 #[test]
+fn a2a_classifier_routing_routes_context_id() {
+    let agent_guard = start_backend_with_shutdown("agent-response");
+    let streaming_guard = start_backend_with_shutdown("streaming-response");
+    let task_specific_guard = start_backend_with_shutdown("task-specific-response");
+    let task_guard = start_backend_with_shutdown("task-response");
+    let message_guard = start_backend_with_shutdown("message-response");
+    let notification_guard = start_backend_with_shutdown("notification-response");
+    let agent_info_guard = start_backend_with_shutdown("agent-info-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_a2a_example_config(
+        proxy_port,
+        agent_guard.port(),
+        streaming_guard.port(),
+        task_specific_guard.port(),
+        task_guard.port(),
+        message_guard.port(),
+        notification_guard.port(),
+        agent_info_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"contextId":"ctx-123","role":"ROLE_USER","parts":[{"text":"hello"}]}}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "SendMessage with context ID should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "message-response",
+        "contextId=ctx-123 should route before the broader SendMessage method route"
+    );
+}
+
+#[test]
 fn a2a_classifier_routing_routes_streaming() {
     let agent_guard = start_backend_with_shutdown("agent-response");
     let streaming_guard = start_backend_with_shutdown("streaming-response");

--- a/tests/integration/tests/suite/examples/agentic_routing.rs
+++ b/tests/integration/tests/suite/examples/agentic_routing.rs
@@ -338,6 +338,90 @@ fn a2a_classifier_routing_routes_context_id() {
 }
 
 #[test]
+fn a2a_classifier_routing_routes_streaming_context_id() {
+    let agent_guard = start_backend_with_shutdown("agent-response");
+    let streaming_guard = start_backend_with_shutdown("streaming-response");
+    let task_specific_guard = start_backend_with_shutdown("task-specific-response");
+    let task_guard = start_backend_with_shutdown("task-response");
+    let message_guard = start_backend_with_shutdown("message-response");
+    let notification_guard = start_backend_with_shutdown("notification-response");
+    let agent_info_guard = start_backend_with_shutdown("agent-info-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_a2a_example_config(
+        proxy_port,
+        agent_guard.port(),
+        streaming_guard.port(),
+        task_specific_guard.port(),
+        task_guard.port(),
+        message_guard.port(),
+        notification_guard.port(),
+        agent_info_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":2,"method":"SendStreamingMessage","params":{"message":{"contextId":"ctx-123","role":"ROLE_USER","parts":[{"text":"hello"}]}}}"#,
+        ),
+    );
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "SendStreamingMessage with context ID should return 200"
+    );
+    assert_eq!(
+        parse_body(&raw),
+        "message-response",
+        "contextId=ctx-123 should route before the broader streaming method route"
+    );
+}
+
+#[test]
+fn a2a_classifier_routing_routes_list_tasks_context_id() {
+    let agent_guard = start_backend_with_shutdown("agent-response");
+    let streaming_guard = start_backend_with_shutdown("streaming-response");
+    let task_specific_guard = start_backend_with_shutdown("task-specific-response");
+    let task_guard = start_backend_with_shutdown("task-response");
+    let message_guard = start_backend_with_shutdown("message-response");
+    let notification_guard = start_backend_with_shutdown("notification-response");
+    let agent_info_guard = start_backend_with_shutdown("agent-info-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_a2a_example_config(
+        proxy_port,
+        agent_guard.port(),
+        streaming_guard.port(),
+        task_specific_guard.port(),
+        task_guard.port(),
+        message_guard.port(),
+        notification_guard.port(),
+        agent_info_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":3,"method":"ListTasks","params":{"contextId":"ctx-123"}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "ListTasks with context ID should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "message-response",
+        "contextId=ctx-123 should route before the broader task family route"
+    );
+}
+
+#[test]
 fn a2a_classifier_routing_routes_streaming() {
     let agent_guard = start_backend_with_shutdown("agent-response");
     let streaming_guard = start_backend_with_shutdown("streaming-response");

--- a/tests/utils/src/example_config.rs
+++ b/tests/utils/src/example_config.rs
@@ -48,8 +48,7 @@ pub fn load_example_config(filename: &str, listener_port: u16, port_map: HashMap
 /// # Examples
 ///
 /// ```
-/// let path =
-///     praxis_test_utils::example_config_path("model-to-header-routing.yaml");
+/// let path = praxis_test_utils::example_config_path("model-to-header-routing.yaml");
 /// assert!(path.contains("examples/configs/"));
 /// ```
 pub fn example_config_path(filename: &str) -> String {


### PR DESCRIPTION
## Summary

Adds support for A2A’s standard contextId field, which groups related messages and tasks. Praxis now extracts contextId from request bodies and promotes it into safe internal routing metadata, so operators can route and observe A2A traffic by context when clients provide one. Requests without a context ID still pass normally. This PR does not store contextId -> backend ownership yet; it only makes context visible so a follow-up can add stateful context routing if needed.

  This PR extracts context IDs from spec-defined request locations:

  - `SendMessage`: `params.message.contextId`
  - `SendStreamingMessage`: `params.message.contextId`
  - `ListTasks`: `params.contextId`

  When present and safe, the value is promoted to durable metadata, filter results, and the configured internal header, defaulting to `x-praxis-a2a-context-id`.

  ## Scope

This is classifier metadata only. It enables configured router matches on contextId, but does not add automatic contextId  backend ownership state, Valkey storage, or stateful context-based follow-up routing. The only thing intentionally not tested is stateful context ownership, because that is out of scope. This PR only promotes request metadata; it does not store contextId -> cluster mappings.

  ## Validation

  - `cargo test -p praxis-ai-filters a2a`
  - `cargo clippy -p praxis-ai-filters -- -D warnings`
  - `make lint`
  - `cargo +nightly fmt --all --check`
  - `git diff --check`

  ## References

Refs praxis-proxy/ai#148
Refs praxis-proxy/ai#157
A2A spec: https://a2a-protocol.org/latest/specification/

