### PR TITLE
fix(apis): match OpenAI JSON field ordering in conversation responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ regex = "1.12.4"
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"] }
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
-serde_json = "1.0.150"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
 syn = { version = "2.0.118", features = ["full", "extra-traits", "visit"] }
 serde_yaml = { package = "yaml_serde", version = "0.10.4" }
 sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "sqlite", "postgres"] }

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -121,12 +121,7 @@ pub(super) async fn handle_create_conversation(
     }
     debug!(conversation_id, tenant_id, "conversation created");
 
-    let body = serde_json::json!({
-        "id": conversation_id,
-        "object": "conversation",
-        "created_at": created_at,
-        "metadata": metadata,
-    });
+    let body = conversation_to_json(&record);
     Ok(FilterAction::Reject(json_response(200, &body)?))
 }
 

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1030,3 +1030,23 @@ async fn create_test_conversation(filter: &dyn HttpFilter, metadata: Value) -> S
     let resp = rejection_body(&rejection);
     resp["id"].as_str().unwrap().to_owned()
 }
+
+#[tokio::test]
+async fn create_conversation_response_field_order_matches_openai() {
+    let filter = build_test_filter();
+
+    let req = make_request(Method::POST, "/v1/conversations");
+    let mut ctx = make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let body_json = serde_json::json!({"metadata": {"project": "test"}});
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject, got {action:?}");
+    };
+    let resp = rejection_body(&rejection);
+    let keys: Vec<&String> = resp.as_object().unwrap().keys().collect();
+    assert_eq!(keys, &["id", "object", "created_at", "metadata"]);
+}


### PR DESCRIPTION
## Summary

Our conversation API responses serialized JSON fields in alphabetical order (`created_at`, `id`, `metadata`, `object`) instead of matching OpenAI's wire format (`id`, `object`, `created_at`, `metadata`).

- Enable `serde_json`'s `preserve_order` feature so `json!({})` macros emit fields in declaration order
- Deduplicate the create handler's inline JSON by reusing `conversation_to_json()`
- Add a regression test asserting field order matches OpenAI's API

## Test plan

- [x] `make lint` passes
- [x] `make build` passes
- [x] `make test` passes (all 1213 tests)
- [x] Manual verification: started server with conversations config, confirmed `curl` response has correct field ordering