### PR TITLE
feat(mcp): add configurable 2026-07-28 stateless profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,6 +2823,7 @@ name = "praxis-ai-filters"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "dashmap 6.2.1",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ repository = "https://github.com/praxis-proxy/ai"
 
 [workspace.dependencies]
 async-trait = "0.1.89"
+base64 = "0.22.1"
 bytes = "1.12.0"
 chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/docs/filters/mcp.md
+++ b/docs/filters/mcp.md
@@ -15,7 +15,9 @@ Methods requiring a name selector (`tools/call`, `resources/read`, `prompts/get`
 
 Writes `mcp.*` and `json_rpc.*` entries to the filter result set for branch chain conditions.
 
-This first MCP static catalog change short-circuits all methods: no request is forwarded to backends. `tools/call` returns a controlled `-32601` error until backend routing is added.
+The broker serves configured catalog operations locally while backend tool routing is not implemented. It deliberately returns `-32601` for `tools/call` rather than forwarding a request whose target is unresolved.
+
+Supports two protocol profiles: `current` (session-based, default) and `stateless` (MCP 2026-07-28, configurable). Version and cache fields are derived from the selected profile when omitted.
 
 ## Configuration
 
@@ -32,10 +34,12 @@ This first MCP static catalog change short-circuits all methods: no request is f
 | `headers.session_present` | string | no | Header name for MCP session presence (e.g. `x-praxis-mcp-session-present`). |
 | `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer`. |
 | `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
-| `default_version` | string | no | Fallback MCP protocol version returned in broker `initialize` responses when the client's requested version is not supported. Must be present in `supported_versions` and implemented by this build. Defaults to [`protocol::DEFAULT_VERSION`]. |
+| `cache_scope` | `public` \| `private` | no | Cache scope for stateless responses. Requires `protocol_profile: stateless`. |
+| `cache_ttl_ms` | u64 | no | Cache TTL in milliseconds for stateless responses. Requires `protocol_profile: stateless`. |
+| `default_version` | string | no | Fallback MCP protocol version. When omitted, derived from the profile. |
 | `invalid_tool_policy` | `reject_server` \| `filter_out` | no | Behavior when a tool has an invalid schema. |
 | `path` | string | no | Public MCP path handled by Praxis. |
-| `protocol_profile` | `current` | no | Protocol profile governing session semantics and header requirements for this broker instance. |
+| `protocol_profile` | `current` \| `stateless` | no | Protocol profile governing session semantics and header requirements for this broker instance. |
 | `servers` | McpServerConfig[] | no | Backend server definitions. |
 | `servers[].name` | string | yes | Unique server name. |
 | `servers[].cluster` | string | yes | Backend cluster name. |
@@ -46,7 +50,7 @@ This first MCP static catalog change short-circuits all methods: no request is f
 | `servers[].tools[].description` | string | no | Optional description. |
 | `servers[].tools[].inputSchema` | any | no | Optional input schema. `schema` is accepted as a local shorthand. |
 | `servers[].tools[].annotations` | any | no | Optional tool annotations. |
-| `supported_versions` | string[] | no | Protocol versions accepted during `initialize` negotiation. Every entry must be implemented by this build (present in [`protocol::SUPPORTED_VERSIONS`]). Defaults to the versions this build implements. |
+| `supported_versions` | string[] | no | Protocol versions accepted during negotiation. When omitted, derived from the profile. |
 
 ## Examples
 
@@ -94,4 +98,23 @@ servers:
     tools:
       - name: create_event
         description: Create a calendar event
+```
+
+### Example 4
+
+```yaml
+filter: mcp
+path: /mcp
+max_body_bytes: 65536
+protocol_profile: stateless
+cache_ttl_ms: 300000
+cache_scope: public
+servers:
+  - name: weather
+    cluster: weather-mcp
+    path: /mcp
+    tool_prefix: weather_
+    tools:
+      - name: get_weather
+        description: Get current weather
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ before sending requests.
 | [credential-injection.yaml](configs/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |
 | [json-rpc-routing.yaml](configs/json-rpc-routing.yaml) | Routes JSON-RPC 2.0 requests to different backends based on the "method" field in the JSON request body |
 | [mcp-classifier-routing.yaml](configs/mcp-classifier-routing.yaml) | Routes MCP requests by body-derived method and tool name |
+| [mcp-stateless-broker.yaml](configs/mcp-stateless-broker.yaml) | Configurable stateless MCP broker using the 2026-07-28 release candidate profile |
 | [model-to-header-routing.yaml](configs/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
 | [prompt-enrichment.yaml](configs/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
 | [token-usage-headers.yaml](configs/token-usage-headers.yaml) | Inject Praxis-Token-Input, Praxis-Token-Output, and Praxis-Token-Total headers into downstream responses when token counts are available in filter metadata |

--- a/examples/configs/mcp-stateless-broker.yaml
+++ b/examples/configs/mcp-stateless-broker.yaml
@@ -1,0 +1,61 @@
+# MCP Stateless Broker (2026-07-28 Profile)
+#
+# Configurable stateless MCP broker using the 2026-07-28
+# release candidate profile. No protocol sessions,
+# no initialize handshake. Clients use server/discover
+# for capability discovery and include
+# MCP-Protocol-Version, Mcp-Method, and Mcp-Name
+# headers on every request.
+#
+# Backend tools/call routing is not yet implemented;
+# tools/call returns a controlled unsupported response.
+#
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/mcp-stateless-broker.yaml
+
+listeners:
+  - name: default
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        path: /mcp
+        max_body_bytes: 65536
+        protocol_profile: stateless
+        cache_ttl_ms: 300000
+        cache_scope: public
+        servers:
+          - name: weather
+            cluster: weather-mcp
+            path: /mcp
+            tool_prefix: "weather_"
+            tools:
+              - name: get_weather
+                description: Get current weather
+                inputSchema:
+                  type: object
+                  properties:
+                    city:
+                      type: string
+              - name: forecast
+                description: Get weather forecast
+          - name: calendar
+            cluster: calendar-mcp
+            path: /mcp
+            tool_prefix: "cal_"
+            tools:
+              - name: create_event
+                description: Create a calendar event
+              - name: list_events
+                description: List calendar events
+
+      - filter: load_balancer
+        clusters:
+          - name: weather-mcp
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: calendar-mcp
+            endpoints:
+              - "127.0.0.1:3002"

--- a/filters/Cargo.toml
+++ b/filters/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 http = { workspace = true }

--- a/filters/src/agentic/mcp/broker/config.rs
+++ b/filters/src/agentic/mcp/broker/config.rs
@@ -8,14 +8,42 @@ use praxis_filter::{
 };
 use serde::Deserialize;
 
-use super::super::protocol::{self, ProtocolProfile};
+use super::super::{
+    config::DEFAULT_MAX_BODY_BYTES,
+    protocol::{self, ProtocolProfile},
+};
 
 // -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
 
-/// Default maximum request body size for `StreamBuffer` mode (64 `KiB`).
-pub(super) const DEFAULT_MAX_BODY_BYTES: usize = 65_536; // 64 KiB
+/// Default cache TTL in milliseconds (5 minutes).
+pub(super) const DEFAULT_CACHE_TTL_MS: u64 = 300_000; // 5 min
+
+// -----------------------------------------------------------------------------
+// CacheScope
+// -----------------------------------------------------------------------------
+
+/// Cache scope for stateless MCP responses.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CacheScope {
+    /// Response may be cached by any intermediary.
+    #[default]
+    Public,
+    /// Response may only be cached by the requesting client.
+    Private,
+}
+
+impl CacheScope {
+    /// String representation for response serialization.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Private => "private",
+        }
+    }
+}
 
 // -----------------------------------------------------------------------------
 // InvalidToolPolicy
@@ -75,19 +103,23 @@ pub(super) struct McpServerConfig {
 }
 
 // -----------------------------------------------------------------------------
-// McpBrokerConfig
+// McpBrokerConfig (raw deserialized)
 // -----------------------------------------------------------------------------
 
-/// MCP static catalog filter configuration.
+/// MCP broker filter configuration.
+///
+/// Supports two protocol profiles: `current` (session-based, default) and
+/// `stateless` (MCP 2026-07-28, configurable). Version and cache fields are
+/// derived from the selected profile when omitted.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct McpBrokerConfig {
-    /// Fallback MCP protocol version returned in broker `initialize`
-    /// responses when the client's requested version is not supported.
-    /// Must be present in `supported_versions` and implemented by this
-    /// build. Defaults to [`protocol::DEFAULT_VERSION`].
-    #[serde(default = "default_version")]
-    pub default_version: String,
+    /// Cache scope for stateless responses. Requires `protocol_profile: stateless`.
+    pub cache_scope: Option<CacheScope>,
+    /// Cache TTL in milliseconds for stateless responses. Requires `protocol_profile: stateless`.
+    pub cache_ttl_ms: Option<u64>,
+    /// Fallback MCP protocol version. When omitted, derived from the profile.
+    pub default_version: Option<String>,
     /// Behavior when a tool has an invalid schema.
     #[serde(default)]
     pub invalid_tool_policy: InvalidToolPolicy,
@@ -104,11 +136,31 @@ pub(super) struct McpBrokerConfig {
     /// Backend server definitions.
     #[serde(default)]
     pub servers: Vec<McpServerConfig>,
-    /// Protocol versions accepted during `initialize` negotiation.
-    /// Every entry must be implemented by this build (present in
-    /// [`protocol::SUPPORTED_VERSIONS`]). Defaults to the versions
-    /// this build implements.
-    #[serde(default = "default_supported_versions")]
+    /// Protocol versions accepted during negotiation.
+    /// When omitted, derived from the profile.
+    pub supported_versions: Option<Vec<String>>,
+}
+
+// -----------------------------------------------------------------------------
+// ValidatedBrokerConfig (normalized)
+// -----------------------------------------------------------------------------
+
+/// Normalized broker configuration with all defaults resolved.
+#[derive(Debug)]
+pub(super) struct ValidatedBrokerConfig {
+    /// Cache scope for stateless responses.
+    pub cache_scope: CacheScope,
+    /// Cache TTL in milliseconds for stateless responses.
+    pub cache_ttl_ms: u64,
+    /// Fallback MCP protocol version.
+    pub default_version: String,
+    /// Maximum body size in bytes.
+    pub max_body_bytes: usize,
+    /// Public MCP path handled by Praxis.
+    pub path: String,
+    /// Protocol profile for this broker instance.
+    pub protocol_profile: ProtocolProfile,
+    /// Protocol versions accepted during negotiation.
     pub supported_versions: Vec<String>,
 }
 
@@ -152,25 +204,51 @@ fn default_max_body_bytes() -> usize {
     DEFAULT_MAX_BODY_BYTES
 }
 
-/// Default protocol version from the centralized constant.
-fn default_version() -> String {
-    protocol::DEFAULT_VERSION.to_owned()
-}
-
-/// Default supported versions from the centralized constant.
-fn default_supported_versions() -> Vec<String> {
-    protocol::SUPPORTED_VERSIONS.iter().map(|s| (*s).to_owned()).collect()
-}
-
 // -----------------------------------------------------------------------------
 // Validation
 // -----------------------------------------------------------------------------
 
 /// Validate configuration and build the static tool catalog.
-pub(super) fn build_config(cfg: McpBrokerConfig) -> Result<(McpBrokerConfig, Vec<CatalogTool>), FilterError> {
+pub(super) fn build_config(cfg: McpBrokerConfig) -> Result<(ValidatedBrokerConfig, Vec<CatalogTool>), FilterError> {
     validate_max_body_bytes("mcp_broker", cfg.max_body_bytes)?;
 
-    validate_versions(&cfg)?;
+    let profile = cfg.protocol_profile;
+
+    validate_cache_fields_for_profile(profile, &cfg)?;
+
+    let catalog = validate_and_build_catalog(&cfg)?;
+
+    let default_version = cfg
+        .default_version
+        .unwrap_or_else(|| protocol::default_version_for_profile(profile).to_owned());
+
+    let supported_versions = cfg.supported_versions.unwrap_or_else(|| {
+        protocol::supported_versions_for_profile(profile)
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect()
+    });
+
+    let cache_scope = cfg.cache_scope.unwrap_or(CacheScope::Public);
+    let cache_ttl_ms = cfg.cache_ttl_ms.unwrap_or(DEFAULT_CACHE_TTL_MS);
+
+    validate_versions(profile, &supported_versions, &default_version)?;
+
+    let validated = ValidatedBrokerConfig {
+        cache_scope,
+        cache_ttl_ms,
+        default_version,
+        max_body_bytes: cfg.max_body_bytes,
+        path: cfg.path,
+        protocol_profile: profile,
+        supported_versions,
+    };
+
+    Ok((validated, catalog))
+}
+
+/// Validate server definitions and build the static tool catalog.
+fn validate_and_build_catalog(cfg: &McpBrokerConfig) -> Result<Vec<CatalogTool>, FilterError> {
     validate_path("mcp", &cfg.path)?;
     validate_unique_server_names(&cfg.servers)?;
     validate_server_clusters(&cfg.servers)?;
@@ -180,29 +258,51 @@ pub(super) fn build_config(cfg: McpBrokerConfig) -> Result<(McpBrokerConfig, Vec
     let catalog = build_catalog(&cfg.servers, cfg.invalid_tool_policy)?;
     validate_unique_exposed_names(&catalog)?;
 
-    Ok((cfg, catalog))
+    Ok(catalog)
 }
 
-/// Validate that every configured version is implemented by this build
-/// and that `default_version` appears in `supported_versions`.
-fn validate_versions(cfg: &McpBrokerConfig) -> Result<(), FilterError> {
-    if cfg.supported_versions.is_empty() {
+/// Reject explicit cache config on profiles that do not use it.
+fn validate_cache_fields_for_profile(profile: ProtocolProfile, cfg: &McpBrokerConfig) -> Result<(), FilterError> {
+    if profile == ProtocolProfile::Current {
+        if cfg.cache_scope.is_some() {
+            return Err("mcp: cache_scope requires protocol_profile 'stateless'".into());
+        }
+        if cfg.cache_ttl_ms.is_some() {
+            return Err("mcp: cache_ttl_ms requires protocol_profile 'stateless'".into());
+        }
+    }
+    Ok(())
+}
+
+/// Rejects versions that the selected profile does not recognize.
+fn validate_versions(
+    profile: ProtocolProfile,
+    supported_versions: &[String],
+    default_version: &str,
+) -> Result<(), FilterError> {
+    if supported_versions.is_empty() {
         return Err("mcp: supported_versions must not be empty".into());
     }
-    for v in &cfg.supported_versions {
+
+    for v in supported_versions {
         if !protocol::is_supported_version(v) {
             return Err(
                 format!("mcp: supported_versions contains '{v}' which is not implemented by this build").into(),
             );
         }
+        if !protocol::is_supported_version_for_profile(profile, v) {
+            return Err(format!(
+                "mcp: version '{v}' is not compatible with protocol_profile '{}'",
+                profile.as_str()
+            )
+            .into());
+        }
     }
-    if !cfg.supported_versions.iter().any(|v| v == &cfg.default_version) {
-        return Err(format!(
-            "mcp: default_version '{}' must appear in supported_versions",
-            cfg.default_version,
-        )
-        .into());
+
+    if !supported_versions.iter().any(|v| v == default_version) {
+        return Err(format!("mcp: default_version '{default_version}' must appear in supported_versions",).into());
     }
+
     Ok(())
 }
 

--- a/filters/src/agentic/mcp/broker/mod.rs
+++ b/filters/src/agentic/mcp/broker/mod.rs
@@ -35,15 +35,30 @@ use praxis_filter::{
 };
 use tracing::{debug, trace};
 
-use self::config::{CatalogTool, McpBrokerConfig, build_config};
-use super::protocol;
+use self::config::{CacheScope, CatalogTool, McpBrokerConfig, build_config};
+use super::protocol::ProtocolProfile;
 
 // -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
 
-/// Server name reported in MCP initialize responses.
+/// Server name reported in MCP responses.
 const SERVER_NAME: &str = "praxis";
+
+/// Server version reported in MCP responses.
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// JSON-RPC error code for stateless header mismatch.
+const ERR_HEADER_MISMATCH: i32 = -32020;
+
+/// JSON-RPC error code for unsupported protocol version.
+const ERR_UNSUPPORTED_VERSION: i32 = -32022;
+
+/// MCP `=?base64?` sentinel prefix.
+const BASE64_SENTINEL_PREFIX: &str = "=?base64?";
+
+/// MCP `=?base64?` sentinel suffix.
+const BASE64_SENTINEL_SUFFIX: &str = "?=";
 
 // -----------------------------------------------------------------------------
 // McpBrokerFilter
@@ -53,9 +68,9 @@ const SERVER_NAME: &str = "praxis";
 /// MCP servers and handles `initialize`, `tools/list`, `tools/call`, `ping`,
 /// and `notifications/initialized` directly as a static broker.
 ///
-/// This first MCP static catalog change short-circuits all methods: no request is
-/// forwarded to backends. `tools/call` returns a controlled `-32601` error
-/// until backend routing is added.
+/// The broker serves configured catalog operations locally while backend tool
+/// routing is not implemented. It deliberately returns `-32601` for
+/// `tools/call` rather than forwarding a request whose target is unresolved.
 ///
 /// # YAML
 ///
@@ -80,18 +95,20 @@ const SERVER_NAME: &str = "praxis";
 ///         description: Create a calendar event
 /// ```
 pub(crate) struct McpBrokerFilter {
+    /// Cache scope for stateless responses.
+    cache_scope: CacheScope,
+    /// Cache TTL in milliseconds for stateless responses.
+    cache_ttl_ms: u64,
     /// Static tool catalog built from config.
     catalog: Vec<CatalogTool>,
-    /// Protocol version the broker uses in `initialize` responses.
+    /// Protocol version the broker uses in responses.
     default_version: String,
     /// Shared JSON-RPC parser configuration.
     json_rpc_config: JsonRpcConfig,
     /// Maximum body bytes for `StreamBuffer`.
     max_body_bytes: usize,
-    /// Configured protocol profile (stored for future profile-aware dispatch).
-    #[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on struct fields")]
-    #[allow(dead_code, reason = "stored for future profile-aware dispatch")]
-    protocol_profile: protocol::ProtocolProfile,
+    /// Configured protocol profile.
+    protocol_profile: ProtocolProfile,
     /// Public path this MCP broker handles (e.g. `/mcp`).
     public_path: String,
     /// Implemented versions used for protocol version negotiation.
@@ -117,6 +134,8 @@ impl McpBrokerFilter {
         let json_rpc_config = build_json_rpc_config(validated.max_body_bytes);
 
         Ok(Box::new(Self {
+            cache_scope: validated.cache_scope,
+            cache_ttl_ms: validated.cache_ttl_ms,
             catalog,
             default_version: validated.default_version.clone(),
             json_rpc_config,
@@ -125,6 +144,241 @@ impl McpBrokerFilter {
             public_path: validated.path.clone(),
             supported_versions: validated.supported_versions.clone(),
         }))
+    }
+
+    // -------------------------------------------------------------------------
+    // Method Dispatch
+    // -------------------------------------------------------------------------
+
+    /// Maps a JSON-RPC method to the MCP handler that owns it.
+    fn dispatch_method(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        value: &serde_json::Value,
+        envelope: &JsonRpcEnvelope,
+        method_str: &str,
+    ) -> Result<FilterAction, FilterError> {
+        match self.protocol_profile {
+            ProtocolProfile::Current => self.dispatch_current(ctx, value, envelope, method_str),
+            ProtocolProfile::Stateless => Ok(self.dispatch_stateless(ctx, value, envelope, method_str)),
+        }
+    }
+
+    /// Current-profile dispatch: preserves existing behavior.
+    fn dispatch_current(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        value: &serde_json::Value,
+        envelope: &JsonRpcEnvelope,
+        method_str: &str,
+    ) -> Result<FilterAction, FilterError> {
+        if method_str.starts_with("notifications/") {
+            return Ok(handle_notification(envelope));
+        }
+
+        if !has_valid_request_id(envelope) {
+            return Ok(invalid_request_action(envelope));
+        }
+
+        let action = match method_str {
+            "initialize" => handle_initialize(ctx, value, envelope, &self.supported_versions, &self.default_version)?,
+            "tools/list" => handle_tools_list(&self.catalog, envelope)?,
+            "tools/call" => json_rpc_error_action(envelope, -32601, "method not yet supported"),
+            "ping" => handle_ping(envelope),
+            _ => {
+                debug!(method_len = method_str.len(), "unsupported MCP method");
+                json_rpc_error_action(envelope, -32601, "method not found")
+            },
+        };
+
+        Ok(action)
+    }
+
+    /// Stateless-profile dispatch: validates stateless headers, then dispatches.
+    #[expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "signature matches dispatch_current for consistent dispatch_method call"
+    )]
+    fn dispatch_stateless(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        value: &serde_json::Value,
+        envelope: &JsonRpcEnvelope,
+        method_str: &str,
+    ) -> FilterAction {
+        let is_notification = method_str.starts_with("notifications/");
+        if is_notification {
+            if let Some(action) = self.validate_stateless_headers(value, &ctx.request.headers, envelope, method_str) {
+                return action;
+            }
+
+            return json_rpc_error_action_with_status(envelope, 404, -32601, "method not found");
+        }
+
+        if !has_valid_request_id(envelope) {
+            return invalid_request_action(envelope);
+        }
+
+        if let Some(action) = self.validate_stateless_headers(value, &ctx.request.headers, envelope, method_str) {
+            return action;
+        }
+
+        match method_str {
+            "server/discover" => self.handle_server_discover(envelope),
+            "tools/list" => self.handle_stateless_tools_list(envelope),
+            "tools/call" => json_rpc_error_action_with_status(envelope, 404, -32601, "method not yet supported"),
+            "ping" => handle_ping(envelope),
+            "initialize" => json_rpc_error_action_with_status(
+                envelope,
+                404,
+                -32601,
+                "method not found: use server/discover for stateless profiles",
+            ),
+            _ => {
+                debug!(method_len = method_str.len(), "unsupported MCP method");
+                json_rpc_error_action_with_status(envelope, 404, -32601, "method not found")
+            },
+        }
+    }
+
+    /// Profile-aware DELETE handler.
+    fn handle_delete(&self, ctx: &HttpFilterContext<'_>) -> FilterAction {
+        match self.protocol_profile {
+            ProtocolProfile::Current => handle_delete_current(ctx),
+            ProtocolProfile::Stateless => FilterAction::Reject(Rejection::status(405)),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Stateless Header Validation
+    // -------------------------------------------------------------------------
+
+    /// Validates stateless request metadata headers.
+    ///
+    /// Returns `Some(FilterAction)` if validation fails, `None` if it passes.
+    fn validate_stateless_headers(
+        &self,
+        value: &serde_json::Value,
+        request_headers: &http::HeaderMap,
+        envelope: &JsonRpcEnvelope,
+        method_str: &str,
+    ) -> Option<FilterAction> {
+        let header_method = header_str(request_headers, "mcp-method");
+        let header_name = header_str(request_headers, "mcp-name");
+        let params_meta = value.get("params").and_then(|p| p.get("_meta"));
+
+        if let Some(action) = self.validate_protocol_version(params_meta, request_headers, envelope) {
+            return Some(action);
+        }
+
+        if let Some(action) = validate_mcp_method(header_method, envelope, method_str) {
+            return Some(action);
+        }
+
+        if let Some(msg) = validate_params_meta(params_meta) {
+            return Some(header_mismatch_action(envelope, msg));
+        }
+
+        validate_mcp_name_header(value, envelope, method_str, header_name)
+    }
+
+    /// Validates `MCP-Protocol-Version` header and `params._meta` version.
+    fn validate_protocol_version(
+        &self,
+        params_meta: Option<&serde_json::Value>,
+        request_headers: &http::HeaderMap,
+        envelope: &JsonRpcEnvelope,
+    ) -> Option<FilterAction> {
+        let header_version = header_str(request_headers, "mcp-protocol-version");
+
+        let body_version = params_meta
+            .and_then(|m| m.get("io.modelcontextprotocol/protocolVersion"))
+            .and_then(|v| v.as_str());
+
+        let Some(header_version) = header_version else {
+            return Some(header_mismatch_action(envelope, "missing MCP-Protocol-Version header"));
+        };
+
+        let Some(body_version) = body_version else {
+            return Some(header_mismatch_action(
+                envelope,
+                "missing params._meta[\"io.modelcontextprotocol/protocolVersion\"]",
+            ));
+        };
+
+        if header_version != body_version {
+            return Some(header_mismatch_action(
+                envelope,
+                "MCP-Protocol-Version header does not match body _meta protocol version",
+            ));
+        }
+
+        if !self.supported_versions.iter().any(|v| v == header_version) {
+            return Some(unsupported_version_action(
+                envelope,
+                header_version,
+                &self.supported_versions,
+            ));
+        }
+
+        None
+    }
+
+    // -------------------------------------------------------------------------
+    // Stateless Response Builders
+    // -------------------------------------------------------------------------
+
+    /// `server/discover` response for the stateless profile.
+    fn handle_server_discover(&self, envelope: &JsonRpcEnvelope) -> FilterAction {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id_value(envelope),
+            "result": {
+                "cacheScope": self.cache_scope.as_str(),
+                "capabilities": {
+                    "tools": { "listChanged": false },
+                },
+                "resultType": "complete",
+                "serverInfo": {
+                    "name": SERVER_NAME,
+                    "version": SERVER_VERSION,
+                },
+                "supportedVersions": self.supported_versions,
+                "ttlMs": self.cache_ttl_ms,
+            },
+        });
+
+        trace!("serving server/discover");
+
+        FilterAction::Reject(
+            Rejection::status(200)
+                .with_header("content-type", "application/json")
+                .with_body(Bytes::from(response.to_string())),
+        )
+    }
+
+    /// `tools/list` response for the stateless profile with cache metadata.
+    fn handle_stateless_tools_list(&self, envelope: &JsonRpcEnvelope) -> FilterAction {
+        let tools: Vec<serde_json::Value> = self.catalog.iter().map(catalog_tool_to_json).collect();
+
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id_value(envelope),
+            "result": {
+                "cacheScope": self.cache_scope.as_str(),
+                "resultType": "complete",
+                "tools": tools,
+                "ttlMs": self.cache_ttl_ms,
+            },
+        });
+
+        trace!(tool_count = self.catalog.len(), "serving stateless tools/list");
+
+        FilterAction::Reject(
+            Rejection::status(200)
+                .with_header("content-type", "application/json")
+                .with_body(Bytes::from(response.to_string())),
+        )
     }
 }
 
@@ -151,12 +405,11 @@ impl HttpFilter for McpBrokerFilter {
 
         match ctx.request.method {
             http::Method::POST => Ok(FilterAction::Continue),
-            http::Method::DELETE => Ok(handle_delete(ctx)),
+            http::Method::DELETE => Ok(self.handle_delete(ctx)),
             _ => Ok(FilterAction::Reject(Rejection::status(405))),
         }
     }
 
-    #[expect(clippy::too_many_lines, reason = "sequential parse-extract-dispatch pipeline")]
     async fn on_request_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -196,62 +449,225 @@ impl HttpFilter for McpBrokerFilter {
             ctx.set_metadata("mcp.method", method_str.clone());
         }
 
-        dispatch_method(
-            ctx,
-            &self.catalog,
-            &value,
-            &envelope,
-            method_str,
-            &self.supported_versions,
-            &self.default_version,
-        )
+        self.dispatch_method(ctx, &value, &envelope, method_str)
     }
 }
 
 // -----------------------------------------------------------------------------
-// Method Dispatch
+// Stateless Helpers
 // -----------------------------------------------------------------------------
 
-/// Maps a JSON-RPC method to the MCP handler that owns it.
-/// Never returns [`FilterAction::Release`] — all paths produce
-/// a terminal synthetic response.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "project threshold is 5; version plumbing adds two"
-)]
-fn dispatch_method(
-    ctx: &mut HttpFilterContext<'_>,
-    catalog: &[CatalogTool],
+/// Validates the `Mcp-Name` header for stateless requests.
+#[expect(clippy::too_many_lines, reason = "linear validation with early returns")]
+fn validate_mcp_name_header(
     value: &serde_json::Value,
     envelope: &JsonRpcEnvelope,
     method_str: &str,
-    supported_versions: &[String],
-    default_version: &str,
-) -> Result<FilterAction, FilterError> {
-    if method_str.starts_with("notifications/") {
-        return Ok(handle_notification(envelope));
+    header_name: Option<&str>,
+) -> Option<FilterAction> {
+    let body_name = extract_body_name(value, method_str);
+    let requires_name = method_requires_mcp_name(method_str);
+
+    if requires_name {
+        let Some(header_name_value) = header_name else {
+            return Some(header_mismatch_action(
+                envelope,
+                "Mcp-Name header is required for this method",
+            ));
+        };
+
+        let decoded = decode_mcp_name(header_name_value);
+        let decoded_ref = match &decoded {
+            Ok(Some(d)) => d.as_str(),
+            Ok(None) => header_name_value,
+            Err(_) => {
+                return Some(header_mismatch_action(
+                    envelope,
+                    "malformed base64 sentinel in Mcp-Name",
+                ));
+            },
+        };
+
+        let Some(body_name_value) = body_name else {
+            return Some(header_mismatch_action(
+                envelope,
+                "Mcp-Name header present but params.name/uri is missing in body",
+            ));
+        };
+
+        if decoded_ref != body_name_value {
+            return Some(header_mismatch_action(
+                envelope,
+                "Mcp-Name header does not match body params.name/uri",
+            ));
+        }
+    } else if header_name.is_some() {
+        return Some(header_mismatch_action(
+            envelope,
+            "Mcp-Name header must not be present for this method",
+        ));
     }
 
-    if !has_valid_request_id(envelope) {
-        return Ok(invalid_request_action(envelope));
-    }
-
-    let action = match method_str {
-        "initialize" => handle_initialize(ctx, value, envelope, supported_versions, default_version)?,
-        "tools/list" => handle_tools_list(catalog, envelope)?,
-        "tools/call" => json_rpc_error_action(envelope, -32601, "method not yet supported"),
-        "ping" => handle_ping(envelope),
-        _ => {
-            debug!(method_len = method_str.len(), "unsupported MCP method");
-            json_rpc_error_action(envelope, -32601, "method not found")
-        },
-    };
-
-    Ok(action)
+    None
 }
 
-/// MCP notifications are one-way messages, so successful handling must not
-/// produce a JSON-RPC response body.
+/// Validates the `Mcp-Method` transport header.
+fn validate_mcp_method(
+    header_method: Option<&str>,
+    envelope: &JsonRpcEnvelope,
+    method_str: &str,
+) -> Option<FilterAction> {
+    let Some(header_method) = header_method else {
+        return Some(header_mismatch_action(envelope, "missing Mcp-Method header"));
+    };
+
+    if header_method != method_str {
+        return Some(header_mismatch_action(
+            envelope,
+            "Mcp-Method header does not match JSON-RPC method",
+        ));
+    }
+
+    None
+}
+
+/// Validates required `params._meta` client metadata fields.
+fn validate_params_meta(params_meta: Option<&serde_json::Value>) -> Option<&'static str> {
+    if let Some(msg) = validate_client_info(params_meta) {
+        return Some(msg);
+    }
+
+    validate_client_capabilities(params_meta)
+}
+
+/// Validates `params._meta["io.modelcontextprotocol/clientInfo"]` is an object
+/// with string `name` and `version` fields.
+fn validate_client_info(params_meta: Option<&serde_json::Value>) -> Option<&'static str> {
+    let Some(info) = params_meta.and_then(|m| m.get("io.modelcontextprotocol/clientInfo")) else {
+        return Some("missing params._meta[\"io.modelcontextprotocol/clientInfo\"]");
+    };
+
+    let Some(obj) = info.as_object() else {
+        return Some("params._meta[\"io.modelcontextprotocol/clientInfo\"] must be an object");
+    };
+
+    if !obj.get("name").is_some_and(serde_json::Value::is_string) {
+        return Some("params._meta clientInfo.name must be a string");
+    }
+
+    if !obj.get("version").is_some_and(serde_json::Value::is_string) {
+        return Some("params._meta clientInfo.version must be a string");
+    }
+
+    None
+}
+
+/// Validates `params._meta["io.modelcontextprotocol/clientCapabilities"]` is an object.
+fn validate_client_capabilities(params_meta: Option<&serde_json::Value>) -> Option<&'static str> {
+    let Some(caps) = params_meta.and_then(|m| m.get("io.modelcontextprotocol/clientCapabilities")) else {
+        return Some("missing params._meta[\"io.modelcontextprotocol/clientCapabilities\"]");
+    };
+
+    if !caps.is_object() {
+        return Some("params._meta[\"io.modelcontextprotocol/clientCapabilities\"] must be an object");
+    }
+
+    None
+}
+
+/// Returns `true` for methods that require the `Mcp-Name` header.
+fn method_requires_mcp_name(method_str: &str) -> bool {
+    matches!(method_str, "tools/call" | "resources/read" | "prompts/get")
+}
+
+/// Extracts the body-derived name for `Mcp-Name` comparison.
+fn extract_body_name<'a>(value: &'a serde_json::Value, method_str: &str) -> Option<&'a str> {
+    let params = value.get("params")?;
+    match method_str {
+        "resources/read" => params.get("uri").and_then(|v| v.as_str()),
+        _ => params.get("name").and_then(|v| v.as_str()),
+    }
+}
+
+/// Failure modes for MCP `=?base64?...?=` sentinel decoding.
+enum McpNameDecodeError {
+    /// Invalid base64 payload.
+    Base64,
+    /// Decoded bytes are not valid UTF-8.
+    Utf8,
+}
+
+/// Decode MCP `=?base64?...?=` sentinel values.
+///
+/// Returns `Ok(Some(decoded))` for valid sentinels, `Ok(None)` for
+/// non-sentinel values, and `Err` for malformed sentinels.
+fn decode_mcp_name(value: &str) -> Result<Option<String>, McpNameDecodeError> {
+    use base64::Engine as _;
+
+    let Some(inner) = value
+        .strip_prefix(BASE64_SENTINEL_PREFIX)
+        .and_then(|rest| rest.strip_suffix(BASE64_SENTINEL_SUFFIX))
+    else {
+        return Ok(None);
+    };
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(inner)
+        .map_err(|_e| McpNameDecodeError::Base64)?;
+
+    String::from_utf8(bytes)
+        .map(Some)
+        .map_err(|_e| McpNameDecodeError::Utf8)
+}
+
+/// Gets a header value as a `&str`.
+fn header_str<'a>(headers: &'a http::HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+// -----------------------------------------------------------------------------
+// Error Response Builders
+// -----------------------------------------------------------------------------
+
+/// Builds a header-mismatch error response (HTTP 400, JSON-RPC -32020).
+fn header_mismatch_action(envelope: &JsonRpcEnvelope, message: &str) -> FilterAction {
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "error": { "code": ERR_HEADER_MISMATCH, "message": message },
+        "id": id_value(envelope),
+    });
+
+    FilterAction::Reject(
+        Rejection::status(400)
+            .with_header("content-type", "application/json")
+            .with_body(Bytes::from(response.to_string())),
+    )
+}
+
+/// Builds an unsupported-version error response (HTTP 400, JSON-RPC -32022).
+fn unsupported_version_action(envelope: &JsonRpcEnvelope, requested: &str, supported: &[String]) -> FilterAction {
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "error": {
+            "code": ERR_UNSUPPORTED_VERSION,
+            "data": { "requested": requested, "supported": supported },
+            "message": "unsupported protocol version",
+        },
+        "id": id_value(envelope),
+    });
+
+    FilterAction::Reject(
+        Rejection::status(400)
+            .with_header("content-type", "application/json")
+            .with_body(Bytes::from(response.to_string())),
+    )
+}
+
+// -----------------------------------------------------------------------------
+// Current-Profile Request Handlers
+// -----------------------------------------------------------------------------
+
+/// MCP notifications are one-way messages.
 fn handle_notification(envelope: &JsonRpcEnvelope) -> FilterAction {
     if matches!(envelope.kind, JsonRpcKind::Notification) && matches!(envelope.id_kind, JsonRpcIdKind::Missing) {
         FilterAction::Reject(Rejection::status(202))
@@ -275,12 +691,8 @@ fn invalid_request_action(envelope: &JsonRpcEnvelope) -> FilterAction {
     json_rpc_error_action_with_id(&id_json, -32600, "invalid request")
 }
 
-// -----------------------------------------------------------------------------
-// Request Handlers
-// -----------------------------------------------------------------------------
-
 /// Returns 204 when a valid `Mcp-Session-Id` header is present, 400 otherwise.
-fn handle_delete(ctx: &HttpFilterContext<'_>) -> FilterAction {
+fn handle_delete_current(ctx: &HttpFilterContext<'_>) -> FilterAction {
     if ctx
         .request
         .headers
@@ -295,7 +707,6 @@ fn handle_delete(ctx: &HttpFilterContext<'_>) -> FilterAction {
 }
 
 /// Generates a new MCP session and returns MCP capabilities.
-/// Does not initialize backends, that belongs to follow-up backend session work.
 #[expect(clippy::unnecessary_wraps, reason = "signature matches sibling handle_* fns")]
 fn handle_initialize(
     ctx: &mut HttpFilterContext<'_>,
@@ -321,10 +732,7 @@ fn handle_initialize(
     ))
 }
 
-/// Select the protocol version for the initialize response.
-///
-/// Echoes the client's requested version when the broker supports it,
-/// otherwise falls back to `default_version`.
+/// Echoes the client's requested version when supported, otherwise falls back.
 fn negotiate_protocol_version<'a>(
     value: &serde_json::Value,
     supported_versions: &'a [String],
@@ -344,8 +752,7 @@ fn negotiate_protocol_version<'a>(
     default_version
 }
 
-/// Persist the client's advertised MCP protocol version for later negotiation
-/// work, avoiding metadata writes for malformed control-character values.
+/// Persist the client's advertised MCP protocol version.
 fn record_client_protocol_version(ctx: &mut HttpFilterContext<'_>, value: &serde_json::Value) {
     if let Some(version) = value
         .get("params")
@@ -358,6 +765,10 @@ fn record_client_protocol_version(ctx: &mut HttpFilterContext<'_>, value: &serde
 }
 
 /// Build the initialize response from the configured protocol version.
+///
+/// `serverInfo` intentionally omits `version` to preserve the established
+/// current-profile response shape; stateless clients get version from
+/// `server/discover` instead.
 fn initialize_response_body(envelope: &JsonRpcEnvelope, protocol_version: &str) -> serde_json::Value {
     serde_json::json!({
         "jsonrpc": "2.0",
@@ -376,8 +787,7 @@ fn initialize_response_body(envelope: &JsonRpcEnvelope, protocol_version: &str) 
     })
 }
 
-/// Returns the aggregated static catalog. Dynamic backend discovery
-/// and per-identity filtering belong to later PRs.
+/// Returns the aggregated static catalog.
 fn handle_tools_list(catalog: &[CatalogTool], envelope: &JsonRpcEnvelope) -> Result<FilterAction, FilterError> {
     let tools_json = serialize_catalog(catalog)?;
     let id_json = format_id_json(envelope);
@@ -392,15 +802,13 @@ fn handle_tools_list(catalog: &[CatalogTool], envelope: &JsonRpcEnvelope) -> Res
     ))
 }
 
-/// Fails at request time if serialization fails, so callers must
-/// return a controlled error rather than silently degrading.
+/// Serialize the tool catalog to JSON.
 fn serialize_catalog(catalog: &[CatalogTool]) -> Result<String, FilterError> {
     let tools: Vec<serde_json::Value> = catalog.iter().map(catalog_tool_to_json).collect();
     serde_json::to_string(&tools).map_err(|e| FilterError::from(format!("mcp: failed to serialize tool catalog: {e}")))
 }
 
-/// Produces the MCP tool object shape (`name`, optional `description`
-/// and `inputSchema`) expected by `tools/list` responses.
+/// Produces the MCP tool object shape expected by `tools/list` responses.
 fn catalog_tool_to_json(tool: &CatalogTool) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
     obj.insert("name".to_owned(), serde_json::Value::String(tool.exposed_name.clone()));
@@ -431,9 +839,6 @@ fn handle_ping(envelope: &JsonRpcEnvelope) -> FilterAction {
 // -----------------------------------------------------------------------------
 
 /// Format the JSON-RPC `id` field for response serialization.
-///
-/// String ids are escaped with [`serde_json::to_string`] so special
-/// characters (quotes, backslashes, control chars) produce valid JSON.
 fn format_id_json(envelope: &JsonRpcEnvelope) -> String {
     let id = envelope.id.as_deref().unwrap_or("null");
     match envelope.id_kind {
@@ -455,16 +860,33 @@ fn id_value(envelope: &JsonRpcEnvelope) -> serde_json::Value {
     }
 }
 
-/// Build a JSON-RPC error [`FilterAction::Reject`] response.
-///
-/// The message is JSON-escaped so future caller-supplied values
-/// (e.g. tool names from backend routing) cannot break the response envelope.
+/// Build a JSON-RPC error response (HTTP 200 for current-profile compatibility).
 fn json_rpc_error_action(envelope: &JsonRpcEnvelope, code: i32, message: &str) -> FilterAction {
     let id_json = format_id_json(envelope);
     json_rpc_error_action_with_id(&id_json, code, message)
 }
 
-/// Some protocol errors cannot safely reuse the parsed request id.
+/// Build a JSON-RPC error response with a specific HTTP status code.
+fn json_rpc_error_action_with_status(
+    envelope: &JsonRpcEnvelope,
+    http_status: u16,
+    code: i32,
+    message: &str,
+) -> FilterAction {
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "error": { "code": code, "message": message },
+        "id": id_value(envelope),
+    });
+
+    FilterAction::Reject(
+        Rejection::status(http_status)
+            .with_header("content-type", "application/json")
+            .with_body(Bytes::from(response.to_string())),
+    )
+}
+
+/// Build a JSON-RPC error response with an explicit id.
 fn json_rpc_error_action_with_id(id_json: &str, code: i32, message: &str) -> FilterAction {
     let message_json = serde_json::to_string(message).unwrap_or_else(|_| "\"internal error\"".to_owned());
     let body = Bytes::from(format!(
@@ -481,8 +903,7 @@ fn json_rpc_error_action_with_id(id_json: &str, code: i32, message: &str) -> Fil
 // Path Matching
 // -----------------------------------------------------------------------------
 
-/// Returns `true` when the request URI path matches the configured MCP
-/// path. Uses exact match on the path component only.
+/// Returns `true` when the request URI path matches the configured MCP path.
 fn request_path_matches(uri: &http::Uri, public_path: &str) -> bool {
     uri.path() == public_path
 }
@@ -491,8 +912,7 @@ fn request_path_matches(uri: &http::Uri, public_path: &str) -> bool {
 // Shared Parser Config
 // -----------------------------------------------------------------------------
 
-/// Build a [`JsonRpcConfig`] for the shared parser with MCP broker-appropriate
-/// defaults.
+/// Build a [`JsonRpcConfig`] for the shared parser.
 fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {
     use praxis_filter::builtins::http::payload_processing::{
         OnInvalidBehavior,

--- a/filters/src/agentic/mcp/broker/tests.rs
+++ b/filters/src/agentic/mcp/broker/tests.rs
@@ -9,6 +9,10 @@ use super::{
     config::{McpBrokerConfig, build_config},
     *,
 };
+use crate::agentic::mcp::{
+    config::DEFAULT_MAX_BODY_BYTES,
+    protocol::{PROTOCOL_VERSION_CURRENT, PROTOCOL_VERSION_STATELESS_2026_07_28, ProtocolProfile},
+};
 
 // -----------------------------------------------------------------------------
 // Config Tests
@@ -504,7 +508,7 @@ servers:
 }
 
 // -----------------------------------------------------------------------------
-// Filter Behavior Tests
+// Filter Behavior Tests (Current Profile)
 // -----------------------------------------------------------------------------
 
 #[tokio::test]
@@ -530,7 +534,7 @@ async fn initialize_returns_session_and_id() {
             assert_eq!(parsed["result"]["serverInfo"]["name"], "praxis");
             assert!(
                 parsed["result"]["serverInfo"].get("version").is_none(),
-                "serverInfo should not leak version"
+                "current-profile initialize must not include serverInfo.version"
             );
             assert_session_id_format(rejection);
         },
@@ -944,7 +948,7 @@ fn body_mode_is_stream_buffer() {
     assert_eq!(
         filter.request_body_mode(),
         BodyMode::StreamBuffer {
-            max_bytes: Some(config::DEFAULT_MAX_BODY_BYTES)
+            max_bytes: Some(DEFAULT_MAX_BODY_BYTES)
         },
         "Praxis should use StreamBuffer body mode"
     );
@@ -1146,12 +1150,11 @@ fn default_profile_config_preserves_current_behavior() {
     let filter = make_broker_filter();
     assert_eq!(
         filter.protocol_profile,
-        protocol::ProtocolProfile::Current,
+        ProtocolProfile::Current,
         "default profile should be Current"
     );
     assert_eq!(
-        filter.default_version,
-        protocol::PROTOCOL_VERSION_CURRENT,
+        filter.default_version, PROTOCOL_VERSION_CURRENT,
         "default version should match centralized constant"
     );
     assert!(
@@ -1177,7 +1180,7 @@ servers:
     let (validated, _catalog) = build_config(cfg).unwrap();
     assert_eq!(
         validated.protocol_profile,
-        protocol::ProtocolProfile::Current,
+        ProtocolProfile::Current,
         "explicit 'current' should parse"
     );
 }
@@ -1403,8 +1406,915 @@ servers: []
     assert_eq!(
         validated.supported_versions,
         vec!["2025-03-26"],
-        "omitting supported_versions should default to implemented versions"
+        "omitting supported_versions should default to profile versions"
     );
+}
+
+// -----------------------------------------------------------------------------
+// Stateless Profile Config Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn stateless_profile_parses_from_yaml() {
+    let yaml = r#"
+protocol_profile: stateless
+servers:
+  - name: s
+    cluster: c
+    tools: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, _catalog) = build_config(cfg).unwrap();
+    assert_eq!(
+        validated.protocol_profile,
+        ProtocolProfile::Stateless,
+        "stateless profile should parse"
+    );
+}
+
+#[test]
+fn stateless_profile_defaults_to_2026_07_28() {
+    let yaml = r#"
+protocol_profile: stateless
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, _catalog) = build_config(cfg).unwrap();
+    assert_eq!(
+        validated.default_version, PROTOCOL_VERSION_STATELESS_2026_07_28,
+        "stateless profile should default to 2026-07-28"
+    );
+    assert_eq!(
+        validated.supported_versions,
+        vec![PROTOCOL_VERSION_STATELESS_2026_07_28],
+        "stateless profile should default supported_versions to 2026-07-28"
+    );
+}
+
+#[test]
+fn current_profile_rejects_2026_07_28_version() {
+    let yaml = r#"
+protocol_profile: current
+supported_versions: ["2026-07-28"]
+default_version: "2026-07-28"
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "current profile should reject 2026-07-28");
+    assert!(
+        result.err().unwrap().to_string().contains("not compatible"),
+        "error should mention profile incompatibility"
+    );
+}
+
+#[test]
+fn stateless_profile_rejects_2025_03_26_version() {
+    let yaml = r#"
+protocol_profile: stateless
+supported_versions: ["2025-03-26"]
+default_version: "2025-03-26"
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "stateless profile should reject 2025-03-26");
+    assert!(
+        result.err().unwrap().to_string().contains("not compatible"),
+        "error should mention profile incompatibility"
+    );
+}
+
+#[test]
+fn stateless_cache_ttl_zero_allowed() {
+    let yaml = r#"
+protocol_profile: stateless
+cache_ttl_ms: 0
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, _catalog) = build_config(cfg).unwrap();
+    assert_eq!(validated.cache_ttl_ms, 0, "cache_ttl_ms 0 should be accepted");
+}
+
+#[test]
+fn stateless_unknown_cache_scope_rejected() {
+    let yaml = r#"
+protocol_profile: stateless
+cache_scope: shared
+servers: []
+"#;
+    let result = serde_yaml::from_str::<McpBrokerConfig>(yaml);
+    assert!(result.is_err(), "unknown cache_scope should fail at parse time");
+}
+
+#[test]
+fn current_profile_rejects_explicit_cache_scope_private() {
+    let yaml = r#"
+protocol_profile: current
+cache_scope: private
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "current profile should reject cache_scope");
+    assert!(
+        result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("cache_scope requires protocol_profile 'stateless'"),
+        "error should mention stateless requirement"
+    );
+}
+
+#[test]
+fn current_profile_rejects_explicit_cache_scope_public() {
+    let yaml = r#"
+protocol_profile: current
+cache_scope: public
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(
+        result.is_err(),
+        "current profile should reject cache_scope even when public"
+    );
+    assert!(
+        result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("cache_scope requires protocol_profile 'stateless'"),
+        "error should mention stateless requirement"
+    );
+}
+
+#[test]
+fn current_profile_rejects_explicit_cache_ttl_ms() {
+    let yaml = r#"
+protocol_profile: current
+cache_ttl_ms: 60000
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "current profile should reject cache_ttl_ms");
+    assert!(
+        result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("cache_ttl_ms requires protocol_profile 'stateless'"),
+        "error should mention stateless requirement"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Current-Profile Regression Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn current_initialize_still_returns_session_header() {
+    let filter = make_broker_filter();
+    let body_str =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert!(
+                rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
+                "current profile initialize must return mcp-session-id header"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn current_delete_session_cleanup_still_works() {
+    let filter = make_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::DELETE, "/mcp");
+    req.headers
+        .insert("mcp-session-id", "mcp-test-cleanup".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 204,
+                "current profile DELETE with session should return 204"
+            );
+        },
+        _ => panic!("expected Reject with 204"),
+    }
+}
+
+#[tokio::test]
+async fn current_tools_list_shape_unchanged() {
+    let filter = make_broker_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert!(
+                parsed["result"]["tools"].is_array(),
+                "current tools/list should have tools array"
+            );
+            assert!(
+                parsed["result"].get("resultType").is_none(),
+                "current tools/list should not include resultType"
+            );
+            assert!(
+                parsed["result"].get("ttlMs").is_none(),
+                "current tools/list should not include ttlMs"
+            );
+            assert!(
+                parsed["result"].get("cacheScope").is_none(),
+                "current tools/list should not include cacheScope"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn current_default_config_does_not_require_stateless_headers() {
+    let filter = make_broker_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 200,
+                "current profile should not require MCP-Protocol-Version or Mcp-Method headers"
+            );
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            assert!(
+                body_str.contains(r#""result":{}"#),
+                "current profile ping should succeed without stateless headers: {body_str}"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Stateless Broker Unit Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "comprehensive response shape assertions")]
+async fn server_discover_returns_supported_versions_and_cache_metadata() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("server/discover", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("server/discover", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 200, "server/discover should return 200");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["result"]["resultType"], "complete");
+            assert_eq!(
+                parsed["result"]["supportedVersions"][0],
+                PROTOCOL_VERSION_STATELESS_2026_07_28
+            );
+            assert!(parsed["result"]["ttlMs"].is_number(), "should include ttlMs");
+            assert_eq!(parsed["result"]["cacheScope"], "public");
+            assert!(
+                parsed["result"]["capabilities"]["tools"].is_object(),
+                "should advertise tools capability"
+            );
+            assert_eq!(parsed["result"]["serverInfo"]["name"], "praxis");
+            assert!(
+                parsed["result"]["serverInfo"]["version"].is_string(),
+                "serverInfo must include version"
+            );
+            assert!(
+                !rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
+                "stateless server/discover must not return mcp-session-id"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_list_returns_result_type_and_cache_metadata() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/list", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("tools/list", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 200, "stateless tools/list should return 200");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["result"]["resultType"], "complete");
+            assert!(parsed["result"]["ttlMs"].is_number(), "should include ttlMs");
+            assert_eq!(parsed["result"]["cacheScope"], "public");
+            assert!(parsed["result"]["tools"].is_array(), "should include tools array");
+            assert!(
+                !rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
+                "stateless tools/list must not return mcp-session-id"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_initialize_returns_method_not_found_without_session_header() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("initialize", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("initialize", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 404,
+                "stateless initialize should return 404 per draft Streamable HTTP"
+            );
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32601, "should return method not found");
+            assert_eq!(
+                parsed["error"]["message"], "method not found: use server/discover for stateless profiles",
+                "should guide clients to server/discover"
+            );
+            assert!(
+                !rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
+                "stateless initialize must not return mcp-session-id"
+            );
+        },
+        _ => panic!("expected Reject with JSON-RPC error"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_delete_returns_405() {
+    let filter = make_stateless_broker_filter();
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/mcp");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 405, "stateless DELETE should return 405");
+        },
+        _ => panic!("expected Reject with 405"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_ignores_mcp_session_id_header() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("ping", None);
+    req.headers
+        .insert("mcp-session-id", "should-be-ignored".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("ping", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 200,
+                "stateless ping should succeed even with session header"
+            );
+            assert!(
+                !rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
+                "stateless response must not echo mcp-session-id"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_missing_protocol_header_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers.insert("mcp-method", "ping".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("ping", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing protocol header should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_missing_body_meta_version_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers
+        .insert("mcp-protocol-version", "2026-07-28".parse().unwrap());
+    req.headers.insert("mcp-method", "ping".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing body _meta version should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_protocol_header_body_mismatch_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers
+        .insert("mcp-protocol-version", "2026-07-28".parse().unwrap());
+    req.headers.insert("mcp-method", "ping".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-03-26","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "header/body version mismatch should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_unsupported_protocol_version_returns_32022() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers
+        .insert("mcp-protocol-version", "9999-12-31".parse().unwrap());
+    req.headers.insert("mcp-method", "ping".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"9999-12-31","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "unsupported version should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_UNSUPPORTED_VERSION);
+            assert!(
+                parsed["error"]["data"]["supported"].is_array(),
+                "should include supported versions"
+            );
+            assert!(
+                parsed["error"]["data"]["requested"].is_string(),
+                "should include requested version"
+            );
+            assert_eq!(parsed["id"], 1, "should preserve request id");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_missing_mcp_method_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers
+        .insert("mcp-protocol-version", "2026-07-28".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("ping", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing Mcp-Method should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_mcp_method_mismatch_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("tools/list", None);
+    req.headers.insert("mcp-method", "tools/call".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("tools/list", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "method mismatch should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_requires_mcp_name() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "tools/call without Mcp-Name should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_mcp_name_mismatch_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("tools/call", Some("wrong_tool"));
+    req.headers.insert("mcp-method", "tools/call".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "Mcp-Name mismatch should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_base64_mcp_name_matches_body() {
+    use base64::Engine as _;
+
+    let filter = make_stateless_broker_filter();
+    let tool_name = "weather_get_weather";
+    let encoded = base64::engine::general_purpose::STANDARD.encode(tool_name);
+    let sentinel = format!("=?base64?{encoded}?=");
+    let mut req = make_stateless_mcp_request("tools/call", None);
+    req.headers.insert("mcp-name", sentinel.parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 404,
+                "base64-encoded Mcp-Name matching body should pass validation but tools/call returns 404"
+            );
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            assert!(
+                body_str.contains("-32601"),
+                "tools/call should still return unsupported: {body_str}"
+            );
+        },
+        _ => panic!("expected Reject with JSON-RPC error (tools/call unsupported)"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_malformed_base64_name_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("tools/call", None);
+    req.headers
+        .insert("mcp-name", "=?base64?!!!invalid!!!?=".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "malformed base64 Mcp-Name should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_list_spurious_mcp_name_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("tools/list", None);
+    req.headers.insert("mcp-name", "spurious".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("tools/list", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 400,
+                "spurious Mcp-Name on tools/list should return 400"
+            );
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_notifications_initialized_returns_method_not_found() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("notifications/initialized", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_notification_body("notifications/initialized");
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 404, "stateless notifications should be unsupported");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32601);
+        },
+        _ => panic!("expected Reject with 404"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_notification_missing_mcp_method_rejected() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers
+        .insert("mcp-protocol-version", "2026-07-28".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_notification_body("notifications/initialized");
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing Mcp-Method should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_notification_mcp_method_mismatch_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_notification_body("notifications/initialized");
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "Mcp-Method mismatch should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn string_json_rpc_id_with_quotes_preserved_in_stateless_error() {
+    let filter = make_stateless_broker_filter();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":"req\"\\1","method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing header should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["id"].as_str().unwrap(),
+                "req\"\\1",
+                "string id with quotes and backslashes should round-trip correctly in error responses"
+            );
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Stateless Metadata Shape Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stateless_missing_client_info_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing clientInfo should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_null_client_info_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":null,"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "null clientInfo should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_string_client_info_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":"not-an-object","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "string clientInfo should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_client_info_missing_name_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "clientInfo missing name should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_client_info_missing_version_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "clientInfo missing version should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_array_client_capabilities_rejected() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":["not","an","object"]}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "array clientCapabilities should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -1457,11 +2367,19 @@ fn make_broker_filter_with_versions(version: &str) -> McpBrokerFilter {
     build_broker_filter_from_yaml(&yaml)
 }
 
+fn make_stateless_broker_filter() -> McpBrokerFilter {
+    let yaml = format!("protocol_profile: stateless\n{BROKER_SERVERS_YAML}");
+    build_broker_filter_from_yaml(&yaml)
+}
+
 fn build_broker_filter_from_yaml(yaml: &str) -> McpBrokerFilter {
     let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
     let (validated, catalog) = build_config(cfg).unwrap();
     let json_rpc_config = build_json_rpc_config(validated.max_body_bytes);
+
     McpBrokerFilter {
+        cache_scope: validated.cache_scope,
+        cache_ttl_ms: validated.cache_ttl_ms,
         catalog,
         default_version: validated.default_version.clone(),
         json_rpc_config,
@@ -1476,6 +2394,38 @@ fn make_mcp_request() -> praxis_filter::Request {
     let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
     req.headers.insert("content-type", "application/json".parse().unwrap());
     req
+}
+
+fn make_stateless_mcp_request(method: &str, mcp_name: Option<&str>) -> praxis_filter::Request {
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    req.headers
+        .insert("mcp-protocol-version", "2026-07-28".parse().unwrap());
+    req.headers.insert("mcp-method", method.parse().unwrap());
+    if let Some(name) = mcp_name {
+        req.headers.insert("mcp-name", name.parse().unwrap());
+    }
+    req
+}
+
+/// Stateless request metadata fragment for `params._meta`.
+const STATELESS_META: &str = concat!(
+    r#""_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","#,
+    r#""io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"#,
+    r#""io.modelcontextprotocol/clientCapabilities":{}}"#,
+);
+
+fn stateless_body(method: &str, id: u64, extra_params: Option<&str>) -> String {
+    let extra = extra_params.map_or(String::new(), |p| format!(",{p}"));
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{{STATELESS_META}{extra}}}}}"#,)
+}
+
+fn stateless_body_with_params(method: &str, id: u64, params_inner: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{{STATELESS_META},{params_inner}}}}}"#,)
+}
+
+fn stateless_notification_body(method: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","method":"{method}","params":{{{STATELESS_META}}}}}"#,)
 }
 
 fn assert_tools_list_schema_defaults(body_str: &str) {

--- a/filters/src/agentic/mcp/envelope.rs
+++ b/filters/src/agentic/mcp/envelope.rs
@@ -12,34 +12,36 @@ use serde_json::Value;
 /// MCP method classification.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum McpMethod {
+    /// `completion/complete` completion request.
+    CompletionComplete,
     /// `initialize` handshake request.
     Initialize,
+    /// `logging/setLevel` log configuration request.
+    LoggingSetLevel,
     /// `notifications/initialized` post-handshake notification.
     NotificationsInitialized,
-    /// `tools/list` discovery request.
-    ToolsList,
-    /// `tools/call` invocation request.
-    ToolsCall,
-    /// `resources/read` resource access request.
-    ResourcesRead,
-    /// `resources/list` resource discovery request.
-    ResourcesList,
+    /// `notifications/prompts/list_changed` prompt change notification.
+    NotificationsPromptsListChanged,
+    /// `notifications/resources/list_changed` resource change notification.
+    NotificationsResourcesListChanged,
+    /// `notifications/tools/list_changed` tool change notification.
+    NotificationsToolsListChanged,
+    /// `ping` keep-alive request.
+    Ping,
     /// `prompts/get` prompt retrieval request.
     PromptsGet,
     /// `prompts/list` prompt discovery request.
     PromptsList,
-    /// `ping` keep-alive request.
-    Ping,
-    /// `logging/setLevel` log configuration request.
-    LoggingSetLevel,
-    /// `completion/complete` completion request.
-    CompletionComplete,
-    /// `notifications/tools/list_changed` tool change notification.
-    NotificationsToolsListChanged,
-    /// `notifications/resources/list_changed` resource change notification.
-    NotificationsResourcesListChanged,
-    /// `notifications/prompts/list_changed` prompt change notification.
-    NotificationsPromptsListChanged,
+    /// `resources/list` resource discovery request.
+    ResourcesList,
+    /// `resources/read` resource access request.
+    ResourcesRead,
+    /// `server/discover` capability and version discovery (stateless profile).
+    ServerDiscover,
+    /// `tools/call` invocation request.
+    ToolsCall,
+    /// `tools/list` discovery request.
+    ToolsList,
     /// Any other method string not in the known set.
     Other(String),
 }
@@ -48,20 +50,21 @@ impl McpMethod {
     /// Parse an MCP method from the JSON-RPC method string.
     pub(crate) fn from_method_str(s: &str) -> Self {
         match s {
+            "completion/complete" => Self::CompletionComplete,
             "initialize" => Self::Initialize,
+            "logging/setLevel" => Self::LoggingSetLevel,
             "notifications/initialized" => Self::NotificationsInitialized,
-            "tools/list" => Self::ToolsList,
-            "tools/call" => Self::ToolsCall,
-            "resources/read" => Self::ResourcesRead,
-            "resources/list" => Self::ResourcesList,
+            "notifications/prompts/list_changed" => Self::NotificationsPromptsListChanged,
+            "notifications/resources/list_changed" => Self::NotificationsResourcesListChanged,
+            "notifications/tools/list_changed" => Self::NotificationsToolsListChanged,
+            "ping" => Self::Ping,
             "prompts/get" => Self::PromptsGet,
             "prompts/list" => Self::PromptsList,
-            "ping" => Self::Ping,
-            "logging/setLevel" => Self::LoggingSetLevel,
-            "completion/complete" => Self::CompletionComplete,
-            "notifications/tools/list_changed" => Self::NotificationsToolsListChanged,
-            "notifications/resources/list_changed" => Self::NotificationsResourcesListChanged,
-            "notifications/prompts/list_changed" => Self::NotificationsPromptsListChanged,
+            "resources/list" => Self::ResourcesList,
+            "resources/read" => Self::ResourcesRead,
+            "server/discover" => Self::ServerDiscover,
+            "tools/call" => Self::ToolsCall,
+            "tools/list" => Self::ToolsList,
             other => Self::Other(other.to_owned()),
         }
     }
@@ -69,20 +72,21 @@ impl McpMethod {
     /// String representation for headers and metadata.
     pub(crate) fn as_str(&self) -> &str {
         match self {
+            Self::CompletionComplete => "completion/complete",
             Self::Initialize => "initialize",
+            Self::LoggingSetLevel => "logging/setLevel",
             Self::NotificationsInitialized => "notifications/initialized",
-            Self::ToolsList => "tools/list",
-            Self::ToolsCall => "tools/call",
-            Self::ResourcesRead => "resources/read",
-            Self::ResourcesList => "resources/list",
+            Self::NotificationsPromptsListChanged => "notifications/prompts/list_changed",
+            Self::NotificationsResourcesListChanged => "notifications/resources/list_changed",
+            Self::NotificationsToolsListChanged => "notifications/tools/list_changed",
+            Self::Ping => "ping",
             Self::PromptsGet => "prompts/get",
             Self::PromptsList => "prompts/list",
-            Self::Ping => "ping",
-            Self::LoggingSetLevel => "logging/setLevel",
-            Self::CompletionComplete => "completion/complete",
-            Self::NotificationsToolsListChanged => "notifications/tools/list_changed",
-            Self::NotificationsResourcesListChanged => "notifications/resources/list_changed",
-            Self::NotificationsPromptsListChanged => "notifications/prompts/list_changed",
+            Self::ResourcesList => "resources/list",
+            Self::ResourcesRead => "resources/read",
+            Self::ServerDiscover => "server/discover",
+            Self::ToolsCall => "tools/call",
+            Self::ToolsList => "tools/list",
             Self::Other(s) => s,
         }
     }

--- a/filters/src/agentic/mcp/protocol.rs
+++ b/filters/src/agentic/mcp/protocol.rs
@@ -5,7 +5,7 @@
 //!
 //! Centralizes the protocol version string so it is not scattered through
 //! handlers and tests. Future MCP spec versions can be added to
-//! [`SUPPORTED_VERSIONS`] without modifying individual request handlers.
+//! [`SUPPORTED_VERSIONS_CURRENT`] without modifying individual request handlers.
 
 use serde::Deserialize;
 
@@ -16,11 +16,17 @@ use serde::Deserialize;
 /// Protocol version implemented by the current broker behavior.
 pub(crate) const PROTOCOL_VERSION_CURRENT: &str = "2025-03-26";
 
-/// All protocol versions this build of Praxis can handle.
-pub(crate) const SUPPORTED_VERSIONS: &[&str] = &[PROTOCOL_VERSION_CURRENT];
+/// Protocol version for the MCP 2026-07-28 stateless profile (release candidate).
+pub(crate) const PROTOCOL_VERSION_STATELESS_2026_07_28: &str = "2026-07-28";
 
-/// Fallback protocol version used when no explicit version is configured.
-pub(crate) const DEFAULT_VERSION: &str = PROTOCOL_VERSION_CURRENT;
+/// Protocol versions supported by the current profile.
+pub(crate) const SUPPORTED_VERSIONS_CURRENT: &[&str] = &[PROTOCOL_VERSION_CURRENT];
+
+/// Protocol versions supported by the stateless profile.
+pub(crate) const SUPPORTED_VERSIONS_STATELESS: &[&str] = &[PROTOCOL_VERSION_STATELESS_2026_07_28];
+
+/// All protocol versions this build of Praxis can handle across all profiles.
+pub(crate) const SUPPORTED_VERSIONS: &[&str] = &[PROTOCOL_VERSION_CURRENT, PROTOCOL_VERSION_STATELESS_2026_07_28];
 
 // -----------------------------------------------------------------------------
 // ProtocolProfile
@@ -29,8 +35,9 @@ pub(crate) const DEFAULT_VERSION: &str = PROTOCOL_VERSION_CURRENT;
 /// MCP protocol profile governing session semantics and header requirements.
 ///
 /// The `Current` profile preserves the existing `initialize`/session behavior.
-/// Future profiles can be added when the MCP spec finalizes additional
-/// transport modes.
+/// The `Stateless` profile implements MCP 2026-07-28 stateless semantics:
+/// no protocol sessions, required request metadata headers, and
+/// `server/discover` instead of `initialize`.
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ProtocolProfile {
@@ -38,21 +45,49 @@ pub(crate) enum ProtocolProfile {
     /// optional `MCP-Session-Id`, and session-aware DELETE.
     #[default]
     Current,
+    /// MCP 2026-07-28 stateless behavior: no protocol sessions,
+    /// required `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers,
+    /// and `server/discover` for capability discovery.
+    Stateless,
 }
 
 impl ProtocolProfile {
     /// String label for logging and metadata.
-    #[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on methods")]
-    #[allow(dead_code, reason = "plumbing for follow-up profile-aware logging")]
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Current => "current",
+            Self::Stateless => "stateless",
         }
     }
 }
 
 // -----------------------------------------------------------------------------
-// Helpers
+// Profile Helpers
+// -----------------------------------------------------------------------------
+
+/// Returns the default protocol version for the given profile.
+pub(crate) fn default_version_for_profile(profile: ProtocolProfile) -> &'static str {
+    match profile {
+        ProtocolProfile::Current => PROTOCOL_VERSION_CURRENT,
+        ProtocolProfile::Stateless => PROTOCOL_VERSION_STATELESS_2026_07_28,
+    }
+}
+
+/// Returns the supported protocol versions for the given profile.
+pub(crate) fn supported_versions_for_profile(profile: ProtocolProfile) -> &'static [&'static str] {
+    match profile {
+        ProtocolProfile::Current => SUPPORTED_VERSIONS_CURRENT,
+        ProtocolProfile::Stateless => SUPPORTED_VERSIONS_STATELESS,
+    }
+}
+
+/// Returns `true` when `version` is supported by the given profile.
+pub(crate) fn is_supported_version_for_profile(profile: ProtocolProfile, version: &str) -> bool {
+    supported_versions_for_profile(profile).contains(&version)
+}
+
+// -----------------------------------------------------------------------------
+// Global Helpers
 // -----------------------------------------------------------------------------
 
 /// Returns `true` when `version` appears in [`SUPPORTED_VERSIONS`].
@@ -77,11 +112,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_version_is_supported() {
-        assert!(
-            is_supported_version(DEFAULT_VERSION),
-            "DEFAULT_VERSION must appear in SUPPORTED_VERSIONS"
-        );
+    fn default_version_for_each_profile_is_supported() {
+        for profile in [ProtocolProfile::Current, ProtocolProfile::Stateless] {
+            let version = default_version_for_profile(profile);
+            assert!(
+                is_supported_version(version),
+                "default version for {profile:?} must appear in SUPPORTED_VERSIONS"
+            );
+        }
     }
 
     #[test]
@@ -89,6 +127,14 @@ mod tests {
         assert!(
             is_supported_version(PROTOCOL_VERSION_CURRENT),
             "PROTOCOL_VERSION_CURRENT must be supported"
+        );
+    }
+
+    #[test]
+    fn stateless_version_is_supported() {
+        assert!(
+            is_supported_version(PROTOCOL_VERSION_STATELESS_2026_07_28),
+            "PROTOCOL_VERSION_STATELESS_2026_07_28 must be supported"
         );
     }
 
@@ -112,6 +158,7 @@ mod tests {
     #[test]
     fn profile_as_str_round_trips() {
         assert_eq!(ProtocolProfile::Current.as_str(), "current");
+        assert_eq!(ProtocolProfile::Stateless.as_str(), "stateless");
     }
 
     #[test]
@@ -121,8 +168,114 @@ mod tests {
     }
 
     #[test]
+    fn stateless_profile_parses_from_yaml() {
+        let profile: ProtocolProfile = serde_yaml::from_str("stateless").unwrap();
+        assert_eq!(profile, ProtocolProfile::Stateless, "should parse 'stateless'");
+    }
+
+    #[test]
     fn profile_rejects_unknown_value() {
         let result = serde_yaml::from_str::<ProtocolProfile>("unknown");
         assert!(result.is_err(), "unknown profile value should fail to parse");
+    }
+
+    #[test]
+    fn default_profile_remains_current() {
+        assert_eq!(
+            ProtocolProfile::default(),
+            ProtocolProfile::Current,
+            "default ProtocolProfile must remain Current for backward compatibility"
+        );
+    }
+
+    #[test]
+    fn stateless_profile_defaults_to_2026_07_28() {
+        assert_eq!(
+            default_version_for_profile(ProtocolProfile::Stateless),
+            PROTOCOL_VERSION_STATELESS_2026_07_28,
+            "stateless profile default version should be 2026-07-28"
+        );
+    }
+
+    #[test]
+    fn current_profile_defaults_to_current() {
+        assert_eq!(
+            default_version_for_profile(ProtocolProfile::Current),
+            PROTOCOL_VERSION_CURRENT,
+            "current profile default version should be 2025-03-26"
+        );
+    }
+
+    #[test]
+    fn supported_versions_for_current_profile() {
+        let versions = supported_versions_for_profile(ProtocolProfile::Current);
+        assert!(
+            versions.contains(&PROTOCOL_VERSION_CURRENT),
+            "current profile should support 2025-03-26"
+        );
+        assert!(
+            !versions.contains(&PROTOCOL_VERSION_STATELESS_2026_07_28),
+            "current profile should not support 2026-07-28"
+        );
+    }
+
+    #[test]
+    fn supported_versions_for_stateless_profile() {
+        let versions = supported_versions_for_profile(ProtocolProfile::Stateless);
+        assert!(
+            versions.contains(&PROTOCOL_VERSION_STATELESS_2026_07_28),
+            "stateless profile should support 2026-07-28"
+        );
+        assert!(
+            !versions.contains(&PROTOCOL_VERSION_CURRENT),
+            "stateless profile should not support 2025-03-26"
+        );
+    }
+
+    #[test]
+    fn is_supported_version_for_current_profile() {
+        assert!(
+            is_supported_version_for_profile(ProtocolProfile::Current, PROTOCOL_VERSION_CURRENT),
+            "2025-03-26 should be supported by current profile"
+        );
+        assert!(
+            !is_supported_version_for_profile(ProtocolProfile::Current, PROTOCOL_VERSION_STATELESS_2026_07_28),
+            "2026-07-28 should not be supported by current profile"
+        );
+    }
+
+    #[test]
+    fn supported_versions_equals_union_of_all_profiles() {
+        let mut union: Vec<&str> = Vec::new();
+        union.extend_from_slice(SUPPORTED_VERSIONS_CURRENT);
+        union.extend_from_slice(SUPPORTED_VERSIONS_STATELESS);
+        union.sort_unstable();
+        union.dedup();
+
+        let mut global = SUPPORTED_VERSIONS.to_vec();
+        global.sort_unstable();
+
+        assert_eq!(
+            global, union,
+            "SUPPORTED_VERSIONS must equal the union of all per-profile version arrays"
+        );
+
+        assert_eq!(
+            global.len(),
+            union.len(),
+            "SUPPORTED_VERSIONS must not contain duplicates or extras"
+        );
+    }
+
+    #[test]
+    fn is_supported_version_for_stateless_profile() {
+        assert!(
+            is_supported_version_for_profile(ProtocolProfile::Stateless, PROTOCOL_VERSION_STATELESS_2026_07_28),
+            "2026-07-28 should be supported by stateless profile"
+        );
+        assert!(
+            !is_supported_version_for_profile(ProtocolProfile::Stateless, PROTOCOL_VERSION_CURRENT),
+            "2025-03-26 should not be supported by stateless profile"
+        );
     }
 }

--- a/tests/integration/tests/suite/examples/mcp_broker.rs
+++ b/tests/integration/tests/suite/examples/mcp_broker.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for MCP broker example configurations.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    free_port, http_send, load_example_config, parse_body, parse_status, start_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_static_catalog_example_serves_prefixed_catalog() {
+    let weather_guard = start_backend_with_shutdown("weather");
+    let calendar_guard = start_backend_with_shutdown("calendar");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "payload-processing/mcp-static-catalog.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", weather_guard.port()),
+            ("127.0.0.1:3002", calendar_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/mcp", r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "tools/list should return 200");
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("weather_get_weather"),
+        "weather tool should include prefix: {body}"
+    );
+    assert!(
+        body.contains("weather_forecast"),
+        "weather forecast should include prefix: {body}"
+    );
+    assert!(
+        body.contains("cal_create_event"),
+        "calendar create tool should include prefix: {body}"
+    );
+    assert!(
+        body.contains("cal_list_events"),
+        "calendar list tool should include prefix: {body}"
+    );
+    assert!(
+        body.contains(r#""city""#),
+        "example inputSchema should be preserved: {body}"
+    );
+}
+
+#[test]
+fn mcp_stateless_broker_example_serves_discover() {
+    let weather_guard = start_backend_with_shutdown("weather");
+    let calendar_guard = start_backend_with_shutdown("calendar");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "mcp-stateless-broker.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", weather_guard.port()),
+            ("127.0.0.1:3002", calendar_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_rpc_body(1, "server/discover");
+    let request = stateless_post("/mcp", &body_str, "server/discover", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "server/discover should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["result"]["resultType"], "complete", "should include resultType");
+    assert!(
+        parsed["result"]["supportedVersions"].is_array(),
+        "should include supportedVersions"
+    );
+    assert!(parsed["result"]["ttlMs"].is_number(), "should include ttlMs");
+    assert_eq!(parsed["result"]["cacheScope"], "public", "should include cacheScope");
+    assert_eq!(
+        parsed["result"]["serverInfo"]["name"], "praxis",
+        "should identify as praxis"
+    );
+    assert!(
+        parsed["result"]["serverInfo"]["version"].is_string(),
+        "serverInfo must include version"
+    );
+}
+
+#[test]
+fn mcp_stateless_broker_example_serves_tools_list() {
+    let weather_guard = start_backend_with_shutdown("weather");
+    let calendar_guard = start_backend_with_shutdown("calendar");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "mcp-stateless-broker.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", weather_guard.port()),
+            ("127.0.0.1:3002", calendar_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_rpc_body(2, "tools/list");
+    let request = stateless_post("/mcp", &body_str, "tools/list", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "tools/list should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["result"]["resultType"], "complete");
+    assert!(parsed["result"]["tools"].is_array(), "should include tools array");
+    assert!(parsed["result"]["ttlMs"].is_number(), "should include ttlMs");
+    assert_eq!(parsed["result"]["cacheScope"], "public");
+    assert!(
+        body.contains("weather_get_weather"),
+        "should contain prefixed weather tool"
+    );
+    assert!(
+        body.contains("cal_create_event"),
+        "should contain prefixed calendar tool"
+    );
+    assert!(!raw.contains("mcp-session-id:"), "should not include session header");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn stateless_rpc_body(id: u64, method: &str) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{"_meta":{{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{{"name":"test","version":"1.0"}},"io.modelcontextprotocol/clientCapabilities":{{}}}}}}}}"#,
+    )
+}
+
+fn json_post(path: &str, body: &str) -> String {
+    format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    )
+}
+
+fn stateless_post(path: &str, body: &str, method: &str, mcp_name: Option<&str>) -> String {
+    let mut headers = format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         MCP-Protocol-Version: 2026-07-28\r\n\
+         Mcp-Method: {method}\r\n",
+        body.len(),
+    );
+    if let Some(name) = mcp_name {
+        headers.push_str(&format!("Mcp-Name: {name}\r\n"));
+    }
+    headers.push_str("Connection: close\r\n\r\n");
+    headers.push_str(body);
+    headers
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -13,6 +13,7 @@ mod anthropic_messages;
 mod credential_injection;
 #[cfg(feature = "ai-inference")]
 mod full_flow;
+mod mcp_broker;
 #[cfg(feature = "ai-inference")]
 mod model_to_header;
 #[cfg(feature = "ai-inference")]

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -45,6 +45,7 @@ mod examples;
 mod failure_mode;
 mod guardrails;
 mod mcp;
+mod mcp_broker;
 #[cfg(feature = "ai-inference")]
 mod openai_responses_format;
 #[cfg(feature = "ai-inference")]

--- a/tests/integration/tests/suite/mcp_broker.rs
+++ b/tests/integration/tests/suite/mcp_broker.rs
@@ -1,0 +1,736 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for MCP static catalog and broker behavior.
+
+use std::collections::HashMap;
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    free_port, http_send, load_example_config, parse_body, parse_status, start_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Current Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_broker_initialize_returns_session() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "initialize should return 200");
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("protocolVersion"),
+        "should contain protocolVersion: {response_body}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&response_body).unwrap();
+    assert_eq!(
+        parsed["result"]["serverInfo"]["name"], "praxis",
+        "should contain Praxis server name: {response_body}"
+    );
+    assert!(
+        raw.contains("mcp-session-id:"),
+        "response should contain mcp-session-id header"
+    );
+    assert_ne!(
+        response_body, "backend",
+        "response should come from Praxis, not backend"
+    );
+}
+
+#[test]
+fn mcp_broker_tools_list_returns_prefixed_catalog() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "tools/list should return 200");
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("weather_get_weather"),
+        "should contain prefixed weather tool: {response_body}"
+    );
+    assert!(
+        response_body.contains("cal_create_event"),
+        "should contain prefixed calendar tool: {response_body}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&response_body).unwrap();
+    let tools = parsed["result"]["tools"].as_array().unwrap();
+    assert!(
+        tools.iter().all(|tool| tool.get("inputSchema").is_some()),
+        "every returned tool should include inputSchema: {response_body}"
+    );
+    assert_eq!(
+        tools[1]["inputSchema"],
+        serde_json::json!({"type": "object", "additionalProperties": false}),
+        "tools without configured schema should get a closed object inputSchema"
+    );
+    assert_ne!(
+        response_body, "backend",
+        "response should come from Praxis, not backend"
+    );
+}
+
+#[test]
+fn mcp_broker_example_serves_prefixed_catalog() {
+    let weather_guard = start_backend_with_shutdown("weather");
+    let calendar_guard = start_backend_with_shutdown("calendar");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "payload-processing/mcp-static-catalog.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", weather_guard.port()),
+            ("127.0.0.1:3002", calendar_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/mcp", r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "tools/list should return 200");
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("weather_get_weather"),
+        "weather tool should include prefix: {body}"
+    );
+    assert!(
+        body.contains("weather_forecast"),
+        "weather forecast should include prefix: {body}"
+    );
+    assert!(
+        body.contains("cal_create_event"),
+        "calendar create tool should include prefix: {body}"
+    );
+    assert!(
+        body.contains("cal_list_events"),
+        "calendar list tool should include prefix: {body}"
+    );
+    assert!(
+        body.contains(r#""city""#),
+        "example inputSchema should be preserved: {body}"
+    );
+}
+
+#[test]
+fn mcp_broker_ping_returns_result() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":5,"method":"ping"}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "ping should return 200");
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains(r#""result":{}"#),
+        "ping should return empty result: {response_body}"
+    );
+    assert!(
+        response_body.contains(r#""id":5"#),
+        "ping should preserve numeric id: {response_body}"
+    );
+}
+
+#[test]
+fn mcp_broker_initialized_notification_returns_202() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 202, "notifications/initialized should return 202");
+    assert_eq!(
+        parse_body(&raw),
+        "",
+        "accepted notifications should not include a JSON-RPC response body"
+    );
+}
+
+#[test]
+fn mcp_broker_ping_with_null_id_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":null,"method":"ping"}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "null request ids should return JSON-RPC errors"
+    );
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("-32600"),
+        "null request ids should return invalid request: {response_body}"
+    );
+    assert!(
+        response_body.contains(r#""id":null"#),
+        "invalid id response should use null id: {response_body}"
+    );
+}
+
+#[test]
+fn mcp_broker_ping_with_missing_id_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","method":"ping"}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "request methods without ids should return JSON-RPC errors"
+    );
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("-32600"),
+        "missing request ids should return invalid request: {response_body}"
+    );
+}
+
+#[test]
+fn mcp_broker_unsupported_method_returns_method_not_found() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":7,"method":"resources/list"}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "unsupported method should return a JSON-RPC error response"
+    );
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("-32601"),
+        "unsupported method should return -32601: {response_body}"
+    );
+}
+
+#[test]
+fn mcp_broker_tools_call_not_forwarded_before_routing() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body =
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"weather_get_weather","arguments":{}}}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    let status = parse_status(&raw);
+    let response_body = parse_body(&raw);
+
+    assert_eq!(
+        status, 200,
+        "tools/call should return a JSON-RPC error response before backend routing is added"
+    );
+    assert!(
+        response_body.contains("-32601"),
+        "tools/call should return -32601 before backend routing is added: {response_body}"
+    );
+    assert!(
+        !response_body.contains("not-reachable-backend"),
+        "tools/call must not reach the backend before routing is added"
+    );
+}
+
+#[test]
+fn mcp_broker_delete_returns_controlled_response() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "DELETE /mcp HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Mcp-Session-Id: mcp-test-session\r\n\
+         Connection: close\r\n\
+         \r\n"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 204, "DELETE with session should return 204");
+}
+
+#[test]
+fn mcp_broker_wrong_path_returns_404() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let request = json_post("/not-mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 404, "POST to /not-mcp should return 404");
+    assert!(
+        !parse_body(&raw).contains("backend"),
+        "wrong-path request must not reach backend"
+    );
+}
+
+#[test]
+fn mcp_broker_ping_with_query_param() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":9,"method":"ping"}"#;
+    let request = json_post("/mcp?x=1", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "POST /mcp?x=1 should match configured MCP path"
+    );
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains(r#""result":{}"#),
+        "ping should return empty result: {response_body}"
+    );
+    assert!(
+        !response_body.contains("not-reachable-backend"),
+        "query-param request must not reach backend"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Stateless Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_stateless_server_discover_returns_200() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(1, "server/discover", None);
+    let request = stateless_post("/mcp", body_str, "server/discover", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "server/discover should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["result"]["resultType"], "complete");
+    assert!(parsed["result"]["supportedVersions"].is_array());
+    assert!(parsed["result"]["ttlMs"].is_number());
+    assert_eq!(parsed["result"]["cacheScope"], "public");
+    assert_eq!(parsed["result"]["serverInfo"]["name"], "praxis");
+    assert!(
+        parsed["result"]["serverInfo"]["version"].is_string(),
+        "serverInfo must include version"
+    );
+    assert!(
+        !raw.contains("mcp-session-id:"),
+        "stateless server/discover must not return session header"
+    );
+    assert!(
+        !body.contains("not-reachable-backend"),
+        "server/discover must not contact backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_list_returns_catalog_with_cache_metadata() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(2, "tools/list", None);
+    let request = stateless_post("/mcp", body_str, "tools/list", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "stateless tools/list should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["result"]["resultType"], "complete");
+    assert!(parsed["result"]["ttlMs"].is_number());
+    assert_eq!(parsed["result"]["cacheScope"], "public");
+    assert!(parsed["result"]["tools"].is_array());
+    assert!(body.contains("weather_get_weather"), "should include prefixed tools");
+    assert!(
+        !raw.contains("mcp-session-id:"),
+        "stateless response must not include session header"
+    );
+    assert!(
+        !body.contains("not-reachable-backend"),
+        "tools/list must not contact backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_returns_unsupported_after_header_validation() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(3, "tools/call", Some(r#""name":"weather_get_weather","arguments":{}"#));
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("weather_get_weather"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        404,
+        "stateless tools/call should return 404 per draft Streamable HTTP"
+    );
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed["error"]["code"], -32601,
+        "should return method not yet supported"
+    );
+    assert!(
+        !body.contains("not-reachable-backend"),
+        "tools/call must not hit backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_missing_mcp_method_rejects_with_400_32020() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_rpc_body(4, "ping", None);
+    let request = format!(
+        "POST /mcp HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         MCP-Protocol-Version: 2026-07-28\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body_str}",
+        body_str.len(),
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 400, "missing Mcp-Method should return 400");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["error"]["code"], -32020, "should return -32020 header mismatch");
+}
+
+#[test]
+fn mcp_stateless_notifications_initialized_rejects_with_404_32601() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_notification_body("notifications/initialized");
+    let request = stateless_post("/mcp", &body_str, "notifications/initialized", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        404,
+        "stateless notifications/initialized should be removed with the initialize handshake"
+    );
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["error"]["code"], -32601, "should return method not found");
+    assert!(
+        !body.contains("not-reachable-backend"),
+        "stateless notifications/initialized must not hit backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_unsupported_version_rejects_with_400_32022() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_rpc_body_with_version(5, "ping", "9999-12-31");
+    let request = format!(
+        "POST /mcp HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         MCP-Protocol-Version: 9999-12-31\r\n\
+         Mcp-Method: ping\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body_str}",
+        body_str.len(),
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 400, "unsupported version should return 400");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed["error"]["code"], -32022,
+        "should return -32022 unsupported version"
+    );
+    assert!(
+        parsed["error"]["data"]["supported"].is_array(),
+        "should include supported list"
+    );
+    assert!(
+        parsed["error"]["data"]["requested"].is_string(),
+        "should include requested version"
+    );
+}
+
+#[test]
+fn mcp_stateless_malformed_client_info_rejected() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = r#"{"jsonrpc":"2.0","id":6,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":"not-an-object","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let request = stateless_post("/mcp", body_str, "ping", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 400, "malformed clientInfo should return 400");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["error"]["code"], -32020, "should return -32020 header mismatch");
+}
+
+#[test]
+fn mcp_current_initialize_still_returns_session_header() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}}"#;
+    let request = json_post("/mcp", body);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "current initialize should return 200");
+    assert!(
+        raw.contains("mcp-session-id:"),
+        "current profile initialize must still return session header"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Stateless request metadata fragment for `params._meta`.
+const STATELESS_META: &str = concat!(
+    r#""_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","#,
+    r#""io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"#,
+    r#""io.modelcontextprotocol/clientCapabilities":{}}"#,
+);
+
+fn stateless_rpc_body(id: u64, method: &str, extra_params: Option<&str>) -> String {
+    let extra = extra_params.map_or(String::new(), |p| format!(",{p}"));
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{{STATELESS_META}{extra}}}}}"#)
+}
+
+fn stateless_notification_body(method: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","method":"{method}","params":{{{STATELESS_META}}}}}"#)
+}
+
+fn stateless_rpc_body_with_version(id: u64, method: &str, version: &str) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{"_meta":{{"io.modelcontextprotocol/protocolVersion":"{version}","io.modelcontextprotocol/clientInfo":{{"name":"test","version":"1.0"}},"io.modelcontextprotocol/clientCapabilities":{{}}}}}}}}"#,
+    )
+}
+
+fn json_post(path: &str, body: &str) -> String {
+    format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    )
+}
+
+fn stateless_post(path: &str, body: &str, method: &str, mcp_name: Option<&str>) -> String {
+    let mut headers = format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         MCP-Protocol-Version: 2026-07-28\r\n\
+         Mcp-Method: {method}\r\n",
+        body.len(),
+    );
+    if let Some(name) = mcp_name {
+        headers.push_str(&format!("Mcp-Name: {name}\r\n"));
+    }
+    headers.push_str("Connection: close\r\n\r\n");
+    headers.push_str(body);
+    headers
+}
+
+fn broker_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        path: /mcp
+        max_body_bytes: 65536
+        servers:
+          - name: weather
+            cluster: weather-mcp
+            path: /mcp
+            tool_prefix: "weather_"
+            tools:
+              - name: get_weather
+                description: Get current weather
+          - name: calendar
+            cluster: calendar-mcp
+            path: /mcp
+            tool_prefix: "cal_"
+            tools:
+              - name: create_event
+                description: Create a calendar event
+      - filter: load_balancer
+        clusters:
+          - name: weather-mcp
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+          - name: calendar-mcp
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn stateless_broker_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        path: /mcp
+        max_body_bytes: 65536
+        protocol_profile: stateless
+        servers:
+          - name: weather
+            cluster: weather-mcp
+            path: /mcp
+            tool_prefix: "weather_"
+            tools:
+              - name: get_weather
+                description: Get current weather
+          - name: calendar
+            cluster: calendar-mcp
+            path: /mcp
+            tool_prefix: "cal_"
+            tools:
+              - name: create_event
+                description: Create a calendar event
+      - filter: load_balancer
+        clusters:
+          - name: weather-mcp
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+          - name: calendar-mcp
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}

--- a/tests/utils/src/example_config.rs
+++ b/tests/utils/src/example_config.rs
@@ -48,8 +48,7 @@ pub fn load_example_config(filename: &str, listener_port: u16, port_map: HashMap
 /// # Examples
 ///
 /// ```
-/// let path =
-///     praxis_test_utils::example_config_path("model-to-header-routing.yaml");
+/// let path = praxis_test_utils::example_config_path("model-to-header-routing.yaml");
 /// assert!(path.contains("examples/configs/"));
 /// ```
 pub fn example_config_path(filename: &str) -> String {


### PR DESCRIPTION
## Summary

 Adds an opt-in MCP stateless broker profile targeting the upcoming [2026-07-28 release candidate](https://modelcontextprotocol.io/specification/draft), while preserving the existing session-based MCP broker as the default. The profile-based configuration can add explicitly implemented session-based or legacy HTTP+SSE MCP support later, while keeping each supported version and its transport semantics independently selectable. We may want to drop legacy support once stateless is GA, but either way, having a swappable profile is a clean approach.

  The implementation centralizes MCP version and profile handling so future finalized MCP versions can be added as explicit supported profiles without redesigning broker configuration or request dispatch. Configuration cannot enable arbitrary version strings: a version must be implemented and registered with its corresponding protocol behavior.

  This PR adds:

  - `current` and `stateless` MCP protocol profiles
  - Centralized profile-specific default and supported protocol versions
  - Profile/version config validation that rejects unsupported or cross-profile versions
  - Stateless `server/discover` capability discovery
  - Stateless `tools/list` responses with cache metadata
  - Required stateless request validation for `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name`
  - Validation that standard headers match the JSON-RPC body and `params._meta` metadata
  - Stateless validation of `clientInfo` and `clientCapabilities`
  - Controlled errors for header mismatches, unsupported versions, and unsupported methods
  - Stateless behavior with no `initialize` session handshake, no `Mcp-Session-Id`, and `DELETE` rejected
  - Existing current-profile behavior retained as the default, including session-based `initialize`
  - Stateless broker example configuration, generated filter documentation, unit tests, integration tests, and example-config coverage

  ## Profiles

  MCP protocol versions change more than a version string. The `2026-07-28` profile changes request metadata, discovery, session behavior, and cache semantics.

  `ProtocolProfile` keeps those behaviors tied to the version they implement. Adding a future MCP version means defining its supported version set and protocol semantics in one place, rather than accepting a configured string that the broker cannot actually serve correctly.

  ## Scope

  This PR implements the static broker portion of the `2026-07-28` stateless profile.

  The existing `current` profile remains the default for compatibility. It continues to support the established session-based broker behavior.

  This does not yet add:

  - Backend `tools/call` forwarding
  - Tool-prefix lookup or prefix stripping
  - Backend path rewrite or multi-backend tool routing
  - Dynamic catalog discovery or subscriptions
  - `Mcp-Param-*` / `x-mcp-*` validation
  - Shared distributed broker state

  ## Validation:
  - `cargo test -p praxis-ai-filters a2a`
  - `cargo clippy -p praxis-ai-filters -- -D warnings`
  - `cargo +nightly fmt --all --check`
  - `cargo xtask lint-example-tests`
  - `git diff --check`

  Refs praxis-proxy/ai#148