### PR TITLE
refactor: remove ai-inference feature gate

### DIFF
--- a/docs/architecture/ai-inference.md
+++ b/docs/architecture/ai-inference.md
@@ -141,8 +141,7 @@ IDs with `resp_` and `conv_` prefixes.
 ### `anthropic_messages_format`
 
 Classifies Anthropic Messages API requests and
-promotes format metadata. Feature-gated behind
-`ai-inference`.
+promotes format metadata.
 
 ### `prompt_enrich`
 
@@ -161,17 +160,6 @@ variable sources.
 
 Persists non-streaming Responses API responses. See
 [Response Store](response-store.md) for details.
-
-## Feature Flags
-
-AI inference filters are gated behind the
-`ai-inference` Cargo feature. The agentic protocol
-filters (JSON-RPC, MCP, A2A) are always compiled.
-
-When `ai-inference` is disabled, the classifier,
-format, validate, store, prompt enrichment, and
-provider-specific filters are excluded from the
-build.
 
 ## Key Files
 

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -8,8 +8,6 @@ readme = "../../README.md"
 publish = false
 
 [features]
-default = ["ai-inference"]
-ai-inference = []
 cpex-policy-engine = ["praxis-filter/cpex-policy-engine"]
 no-mac-cert-rotation-tests = [] # We use this to disable testing cert rotation on macOS
 

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -8,32 +8,19 @@ mod test_utils;
 pub use test_utils::load_example_config;
 
 mod agentic_routing;
-#[cfg(feature = "ai-inference")]
 mod anthropic_messages;
 mod credential_injection;
-#[cfg(feature = "ai-inference")]
 mod full_flow;
 mod mcp_broker;
-#[cfg(feature = "ai-inference")]
 mod model_to_header;
-#[cfg(feature = "ai-inference")]
 mod openai_conversations;
-#[cfg(feature = "ai-inference")]
 mod openai_response_store;
-#[cfg(feature = "ai-inference")]
 mod openai_response_store_postgres;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_format;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_model_rewrite;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_validate;
-#[cfg(feature = "ai-inference")]
 mod prompt_enrichment;
-#[cfg(feature = "ai-inference")]
 mod rehydrate;
-#[cfg(feature = "ai-inference")]
 mod responses_proxy;
-#[cfg(feature = "ai-inference")]
 mod responses_routing;
 mod token_usage_headers;

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -39,18 +39,13 @@
 
 mod a2a;
 mod agentic_mocks;
-#[cfg(feature = "ai-inference")]
 mod anthropic_messages;
 mod examples;
 mod failure_mode;
 mod guardrails;
 mod mcp;
 mod mcp_broker;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_format;
-#[cfg(feature = "ai-inference")]
 mod openai_responses_model_rewrite;
-#[cfg(feature = "ai-inference")]
 mod prompt_enrich;
-#[cfg(feature = "ai-inference")]
 mod responses_routing;

--- a/tests/schema/Cargo.toml
+++ b/tests/schema/Cargo.toml
@@ -7,10 +7,6 @@ license.workspace = true
 readme = "../../README.md"
 publish = false
 
-[features]
-default = ["ai-inference"]
-ai-inference = []
-
 [lints]
 workspace = true
 

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -34,6 +34,3 @@ tokio = { workspace = true, features = ["rt", "net", "io-util", "time", "sync"] 
 tracing = { workspace = true }
 futures = { workspace = true }
 tokio-rustls = { workspace = true }
-
-[features]
-ai-inference = []

--- a/xtask/src/sync_example_readme.rs
+++ b/xtask/src/sync_example_readme.rs
@@ -412,8 +412,8 @@ listeners:
         let input = "\
 # Title
 #
-# Requires the ai-inference feature:
-#   cargo build --features ai-inference
+# Requires a running Redis instance:
+#   docker run -p 6379:6379 redis
 #
 # Real description here.
 ";


### PR DESCRIPTION
## Summary

Remove the `ai-inference` Cargo feature flag that was re-introduced by PR #244 after PR #245 had removed it. All AI inference test modules are now compiled unconditionally — the feature gate is unnecessary in this dedicated AI repo.

Changes across 7 files: removed `ai-inference` feature definitions from three `Cargo.toml` files, removed all `#[cfg(feature = "ai-inference")]` gates from integration test module declarations, removed the "Feature Flags" section from the architecture doc, and updated an xtask test to use a generic example.