### PR TITLE
refactor(headers): Do no clone when not needed, rely on laziness

### DIFF
--- a/filters/src/token_usage_headers.rs
+++ b/filters/src/token_usage_headers.rs
@@ -115,15 +115,15 @@ fn inject_usage_headers(ctx: &mut HttpFilterContext<'_>) {
     ctx.response_headers_modified = true;
 
     let headers = &mut resp.headers;
-    insert_token_header(headers, HEADER_TOKEN_INPUT.clone(), &input);
-    insert_token_header(headers, HEADER_TOKEN_OUTPUT.clone(), &output);
-    insert_token_header(headers, HEADER_TOKEN_TOTAL.clone(), &total);
+    insert_token_header(headers, &HEADER_TOKEN_INPUT, &input);
+    insert_token_header(headers, &HEADER_TOKEN_OUTPUT, &output);
+    insert_token_header(headers, &HEADER_TOKEN_TOTAL, &total);
 
     trace!("injected token usage response headers");
 }
 
 /// Insert a token count as a response header, logging on failure.
-fn insert_token_header(headers: &mut http::HeaderMap, name: HeaderName, value: &str) {
+fn insert_token_header(headers: &mut http::HeaderMap, name: &HeaderName, value: &str) {
     match HeaderValue::from_str(value) {
         Ok(hv) => {
             headers.insert(name, hv);


### PR DESCRIPTION
Slight nitpick, but there is no need to eagerly `.clone()` those (arguably not _too_ expensive) `HeaderName`s.
I swear the next PR will be more fun ;P  