### PR TITLE
ci(coverage): bump line coverage threshold to 93%

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -62,5 +62,5 @@ jobs:
             ${{ runner.os }}-rust-1.96.0-coverage-
           save-always: true
 
-      - name: Check coverage (≥95% lines)
+      - name: Check coverage (≥93% lines)
         run: make coverage-check

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ coverage-check:
 		--output-path coverage.json
 	@LINE_PCT=$$(jq '.data[0].totals.lines.percent' coverage.json); \
 	echo "Line coverage: $${LINE_PCT}%"; \
-	if [ $$(echo "$${LINE_PCT} < 90" | bc -l) -eq 1 ]; then \
-		echo "FAIL: coverage $${LINE_PCT}% is below 90% threshold"; \
+	if [ $$(echo "$${LINE_PCT} < 93" | bc -l) -eq 1 ]; then \
+		echo "FAIL: coverage $${LINE_PCT}% is below 93% threshold"; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
## Summary

- Raise the minimum line coverage gate from 90% to 93% in the Makefile `coverage-check` target
- Correct the coverage workflow step name which previously said ≥95% but enforced 90%
- Both the Makefile threshold and CI workflow comment now consistently say 93%