### PR TITLE
fix: correct README links to point to ai repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ with the following documentation first:
 
 For larger changes, open a [discussion] and follow the [proposal process](docs/proposals.md).
 
-[Issues]:https://github.com/praxis-proxy/praxis/issues/new
-[pull requests]:https://github.com/praxis-proxy/praxis/compare
-[discussion]:https://github.com/praxis-proxy/praxis/discussions
+[Issues]:https://github.com/praxis-proxy/ai/issues/new
+[pull requests]:https://github.com/praxis-proxy/ai/compare
+[discussion]:https://github.com/praxis-proxy/ai/discussions


### PR DESCRIPTION
The Issues, pull requests, and discussion links in README.md pointed to `praxis-proxy/praxis` (the core repo) instead of `praxis-proxy/ai`. This fixes them to point to the correct repository.