### PR TITLE
feat/220 token counting integration tests

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ before sending requests.
 | [mcp-stateless-broker.yaml](configs/mcp-stateless-broker.yaml) | Configurable stateless MCP broker using the 2026-07-28 release candidate profile |
 | [model-to-header-routing.yaml](configs/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
 | [prompt-enrichment.yaml](configs/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
-| [token-counting.yaml](configs/token-counting.yaml) | Extracts token usage from AI inference responses (streaming and non-streaming) and makes counts available to downstream filters via filter metadata |
+| [token-counting.yaml](configs/token-counting.yaml) | Extracts token usage from AI inference responses (streaming and non-streaming) and makes counts available to downstream filters via filter metadata as token.input, token.output, and token.total |
 | [token-usage-headers.yaml](configs/token-usage-headers.yaml) | Inject Praxis-Token-Input, Praxis-Token-Output, and Praxis-Token-Total headers into downstream responses when token counts are available in filter metadata |
 
 ### Anthropic

--- a/examples/configs/token-counting.yaml
+++ b/examples/configs/token-counting.yaml
@@ -2,18 +2,29 @@
 #
 # Extracts token usage from AI inference responses (streaming and
 # non-streaming) and makes counts available to downstream filters
-# via filter metadata.
+# via filter metadata as token.input, token.output, and token.total.
 #
 # Usage:
 #   cargo run -p praxis-ai-proxy -- -c examples/configs/token-counting.yaml
 #   curl http://localhost:8080/v1/chat/completions -d '{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}'
 #
-# The filter reads the response body (streaming SSE or buffered JSON),
-# extracts provider-specific token usage, and writes unified counts
-# to filter_metadata as token.input, token.output, and token.total.
+# token_count reads the response body, extracts provider-specific
+# token usage, and writes the counts to filter_metadata.
 #
-# Counts are available to access logs, metrics, and filters that
-# read metadata during the response body phase.
+# token_usage_headers injects Praxis-Token-Input, Praxis-Token-Output,
+# and Praxis-Token-Total into the downstream response — but only when
+# counts are available during the response-header phase. token_count
+# extracts counts from the response body inside on_response_body,
+# which runs after response headers have already been sent
+# downstream, so for every provider currently supported here the
+# counts remain in filter_metadata for other response-phase filters
+# to read, but the Praxis-Token-* headers are not injected.
+#
+# access_log demonstrates that token_count composes cleanly alongside
+# other response-phase filters in the same pipeline.
+#
+# Supported provider values:
+#   openai | anthropic | google | bedrock | azure
 
 listeners:
   - name: default
@@ -29,8 +40,16 @@ filter_chains:
           - path_prefix: "/"
             cluster: backend
 
+      # token_usage_headers is declared before token_count: response
+      # hooks run in reverse declared order, so token_count's
+      # on_response_body (which sets filter_metadata) runs before
+      # token_usage_headers reads it.
+      - filter: token_usage_headers
+
       - filter: token_count
-        provider: openai
+        provider: openai   # openai | anthropic | google | bedrock | azure
+
+      - filter: access_log
 
       - filter: load_balancer
         clusters:

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -26,5 +26,6 @@ mod responses_proxy;
 mod responses_routing;
 mod session_replay;
 mod token_count;
+mod token_counting;
 mod token_usage_headers;
 mod tool_parse;

--- a/tests/integration/tests/suite/examples/token_counting.rs
+++ b/tests/integration/tests/suite/examples/token_counting.rs
@@ -3,16 +3,23 @@
 
 //! Integration tests for token counting filters.
 //!
+//! These tests only verify that the proxy passes requests/responses
+//! through **unchanged** (status, headers, body) when the `token_count`
+//! filter is in the chain; they do not assert the extracted token
+//! counts themselves — see "Why extracted counts aren't asserted here"
+//! below for why that isn't observable from an HTTP integration test
+//! for these providers.
+//!
 //! ## What is tested
 //!
 //! | Test | Provider | What is verified |
 //! |------|----------|-----------------|
-//! | Non-streaming | openai/anthropic/google/bedrock/azure | 200 OK + body byte-for-byte unchanged |
-//! | SSE streaming | openai/anthropic/google | 200 OK + body byte-for-byte unchanged |
+//! | `*_body_passes_through` (non-streaming) | openai/anthropic/google/bedrock/azure | 200 OK + body byte-for-byte unchanged |
+//! | `*_body_passes_through` (SSE streaming) | openai/anthropic/google | 200 OK + body byte-for-byte unchanged |
 //! | `missing_usage_fields_*` | openai | Praxis-Token-* headers absent |
 //! | `example_config_*` | openai | 200 OK + body unchanged |
 //!
-//! ## Why Praxis-Token headers are never asserted present here
+//! ## Why extracted counts aren't asserted here
 //!
 //! In the Praxis/Pingora filter pipeline, response headers are committed
 //! *before* the response body is processed. The `token_usage_headers`
@@ -22,17 +29,19 @@
 //! Every provider covered by this test file extracts counts from the
 //! response body inside `on_response_body`, at which point response
 //! headers have already been sent downstream — so `token_usage_headers`
-//! never has anything to inject for these providers. The `Praxis-Token-*`
-//! header assertions below only check for *absence*.
+//! never has anything to inject for these providers, and the extracted
+//! counts (written to internal `filter_metadata`) are otherwise not
+//! observable from an HTTP client. The `Praxis-Token-*` header
+//! assertions below only check for *absence*.
 //!
 //! Header-based extraction (e.g. Bedrock `InvokeModel`, which reports
 //! counts via upstream response *headers* available during
-//! `token_count.on_response`) is the one case where header injection is
-//! observable; that provider is not yet supported by `token_count` and is
-//! covered separately once it lands.
+//! `token_count.on_response`) is the one case where header injection
+//! *is* observable end-to-end; that path is covered separately in
+//! `tests/integration/tests/suite/examples/token_count.rs`.
 //!
-//! Detailed token extraction logic is covered by unit tests in
-//! `filters/src/token_count/tests.rs`.
+//! Actual extracted-value correctness for every provider is covered by
+//! unit tests in `filters/src/token_count/tests.rs`.
 
 use std::collections::HashMap;
 
@@ -106,7 +115,7 @@ fn token_count_config(proxy_port: u16, backend_port: u16, provider: &str) -> pra
 // -----------------------------------------------------------------------------
 
 #[test]
-fn openai_non_streaming_extracts_token_counts() {
+fn openai_non_streaming_body_passes_through() {
     let backend = Backend::fixed(OPENAI_JSON)
         .header("content-type", "application/json")
         .start_with_shutdown();
@@ -120,7 +129,7 @@ fn openai_non_streaming_extracts_token_counts() {
 }
 
 #[test]
-fn anthropic_non_streaming_extracts_token_counts() {
+fn anthropic_non_streaming_body_passes_through() {
     let backend = Backend::fixed(ANTHROPIC_JSON)
         .header("content-type", "application/json")
         .start_with_shutdown();
@@ -134,7 +143,7 @@ fn anthropic_non_streaming_extracts_token_counts() {
 }
 
 #[test]
-fn google_non_streaming_extracts_token_counts() {
+fn google_non_streaming_body_passes_through() {
     let backend = Backend::fixed(GOOGLE_JSON)
         .header("content-type", "application/json")
         .start_with_shutdown();
@@ -151,7 +160,7 @@ fn google_non_streaming_extracts_token_counts() {
 }
 
 #[test]
-fn bedrock_converse_non_streaming_extracts_token_counts() {
+fn bedrock_converse_non_streaming_body_passes_through() {
     let backend = Backend::fixed(BEDROCK_CONVERSE_JSON)
         .header("content-type", "application/json")
         .start_with_shutdown();
@@ -169,7 +178,7 @@ fn bedrock_converse_non_streaming_extracts_token_counts() {
 }
 
 #[test]
-fn azure_non_streaming_extracts_token_counts() {
+fn azure_non_streaming_body_passes_through() {
     let backend = Backend::fixed(AZURE_JSON)
         .header("content-type", "application/json")
         .start_with_shutdown();
@@ -190,7 +199,7 @@ fn azure_non_streaming_extracts_token_counts() {
 // -----------------------------------------------------------------------------
 
 #[test]
-fn openai_streaming_extracts_token_counts() {
+fn openai_streaming_body_passes_through() {
     let backend = Backend::fixed(OPENAI_SSE)
         .header("content-type", "text/event-stream")
         .header("cache-control", "no-cache")
@@ -205,7 +214,7 @@ fn openai_streaming_extracts_token_counts() {
 }
 
 #[test]
-fn anthropic_streaming_split_events_extracts_token_counts() {
+fn anthropic_streaming_split_events_body_passes_through() {
     let backend = Backend::fixed(ANTHROPIC_SSE)
         .header("content-type", "text/event-stream")
         .header("cache-control", "no-cache")
@@ -224,7 +233,7 @@ fn anthropic_streaming_split_events_extracts_token_counts() {
 }
 
 #[test]
-fn google_streaming_no_done_sentinel_extracts_token_counts() {
+fn google_streaming_no_done_sentinel_body_passes_through() {
     let backend = Backend::fixed(GOOGLE_SSE)
         .header("content-type", "text/event-stream")
         .header("cache-control", "no-cache")

--- a/tests/integration/tests/suite/examples/token_counting.rs
+++ b/tests/integration/tests/suite/examples/token_counting.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for token counting filters.
+//!
+//! ## What is tested
+//!
+//! | Test | Provider | What is verified |
+//! |------|----------|-----------------|
+//! | Non-streaming | openai/anthropic/google/bedrock/azure | 200 OK + body byte-for-byte unchanged |
+//! | SSE streaming | openai/anthropic/google | 200 OK + body byte-for-byte unchanged |
+//! | `missing_usage_fields_*` | openai | Praxis-Token-* headers absent |
+//! | `example_config_*` | openai | 200 OK + body unchanged |
+//!
+//! ## Why Praxis-Token headers are never asserted present here
+//!
+//! In the Praxis/Pingora filter pipeline, response headers are committed
+//! *before* the response body is processed. The `token_usage_headers`
+//! filter runs its `on_response` hook (where it can write headers) in
+//! *reverse* pipeline order, which means it executes *after*
+//! `token_count.on_response` but *before* `token_count.on_response_body`.
+//! Every provider covered by this test file extracts counts from the
+//! response body inside `on_response_body`, at which point response
+//! headers have already been sent downstream — so `token_usage_headers`
+//! never has anything to inject for these providers. The `Praxis-Token-*`
+//! header assertions below only check for *absence*.
+//!
+//! Header-based extraction (e.g. Bedrock `InvokeModel`, which reports
+//! counts via upstream response *headers* available during
+//! `token_count.on_response`) is the one case where header injection is
+//! observable; that provider is not yet supported by `token_count` and is
+//! covered separately once it lands.
+//!
+//! Detailed token extraction logic is covered by unit tests in
+//! `filters/src/token_count/tests.rs`.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    Backend, example_config_path, free_port, http_send, json_post, load_example_config, parse_body, parse_header,
+    parse_status, patch_yaml, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Mock response bodies
+// -----------------------------------------------------------------------------
+
+const OPENAI_JSON: &str = r#"{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}"#;
+
+const ANTHROPIC_JSON: &str = r#"{"content":[],"usage":{"input_tokens":10,"output_tokens":20}}"#;
+
+const GOOGLE_JSON: &str =
+    r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":20,"totalTokenCount":30}}"#;
+
+const BEDROCK_CONVERSE_JSON: &str = r#"{"output":{},"usage":{"inputTokens":10,"outputTokens":20}}"#;
+
+const AZURE_JSON: &str = OPENAI_JSON;
+
+const OPENAI_SSE: &str = concat!(
+    "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}],\"usage\":null}\n\n",
+    "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\n",
+    "data: [DONE]\n\n",
+);
+
+const ANTHROPIC_SSE: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":10}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":20}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+const GOOGLE_SSE: &str = concat!(
+    "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}\n\n",
+    "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}]}}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":20,\"totalTokenCount\":30}}\n\n",
+);
+
+const OPENAI_SSE_NOISY: &str = concat!(
+    ": ping\n\n",
+    "\n",
+    "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}],\"usage\":null}\n\n",
+    "\n",
+    ": keep-alive\n\n",
+    "data: {\n  \"choices\": [],\n  \"usage\": {\n    \"prompt_tokens\": 10,\n    \"completion_tokens\": 20,\n    \"total_tokens\": 30\n  }\n}\n\n",
+    "data: [DONE]\n\n",
+);
+
+const OPENAI_NO_USAGE_JSON: &str = r#"{"choices":[{"message":{"content":"Hello"}}]}"#;
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Build a YAML config for the token counting pipeline using the example file,
+/// substituting `provider: openai` with the given provider name.
+fn token_count_config(proxy_port: u16, backend_port: u16, provider: &str) -> praxis_core::config::Config {
+    let path = example_config_path("token-counting.yaml");
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let yaml = yaml.replace("provider: openai", &format!("provider: {provider}"));
+    let patched = patch_yaml(&yaml, proxy_port, &HashMap::from([("127.0.0.1:3000", backend_port)]));
+    praxis_core::config::Config::from_yaml(&patched).expect("config should parse")
+}
+
+// -----------------------------------------------------------------------------
+// Non-streaming tests — body passthrough
+// -----------------------------------------------------------------------------
+
+#[test]
+fn openai_non_streaming_extracts_token_counts() {
+    let backend = Backend::fixed(OPENAI_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "openai");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", "{}"));
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), OPENAI_JSON, "body should pass through unchanged");
+}
+
+#[test]
+fn anthropic_non_streaming_extracts_token_counts() {
+    let backend = Backend::fixed(ANTHROPIC_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "anthropic");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/messages", "{}"));
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), ANTHROPIC_JSON, "body should pass through unchanged");
+}
+
+#[test]
+fn google_non_streaming_extracts_token_counts() {
+    let backend = Backend::fixed(GOOGLE_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "google");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1beta/models/gemini-pro:generateContent", "{}"),
+    );
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), GOOGLE_JSON, "body should pass through unchanged");
+}
+
+#[test]
+fn bedrock_converse_non_streaming_extracts_token_counts() {
+    let backend = Backend::fixed(BEDROCK_CONVERSE_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "bedrock");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/model/anthropic.claude-3/converse", "{}"));
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        BEDROCK_CONVERSE_JSON,
+        "body should pass through unchanged"
+    );
+}
+
+#[test]
+fn azure_non_streaming_extracts_token_counts() {
+    let backend = Backend::fixed(AZURE_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "azure");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/openai/deployments/gpt-4/chat/completions", "{}"),
+    );
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), AZURE_JSON, "body should pass through unchanged");
+}
+
+// -----------------------------------------------------------------------------
+// SSE streaming tests — body passthrough
+// -----------------------------------------------------------------------------
+
+#[test]
+fn openai_streaming_extracts_token_counts() {
+    let backend = Backend::fixed(OPENAI_SSE)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "openai");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", r#"{"stream":true}"#));
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), OPENAI_SSE, "SSE body should pass through unchanged");
+}
+
+#[test]
+fn anthropic_streaming_split_events_extracts_token_counts() {
+    let backend = Backend::fixed(ANTHROPIC_SSE)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "anthropic");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/messages", r#"{"stream":true}"#));
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        ANTHROPIC_SSE,
+        "SSE body should pass through unchanged"
+    );
+}
+
+#[test]
+fn google_streaming_no_done_sentinel_extracts_token_counts() {
+    let backend = Backend::fixed(GOOGLE_SSE)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "google");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1beta/models/gemini-pro:streamGenerateContent", r#"{"stream":true}"#),
+    );
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), GOOGLE_SSE, "SSE body should pass through unchanged");
+}
+
+// -----------------------------------------------------------------------------
+// Passthrough and edge cases
+// -----------------------------------------------------------------------------
+
+#[test]
+fn non_json_response_body_passes_through_unchanged() {
+    let backend = Backend::fixed("Internal Server Error")
+        .header("content-type", "text/plain")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "openai");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", "{}"));
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "non-JSON upstream response should still return 200"
+    );
+    assert_eq!(
+        parse_body(&raw),
+        "Internal Server Error",
+        "non-JSON body must be forwarded byte-for-byte"
+    );
+    assert!(
+        parse_header(&raw, "praxis-token-input").is_none(),
+        "praxis-token-input must be absent when body is not valid JSON"
+    );
+}
+
+#[test]
+fn missing_usage_fields_no_token_headers_injected() {
+    let backend = Backend::fixed(OPENAI_NO_USAGE_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "openai");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", "{}"));
+    assert_eq!(parse_status(&raw), 200);
+    assert!(
+        parse_header(&raw, "praxis-token-input").is_none(),
+        "praxis-token-input must be absent when usage fields are missing"
+    );
+    assert!(
+        parse_header(&raw, "praxis-token-output").is_none(),
+        "praxis-token-output must be absent when usage fields are missing"
+    );
+    assert!(
+        parse_header(&raw, "praxis-token-total").is_none(),
+        "praxis-token-total must be absent when usage fields are missing"
+    );
+}
+
+#[test]
+fn openai_streaming_whitespace_and_comments() {
+    let backend = Backend::fixed(OPENAI_SSE_NOISY)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = token_count_config(proxy_port, backend.port(), "openai");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", r#"{"stream":true}"#));
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        OPENAI_SSE_NOISY,
+        "noisy SSE body must pass through byte-for-byte unchanged"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Example config smoke test
+// -----------------------------------------------------------------------------
+
+#[test]
+fn example_config_token_counting_openai() {
+    let backend = Backend::fixed(OPENAI_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "token-counting.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3000", backend.port())]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", "{}"));
+    assert_eq!(parse_status(&raw), 200, "example config smoke test should return 200");
+    assert_eq!(parse_body(&raw), OPENAI_JSON, "body should pass through unchanged");
+}


### PR DESCRIPTION
# test(examples): add token_counting integration tests and example config (`#220`)

## Summary

Adds an end-to-end integration test suite and example configuration for
the `token_count` filter (merged in #262), covering all five provider
response formats, both streaming and non-streaming delivery, and
response-body passthrough guarantees, as described in
[proposal `#220`](docs/proposals/00220_token-counting-integration-tests.md).

Rebased onto current `main`: uses the actual merged filter names
(`token_count`, `token_usage_headers`) and header names
(`Praxis-Token-Input/Output/Total`) rather than the placeholder names
from the original proposal draft (`x_token_headers`, `X-Token-*`).

---

## What changed

### `examples/configs/token-counting.yaml`

Rewrote the example pipeline to chain
`router → token_usage_headers → token_count → access_log → load_balancer`,
matching the filters that actually exist on `main`. Documents that
response headers are committed before the response body phase, so
`token_usage_headers` (declared before `token_count` to run *after* it
in the reverse response-hook order) has nothing to inject for any of
the currently-supported providers (openai, anthropic, google, bedrock,
azure) — they all extract counts from the response body in
`on_response_body`, after headers have already been sent. Counts remain
available in `filter_metadata` for other response-phase filters.

### `tests/integration/tests/suite/examples/token_counting.rs`

12 integration tests covering the provider/mode matrix from proposal
`#220` that's actually supported by the merged filter:

| Test | Provider | What is verified |
|---|---|---|
| `openai_non_streaming_extracts_token_counts` | OpenAI | 200 OK + body passthrough |
| `anthropic_non_streaming_extracts_token_counts` | Anthropic | 200 OK + body passthrough |
| `google_non_streaming_extracts_token_counts` | Google | 200 OK + body passthrough |
| `bedrock_converse_non_streaming_extracts_token_counts` | Bedrock Converse | 200 OK + body passthrough |
| `azure_non_streaming_extracts_token_counts` | Azure | 200 OK + body passthrough |
| `openai_streaming_extracts_token_counts` | OpenAI | 200 OK + SSE body passthrough |
| `anthropic_streaming_split_events_extracts_token_counts` | Anthropic | 200 OK + SSE body passthrough (input/output tokens split across `message_start`/`message_delta`) |
| `google_streaming_no_done_sentinel_extracts_token_counts` | Google | 200 OK + SSE body passthrough (no `[DONE]` sentinel) |
| `non_json_response_body_passes_through_unchanged` | OpenAI | Body byte-for-byte identical; no `Praxis-Token-*` headers |
| `missing_usage_fields_no_token_headers_injected` | OpenAI | `Praxis-Token-*` headers absent when no usage |
| `openai_streaming_whitespace_and_comments` | OpenAI | Noisy SSE (keep-alive comments, empty lines, pretty-printed JSON) passes through unchanged |
| `example_config_token_counting_openai` | OpenAI | Example config smoke test — config parses and proxy returns 200 |

> **Why `Praxis-Token-*` headers are never asserted present here:**
> Response headers are committed before the response body filter phase
> begins. `token_usage_headers` runs its `on_response` hook in reverse
> pipeline order — after `token_count.on_response` but before
> `token_count.on_response_body`. Every provider covered here extracts
> counts from the response body inside `on_response_body`, at which
> point headers have already been sent downstream, so
> `token_usage_headers` never has anything to inject. Header-based
> extraction (e.g. a future Bedrock `InvokeModel` provider using
> upstream response headers) is the one case where header injection
> would be observable; that provider isn't part of this PR and is
> tracked separately.

### Wiring

- `tests/.../examples/mod.rs` — adds `mod token_counting;`
- `examples/README.md` — adds `token-counting.yaml` entry

---

## Test plan

- [x] `make lint` passes (clippy, nightly fmt, separators, filter-docs)
- [x] `make test` passes (full unit + integration + doctest suite)
- [x] All 12 integration tests pass locally

## Related

- Proposal: [docs/proposals/00220_token-counting-integration-tests.md](docs/proposals/00220_token-counting-integration-tests.md)
  (note: `#220` in the proposal frontmatter/title refers to the original
  cross-repo tracking number, not an issue in this repo — left as
  `` `#220` `` above rather than bare text so GitHub doesn't autolink it
  to the unrelated `praxis-proxy/ai#220`)

Related to #88

