### PR TITLE
docs(mcp): restore static catalog example

### DIFF
--- a/examples/configs/payload-processing/mcp-static-catalog.yaml
+++ b/examples/configs/payload-processing/mcp-static-catalog.yaml
@@ -1,0 +1,60 @@
+# MCP Static Catalog
+#
+# Provides a static MCP catalog and broker for initialize,
+# tools/list, ping, and notifications/initialized requests.
+#
+# Pipeline: mcp -> load_balancer (no router).
+# Praxis short-circuits initialize, tools/list, ping,
+# and notifications/initialized. tools/call routing is added
+# in a follow-up PR.
+#
+# Backend endpoints are placeholders for follow-up tools/call routing.
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/payload-processing/mcp-static-catalog.yaml
+
+listeners:
+  - name: default
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        path: /mcp
+        max_body_bytes: 65536
+        protocol_profile: current
+        default_version: "2025-03-26"
+        supported_versions: ["2025-03-26"]
+        servers:
+          - name: weather
+            cluster: weather-mcp
+            path: /mcp
+            tool_prefix: "weather_"
+            tools:
+              - name: get_weather
+                description: Get current weather
+                inputSchema:
+                  type: object
+                  properties:
+                    city:
+                      type: string
+              - name: forecast
+                description: Get weather forecast
+          - name: calendar
+            cluster: calendar-mcp
+            path: /mcp
+            tool_prefix: "cal_"
+            tools:
+              - name: create_event
+                description: Create a calendar event
+              - name: list_events
+                description: List calendar events
+
+      - filter: load_balancer
+        clusters:
+          - name: weather-mcp
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: calendar-mcp
+            endpoints:
+              - "127.0.0.1:3002"


### PR DESCRIPTION
## Summary

  Restores the MCP static catalog example config in the split `ai` repo.

  The example README and integration example coverage already reference `examples/configs/payload-processing/mcp-static-catalog.yaml`, but the config file itself was missing from the migration.

  ## Scope

  Example config only. No MCP runtime behavior changes.

  ## Validation

  - `cargo +nightly fmt --all --check`
  - `git diff --check`
