### PR TITLE
test(store): add unit tests for SQLite backend and storage traits

### DIFF
--- a/apis/src/store/sqlite.rs
+++ b/apis/src/store/sqlite.rs
@@ -594,57 +594,6 @@ fn row_to_conversation_item_record(row: &sqlx::sqlite::SqliteRow) -> Result<Conv
     })
 }
 
-// -----------------------------------------------------------------------------
-// Tests
-// -----------------------------------------------------------------------------
-
-#[cfg(test)]
-#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
-#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn memory_url_short_form() {
-        assert!(is_memory_database_url("sqlite::memory:"));
-    }
-
-    #[test]
-    fn memory_url_slash_form() {
-        assert!(is_memory_database_url("sqlite://:memory:"));
-    }
-
-    #[test]
-    fn memory_url_query_param() {
-        assert!(is_memory_database_url("sqlite:///test.db?mode=memory"));
-    }
-
-    #[test]
-    fn memory_url_query_param_not_first() {
-        assert!(is_memory_database_url("sqlite:///test.db?cache=shared&mode=memory"));
-    }
-
-    #[test]
-    fn memory_url_whitespace_trimmed() {
-        assert!(is_memory_database_url("  sqlite::memory:  "));
-    }
-
-    #[test]
-    fn file_url_is_not_memory() {
-        assert!(!is_memory_database_url("sqlite:///path/to/db.sqlite"));
-    }
-
-    #[test]
-    fn file_url_with_mode_rwc_is_not_memory() {
-        assert!(!is_memory_database_url("sqlite:///test.db?mode=rwc"));
-    }
-
-    #[test]
-    fn empty_url_is_not_memory() {
-        assert!(!is_memory_database_url(""));
-    }
-}
-
 /// Convert a sqlx row to a [`ConversationRecord`].
 fn row_to_conversation_record(row: &sqlx::sqlite::SqliteRow) -> Result<ConversationRecord, StoreError> {
     let messages_json: String = row
@@ -667,4 +616,58 @@ fn row_to_conversation_record(row: &sqlx::sqlite::SqliteRow) -> Result<Conversat
         metadata: serde_json::from_str(&metadata_json).map_err(|e| StoreError::Serialization(e.to_string()))?,
         messages: serde_json::from_str(&messages_json).map_err(|e| StoreError::Serialization(e.to_string()))?,
     })
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_url_short_form() {
+        assert!(is_memory_database_url("sqlite::memory:"), "short-form memory URL should be detected");
+    }
+
+    #[test]
+    fn memory_url_slash_form() {
+        assert!(is_memory_database_url("sqlite://:memory:"), "slash-form memory URL should be detected");
+    }
+
+    #[test]
+    fn memory_url_query_param() {
+        assert!(is_memory_database_url("sqlite:///test.db?mode=memory"), "mode=memory query param should be detected");
+    }
+
+    #[test]
+    fn memory_url_query_param_not_first() {
+        assert!(
+            is_memory_database_url("sqlite:///test.db?cache=shared&mode=memory"),
+            "mode=memory should be detected even when not the first query param"
+        );
+    }
+
+    #[test]
+    fn memory_url_whitespace_trimmed() {
+        assert!(is_memory_database_url("  sqlite::memory:  "), "leading/trailing whitespace should be trimmed");
+    }
+
+    #[test]
+    fn file_url_is_not_memory() {
+        assert!(!is_memory_database_url("sqlite:///path/to/db.sqlite"), "file-backed URL should not be detected as memory");
+    }
+
+    #[test]
+    fn file_url_with_mode_rwc_is_not_memory() {
+        assert!(!is_memory_database_url("sqlite:///test.db?mode=rwc"), "mode=rwc should not be detected as memory");
+    }
+
+    #[test]
+    fn empty_url_is_not_memory() {
+        assert!(!is_memory_database_url(""), "empty URL should not be detected as memory");
+    }
 }

--- a/apis/src/store/sqlite.rs
+++ b/apis/src/store/sqlite.rs
@@ -594,6 +594,57 @@ fn row_to_conversation_item_record(row: &sqlx::sqlite::SqliteRow) -> Result<Conv
     })
 }
 
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_url_short_form() {
+        assert!(is_memory_database_url("sqlite::memory:"));
+    }
+
+    #[test]
+    fn memory_url_slash_form() {
+        assert!(is_memory_database_url("sqlite://:memory:"));
+    }
+
+    #[test]
+    fn memory_url_query_param() {
+        assert!(is_memory_database_url("sqlite:///test.db?mode=memory"));
+    }
+
+    #[test]
+    fn memory_url_query_param_not_first() {
+        assert!(is_memory_database_url("sqlite:///test.db?cache=shared&mode=memory"));
+    }
+
+    #[test]
+    fn memory_url_whitespace_trimmed() {
+        assert!(is_memory_database_url("  sqlite::memory:  "));
+    }
+
+    #[test]
+    fn file_url_is_not_memory() {
+        assert!(!is_memory_database_url("sqlite:///path/to/db.sqlite"));
+    }
+
+    #[test]
+    fn file_url_with_mode_rwc_is_not_memory() {
+        assert!(!is_memory_database_url("sqlite:///test.db?mode=rwc"));
+    }
+
+    #[test]
+    fn empty_url_is_not_memory() {
+        assert!(!is_memory_database_url(""));
+    }
+}
+
 /// Convert a sqlx row to a [`ConversationRecord`].
 fn row_to_conversation_record(row: &sqlx::sqlite::SqliteRow) -> Result<ConversationRecord, StoreError> {
     let messages_json: String = row

--- a/apis/src/store/sqlite.rs
+++ b/apis/src/store/sqlite.rs
@@ -630,17 +630,26 @@ mod tests {
 
     #[test]
     fn memory_url_short_form() {
-        assert!(is_memory_database_url("sqlite::memory:"), "short-form memory URL should be detected");
+        assert!(
+            is_memory_database_url("sqlite::memory:"),
+            "short-form memory URL should be detected"
+        );
     }
 
     #[test]
     fn memory_url_slash_form() {
-        assert!(is_memory_database_url("sqlite://:memory:"), "slash-form memory URL should be detected");
+        assert!(
+            is_memory_database_url("sqlite://:memory:"),
+            "slash-form memory URL should be detected"
+        );
     }
 
     #[test]
     fn memory_url_query_param() {
-        assert!(is_memory_database_url("sqlite:///test.db?mode=memory"), "mode=memory query param should be detected");
+        assert!(
+            is_memory_database_url("sqlite:///test.db?mode=memory"),
+            "mode=memory query param should be detected"
+        );
     }
 
     #[test]
@@ -653,21 +662,33 @@ mod tests {
 
     #[test]
     fn memory_url_whitespace_trimmed() {
-        assert!(is_memory_database_url("  sqlite::memory:  "), "leading/trailing whitespace should be trimmed");
+        assert!(
+            is_memory_database_url("  sqlite::memory:  "),
+            "leading/trailing whitespace should be trimmed"
+        );
     }
 
     #[test]
     fn file_url_is_not_memory() {
-        assert!(!is_memory_database_url("sqlite:///path/to/db.sqlite"), "file-backed URL should not be detected as memory");
+        assert!(
+            !is_memory_database_url("sqlite:///path/to/db.sqlite"),
+            "file-backed URL should not be detected as memory"
+        );
     }
 
     #[test]
     fn file_url_with_mode_rwc_is_not_memory() {
-        assert!(!is_memory_database_url("sqlite:///test.db?mode=rwc"), "mode=rwc should not be detected as memory");
+        assert!(
+            !is_memory_database_url("sqlite:///test.db?mode=rwc"),
+            "mode=rwc should not be detected as memory"
+        );
     }
 
     #[test]
     fn empty_url_is_not_memory() {
-        assert!(!is_memory_database_url(""), "empty URL should not be detected as memory");
+        assert!(
+            !is_memory_database_url(""),
+            "empty URL should not be detected as memory"
+        );
     }
 }

--- a/apis/src/store/tests.rs
+++ b/apis/src/store/tests.rs
@@ -963,6 +963,179 @@ async fn delete_conversation_preserves_items() {
 }
 
 #[tokio::test]
+async fn get_existing_conversation_item_ids_returns_matching() {
+    let store = make_store_with_items().await;
+    let items = [
+        make_conversation_item("item_1", "tenant_a", "conv_1", 1),
+        make_conversation_item("item_2", "tenant_a", "conv_1", 2),
+        make_conversation_item("item_3", "tenant_a", "conv_1", 3),
+    ];
+    store
+        .create_conversation_items(&items)
+        .await
+        .expect("item insert should succeed");
+
+    let existing = store
+        .get_existing_conversation_item_ids("tenant_a", "conv_1", &["item_1", "item_3", "item_99"])
+        .await
+        .expect("get_existing should succeed");
+
+    assert_eq!(existing.len(), 2, "should find 2 of 3 queried IDs");
+    assert!(existing.contains(&"item_1".to_owned()), "item_1 should be found");
+    assert!(existing.contains(&"item_3".to_owned()), "item_3 should be found");
+}
+
+#[tokio::test]
+async fn get_existing_conversation_item_ids_empty_input() {
+    let store = make_store_with_items().await;
+    let item = make_conversation_item("item_1", "tenant_a", "conv_1", 1);
+    store
+        .create_conversation_items(&[item])
+        .await
+        .expect("item insert should succeed");
+
+    let existing = store
+        .get_existing_conversation_item_ids("tenant_a", "conv_1", &[])
+        .await
+        .expect("get_existing with empty input should succeed");
+
+    assert!(existing.is_empty(), "empty input should return empty result");
+}
+
+#[tokio::test]
+async fn get_existing_conversation_item_ids_tenant_isolation() {
+    let store = make_store_with_items().await;
+    let item = make_conversation_item("item_1", "tenant_a", "conv_1", 1);
+    store
+        .create_conversation_items(&[item])
+        .await
+        .expect("item insert should succeed");
+
+    let existing = store
+        .get_existing_conversation_item_ids("tenant_b", "conv_1", &["item_1"])
+        .await
+        .expect("get_existing should succeed");
+
+    assert!(existing.is_empty(), "tenant_b should not see tenant_a items");
+}
+
+#[tokio::test]
+async fn delete_conversation_item_returns_true() {
+    let store = make_store_with_items().await;
+    let items = [
+        make_conversation_item("item_1", "tenant_a", "conv_1", 1),
+        make_conversation_item("item_2", "tenant_a", "conv_1", 2),
+    ];
+    store
+        .create_conversation_items(&items)
+        .await
+        .expect("item insert should succeed");
+
+    let deleted = store
+        .delete_conversation_item("tenant_a", "conv_1", "item_1")
+        .await
+        .expect("delete should succeed");
+    assert!(deleted, "delete should return true for existing item");
+
+    let fetched = store
+        .get_conversation_item("tenant_a", "conv_1", "item_1")
+        .await
+        .expect("get should succeed");
+    assert!(fetched.is_none(), "deleted item should not be retrievable");
+
+    let remaining = store
+        .list_conversation_items("tenant_a", "conv_1", None, 100, true)
+        .await
+        .expect("list should succeed");
+    assert_item_ids(&remaining, &["item_2"]);
+}
+
+#[tokio::test]
+async fn delete_nonexistent_conversation_item_returns_false() {
+    let store = make_store_with_items().await;
+
+    let deleted = store
+        .delete_conversation_item("tenant_a", "conv_1", "nonexistent")
+        .await
+        .expect("delete should succeed");
+
+    assert!(!deleted, "delete should return false for nonexistent item");
+}
+
+#[tokio::test]
+async fn conversation_item_position_returns_existing() {
+    let store = make_store_with_items().await;
+    let items = [
+        make_conversation_item("item_1", "tenant_a", "conv_1", 5),
+        make_conversation_item("item_2", "tenant_a", "conv_1", 10),
+    ];
+    store
+        .create_conversation_items(&items)
+        .await
+        .expect("item insert should succeed");
+
+    let position = store
+        .conversation_item_position("tenant_a", "conv_1", "item_2")
+        .await
+        .expect("position lookup should succeed");
+
+    assert_eq!(position, Some(10), "position should be 10");
+}
+
+#[tokio::test]
+async fn conversation_item_position_returns_none_for_missing() {
+    let store = make_store_with_items().await;
+
+    let position = store
+        .conversation_item_position("tenant_a", "conv_1", "nonexistent")
+        .await
+        .expect("position lookup should succeed");
+
+    assert!(position.is_none(), "missing item should return None");
+}
+
+#[tokio::test]
+async fn update_conversation_messages_nonexistent_returns_false() {
+    let store = make_store().await;
+
+    let updated = store
+        .update_conversation_messages("tenant_a", "nonexistent", &json!({"new": "messages"}))
+        .await
+        .expect("update should succeed");
+
+    assert!(!updated, "updating nonexistent conversation should return false");
+}
+
+#[tokio::test]
+async fn update_conversation_messages_tenant_isolation() {
+    let store = make_store().await;
+    let record = ConversationRecord {
+        conversation_id: "conv_1".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        created_at: 1000,
+        metadata: json!({}),
+        messages: json!([{"role": "user", "content": "original"}]),
+    };
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let updated = store
+        .update_conversation_messages("tenant_b", "conv_1", &json!([{"role": "user", "content": "hijack"}]))
+        .await
+        .expect("cross-tenant update should succeed");
+    assert!(!updated, "tenant_b should not be able to update tenant_a messages");
+
+    let fetched = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_1")
+        .await
+        .expect("get should succeed")
+        .expect("record should exist");
+    assert_eq!(
+        fetched.messages,
+        json!([{"role": "user", "content": "original"}]),
+        "messages should not have changed"
+    );
+}
+
+#[tokio::test]
 async fn conversation_item_methods_fail_without_items_table() {
     let store = make_store().await;
     let item = make_conversation_item("item_1", "tenant_a", "conv_1", 1);


### PR DESCRIPTION
## Summary

- Add 8 unit tests for `is_memory_database_url` in `sqlite.rs` covering all URL pattern branches (short form, slash form, query params, file-based, whitespace trimming)
- Add 10 integration tests for previously untested SQLite store methods: `get_existing_conversation_item_ids`, `delete_conversation_item`, `conversation_item_position`, and `update_conversation_messages` edge cases including tenant isolation

## Test plan

- [x] All new tests pass (`cargo test -p praxis-ai-apis store::`)
- [x] Clippy clean (`cargo clippy -p praxis-ai-apis -- -D warnings`)
- [x] No existing tests broken (219 total passed, 25 PG tests ignored as expected)

Partly addresses #232