### PR TITLE
chore: remove stale ai-inference feature flag

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Configuration examples organized by category.
 ## Running an Example
 
 ```console
-cargo run -p praxis-proxy -- -c examples/configs/traffic-management/basic-reverse-proxy.yaml
+cargo run -p praxis-ai-proxy -- -c examples/configs/traffic-management/basic-reverse-proxy.yaml
 curl http://localhost:8080/
 ```
 
@@ -18,154 +18,31 @@ page.
 
 ## Configs
 
-### AI / Inference
+### Anthropic
 
 | File | Description |
 | ------ | ------------- |
-| [a2a-classifier-routing.yaml](configs/ai/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, task ID, and streaming detection |
-| [a2a-task-routing.yaml](configs/ai/a2a-task-routing.yaml) | Captures task ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up task operations back to the backend cluster that created the task |
-| [ai-inference-body-based-routing.yaml](configs/ai/ai-inference-body-based-routing.yaml) | Routes LLM API requests to different backends based on the `model` field in the JSON request body |
-| [messages-protocol.yaml](configs/ai/anthropic/messages-protocol.yaml) | Routes Anthropic Messages API requests to a native `/v1/messages` backend |
-| [messages-to-openai.yaml](configs/ai/anthropic/messages-to-openai.yaml) | Transforms Anthropic Messages API requests and responses for Chat Completions-compatible inference backends |
-| [request-validate.yaml](configs/ai/anthropic/request-validate.yaml) | Rejects empty, malformed, or non-object JSON request bodies |
-| [unified-gateway.yaml](configs/ai/anthropic/unified-gateway.yaml) | Routes traffic by classifier-promoted headers so a single listener handles Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses requests |
-| [credential-injection.yaml](configs/ai/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |
-| [json-rpc-routing.yaml](configs/ai/json-rpc-routing.yaml) | Routes JSON-RPC 2.0 requests to different backends based on the "method" field in the JSON request body |
-| [mcp-classifier-routing.yaml](configs/ai/mcp-classifier-routing.yaml) | Routes MCP requests by body-derived method and tool name |
-| [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
-| [conversations.yaml](configs/ai/openai/conversations/conversations.yaml) | Local /v1/conversations endpoints for conversation lifecycle, backed by the ConversationItemStore |
-| [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |
-| [full-flow.yaml](configs/ai/openai/responses/full-flow.yaml) | Combines format classification, request validation, and backend routing into a single pipeline |
-| [model-rewrite.yaml](configs/ai/openai/responses/model-rewrite.yaml) | Rewrites or injects the top-level `model` field in Responses API request bodies before forwarding to the inference backend |
-| [rehydrate.yaml](configs/ai/openai/responses/rehydrate.yaml) | Validates `previous_response_id` by fetching the stored response, confirming its status is completed, and promoting the ID to filter metadata |
-| [request-validate.yaml](configs/ai/openai/responses/request-validate.yaml) | Validates Responses API requests and rejects invalid parameter combinations |
-| [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persists non-streaming Responses API responses to a database and serves stored data via GET endpoints and handles DELETE /v1/responses/{id} locally |
-| [responses-proxy.yaml](configs/ai/openai/responses/responses-proxy.yaml) | Proxies OpenAI Responses API requests to a native /v1/responses backend |
-| [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Routes Responses API traffic by detected mode |
-| [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
-| [token-usage-headers.yaml](configs/ai/token-usage-headers.yaml) | Inject Praxis-Token-Input, Praxis-Token-Output, and Praxis-Token-Total headers into downstream responses when token counts are available in filter metadata |
+| [messages-protocol.yaml](configs/anthropic/messages-protocol.yaml) | Routes Anthropic Messages API requests to a native `/v1/messages` backend |
+| [messages-to-openai.yaml](configs/anthropic/messages-to-openai.yaml) | Transforms Anthropic Messages API requests and responses for Chat Completions-compatible inference backends |
+| [request-validate.yaml](configs/anthropic/request-validate.yaml) | Rejects empty, malformed, or non-object JSON request bodies |
+| [unified-gateway.yaml](configs/anthropic/unified-gateway.yaml) | Routes traffic by classifier-promoted headers so a single listener handles Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses requests |
 
-### Branching
+### OpenAI
 
 | File | Description |
 | ------ | ------------- |
-| [conditional-skip-to.yaml](configs/branching/conditional-skip-to.yaml) | Skips browser-facing middleware for clean requests |
-| [conditional-terminal.yaml](configs/branching/conditional-terminal.yaml) | Short-circuits the pipeline when guardrails detects a dangerous request header |
-| [cross-chain-flat.yaml](configs/branching/cross-chain-flat.yaml) | A listener references two chains: preprocessing and routing |
-| [multiple-branches.yaml](configs/branching/multiple-branches.yaml) | Multiple branches on a single filter, evaluated in order |
-| [named-chain-ref.yaml](configs/branching/named-chain-ref.yaml) | A branch references a top-level chain by name instead of defining filters inline |
-| [nested-branches.yaml](configs/branching/nested-branches.yaml) | Branch filters that themselves contain branches, forming a multi-level decision tree |
-| [reentrance.yaml](configs/branching/reentrance.yaml) | Loops back to a named filter up to N times |
-| [unconditional-branch.yaml](configs/branching/unconditional-branch.yaml) | Always runs a utility chain before continuing the main pipeline |
-
-### Observability
-
-| File | Description |
-| ------ | ------------- |
-| [access-logging.yaml](configs/observability/access-logging.yaml) | Structured JSON logging with sampling; logs ~10% of requests. request_id ensures each log line has a correlation ID. access_log emits method, path, status, and timing |
-| [logging.yaml](configs/observability/logging.yaml) | request_id — ensures every request has a correlation ID |
-| [tcp-access-log.yaml](configs/observability/tcp-access-log.yaml) | Structured JSON logging of TCP connection events (connect and disconnect) |
-
-### Operations
-
-| File | Description |
-| ------ | ------------- |
-| [admin-interface.yaml](configs/operations/admin-interface.yaml) | Exposes an admin endpoint for operational health checks, readiness probes, and Prometheus metrics |
-| [container-default.yaml](configs/operations/container-default.yaml) | Default config for containerized deployments |
-| [hot-reload.yaml](configs/operations/hot-reload.yaml) | Filter pipelines are swapped atomically at runtime when the config file changes |
-| [log-overrides.yaml](configs/operations/log-overrides.yaml) | Use `runtime.log_overrides` to raise or lower log verbosity for specific modules without flooding output from every subsystem |
-| [max-connections.yaml](configs/operations/max-connections.yaml) | HTTP listeners return 503 with Retry-After: 1. TCP listeners close the socket immediately |
-| [multi-listener.yaml](configs/operations/multi-listener.yaml) | Demonstrates multiple HTTP listeners, each with its own filter pipeline |
-| [production-gateway.yaml](configs/operations/production-gateway.yaml) | Combines TLS, logging, timeouts, security headers, path routing, and load balancing |
+| [conversations.yaml](configs/openai/conversations/conversations.yaml) | Local /v1/conversations endpoints for conversation lifecycle, backed by the ConversationItemStore |
+| [format-routing.yaml](configs/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |
+| [full-flow.yaml](configs/openai/responses/full-flow.yaml) | Combines format classification, request validation, and backend routing into a single pipeline |
+| [model-rewrite.yaml](configs/openai/responses/model-rewrite.yaml) | Rewrites or injects the top-level `model` field in Responses API request bodies before forwarding to the inference backend |
+| [rehydrate.yaml](configs/openai/responses/rehydrate.yaml) | Validates `previous_response_id` by fetching the stored response, confirming its status is completed, and promoting the ID to filter metadata |
+| [request-validate.yaml](configs/openai/responses/request-validate.yaml) | Validates Responses API requests and rejects invalid parameter combinations |
+| [response-store.yaml](configs/openai/responses/response-store.yaml) | Persists non-streaming Responses API responses to a database and serves stored data via GET endpoints and handles DELETE /v1/responses/{id} locally |
+| [responses-proxy.yaml](configs/openai/responses/responses-proxy.yaml) | Proxies OpenAI Responses API requests to a native /v1/responses backend |
+| [responses-routing.yaml](configs/openai/responses/responses-routing.yaml) | Routes Responses API traffic by detected mode |
 
 ### Payload Processing
 
 | File | Description |
 | ------ | ------------- |
-| [body-size-limit-with-extraction.yaml](configs/payload-processing/body-size-limit-with-extraction.yaml) | Combines body_limits.max_request_bytes with json_body_field to enforce a global body ceiling while still performing body-based routing |
-| [compression.yaml](configs/payload-processing/compression.yaml) | Enables transparent response compression using Pingora's built-in compression module |
-| [conditional-field-extraction.yaml](configs/payload-processing/conditional-field-extraction.yaml) | Uses the condition system to apply json_body_field only on specific request paths |
-| [field-extraction-access-control.yaml](configs/payload-processing/field-extraction-access-control.yaml) | Extracts the "tenant_id" field from the JSON request body and promotes it to an X-Tenant-Id header |
 | [mcp-static-catalog.yaml](configs/payload-processing/mcp-static-catalog.yaml) | Provides a static MCP catalog and broker for initialize, tools/list, ping, and notifications/initialized requests |
-| [multi-field-extraction.yaml](configs/payload-processing/multi-field-extraction.yaml) | A single json_body_field filter extracts multiple top-level JSON fields into separate request headers in one pass |
-| [multi-listener-body-pipeline.yaml](configs/payload-processing/multi-listener-body-pipeline.yaml) | Three listeners, each with a different body processing strategy |
-| [stream-buffer.yaml](configs/payload-processing/stream-buffer.yaml) | json_body_field inspects request body chunks as they arrive and defers upstream forwarding until the field is extracted (or end-of-stream) |
-
-### Pipeline
-
-| File | Description |
-| ------ | ------------- |
-| [default.yaml](../core/src/config/default.yaml) | Built-in default config (static JSON on /) |
-| [branch-chains.yaml](configs/pipeline/branch-chains.yaml) | Filters write structured results to FilterResultSet |
-| [composed-chains.yaml](configs/pipeline/composed-chains.yaml) | Multiple named chains are composed per listener |
-| [conditional-filters.yaml](configs/pipeline/conditional-filters.yaml) | Filters support `conditions` (request phase) and `response_conditions` (response phase) to gate execution |
-| [failure-mode.yaml](configs/pipeline/failure-mode.yaml) | Demonstrates open and closed failure handling for filters |
-
-### Protocols
-
-| File | Description |
-| ------ | ------------- |
-| [mixed-protocol.yaml](configs/protocols/mixed-protocol.yaml) | HTTP and TCP listeners run on a single server instance |
-| [tcp-consistent-hash.yaml](configs/protocols/tcp-consistent-hash.yaml) | TCP consistent-hash load balancing (client IP affinity) |
-| [tcp-least-connections.yaml](configs/protocols/tcp-least-connections.yaml) | TCP least-connections load balancing |
-| [tcp-proxy.yaml](configs/protocols/tcp-proxy.yaml) | Bidirectional TCP forwarding |
-| [tcp-round-robin.yaml](configs/protocols/tcp-round-robin.yaml) | TCP round-robin load balancing across database replicas |
-| [tcp-timeouts.yaml](configs/protocols/tcp-timeouts.yaml) | TCP proxy with session and max duration timeouts. `tcp_session_timeout_ms` wraps the entire TCP forwarding session in a hard deadline, terminating connections after the threshold regardless of activity. `tcp_max_duration_secs` caps the total session duration in seconds |
-| [tcp-tls-mtls.yaml](configs/protocols/tcp-tls-mtls.yaml) | The proxy requires TCP clients to present a valid TLS certificate signed by the trusted CA |
-| [tcp-tls-termination.yaml](configs/protocols/tcp-tls-termination.yaml) | TLS on the listener; plain TCP to the upstream backend |
-| [tls-cipher-suites.yaml](configs/protocols/tls-cipher-suites.yaml) | Restrict accepted cipher suites per listener |
-| [tls-http-reencrypt.yaml](configs/protocols/tls-http-reencrypt.yaml) | HTTPS on the listener; TLS to the upstream backend |
-| [tls-mtls-both.yaml](configs/protocols/tls-mtls-both.yaml) | Client mTLS to the proxy (client cert required), and proxy mTLS to the upstream backend (proxy presents its own client certificate) |
-| [tls-mtls-listener-request.yaml](configs/protocols/tls-mtls-listener-request.yaml) | The proxy requests a client certificate but does not require one |
-| [tls-mtls-listener.yaml](configs/protocols/tls-mtls-listener.yaml) | The proxy requires clients to present a valid TLS certificate signed by the trusted CA |
-| [tls-mtls-upstream.yaml](configs/protocols/tls-mtls-upstream.yaml) | Plain HTTP from clients; the proxy presents a client certificate to the upstream backend, which requires mutual TLS authentication |
-| [tls-multi-cert.yaml](configs/protocols/tls-multi-cert.yaml) | Multiple certificates on one listener; Praxis selects the certificate matching the client's SNI hostname |
-| [tls-sni-routing.yaml](configs/protocols/tls-sni-routing.yaml) | Routes TLS connections to different upstreams based on the Server Name Indication (SNI) hostname in the ClientHello |
-| [tls-termination.yaml](configs/protocols/tls-termination.yaml) | HTTPS on the listener; plain HTTP to the backend |
-| [tls-verify-disabled.yaml](configs/protocols/tls-verify-disabled.yaml) | Plain HTTP listener; TLS to the upstream with certificate verification disabled |
-| [tls-version-constraint.yaml](configs/protocols/tls-version-constraint.yaml) | Restrict accepted TLS versions via `min_version` |
-| [upstream-ca-file.yaml](configs/protocols/upstream-ca-file.yaml) | Sets a trusted CA bundle for all upstream TLS connections via `runtime.upstream_ca_file` |
-| [upstream-tls.yaml](configs/protocols/upstream-tls.yaml) | Plain HTTP on the listener; TLS to the upstream |
-| [websocket.yaml](configs/protocols/websocket.yaml) | HTTP listener that transparently proxies WebSocket upgrade requests |
-
-### Security
-
-| File | Description |
-| ------ | ------------- |
-| [cors.yaml](configs/security/cors.yaml) | Spec-compliant CORS filter with preflight handling, origin validation, and credential support |
-| [csrf.yaml](configs/security/csrf.yaml) | Cross-site request forgery protection via origin validation |
-| [downstream-read-timeout.yaml](configs/security/downstream-read-timeout.yaml) | Protects against slow client attacks by limiting how long the proxy waits for data from downstream clients |
-| [forwarded-headers.yaml](configs/security/forwarded-headers.yaml) | Injects X-Forwarded-For, X-Forwarded-Proto, and X-Forwarded-Host into upstream requests |
-| [guardrails.yaml](configs/security/guardrails.yaml) | Reject requests that match header or body inspection rules |
-| [ip-acl.yaml](configs/security/ip-acl.yaml) | Allow or deny requests by source IP/CIDR |
-| [policy.yaml](configs/security/policy.yaml) | Embeds the CPEX policy engine in-process to enforce multi-source JWT identity, APL route policy, RFC 8693 OAuth 2.0 token exchange, PII scanning, audit emission, and (under `body_access: read_write`) request / response body rewriting |
-
-### Traffic Management
-
-| File | Description |
-| ------ | ------------- |
-| [basic-reverse-proxy.yaml](configs/traffic-management/basic-reverse-proxy.yaml) | Minimal config: one listener, one upstream, default filter chain |
-| [canary-routing.yaml](configs/traffic-management/canary-routing.yaml) | Sends ~10% of traffic to a canary backend while the stable backend handles the remaining ~90% |
-| [circuit-breaker.yaml](configs/traffic-management/circuit-breaker.yaml) | Prevents cascading failures by tracking consecutive upstream errors per cluster |
-| [grpc-detection.yaml](configs/traffic-management/grpc-detection.yaml) | Detects gRPC requests from the content-type header and promotes the variant to filter metadata and results |
-| [health-checks.yaml](configs/traffic-management/health-checks.yaml) | Per-cluster health checks probe endpoints on a timer and remove unhealthy backends from the load balancer rotation |
-| [hostname-upstream.yaml](configs/traffic-management/hostname-upstream.yaml) | Demonstrates using DNS hostnames instead of IP addresses for upstream endpoints |
-| [hosts.yaml](configs/traffic-management/hosts.yaml) | One listener serves multiple domains |
-| [least-connections.yaml](configs/traffic-management/least-connections.yaml) | Routes each request to the backend with the fewest in-flight requests |
-| [p2c.yaml](configs/traffic-management/p2c.yaml) | Samples two random endpoints and picks the one with fewer in-flight requests |
-| [path-based-routing.yaml](configs/traffic-management/path-based-routing.yaml) | Routes by URL path prefix |
-| [rate-limiting.yaml](configs/traffic-management/rate-limiting.yaml) | Token bucket rate limiter with per-IP or global modes |
-| [redirect.yaml](configs/traffic-management/redirect.yaml) | Returns a 3xx redirect without contacting any upstream |
-| [round-robin.yaml](configs/traffic-management/round-robin.yaml) | Default strategy |
-| [session-affinity.yaml](configs/traffic-management/session-affinity.yaml) | Hashes a request header to pin a user's requests to one backend |
-| [static-response.yaml](configs/traffic-management/static-response.yaml) | Returns a fixed response without contacting any upstream |
-| [timeout.yaml](configs/traffic-management/timeout.yaml) | Returns 504 if the upstream takes longer than timeout_ms to respond |
-| [weighted-load-balancing.yaml](configs/traffic-management/weighted-load-balancing.yaml) | Traffic split proportional to per-endpoint weights |
-
-### Transformation
-
-| File | Description |
-| ------ | ------------- |
-| [header-manipulation.yaml](configs/transformation/header-manipulation.yaml) | Add, overwrite, and remove headers on requests and responses |
-| [path-rewriting.yaml](configs/transformation/path-rewriting.yaml) | Rewrite request paths before forwarding to upstream |
-| [url-rewriting.yaml](configs/transformation/url-rewriting.yaml) | Regex-based path transformation and query string manipulation |

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,18 +5,29 @@ Configuration examples organized by category.
 ## Running an Example
 
 ```console
-cargo run -p praxis-ai-proxy -- -c examples/configs/traffic-management/basic-reverse-proxy.yaml
+cargo run -p praxis-ai-proxy -- -c examples/configs/openai/responses/full-flow.yaml
 curl http://localhost:8080/
 ```
 
 Configs use local ports (`3000`, `3001`, ...) for
-upstreams. For quick experiments without a real backend,
-use `static_response` (see
-[static-response.yaml](configs/traffic-management/static-response.yaml))
-or run Praxis with no config file for a built-in welcome
-page.
+upstreams — start a real backend or stub on those ports
+before sending requests.
 
 ## Configs
+
+### General
+
+| File | Description |
+| ------ | ------------- |
+| [a2a-classifier-routing.yaml](configs/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, task ID, and streaming detection |
+| [a2a-task-routing.yaml](configs/a2a-task-routing.yaml) | Captures task ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up task operations back to the backend cluster that created the task |
+| [ai-inference-body-based-routing.yaml](configs/ai-inference-body-based-routing.yaml) | Routes LLM API requests to different backends based on the `model` field in the JSON request body |
+| [credential-injection.yaml](configs/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |
+| [json-rpc-routing.yaml](configs/json-rpc-routing.yaml) | Routes JSON-RPC 2.0 requests to different backends based on the "method" field in the JSON request body |
+| [mcp-classifier-routing.yaml](configs/mcp-classifier-routing.yaml) | Routes MCP requests by body-derived method and tool name |
+| [model-to-header-routing.yaml](configs/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
+| [prompt-enrichment.yaml](configs/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
+| [token-usage-headers.yaml](configs/token-usage-headers.yaml) | Inject Praxis-Token-Input, Praxis-Token-Output, and Praxis-Token-Total headers into downstream responses when token counts are available in filter metadata |
 
 ### Anthropic
 

--- a/examples/configs/model-to-header-routing.yaml
+++ b/examples/configs/model-to-header-routing.yaml
@@ -1,8 +1,5 @@
 # AI Inference Model Routing
 #
-# Requires the ai-inference feature:
-#   cargo build -p praxis-proxy --features ai-inference
-#
 # Routes LLM API requests to different backends based on the
 # "model" field in the JSON request body. Uses the model_to_header
 # filter to extract the model name into an X-Model header, then

--- a/examples/configs/model-to-header-routing.yaml
+++ b/examples/configs/model-to-header-routing.yaml
@@ -1,5 +1,8 @@
 # AI Inference Model Routing
 #
+# Build:
+#   cargo build -p praxis-ai-proxy
+#
 # Routes LLM API requests to different backends based on the
 # "model" field in the JSON request body. Uses the model_to_header
 # filter to extract the model name into an X-Model header, then

--- a/examples/configs/openai/conversations/conversations.yaml
+++ b/examples/configs/openai/conversations/conversations.yaml
@@ -10,7 +10,7 @@
 #   DELETE /v1/conversations/{id}   — delete conversation
 #
 # Usage:
-#   cargo run -p praxis-ai-proxy -- -c examples/configs/ai/openai/conversations/conversations.yaml
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/openai/conversations/conversations.yaml
 
 listeners:
   - name: conversations-gateway

--- a/examples/configs/openai/conversations/conversations.yaml
+++ b/examples/configs/openai/conversations/conversations.yaml
@@ -10,7 +10,7 @@
 #   DELETE /v1/conversations/{id}   — delete conversation
 #
 # Usage:
-#   cargo run -p praxis-proxy -- -c examples/configs/ai/openai/conversations/conversations.yaml
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/ai/openai/conversations/conversations.yaml
 
 listeners:
   - name: conversations-gateway

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -61,9 +61,6 @@
 #   curl -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
 #     -d '{"model":"gpt-4.1","input":"test","stream":true,"background":true}'
-#
-# Requires the ai-inference feature:
-#   cargo build -p praxis-proxy --features ai-inference
 
 listeners:
   - name: ai-gateway

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -61,6 +61,9 @@
 #   curl -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
 #     -d '{"model":"gpt-4.1","input":"test","stream":true,"background":true}'
+#
+# Build:
+#   cargo build -p praxis-ai-proxy
 
 listeners:
   - name: ai-gateway

--- a/examples/configs/openai/responses/model-rewrite.yaml
+++ b/examples/configs/openai/responses/model-rewrite.yaml
@@ -12,9 +12,6 @@
 # Use case: Codex or other Responses API clients send
 # `model: "codex-mini-2026-06-24"` and the proxy transparently
 # rewrites it to a locally-hosted model before forwarding.
-#
-# Requires the ai-inference feature:
-#   cargo build -p praxis-proxy --features ai-inference
 
 listeners:
   - name: ai-gateway

--- a/examples/configs/openai/responses/model-rewrite.yaml
+++ b/examples/configs/openai/responses/model-rewrite.yaml
@@ -12,6 +12,9 @@
 # Use case: Codex or other Responses API clients send
 # `model: "codex-mini-2026-06-24"` and the proxy transparently
 # rewrites it to a locally-hosted model before forwarding.
+#
+# Build:
+#   cargo build -p praxis-ai-proxy
 
 listeners:
   - name: ai-gateway

--- a/examples/configs/openai/responses/rehydrate.yaml
+++ b/examples/configs/openai/responses/rehydrate.yaml
@@ -27,6 +27,9 @@
 #   curl -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
 #     -d '{"model":"gpt-4.1","input":"What next?","previous_response_id":"resp_abc"}'
+#
+# Build:
+#   cargo build -p praxis-ai-proxy
 
 listeners:
   - name: ai-gateway

--- a/examples/configs/openai/responses/rehydrate.yaml
+++ b/examples/configs/openai/responses/rehydrate.yaml
@@ -27,9 +27,6 @@
 #   curl -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
 #     -d '{"model":"gpt-4.1","input":"What next?","previous_response_id":"resp_abc"}'
-#
-# Requires the ai-inference feature:
-#   cargo build -p praxis-proxy --features ai-inference
 
 listeners:
   - name: ai-gateway

--- a/examples/configs/openai/responses/request-validate.yaml
+++ b/examples/configs/openai/responses/request-validate.yaml
@@ -3,6 +3,9 @@
 # Validates Responses API requests and rejects invalid parameter
 # combinations.
 #
+# Build:
+#   cargo build -p praxis-ai-proxy
+#
 # The openai_responses_format classifier must run before openai_responses_validate.
 # It buffers the body, classifies the request as Responses API, and
 # promotes model/stream/store/background to openai_responses_format.*

--- a/examples/configs/openai/responses/request-validate.yaml
+++ b/examples/configs/openai/responses/request-validate.yaml
@@ -3,9 +3,6 @@
 # Validates Responses API requests and rejects invalid parameter
 # combinations.
 #
-# Requires the ai-inference feature:
-#   cargo build -p praxis-proxy --features ai-inference
-#
 # The openai_responses_format classifier must run before openai_responses_validate.
 # It buffers the body, classifies the request as Responses API, and
 # promotes model/stream/store/background to openai_responses_format.*

--- a/examples/configs/prompt-enrichment.yaml
+++ b/examples/configs/prompt-enrichment.yaml
@@ -1,8 +1,5 @@
 # Prompt Enrichment
 #
-# Requires the ai-inference feature:
-#   cargo build -p praxis-proxy --features ai-inference
-#
 # Injects system messages into OpenAI-compatible chat completion
 # requests before forwarding to the upstream provider. The system
 # prompt is defined at the proxy layer and cannot be overridden

--- a/examples/configs/prompt-enrichment.yaml
+++ b/examples/configs/prompt-enrichment.yaml
@@ -1,5 +1,8 @@
 # Prompt Enrichment
 #
+# Build:
+#   cargo build -p praxis-ai-proxy
+#
 # Injects system messages into OpenAI-compatible chat completion
 # requests before forwarding to the upstream provider. The system
 # prompt is defined at the proxy layer and cannot be overridden

--- a/examples/configs/token-usage-headers.yaml
+++ b/examples/configs/token-usage-headers.yaml
@@ -5,7 +5,7 @@
 # token counts are available in filter metadata.
 #
 # Usage:
-#   cargo run -p praxis-proxy -- -c examples/configs/ai/token-usage-headers.yaml
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/ai/token-usage-headers.yaml
 #   curl -v http://localhost:8080/v1/chat/completions
 #
 # The filter reads token.input, token.output, and token.total from

--- a/examples/configs/token-usage-headers.yaml
+++ b/examples/configs/token-usage-headers.yaml
@@ -5,7 +5,7 @@
 # token counts are available in filter metadata.
 #
 # Usage:
-#   cargo run -p praxis-ai-proxy -- -c examples/configs/ai/token-usage-headers.yaml
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/token-usage-headers.yaml
 #   curl -v http://localhost:8080/v1/chat/completions
 #
 # The filter reads token.input, token.output, and token.total from

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -8,8 +8,6 @@ readme = "../../README.md"
 publish = false
 
 [features]
-default = ["ai-inference"]
-ai-inference = ["praxis-filter/ai-inference", "praxis-test-utils/ai-inference"]
 cpex-policy-engine = ["praxis-filter/cpex-policy-engine"]
 no-mac-cert-rotation-tests = [] # We use this to disable testing cert rotation on macOS
 

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -10,7 +10,6 @@ pub use test_utils::load_example_config;
 mod access_logging;
 mod admin_interface;
 mod agentic_routing;
-#[cfg(feature = "ai-inference")]
 mod anthropic_messages;
 mod api_key_filter;
 mod basic_reverse_proxy;
@@ -20,7 +19,6 @@ mod conditional_filters;
 mod credential_injection;
 mod csrf;
 mod default_config;
-#[cfg(feature = "ai-inference")]
 mod full_flow;
 mod grpc_detection;
 mod guardrails;
@@ -31,20 +29,13 @@ mod least_connections;
 mod logging;
 mod max_body_guard;
 mod max_connections;
-#[cfg(feature = "ai-inference")]
 mod model_to_header;
 mod multi_listener;
-#[cfg(feature = "ai-inference")]
 mod openai_conversations;
-#[cfg(feature = "ai-inference")]
 mod openai_response_store;
-#[cfg(feature = "ai-inference")]
 mod openai_response_store_postgres;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_format;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_model_rewrite;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_validate;
 mod p2c;
 mod path_based_routing;
@@ -52,15 +43,11 @@ mod path_rewriting;
 mod payload_processing;
 #[cfg(feature = "cpex-policy-engine")]
 mod policy;
-#[cfg(feature = "ai-inference")]
 mod prompt_enrichment;
 mod protocols;
 mod redirect;
-#[cfg(feature = "ai-inference")]
 mod rehydrate;
-#[cfg(feature = "ai-inference")]
 mod responses_proxy;
-#[cfg(feature = "ai-inference")]
 mod responses_routing;
 mod round_robin;
 mod session_affinity;

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -40,7 +40,6 @@
 mod a2a;
 mod adversarial;
 mod agentic_mocks;
-#[cfg(feature = "ai-inference")]
 mod anthropic_messages;
 mod body;
 mod body_pipeline;
@@ -61,17 +60,13 @@ mod json_body_field;
 mod json_rpc;
 mod mcp;
 mod mcp_broker;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_format;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_model_rewrite;
 mod path_rewrite;
 mod payload_processing;
 mod per_listener_pipeline;
-#[cfg(feature = "ai-inference")]
 mod prompt_enrich;
 mod rate_limit;
-#[cfg(feature = "ai-inference")]
 mod responses_routing;
 mod retry;
 mod routing;

--- a/tests/schema/Cargo.toml
+++ b/tests/schema/Cargo.toml
@@ -7,10 +7,6 @@ license.workspace = true
 readme = "../../README.md"
 publish = false
 
-[features]
-default = ["ai-inference"]
-ai-inference = ["praxis-filter/ai-inference"]
-
 [lints]
 workspace = true
 

--- a/tests/schema/tests/suite/examples/ai/mod.rs
+++ b/tests/schema/tests/suite/examples/ai/mod.rs
@@ -3,7 +3,5 @@
 
 //! AI example configuration tests.
 
-#[cfg(feature = "ai-inference")]
 mod model_to_header;
-#[cfg(feature = "ai-inference")]
 mod responses_proxy;

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -33,6 +33,3 @@ tracing = { workspace = true }
 futures = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-tungstenite = { workspace = true }
-
-[features]
-ai-inference = ["praxis-filter/ai-inference"]

--- a/xtask/src/sync_example_readme.rs
+++ b/xtask/src/sync_example_readme.rs
@@ -25,6 +25,7 @@ const TITLE_OVERRIDES: &[(&str, &str)] = &[("openai", "OpenAI")];
 /// extraction.
 const SKIP_PREFIXES: &[&str] = &[
     "Backend endpoints ",
+    "Build:",
     "Example:",
     "Flow:",
     "Pipeline:",
@@ -38,12 +39,7 @@ const SKIP_PREFIXES: &[&str] = &[
 
 /// Entries that live outside `examples/configs/` but belong in the README.
 /// `(category, filename, link_path, description)`.
-const SPECIAL_ENTRIES: &[(&str, &str, &str, &str)] = &[(
-    "pipeline",
-    "default.yaml",
-    "../core/src/config/default.yaml",
-    "Built-in default config (static JSON on /)",
-)];
+const SPECIAL_ENTRIES: &[(&str, &str, &str, &str)] = &[];
 
 /// Marker line that separates the hand-maintained header from the
 /// auto-generated tables.

--- a/xtask/src/sync_example_readme.rs
+++ b/xtask/src/sync_example_readme.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 /// Title overrides for category directories whose display name cannot be
 /// derived by simple title-casing. All other directories are converted
 /// automatically (e.g. `"traffic-management"` → `"Traffic Management"`).
-const TITLE_OVERRIDES: &[(&str, &str)] = &[("openai", "OpenAI")];
+const TITLE_OVERRIDES: &[(&str, &str)] = &[("_root", "General"), ("openai", "OpenAI")];
 
 /// Comment-line prefixes that begin a non-description block. Paragraphs
 /// whose first line starts with any of these are skipped during description
@@ -114,15 +114,27 @@ fn discover_categories(configs_dir: &Path) -> Vec<(String, String)> {
     let Ok(entries) = std::fs::read_dir(configs_dir) else {
         return Vec::new();
     };
+    let mut has_root_files = false;
     let mut categories: Vec<(String, String)> = entries
         .flatten()
-        .filter(|e| e.path().is_dir())
+        .filter(|e| {
+            if e.path().is_dir() {
+                return true;
+            }
+            if e.path().extension().is_some_and(|ext| ext == "yaml") {
+                has_root_files = true;
+            }
+            false
+        })
         .map(|e| {
             let name = e.file_name().to_string_lossy().into_owned();
             let title = category_title(&name);
             (name, title)
         })
         .collect();
+    if has_root_files {
+        categories.push(("_root".to_owned(), category_title("_root")));
+    }
     categories.sort();
     categories
 }
@@ -159,13 +171,16 @@ fn collect_entries(configs_dir: &Path) -> BTreeMap<String, Vec<ExampleEntry>> {
 
     for path in &paths {
         let rel = path.strip_prefix(configs_dir).unwrap();
-        let category = rel
-            .components()
-            .next()
-            .unwrap()
-            .as_os_str()
-            .to_string_lossy()
-            .into_owned();
+        let category = match rel.parent().filter(|p| p != &Path::new("")) {
+            Some(parent) => parent
+                .components()
+                .next()
+                .unwrap()
+                .as_os_str()
+                .to_string_lossy()
+                .into_owned(),
+            None => "_root".to_owned(),
+        };
 
         let filename = path.file_name().unwrap().to_string_lossy().into_owned();
         let link_path = format!("configs/{}", rel.to_string_lossy());


### PR DESCRIPTION
## Summary

- Remove the `ai-inference` feature from test manifests (`tests/integration`, `tests/schema`, `tests/utils`)
- Remove all `#[cfg(feature = "ai-inference")]` gates from test source files
- Remove stale "Requires the ai-inference feature" comments from 6 example YAML configs

The feature was a leftover from when AI code lived inside praxis core. It forwards to `praxis-filter/ai-inference` which does not exist upstream, making it dead wiring that would break compilation when test crates are re-enabled.

## Test plan

- [x] `make lint` passes (clippy + nightly fmt check)
- [x] Verified `praxis-filter` does not define `ai-inference`
- [x] No CI or Makefile targets use `--no-default-features` or `--features ai-inference`