### PR TITLE
feat(conversations): rehydrate and append via conversation.id

### DIFF
--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -453,9 +453,7 @@ impl HttpFilter for OpenaiConversationsFilter {
         };
 
         let conv_id = items.conversation_id;
-        if let Err(e) = self.append_items_blocking(&items.tenant_id, &conv_id, ctx, items.all_items) {
-            warn!(error = %e, conversation_id = %conv_id, "conversation append-back failed");
-        }
+        self.append_items_blocking(&items.tenant_id, &conv_id, ctx, items.all_items)?;
 
         Ok(FilterAction::Continue)
     }

--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -311,7 +311,11 @@ impl HttpFilter for OpenaiConversationsFilter {
         true
     }
 
-    #[expect(clippy::too_many_lines, reason = "dispatcher with one arm per endpoint")]
+    #[expect(
+        clippy::large_stack_frames,
+        clippy::too_many_lines,
+        reason = "dispatcher with one arm per endpoint"
+    )]
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
         let path = ctx.request.uri.path();
         let path = path.strip_suffix('/').filter(|p| !p.is_empty()).unwrap_or(path);

--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -15,14 +15,18 @@ use praxis_filter::{
     parse_filter_config,
 };
 use secrecy::ExposeSecret as _;
+use serde_json::Value;
 use tokio::sync::OnceCell;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use super::{
     config::{ConversationsConfig, StorageBackend, revalidate_postgres_host, validate_config},
     handlers,
 };
-use crate::store::{ConversationItemStore, PostgresResponseStore, SqliteResponseStore, StoreError};
+use crate::{
+    openai::responses::{DEFAULT_TENANT_ID, TENANT_METADATA_KEY, state::ResponsesState},
+    store::{ConversationItemStore, ConversationRecord, PostgresResponseStore, SqliteResponseStore, StoreError},
+};
 
 // -----------------------------------------------------------------------------
 // OpenaiConversationsFilter
@@ -58,6 +62,13 @@ struct ConversationRequestState {
 
     /// Full body captured by an early pre-read pass.
     deferred_body: Option<Bytes>,
+}
+
+/// Per-request response-phase state that controls whether append-back
+/// should run during `on_response_body`.
+struct ConversationResponseState {
+    /// Whether response body buffering is armed for append-back.
+    armed: bool,
 }
 
 /// Matched POST route variants handled locally.
@@ -244,6 +255,26 @@ impl OpenaiConversationsFilter {
             PostRoute::CreateItems(id) => handlers::handle_create_items(ctx, store, id, body).await,
         }
     }
+
+    /// Persist conversation items synchronously using `block_in_place`.
+    fn append_items_blocking(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+        ctx: &HttpFilterContext<'_>,
+        items: Vec<Value>,
+    ) -> Result<(), FilterError> {
+        let store = self
+            .store
+            .get()
+            .and_then(Option::as_ref)
+            .ok_or_else(|| FilterError::from("openai_conversations: store unavailable for append-back"))?;
+
+        let handle = tokio::runtime::Handle::current();
+        tokio::task::block_in_place(|| {
+            handle.block_on(persist_items(store.as_ref(), tenant_id, conversation_id, ctx, items))
+        })
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -260,10 +291,24 @@ impl HttpFilter for OpenaiConversationsFilter {
         BodyAccess::ReadOnly
     }
 
+    fn response_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
     fn request_body_mode(&self) -> BodyMode {
         BodyMode::StreamBuffer {
             max_bytes: Some(MAX_JSON_BODY_BYTES),
         }
+    }
+
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(MAX_JSON_BODY_BYTES),
+        }
+    }
+
+    fn needs_request_context(&self) -> bool {
+        true
     }
 
     #[expect(clippy::too_many_lines, reason = "dispatcher with one arm per endpoint")]
@@ -309,7 +354,12 @@ impl HttpFilter for OpenaiConversationsFilter {
                 };
                 Box::pin(Self::handle_post_route(ctx, store.as_ref(), route, &body)).await
             },
-            _ => Ok(FilterAction::Continue),
+            _ => {
+                if should_append_back(ctx) {
+                    drop(self.get_or_init_store().await);
+                }
+                Ok(FilterAction::Continue)
+            },
         }
     }
 
@@ -342,6 +392,199 @@ impl HttpFilter for OpenaiConversationsFilter {
             return Ok(FilterAction::Reject(reject_store_unavailable()));
         };
         Box::pin(Self::handle_post_route(ctx, store.as_ref(), route, bytes)).await
+    }
+
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if !should_append_back(ctx) {
+            ctx.insert_filter_state(ConversationResponseState { armed: false });
+            return Ok(FilterAction::Continue);
+        }
+
+        let resp = ctx.response_header.as_ref();
+        let is_success = resp.is_none_or(|r| r.status.is_success());
+        let is_json = resp
+            .and_then(|r| r.headers.get(http::header::CONTENT_TYPE))
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|ct| {
+                ct.split(';')
+                    .next()
+                    .unwrap_or_default()
+                    .trim()
+                    .eq_ignore_ascii_case("application/json")
+            });
+
+        let armed = is_success && is_json;
+        if !armed {
+            trace!("conversation append-back skipped (non-2xx or non-JSON response)");
+        }
+        ctx.insert_filter_state(ConversationResponseState { armed });
+
+        if armed {
+            drop(self.get_or_init_store().await);
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let armed = ctx
+            .get_filter_state::<ConversationResponseState>()
+            .is_some_and(|s| s.armed);
+
+        if !armed {
+            return Ok(FilterAction::Release);
+        }
+
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let Some(items) = extract_append_back_items(ctx, body) else {
+            return Ok(FilterAction::Continue);
+        };
+
+        let conv_id = items.conversation_id;
+        if let Err(e) = self.append_items_blocking(&items.tenant_id, &conv_id, ctx, items.all_items) {
+            warn!(error = %e, conversation_id = %conv_id, "conversation append-back failed");
+        }
+
+        Ok(FilterAction::Continue)
+    }
+}
+
+/// Whether this request should trigger conversation append-back on
+/// the response path.
+fn should_append_back(ctx: &HttpFilterContext<'_>) -> bool {
+    ctx.get_metadata("openai_responses_format.has_conversation") == Some("true")
+        && ctx.get_metadata("responses.conversation_id").is_some()
+        && ctx.get_metadata("openai_responses_format.stream") != Some("true")
+        && ctx.get_metadata("openai_responses_format.background") != Some("true")
+}
+
+// -----------------------------------------------------------------------------
+// Append-Back
+// -----------------------------------------------------------------------------
+
+/// Collected items for append-back persistence.
+struct AppendBackItems {
+    /// Target conversation ID.
+    conversation_id: String,
+    /// Tenant scope for the conversation.
+    tenant_id: String,
+    /// Input + output items to persist.
+    all_items: Vec<Value>,
+}
+
+/// Extract and merge input+output items from the response body for
+/// append-back. Returns `None` when there is nothing to persist.
+fn extract_append_back_items(ctx: &HttpFilterContext<'_>, body: &Option<Bytes>) -> Option<AppendBackItems> {
+    let bytes = body.as_ref().filter(|b| !b.is_empty())?;
+    let conv_id = ctx.get_metadata("responses.conversation_id")?.to_owned();
+    let tenant_id = ctx
+        .get_metadata(TENANT_METADATA_KEY)
+        .unwrap_or(DEFAULT_TENANT_ID)
+        .to_owned();
+
+    let all_items = merge_input_output_items(ctx, bytes)?;
+
+    Some(AppendBackItems {
+        conversation_id: conv_id,
+        tenant_id,
+        all_items,
+    })
+}
+
+/// Parse the response body and combine request input items with
+/// response output items. Returns `None` when both are empty.
+fn merge_input_output_items(ctx: &HttpFilterContext<'_>, bytes: &[u8]) -> Option<Vec<Value>> {
+    let response_json: Value = match serde_json::from_slice(bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "conversation append-back: invalid response JSON");
+            return None;
+        },
+    };
+
+    let status = response_json.get("status").and_then(Value::as_str).unwrap_or_default();
+    if status != "completed" {
+        trace!(status, "conversation append-back skipped (response not completed)");
+        return None;
+    }
+
+    let output_items = response_json
+        .get("output")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let input_items = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .map(|state| state.input.clone())
+        .unwrap_or_default();
+
+    if input_items.is_empty() && output_items.is_empty() {
+        return None;
+    }
+
+    let mut all_items = input_items;
+    all_items.extend(output_items);
+    Some(all_items)
+}
+
+/// Persist items and refresh the denormalized message cache.
+async fn persist_items(
+    store: &dyn ConversationItemStore,
+    tenant_id: &str,
+    conversation_id: &str,
+    ctx: &HttpFilterContext<'_>,
+    items: Vec<Value>,
+) -> Result<(), FilterError> {
+    let max_pos = store
+        .max_item_position(tenant_id, conversation_id)
+        .await
+        .map_err(|e| -> FilterError { Box::new(e) })?;
+    let start_position = max_pos.saturating_add(1);
+    let created_at = handlers::current_timestamp(ctx);
+
+    let records = handlers::build_item_records(ctx, tenant_id, conversation_id, created_at, start_position, items)
+        .map_err(|e| -> FilterError { e.into() })?;
+
+    if records.is_empty() {
+        return Ok(());
+    }
+
+    let count = records.len();
+    store
+        .create_conversation_items(&records)
+        .await
+        .map_err(|e| -> FilterError { Box::new(e) })?;
+
+    refresh_message_cache(store, tenant_id, conversation_id).await;
+    debug!(
+        conversation_id,
+        tenant_id, count, "conversation items appended from response"
+    );
+
+    Ok(())
+}
+
+/// Refresh the denormalized conversation message cache after item mutation.
+async fn refresh_message_cache(store: &dyn ConversationItemStore, tenant_id: &str, conversation_id: &str) {
+    let record = ConversationRecord {
+        conversation_id: conversation_id.to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        created_at: 0,
+        metadata: Value::Object(serde_json::Map::default()),
+        messages: Value::Null,
+    };
+    if let Err(e) = handlers::sync_conversation_messages(store, record).await {
+        warn!(error = %e, conversation_id, "conversation message sync failed after append-back");
     }
 }
 

--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -453,7 +453,9 @@ impl HttpFilter for OpenaiConversationsFilter {
         };
 
         let conv_id = items.conversation_id;
-        self.append_items_blocking(&items.tenant_id, &conv_id, ctx, items.all_items)?;
+        if let Err(e) = self.append_items_blocking(&items.tenant_id, &conv_id, ctx, items.all_items) {
+            warn!(error = %e, conversation_id = %conv_id, "conversation append-back failed");
+        }
 
         Ok(FilterAction::Continue)
     }

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -484,7 +484,7 @@ fn duplicate_item_id(items: &[ConversationItemRecord]) -> Option<&str> {
 
 /// Build store records for normalized conversation item JSON values.
 #[expect(clippy::too_many_arguments, reason = "factoring into struct would add indirection")]
-fn build_item_records(
+pub(super) fn build_item_records(
     ctx: &HttpFilterContext<'_>,
     tenant_id: &str,
     conversation_id: &str,
@@ -511,7 +511,7 @@ fn build_item_records(
 }
 
 /// Ensure an item is an object and has a usable ID.
-fn normalize_item(ctx: &HttpFilterContext<'_>, item: Value) -> Result<(String, Value), String> {
+pub(super) fn normalize_item(ctx: &HttpFilterContext<'_>, item: Value) -> Result<(String, Value), String> {
     let Value::Object(mut map) = item else {
         return Err("each item must be a JSON object".to_owned());
     };
@@ -573,7 +573,7 @@ fn normalize_message_content(role: &str, content: Value) -> Result<Value, String
 }
 
 /// Generate a conversation item ID.
-fn generated_item_id(ctx: &HttpFilterContext<'_>) -> String {
+pub(super) fn generated_item_id(ctx: &HttpFilterContext<'_>) -> String {
     let raw_id = ctx.id_generator.generate(ctx.time_source);
     format!("item_{raw_id}")
 }
@@ -648,7 +648,7 @@ fn decode_query_component(value: &str) -> String {
 }
 
 /// Return the current Unix timestamp as an `i64`.
-fn current_timestamp(ctx: &HttpFilterContext<'_>) -> i64 {
+pub(super) fn current_timestamp(ctx: &HttpFilterContext<'_>) -> i64 {
     i64::try_from(ctx.time_source.now().as_secs()).unwrap_or(i64::MAX)
 }
 
@@ -739,7 +739,7 @@ fn store_error_response(error: &StoreError) -> Result<Rejection, FilterError> {
 /// Re-reads all items on every mutation rather than patching the JSON
 /// array incrementally. Acceptable because conversations hold a small
 /// number of items; incremental updates would risk drift.
-async fn sync_conversation_messages(
+pub(super) async fn sync_conversation_messages(
     store: &dyn ConversationItemStore,
     record: ConversationRecord,
 ) -> Result<(), StoreError> {

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -11,7 +11,10 @@ use super::{
     filter::OpenaiConversationsFilter,
     validate::validate_metadata,
 };
-use crate::test_utils::{make_filter_context, make_request};
+use crate::{
+    openai::responses::state::ResponsesState,
+    test_utils::{make_filter_context, make_request, make_response},
+};
 
 fn rejection_body(rejection: &praxis_filter::Rejection) -> Value {
     serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap()
@@ -2772,6 +2775,272 @@ async fn patch_on_conversation_path_continues() {
     let mut ctx = make_filter_context(&req);
     let action = filter.on_request(&mut ctx).await.unwrap();
     assert!(matches!(action, FilterAction::Continue), "PATCH should not be handled");
+}
+
+// -----------------------------------------------------------------------------
+// Append-Back: on_response
+// -----------------------------------------------------------------------------
+
+fn set_append_back_metadata(ctx: &mut praxis_filter::HttpFilterContext<'_>) {
+    ctx.set_metadata("openai_responses_format.has_conversation", "true");
+    ctx.set_metadata("responses.conversation_id", "conv_test_123");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_not_armed_without_conversation_metadata() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_not_armed_when_streaming() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+    ctx.set_metadata("openai_responses_format.stream", "true");
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_not_armed_when_background() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+    ctx.set_metadata("openai_responses_format.background", "true");
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_not_armed_for_non_2xx() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.status = http::StatusCode::INTERNAL_SERVER_ERROR;
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_not_armed_for_non_json_content_type() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_armed_for_json_200() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+// -----------------------------------------------------------------------------
+// Append-Back: on_response_body
+// -----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_releases_when_not_armed() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let mut body = Some(Bytes::from_static(b"{}"));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(matches!(action, FilterAction::Release));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_continues_when_not_end_of_stream() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let mut body = Some(Bytes::from_static(b"partial"));
+    let action = filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_skips_non_completed_status() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let response_json = serde_json::json!({
+        "status": "failed",
+        "output": [{"type": "message", "role": "assistant", "content": "oops"}]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&response_json).unwrap()));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_skips_invalid_json() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let mut body = Some(Bytes::from_static(b"{not-json"));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_skips_empty_items() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let response_json = serde_json::json!({
+        "status": "completed",
+        "output": []
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&response_json).unwrap()));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_skips_empty_body() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    set_append_back_metadata(&mut ctx);
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let mut body: Option<Bytes> = None;
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_body_appends_completed_response() {
+    let filter = build_test_filter();
+    let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({})).await;
+
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    ctx.set_metadata("openai_responses_format.has_conversation", "true");
+    ctx.set_metadata("responses.conversation_id", &conv_id);
+
+    let input_items = vec![serde_json::json!({
+        "type": "message",
+        "role": "user",
+        "content": "hello from append"
+    })];
+    ctx.extensions.insert(ResponsesState {
+        input: input_items,
+        ..ResponsesState::default()
+    });
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut resp = make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let response_json = serde_json::json!({
+        "status": "completed",
+        "output": [{"type": "message", "role": "assistant", "content": "hi from model"}]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&response_json).unwrap()));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let req = make_request(Method::GET, &format!("/v1/conversations/{conv_id}/items?order=asc"));
+    let mut ctx = make_filter_context(&req);
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject from list items after append-back");
+    };
+    assert_eq!(rejection.status, 200);
+    let resp = rejection_body(&rejection);
+    let items = resp["data"].as_array().unwrap();
+    assert_eq!(items.len(), 2, "append-back should persist both input and output items");
 }
 
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/proxy/mod.rs
+++ b/apis/src/openai/responses/proxy/mod.rs
@@ -168,6 +168,7 @@ impl HttpFilter for ResponsesProxyFilter {
         }
 
         let Some(state) = ctx.extensions.get::<ResponsesState>() else {
+            strip_conversation_field(body);
             debug!("no ResponsesState in extensions, passthrough");
             return Ok(FilterAction::Continue);
         };
@@ -190,9 +191,29 @@ impl HttpFilter for ResponsesProxyFilter {
     }
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Helpers
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+/// Defensively strip `conversation` from a passthrough body so it never
+/// leaks to the backend even when no [`ResponsesState`] was produced.
+fn strip_conversation_field(body: &mut Option<Bytes>) {
+    let Some(bytes) = body.as_ref() else {
+        return;
+    };
+    let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return;
+    };
+    if parsed
+        .as_object_mut()
+        .is_some_and(|obj| obj.remove("conversation").is_some())
+    {
+        debug!("stripped conversation from passthrough body");
+        if let Ok(serialized) = serde_json::to_vec(&parsed) {
+            *body = Some(Bytes::from(serialized));
+        }
+    }
+}
 
 /// Build the outbound JSON body from conversation state.
 fn rebuild_outbound_body(state: &ResponsesState) -> serde_json::Value {

--- a/apis/src/openai/responses/proxy/mod.rs
+++ b/apis/src/openai/responses/proxy/mod.rs
@@ -109,14 +109,7 @@ impl ResponsesProxyFilter {
         state: &ResponsesState,
         streaming: bool,
     ) -> Result<Result<Vec<u8>, FilterAction>, FilterError> {
-        let mut outbound = state.request_body.clone();
-        if let Some(obj) = outbound.as_object_mut() {
-            obj.insert("input".to_owned(), serde_json::Value::Array(state.messages.clone()));
-            if obj.remove("previous_response_id").is_some() {
-                debug!("stripped previous_response_id from outbound body");
-            }
-        }
-
+        let outbound = rebuild_outbound_body(state);
         let serialized =
             serde_json::to_vec(&outbound).map_err(|e| -> FilterError { format!("responses_proxy: {e}").into() })?;
         if serialized.len() > self.config.max_body_bytes {
@@ -195,4 +188,23 @@ impl HttpFilter for ResponsesProxyFilter {
 
         Ok(FilterAction::Continue)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build the outbound JSON body from conversation state.
+fn rebuild_outbound_body(state: &ResponsesState) -> serde_json::Value {
+    let mut outbound = state.request_body.clone();
+    if let Some(obj) = outbound.as_object_mut() {
+        obj.insert("input".to_owned(), serde_json::Value::Array(state.messages.clone()));
+        if obj.remove("previous_response_id").is_some() {
+            debug!("stripped previous_response_id from outbound body");
+        }
+        if obj.remove("conversation").is_some() {
+            debug!("stripped conversation from outbound body");
+        }
+    }
+    outbound
 }

--- a/apis/src/openai/responses/proxy/tests.rs
+++ b/apis/src/openai/responses/proxy/tests.rs
@@ -258,6 +258,66 @@ async fn rejects_oversized_rebuilt_body_with_413() {
     );
 }
 
+#[tokio::test]
+async fn strips_conversation_from_outbound_body() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+
+    let request_body = json!({
+        "model": "gpt-4o",
+        "input": "hello",
+        "conversation": {"id": "conv_abc123"}
+    });
+    let state = ResponsesState::from_request_body(request_body);
+    ctx.extensions.insert(state);
+
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4o","input":"hello","conversation":{"id":"conv_abc123"}}"#,
+    ));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let rebuilt: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert!(
+        rebuilt.get("conversation").is_none(),
+        "conversation should be stripped from outbound body"
+    );
+    assert_eq!(rebuilt["model"], "gpt-4o");
+}
+
+#[tokio::test]
+async fn strips_both_previous_response_id_and_conversation() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+
+    let request_body = json!({
+        "model": "gpt-4o",
+        "input": "hello",
+        "previous_response_id": "resp_abc123",
+        "conversation": "conv_xyz789"
+    });
+    let mut state = ResponsesState::from_request_body(request_body);
+    state
+        .messages
+        .splice(0..0, vec![json!({"role": "user", "content": "stored"})]);
+    ctx.extensions.insert(state);
+
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4o","input":"hello","previous_response_id":"resp_abc123","conversation":"conv_xyz789"}"#,
+    ));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let rebuilt: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert!(
+        rebuilt.get("previous_response_id").is_none(),
+        "previous_response_id should be stripped"
+    );
+    assert!(rebuilt.get("conversation").is_none(), "conversation should be stripped");
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/proxy/tests.rs
+++ b/apis/src/openai/responses/proxy/tests.rs
@@ -318,6 +318,24 @@ async fn strips_both_previous_response_id_and_conversation() {
     assert!(rebuilt.get("conversation").is_none(), "conversation should be stripped");
 }
 
+#[tokio::test]
+async fn passthrough_strips_conversation_from_body() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let mut body = Some(Bytes::from(r#"{"model":"gpt-4.1","input":"hello","conversation":42}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let parsed: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert!(
+        parsed.get("conversation").is_none(),
+        "conversation should be stripped even without ResponsesState"
+    );
+    assert_eq!(parsed["model"], "gpt-4.1", "other fields should be preserved");
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -26,7 +26,7 @@ use tracing::{debug, trace, warn};
 use super::{
     DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, error::responses_error_rejection, state::ResponsesState,
 };
-use crate::store::{ResponseRecord, ResponseStoreRegistry};
+use crate::store::{ConversationRecord, ResponseRecord, ResponseStoreRegistry};
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -133,7 +133,7 @@ impl HttpFilter for RehydrateFilter {
             .get_metadata("openai_responses_format.stream")
             .is_some_and(|v| v == "true");
 
-        validate_previous_response(ctx, body, streaming).await
+        rehydrate(ctx, body, streaming).await
     }
 }
 
@@ -151,9 +151,13 @@ fn is_responses_cancel_path(path: &str) -> bool {
     !response_id.is_empty() && !response_id.contains('/')
 }
 
-/// Parse body, fetch stored response, validate status,
-/// populate [`ResponsesState`], and promote metadata.
-async fn validate_previous_response(
+/// Parse body, resolve rehydration source (`previous_response_id` or
+/// `conversation`), and populate [`ResponsesState`] with the full
+/// conversation history.
+///
+/// `previous_response_id` takes precedence when both fields are
+/// present.
+async fn rehydrate(
     ctx: &mut HttpFilterContext<'_>,
     body: &Option<Bytes>,
     streaming: bool,
@@ -164,7 +168,7 @@ async fn validate_previous_response(
 
     let (parsed_body, prev_id) = match parse_body_and_extract_id(bytes, streaming) {
         Ok((body, Some(id))) => (body, id),
-        Ok((_, None)) => return Ok(FilterAction::Release),
+        Ok((body, None)) => return rehydrate_from_conversation(ctx, body, streaming).await,
         Err(action) => return Ok(action),
     };
 
@@ -188,6 +192,85 @@ async fn validate_previous_response(
     ctx.set_metadata("responses.previous_response_id", prev_id);
 
     Ok(FilterAction::Release)
+}
+
+/// Rehydrate from a stored conversation when no `previous_response_id`
+/// is present.
+async fn rehydrate_from_conversation(
+    ctx: &mut HttpFilterContext<'_>,
+    parsed_body: Value,
+    streaming: bool,
+) -> Result<FilterAction, FilterError> {
+    let Some(conv_id) = extract_conversation_id(&parsed_body) else {
+        return Ok(FilterAction::Release);
+    };
+
+    let tenant_id = ctx
+        .get_metadata(TENANT_METADATA_KEY)
+        .unwrap_or(DEFAULT_TENANT_ID)
+        .to_owned();
+
+    let record = match fetch_conversation(ctx, &tenant_id, &conv_id, streaming).await {
+        Ok(r) => r,
+        Err(action) => return Ok(action),
+    };
+
+    let stored = conversation_messages_for_rehydrate(&record);
+    let replay = replay_messages_from_stored(&stored);
+    let mut state = ResponsesState::from_request_body(parsed_body);
+    state.messages.splice(0..0, replay);
+    state.persisted_messages.splice(0..0, stored);
+    ctx.extensions.insert(state);
+
+    debug!(conversation_id = %conv_id, "conversation rehydrated, state populated");
+
+    Ok(FilterAction::Release)
+}
+
+/// Extract a conversation ID from the request body.
+///
+/// Accepts both string and object forms:
+/// - `"conversation": "conv_abc"`
+/// - `"conversation": {"id": "conv_abc"}`
+fn extract_conversation_id(body: &Value) -> Option<String> {
+    body.get("conversation").and_then(|c| {
+        c.as_str()
+            .or_else(|| c.get("id").and_then(Value::as_str))
+            .map(ToOwned::to_owned)
+    })
+}
+
+/// Fetch a conversation record from the store.
+async fn fetch_conversation(
+    ctx: &HttpFilterContext<'_>,
+    tenant_id: &str,
+    conv_id: &str,
+    streaming: bool,
+) -> Result<ConversationRecord, FilterAction> {
+    let registry = ctx.extensions.get::<ResponseStoreRegistry>().ok_or_else(|| {
+        warn!("rehydrate: response store registry not available");
+        reject_server_error("response store is not available", streaming)
+    })?;
+
+    let store = registry.get(DEFAULT_STORE_NAME).ok_or_else(|| {
+        warn!("rehydrate: default response store not registered");
+        reject_server_error("response store is not available", streaming)
+    })?;
+
+    let record = store.get_conversation(tenant_id, conv_id).await.map_err(|e| {
+        warn!(error = %e, "rehydrate: failed to fetch conversation");
+        reject_server_error("failed to fetch conversation", streaming)
+    })?;
+
+    record.ok_or_else(|| {
+        debug!(id = %conv_id, "rehydrate: conversation not found");
+        reject_invalid(&format!("conversation '{conv_id}' not found"), streaming)
+    })
+}
+
+/// Extract messages from a conversation record for rehydration.
+fn conversation_messages_for_rehydrate(record: &ConversationRecord) -> Vec<Value> {
+    record.messages.as_array().cloned().unwrap_or_default()
 }
 
 /// Insert rehydrated request state and promote previous usage metadata.

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -201,7 +201,16 @@ async fn rehydrate_from_conversation(
     parsed_body: Value,
     streaming: bool,
 ) -> Result<FilterAction, FilterError> {
+    let has_conversation_field = parsed_body.get("conversation").is_some();
     let Some(conv_id) = extract_conversation_id(&parsed_body) else {
+        if has_conversation_field {
+            return Ok(FilterAction::Reject(responses_error_rejection(
+                400,
+                "invalid_request_error",
+                "invalid conversation value: expected a string ID or {\"id\": \"...\"}",
+                streaming,
+            )));
+        }
         return Ok(FilterAction::Release);
     };
 

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -648,6 +648,7 @@ async fn deduplicates_mcp_tools_independent_of_tool_order() {
     );
     let store = MockStore {
         records,
+        conversations: std::collections::HashMap::new(),
         should_fail: false,
     };
     let registry = setup_registry(store);
@@ -708,6 +709,7 @@ async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
     );
     let store = MockStore {
         records,
+        conversations: std::collections::HashMap::new(),
         should_fail: false,
     };
     let registry = setup_registry(store);
@@ -958,6 +960,7 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
     );
     let store = MockStore {
         records,
+        conversations: std::collections::HashMap::new(),
         should_fail: false,
     };
     let registry = setup_registry(store);
@@ -1014,11 +1017,253 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
 }
 
 // -----------------------------------------------------------------------------
+// Conversation Rehydration
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rehydrates_from_conversation_string_id() {
+    let messages = json!([
+        {"role": "user", "content": "turn one"},
+        {"role": "assistant", "content": "reply one"}
+    ]);
+    let store = MockStore::with_conversation("conv_abc", messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"turn two","conversation":"conv_abc"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after conversation rehydration"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated from conversation");
+    assert_eq!(
+        state.messages.len(),
+        3,
+        "messages should contain 2 stored + 1 current input"
+    );
+    assert_eq!(state.messages[0]["content"], "turn one", "first stored message");
+    assert_eq!(state.messages[1]["content"], "reply one", "second stored message");
+    assert_eq!(state.messages[2]["content"], "turn two", "current input should be last");
+
+    assert_eq!(
+        state.persisted_messages.len(),
+        3,
+        "persisted_messages should mirror messages for conversation rehydration"
+    );
+}
+
+#[tokio::test]
+async fn rehydrates_from_conversation_object_form() {
+    let messages = json!([
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"}
+    ]);
+    let store = MockStore::with_conversation("conv_obj", messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"follow up","conversation":{"id":"conv_obj"}}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after conversation object rehydration"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated from conversation object");
+    assert_eq!(
+        state.messages.len(),
+        3,
+        "messages should contain 2 stored + 1 current input"
+    );
+    assert_eq!(state.messages[0]["content"], "hello", "first stored message");
+    assert_eq!(
+        state.messages[2]["content"], "follow up",
+        "current input should be last"
+    );
+}
+
+#[tokio::test]
+async fn previous_response_id_takes_precedence_over_conversation() {
+    let response_messages = json!([
+        {"role": "user", "content": "from response"},
+        {"role": "assistant", "content": "response reply"}
+    ]);
+    let mut store = MockStore::with_completed_response("resp_win", json!("from response"), response_messages);
+    store.conversations.insert(
+        "conv_lose".to_owned(),
+        ConversationRecord {
+            conversation_id: "conv_lose".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1000,
+            metadata: json!({}),
+            messages: json!([
+                {"role": "user", "content": "from conversation"},
+                {"role": "assistant", "content": "conversation reply"}
+            ]),
+        },
+    );
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"next","previous_response_id":"resp_win","conversation":"conv_lose"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.messages[0]["content"], "from response",
+        "previous_response_id should take precedence over conversation"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.previous_response_id"),
+        Some("resp_win"),
+        "previous_response_id metadata should be set"
+    );
+}
+
+#[tokio::test]
+async fn rejects_when_conversation_not_found() {
+    let store = MockStore::empty();
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_missing"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => assert_eq!(r.status, 400, "missing conversation should reject with 400"),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_conversation_produces_valid_state() {
+    let store = MockStore::with_conversation("conv_empty", json!([]));
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"first message","conversation":"conv_empty"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "empty conversation should release successfully"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated for empty conversation");
+    assert_eq!(
+        state.messages.len(),
+        1,
+        "messages should contain only the current input"
+    );
+    assert_eq!(state.messages[0]["content"], "first message", "current input");
+}
+
+#[tokio::test]
+async fn conversation_rehydration_requires_store_registry() {
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_123"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => assert_eq!(r.status, 500, "missing store registry should reject with 500"),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn conversation_null_messages_treated_as_empty() {
+    let store = MockStore::with_conversation("conv_null_msgs", Value::Null);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"test","conversation":"conv_null_msgs"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "null messages should release successfully"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.messages.len(),
+        1,
+        "null conversation messages should contribute zero stored items"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
 struct MockStore {
     records: std::collections::HashMap<String, ResponseRecord>,
+    conversations: std::collections::HashMap<String, ConversationRecord>,
     should_fail: bool,
 }
 
@@ -1043,6 +1288,26 @@ impl MockStore {
         );
         Self {
             records,
+            conversations: std::collections::HashMap::new(),
+            should_fail: false,
+        }
+    }
+
+    fn with_conversation(id: &str, messages: Value) -> Self {
+        let mut conversations = std::collections::HashMap::new();
+        conversations.insert(
+            id.to_owned(),
+            ConversationRecord {
+                conversation_id: id.to_owned(),
+                tenant_id: "default".to_owned(),
+                created_at: 1000,
+                metadata: json!({}),
+                messages,
+            },
+        );
+        Self {
+            records: std::collections::HashMap::new(),
+            conversations,
             should_fail: false,
         }
     }
@@ -1077,6 +1342,7 @@ impl MockStore {
         );
         Self {
             records,
+            conversations: std::collections::HashMap::new(),
             should_fail: false,
         }
     }
@@ -1097,6 +1363,7 @@ impl MockStore {
         );
         Self {
             records,
+            conversations: std::collections::HashMap::new(),
             should_fail: false,
         }
     }
@@ -1104,6 +1371,7 @@ impl MockStore {
     fn empty() -> Self {
         Self {
             records: std::collections::HashMap::new(),
+            conversations: std::collections::HashMap::new(),
             should_fail: false,
         }
     }
@@ -1111,6 +1379,7 @@ impl MockStore {
     fn failing() -> Self {
         Self {
             records: std::collections::HashMap::new(),
+            conversations: std::collections::HashMap::new(),
             should_fail: true,
         }
     }
@@ -1136,9 +1405,18 @@ impl ResponseStore for MockStore {
     async fn get_conversation(
         &self,
         _tenant_id: &str,
-        _conversation_id: &str,
+        conversation_id: &str,
     ) -> Result<Option<ConversationRecord>, StoreError> {
-        Ok(None)
+        if self.should_fail {
+            return Err(StoreError::Unavailable("mock failure".to_owned()));
+        }
+        Ok(self.conversations.get(conversation_id).map(|c| ConversationRecord {
+            conversation_id: c.conversation_id.clone(),
+            tenant_id: c.tenant_id.clone(),
+            created_at: c.created_at,
+            metadata: c.metadata.clone(),
+            messages: c.messages.clone(),
+        }))
     }
 }
 

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -465,6 +465,27 @@ async fn rejects_when_store_fetch_fails() {
     }
 }
 
+#[tokio::test]
+async fn rejects_when_conversation_store_fails() {
+    let store = MockStore::failing();
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_abc"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => assert_eq!(r.status, 500, "store failure should reject with 500"),
+        other => panic!("expected Reject for conversation store failure, got {other:?}"),
+    }
+}
+
 // -----------------------------------------------------------------------------
 // MCP Tool Recovery
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -1178,6 +1178,74 @@ async fn rejects_when_conversation_not_found() {
 }
 
 #[tokio::test]
+async fn tenant_mismatch_rejects_conversation() {
+    let store = MockStore::with_conversation("conv_abc", json!([{"role": "user", "content": "hello"}]));
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    ctx.set_metadata(TENANT_METADATA_KEY, "tenant_b");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_abc"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => assert_eq!(
+            r.status, 400,
+            "conversation stored under different tenant should not be found"
+        ),
+        other => panic!("expected Reject for tenant mismatch, got {other:?}"),
+    }
+
+    assert!(
+        ctx.extensions.get::<ResponsesState>().is_none(),
+        "no state should be produced for cross-tenant lookup"
+    );
+}
+
+#[tokio::test]
+async fn rejects_malformed_conversation_empty_object() {
+    let store = MockStore::empty();
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"model":"gpt-4.1","input":"Hi","conversation":{}}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => assert_eq!(r.status, 400, "empty object conversation should be rejected"),
+        other => panic!("expected Reject for malformed conversation, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejects_malformed_conversation_numeric() {
+    let store = MockStore::empty();
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"model":"gpt-4.1","input":"Hi","conversation":42}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => assert_eq!(r.status, 400, "numeric conversation should be rejected"),
+        other => panic!("expected Reject for malformed conversation, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn empty_conversation_produces_valid_state() {
     let store = MockStore::with_conversation("conv_empty", json!([]));
     let registry = setup_registry(store);
@@ -1391,11 +1459,11 @@ impl ResponseStore for MockStore {
         Ok(())
     }
 
-    async fn get_response(&self, _tenant_id: &str, id: &str) -> Result<Option<ResponseRecord>, StoreError> {
+    async fn get_response(&self, tenant_id: &str, id: &str) -> Result<Option<ResponseRecord>, StoreError> {
         if self.should_fail {
             return Err(StoreError::Unavailable("mock failure".to_owned()));
         }
-        Ok(self.records.get(id).cloned())
+        Ok(self.records.get(id).filter(|r| r.tenant_id == tenant_id).cloned())
     }
 
     async fn delete_response(&self, _tenant_id: &str, _id: &str) -> Result<bool, StoreError> {
@@ -1404,19 +1472,23 @@ impl ResponseStore for MockStore {
 
     async fn get_conversation(
         &self,
-        _tenant_id: &str,
+        tenant_id: &str,
         conversation_id: &str,
     ) -> Result<Option<ConversationRecord>, StoreError> {
         if self.should_fail {
             return Err(StoreError::Unavailable("mock failure".to_owned()));
         }
-        Ok(self.conversations.get(conversation_id).map(|c| ConversationRecord {
-            conversation_id: c.conversation_id.clone(),
-            tenant_id: c.tenant_id.clone(),
-            created_at: c.created_at,
-            metadata: c.metadata.clone(),
-            messages: c.messages.clone(),
-        }))
+        Ok(self
+            .conversations
+            .get(conversation_id)
+            .filter(|c| c.tenant_id == tenant_id)
+            .map(|c| ConversationRecord {
+                conversation_id: c.conversation_id.clone(),
+                tenant_id: c.tenant_id.clone(),
+                created_at: c.created_at,
+                metadata: c.metadata.clone(),
+                messages: c.messages.clone(),
+            }))
     }
 }
 

--- a/apis/src/openai/responses/store/filter.rs
+++ b/apis/src/openai/responses/store/filter.rs
@@ -489,7 +489,14 @@ fn request_will_persist_response(ctx: &HttpFilterContext<'_>) -> bool {
 
 /// Check whether rehydrate needs the store before the request phase.
 fn request_needs_rehydrate_store(ctx: &HttpFilterContext<'_>) -> bool {
-    ctx.request.method == http::Method::POST && is_responses_format(ctx) && has_previous_response_id(ctx)
+    ctx.request.method == http::Method::POST
+        && is_responses_format(ctx)
+        && (has_previous_response_id(ctx) || has_conversation(ctx))
+}
+
+/// Return whether the request references a conversation.
+fn has_conversation(ctx: &HttpFilterContext<'_>) -> bool {
+    ctx.get_metadata("openai_responses_format.has_conversation") == Some("true")
 }
 
 /// Return whether the request method is not persistable.

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -1,33 +1,43 @@
 # Responses API Full Flow
 #
-# Combines format classification, request validation, and backend
-# routing into a single pipeline. This is the unified config that
-# operators would deploy for a Responses API gateway:
+# Combines conversations, format classification, request validation,
+# and backend routing into a single pipeline. This is the unified
+# config that operators would deploy for a Responses API gateway:
 #
-#   1. openai_responses_format classifies the request and rejects
-#      unknown/invalid/non-JSON traffic. It promotes format, model,
-#      stream, and mode to internal routing headers.
+#   1. openai_conversations handles CRUD for the Conversations API
+#      (/v1/conversations) and sets has_conversation metadata when
+#      a Responses request carries a conversation field. On the
+#      response path it appends input+output items back to the
+#      conversation after a successful non-streaming response.
 #
-#   2. openai_responses_validate checks parameter combinations
+#   2. openai_responses_format classifies the request and promotes
+#      format, model, stream, and mode to internal routing headers.
+#      on_invalid is left at the default (passthrough) so that
+#      Conversations API traffic is not rejected before the
+#      conversations filter can handle it in the body phase.
+#
+#   3. openai_responses_validate checks parameter combinations
 #      (stream+background, background+store), generates response
 #      and conversation IDs, and writes responses.* metadata for
 #      downstream filters. Skips non-Responses requests gracefully.
 #
-#   3. openai_response_store persists non-streaming responses to
+#   4. openai_response_store persists non-streaming responses to
 #      SQLite and registers the store backend so downstream filters
 #      (rehydrate, compact) can read from it.
 #
-#   4. openai_responses_rehydrate loads conversation context from
-#      previous_response_id by fetching stored responses and
-#      prepending their message history to the current request.
-#      Passthrough for requests without previous_response_id.
+#   5. openai_responses_rehydrate loads conversation context from
+#      previous_response_id or conversation field by fetching
+#      stored responses/conversations and prepending their message
+#      history to the current request. previous_response_id takes
+#      precedence when both are present.
 #
-#   5. responses_proxy reads the assembled ResponsesState and
+#   6. responses_proxy reads the assembled ResponsesState and
 #      rebuilds the outbound request body with the full conversation
-#      history. Strips previous_response_id (already resolved by
-#      rehydrate). Passthrough when no ResponsesState exists.
+#      history. Strips previous_response_id and conversation
+#      (already resolved by rehydrate). Passthrough when no
+#      ResponsesState exists.
 #
-#   6. The router sends all valid Responses API create requests to
+#   7. The router sends all valid Responses API create requests to
 #      the same inference backend. The promoted mode remains available
 #      as headers/metadata for downstream filters; it does not change
 #      backend selection in this example.
@@ -57,6 +67,11 @@
 #     -H "Content-Type: application/json" \
 #     -d '{"model":"gpt-4.1","input":"What next?","previous_response_id":"resp_abc"}'
 #
+#   # Multi-turn with conversation
+#   curl -X POST http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"gpt-4.1","input":"What next?","conversation":"conv_abc"}'
+#
 #   # Rejected (stream + background conflict)
 #   curl -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
@@ -73,8 +88,14 @@ listeners:
 filter_chains:
   - name: responses-pipeline
     filters:
+      - filter: openai_conversations
+        backend: sqlite
+        database_url: "sqlite://responses.db?mode=rwc"
+        conversations_table: openai_conversations
+        items_table: openai_conversation_items
+
       - filter: openai_responses_format
-        on_invalid: reject
+        on_invalid: continue
         headers:
           format: x-praxis-ai-format
           model: x-praxis-ai-model
@@ -110,4 +131,4 @@ filter_chains:
         clusters:
           - name: "inference-backend"
             endpoints:
-              - "127.0.0.1:3001"
+              - "127.0.0.1:8000"

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -131,4 +131,4 @@ filter_chains:
         clusters:
           - name: "inference-backend"
             endpoints:
-              - "127.0.0.1:8000"
+              - "127.0.0.1:3001"

--- a/tests/integration/tests/suite/conversations_rehydrate.rs
+++ b/tests/integration/tests/suite/conversations_rehydrate.rs
@@ -247,7 +247,7 @@ impl Drop for TempDb {
     }
 }
 
-fn start_test_env() -> (praxis_test_utils::ProxyGuard, praxis_test_utils::BackendGuard, TempDb) {
+fn start_test_env() -> (praxis_test_utils::ProxyGuard, praxis_test_utils::net::backend::BackendGuard, TempDb) {
     let echo = start_echo_backend();
     let db = TempDb::new();
     let proxy_port = free_port();

--- a/tests/integration/tests/suite/conversations_rehydrate.rs
+++ b/tests/integration/tests/suite/conversations_rehydrate.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for conversation-based rehydration in the
+//! Responses API pipeline.
+//!
+//! Verifies that `POST /v1/responses` with a `conversation` field
+//! loads stored conversation items, prepends them to the input,
+//! and strips the `conversation` field before forwarding to the
+//! backend.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    Backend, free_port, http_send, json_post, parse_body, parse_status, start_echo_backend, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rehydrates_from_conversation_string_id() {
+    let (proxy, _backend, _db) = start_test_env();
+
+    let conv_id = create_conversation(
+        &proxy,
+        r#"{"metadata":{},"items":[
+            {"id":"item_1","type":"message","role":"user","content":"first turn"},
+            {"id":"item_2","type":"message","role":"assistant","content":"first reply"}
+        ]}"#,
+    );
+
+    let body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "second turn",
+        "conversation": conv_id,
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&body).unwrap()),
+    );
+    assert_eq!(parse_status(&raw), 200, "responses request should succeed");
+
+    let echoed: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert!(
+        echoed.get("conversation").is_none(),
+        "conversation field should be stripped from forwarded body"
+    );
+    assert_eq!(echoed["model"], "gpt-4.1", "model should be preserved");
+
+    let input = echoed["input"].as_array().expect("input should be an array");
+    assert!(
+        input.len() >= 3,
+        "input should contain stored history + new message, got {input:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rehydrates_from_conversation_object_form() {
+    let (proxy, _backend, _db) = start_test_env();
+
+    let conv_id = create_conversation(
+        &proxy,
+        r#"{"metadata":{},"items":[
+            {"id":"item_1","type":"message","role":"user","content":"hello"}
+        ]}"#,
+    );
+
+    let body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "follow-up",
+        "conversation": {"id": conv_id},
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&body).unwrap()),
+    );
+    assert_eq!(parse_status(&raw), 200, "responses request should succeed");
+
+    let echoed: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert!(echoed.get("conversation").is_none(), "conversation should be stripped");
+
+    let input = echoed["input"].as_array().expect("input should be an array");
+    assert!(
+        input.len() >= 2,
+        "input should contain stored item + new message, got {input:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn previous_response_id_takes_precedence_over_conversation() {
+    let (proxy, _backend, _db) = start_test_env();
+
+    let conv_id = create_conversation(
+        &proxy,
+        r#"{"metadata":{},"items":[
+            {"id":"item_1","type":"message","role":"user","content":"conv turn"}
+        ]}"#,
+    );
+
+    let body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "test",
+        "previous_response_id": "resp_nonexistent",
+        "conversation": conv_id,
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&body).unwrap()),
+    );
+
+    let status = parse_status(&raw);
+    assert!(
+        status == 400 || status == 404,
+        "should reject with error when previous_response_id is invalid (got {status})"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nonexistent_conversation_returns_error() {
+    let (proxy, _backend, _db) = start_test_env();
+
+    let body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "hello",
+        "conversation": "conv_does_not_exist",
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&body).unwrap()),
+    );
+
+    let status = parse_status(&raw);
+    assert!(
+        status == 400 || status == 404,
+        "nonexistent conversation should return error (got {status})"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_without_conversation_passes_through() {
+    let (proxy, _backend, _db) = start_test_env();
+
+    let body = r#"{"model":"gpt-4.1","input":"no conversation"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "request without conversation should pass through"
+    );
+
+    let echoed: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(echoed["input"], "no conversation", "input should be unchanged");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn append_back_persists_items_after_response() {
+    let response_body = serde_json::json!({
+        "id": "resp_test123",
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_out1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "backend reply"}]
+            }
+        ]
+    });
+    let backend = Backend::fixed(&serde_json::to_string(&response_body).unwrap())
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+
+    let db = TempDb::new();
+    let proxy_port = free_port();
+    let yaml = pipeline_yaml(proxy_port, backend.port(), &db.url());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let conv_id = create_conversation(
+        &proxy,
+        r#"{"metadata":{},"items":[
+            {"id":"item_seed","type":"message","role":"user","content":"seed turn"}
+        ]}"#,
+    );
+
+    let body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "follow-up turn",
+        "conversation": conv_id,
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&body).unwrap()),
+    );
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "responses request should succeed for append-back"
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let raw = http_send(
+        proxy.addr(),
+        &format!(
+            "GET /v1/conversations/{conv_id}/items?order=asc HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "list items should return 200");
+    let items: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    let data = items["data"].as_array().expect("items should have data array");
+
+    assert!(
+        data.len() >= 2,
+        "conversation should have at least seed + appended items, got {}",
+        data.len()
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+struct TempDb {
+    path: std::path::PathBuf,
+}
+
+impl TempDb {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("praxis_test_{}.db", std::process::id()));
+        let unique = path.with_extension(format!("{}.db", free_port()));
+        Self { path: unique }
+    }
+
+    fn url(&self) -> String {
+        format!("sqlite://{}?mode=rwc", self.path.display())
+    }
+}
+
+impl Drop for TempDb {
+    fn drop(&mut self) {
+        drop(std::fs::remove_file(&self.path));
+        drop(std::fs::remove_file(self.path.with_extension("db-shm")));
+        drop(std::fs::remove_file(self.path.with_extension("db-wal")));
+    }
+}
+
+fn start_test_env() -> (praxis_test_utils::ProxyGuard, praxis_test_utils::BackendGuard, TempDb) {
+    let echo = start_echo_backend();
+    let db = TempDb::new();
+    let proxy_port = free_port();
+    let yaml = pipeline_yaml(proxy_port, echo.port(), &db.url());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+    (proxy, echo, db)
+}
+
+fn pipeline_yaml(proxy_port: u16, backend_port: u16, db_url: &str) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: openai_conversations
+        backend: sqlite
+        database_url: "{db_url}"
+        conversations_table: test_conversations
+        items_table: test_conversation_items
+
+      - filter: openai_responses_format
+
+      - filter: openai_responses_validate
+
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "{db_url}"
+        responses_table: test_responses
+        conversations_table: test_conversations
+
+      - filter: openai_responses_rehydrate
+
+      - filter: responses_proxy
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn create_conversation(proxy: &praxis_test_utils::ProxyGuard, body: &str) -> String {
+    let raw = http_send(proxy.addr(), &json_post("/v1/conversations", body));
+    assert_eq!(parse_status(&raw), 200, "create conversation should succeed");
+    let json: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    json["id"].as_str().unwrap().to_owned()
+}

--- a/tests/integration/tests/suite/conversations_rehydrate.rs
+++ b/tests/integration/tests/suite/conversations_rehydrate.rs
@@ -200,22 +200,29 @@ async fn append_back_persists_items_after_response() {
         "responses request should succeed for append-back"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
-
-    let raw = http_send(
-        proxy.addr(),
-        &format!(
-            "GET /v1/conversations/{conv_id}/items?order=asc HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-        ),
-    );
-    assert_eq!(parse_status(&raw), 200, "list items should return 200");
-    let items: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
-    let data = items["data"].as_array().expect("items should have data array");
+    let mut data_len = 0;
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let raw = http_send(
+            proxy.addr(),
+            &format!(
+                "GET /v1/conversations/{conv_id}/items?order=asc HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            ),
+        );
+        if parse_status(&raw) == 200 {
+            let items: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+            if let Some(arr) = items["data"].as_array() {
+                data_len = arr.len();
+                if data_len >= 2 {
+                    break;
+                }
+            }
+        }
+    }
 
     assert!(
-        data.len() >= 2,
-        "conversation should have at least seed + appended items, got {}",
-        data.len()
+        data_len >= 2,
+        "conversation should have at least seed + appended items, got {data_len}",
     );
 }
 

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -40,6 +40,8 @@
 mod a2a;
 mod agentic_mocks;
 mod anthropic_messages;
+#[cfg(feature = "ai-inference")]
+mod conversations_rehydrate;
 mod examples;
 mod failure_mode;
 mod guardrails;

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -40,7 +40,6 @@
 mod a2a;
 mod agentic_mocks;
 mod anthropic_messages;
-#[cfg(feature = "ai-inference")]
 mod conversations_rehydrate;
 mod examples;
 mod failure_mode;


### PR DESCRIPTION
## Summary

- When `POST /v1/responses` includes a `conversation` field (string ID or `{"id": "..."}` object), the rehydrate filter loads the stored conversation and prepends its messages to the input. `previous_response_id` takes precedence when both are present.
- After a successful non-streaming response with `status: "completed"`, input and output items are appended back to the conversation, building up multi-turn history automatically.
- The `conversation` field is stripped from the outbound body before forwarding to the backend.
- The full-flow example config now includes the `openai_conversations` filter with `on_invalid: continue` for format classifier compatibility.
- Guards skip append-back for streaming, background, and non-completed responses to avoid persisting unfinished turns.

## Test plan

- [x] Unit tests for conversation rehydration (string and object form), precedence over `previous_response_id`, not-found errors, empty conversations, null messages
- [x] Unit tests for `conversation` field stripping in proxy, including combined strip of both `previous_response_id` and `conversation`
- [x] Integration tests for end-to-end conversation rehydration, append-back persistence, and passthrough without conversation
- [x] `make lint`, `make build`, `make test` all pass
- [x] Manual e2e verification with live proxy and echo backend

Fixes #52