### PR TITLE
Implements issue 211: a new filter that extracts token usage from AI

### DIFF
--- a/apis/src/token_usage/mod.rs
+++ b/apis/src/token_usage/mod.rs
@@ -7,6 +7,9 @@
 //! `Bedrock`, Azure) into a common [`TokenUsage`] representation.
 
 mod providers;
+mod streaming;
+
+pub use streaming::extract_streaming_tokens;
 
 #[cfg(test)]
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
@@ -21,6 +24,7 @@ mod tests;
 
 use praxis_filter::HttpFilterContext;
 use providers::{parse_anthropic, parse_bedrock, parse_google, parse_openai};
+use serde::Deserialize;
 
 // -----------------------------------------------------------------------------
 // Public Types
@@ -75,9 +79,11 @@ impl TokenUsage {
 }
 
 /// AI provider identifier for response format selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum TokenUsageProvider {
     /// `OpenAI` API (`usage.prompt_tokens`, `usage.completion_tokens`).
+    #[serde(alias = "open_ai")]
     OpenAi,
 
     /// `Anthropic` Claude API (`usage.input_tokens`, `usage.output_tokens`).

--- a/apis/src/token_usage/streaming.rs
+++ b/apis/src/token_usage/streaming.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Streaming token extraction from individual SSE events.
+//!
+//! Handles providers that spread token counts across multiple SSE
+//! events rather than including complete usage in a single event.
+
+use serde::Deserialize;
+
+use super::TokenUsageProvider;
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+
+/// Extracts partial token counts from a single SSE event payload.
+///
+/// Returns `Some((input, output))` where either field may be `None`
+/// when only one count is present in the event. Returns `None` when
+/// the event contains no token usage data.
+///
+/// Used as a fallback when [`extract_token_usage`] returns `None` for
+/// providers that distribute token counts across multiple events
+/// (Anthropic, Bedrock).
+///
+/// [`extract_token_usage`]: super::extract_token_usage
+pub fn extract_streaming_tokens(provider: TokenUsageProvider, event_data: &[u8]) -> Option<(Option<u64>, Option<u64>)> {
+    match provider {
+        TokenUsageProvider::Anthropic => parse_anthropic_event(event_data),
+        TokenUsageProvider::Bedrock => parse_bedrock_event(event_data),
+        TokenUsageProvider::OpenAi | TokenUsageProvider::Azure | TokenUsageProvider::Google => None,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Anthropic Streaming
+// -----------------------------------------------------------------------------
+
+/// Anthropic `message_start` event with nested usage under `message`.
+#[derive(Deserialize)]
+struct AnthropicMessageStart {
+    /// Nested message object containing usage.
+    message: Option<AnthropicMessageStartMessage>,
+
+    /// Event type discriminator.
+    #[serde(rename = "type")]
+    event_type: Option<String>,
+}
+
+/// Inner message object from `message_start`.
+#[derive(Deserialize)]
+struct AnthropicMessageStartMessage {
+    /// Token usage for the input.
+    usage: Option<AnthropicStartUsage>,
+}
+
+/// Usage object inside `message_start.message.usage`.
+#[derive(Deserialize)]
+struct AnthropicStartUsage {
+    /// Tokens in the input prompt.
+    input_tokens: u64,
+
+    /// Tokens written to cache (prompt caching).
+    cache_creation_input_tokens: Option<u64>,
+
+    /// Tokens read from cache (prompt caching).
+    cache_read_input_tokens: Option<u64>,
+}
+
+/// Anthropic `message_delta` event with usage at root level.
+#[derive(Deserialize)]
+struct AnthropicMessageDelta {
+    /// Event type discriminator.
+    #[serde(rename = "type")]
+    event_type: Option<String>,
+
+    /// Token usage for the output.
+    usage: Option<AnthropicDeltaUsage>,
+}
+
+/// Usage object inside `message_delta.usage`.
+#[derive(Deserialize)]
+struct AnthropicDeltaUsage {
+    /// Tokens in the output completion.
+    output_tokens: u64,
+}
+
+/// Parses Anthropic streaming events for partial token counts.
+fn parse_anthropic_event(data: &[u8]) -> Option<(Option<u64>, Option<u64>)> {
+    if let Ok(start) = serde_json::from_slice::<AnthropicMessageStart>(data)
+        && start.event_type.as_deref() == Some("message_start")
+        && let Some(message) = start.message
+        && let Some(usage) = message.usage
+    {
+        let actual_input = usage
+            .input_tokens
+            .saturating_add(usage.cache_creation_input_tokens.unwrap_or(0))
+            .saturating_add(usage.cache_read_input_tokens.unwrap_or(0));
+        return Some((Some(actual_input), None));
+    }
+
+    if let Ok(delta) = serde_json::from_slice::<AnthropicMessageDelta>(data)
+        && delta.event_type.as_deref() == Some("message_delta")
+        && let Some(usage) = delta.usage
+    {
+        return Some((None, Some(usage.output_tokens)));
+    }
+
+    None
+}
+
+// -----------------------------------------------------------------------------
+// Bedrock ConverseStream
+// -----------------------------------------------------------------------------
+
+/// Bedrock `ConverseStream` metadata event.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BedrockStreamMetadata {
+    /// Token usage metadata from the stream.
+    metadata: Option<BedrockStreamMetadataInner>,
+}
+
+/// Inner metadata object containing usage.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BedrockStreamMetadataInner {
+    /// Token usage statistics.
+    usage: Option<BedrockStreamUsage>,
+}
+
+/// Bedrock streaming usage object.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BedrockStreamUsage {
+    /// Tokens in the input.
+    input_tokens: u64,
+
+    /// Tokens in the output.
+    output_tokens: u64,
+}
+
+/// Parses Bedrock `ConverseStream` metadata events for token counts.
+fn parse_bedrock_event(data: &[u8]) -> Option<(Option<u64>, Option<u64>)> {
+    let meta: BedrockStreamMetadata = serde_json::from_slice(data).ok()?;
+    let usage = meta.metadata?.usage?;
+    Some((Some(usage.input_tokens), Some(usage.output_tokens)))
+}

--- a/apis/src/token_usage/tests.rs
+++ b/apis/src/token_usage/tests.rs
@@ -3,7 +3,7 @@
 
 //! Unit tests for token usage extraction.
 
-use super::{TokenUsageProvider, extract_token_usage, set_token_usage};
+use super::{TokenUsageProvider, extract_token_usage, set_token_usage, streaming::extract_streaming_tokens};
 
 // -----------------------------------------------------------------------------
 // set_token_usage Tests
@@ -274,4 +274,165 @@ fn error_response_returns_none() {
     let result = extract_token_usage(TokenUsageProvider::OpenAi, json);
 
     assert!(result.is_none(), "error response should return None");
+}
+
+// -----------------------------------------------------------------------------
+// Streaming Token Extraction Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn anthropic_message_start_yields_input_tokens() {
+    let event = br#"{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"usage":{"input_tokens":25}}}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Anthropic, event);
+
+    assert_eq!(
+        result,
+        Some((Some(25), None)),
+        "message_start should yield input tokens only"
+    );
+}
+
+#[test]
+fn anthropic_message_start_with_caching() {
+    let event = br#"{"type":"message_start","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":500}}}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Anthropic, event);
+
+    assert_eq!(
+        result,
+        Some((Some(610), None)),
+        "message_start should sum all input token types: 10 + 100 + 500"
+    );
+}
+
+#[test]
+fn anthropic_message_delta_yields_output_tokens() {
+    let event = br#"{"type":"message_delta","usage":{"output_tokens":42}}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Anthropic, event);
+
+    assert_eq!(
+        result,
+        Some((None, Some(42))),
+        "message_delta should yield output tokens only"
+    );
+}
+
+#[test]
+fn anthropic_content_block_delta_returns_none() {
+    let event = br#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Anthropic, event);
+
+    assert!(
+        result.is_none(),
+        "content_block_delta has no token data and should return None"
+    );
+}
+
+#[test]
+fn openai_streaming_returns_none() {
+    let event = br#"{"id":"chatcmpl-abc","choices":[{"delta":{"content":"Hi"}}]}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::OpenAi, event);
+
+    assert!(
+        result.is_none(),
+        "OpenAI streaming should return None (handled by extract_token_usage)"
+    );
+}
+
+#[test]
+fn azure_streaming_returns_none() {
+    let event = br#"{"id":"chatcmpl-abc","choices":[{"delta":{"content":"Hi"}}]}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Azure, event);
+
+    assert!(
+        result.is_none(),
+        "Azure streaming should return None (handled by extract_token_usage)"
+    );
+}
+
+#[test]
+fn google_streaming_returns_none() {
+    let event = br#"{"candidates":[{"content":{"parts":[{"text":"Hi"}]}}]}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Google, event);
+
+    assert!(
+        result.is_none(),
+        "Google streaming should return None (handled by extract_token_usage)"
+    );
+}
+
+#[test]
+fn bedrock_converse_stream_metadata_yields_both() {
+    let event = br#"{"metadata":{"usage":{"inputTokens":15,"outputTokens":42}}}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Bedrock, event);
+
+    assert_eq!(
+        result,
+        Some((Some(15), Some(42))),
+        "Bedrock metadata event should yield both input and output"
+    );
+}
+
+#[test]
+fn bedrock_content_block_returns_none() {
+    let event = br#"{"contentBlockDelta":{"delta":{"text":"Hi"},"contentBlockIndex":0}}"#;
+
+    let result = extract_streaming_tokens(TokenUsageProvider::Bedrock, event);
+
+    assert!(result.is_none(), "Bedrock content delta has no token metadata");
+}
+
+#[test]
+fn streaming_invalid_json_returns_none() {
+    let result = extract_streaming_tokens(TokenUsageProvider::Anthropic, b"not json");
+
+    assert!(
+        result.is_none(),
+        "invalid JSON should return None for streaming extraction"
+    );
+}
+
+#[test]
+fn streaming_empty_returns_none() {
+    let result = extract_streaming_tokens(TokenUsageProvider::Anthropic, b"");
+
+    assert!(
+        result.is_none(),
+        "empty input should return None for streaming extraction"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// TokenUsageProvider Deserialization Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn provider_deserializes_lowercase() {
+    let providers = [
+        ("\"openai\"", TokenUsageProvider::OpenAi),
+        ("\"anthropic\"", TokenUsageProvider::Anthropic),
+        ("\"google\"", TokenUsageProvider::Google),
+        ("\"bedrock\"", TokenUsageProvider::Bedrock),
+        ("\"azure\"", TokenUsageProvider::Azure),
+    ];
+
+    for (json, expected) in providers {
+        let result: TokenUsageProvider =
+            serde_json::from_str(json).unwrap_or_else(|_| panic!("should deserialize {json}"));
+        assert_eq!(result, expected, "deserializing {json} should yield {expected:?}");
+    }
+}
+
+#[test]
+fn provider_rejects_unknown() {
+    let result = serde_json::from_str::<TokenUsageProvider>("\"unknown\"");
+
+    assert!(result.is_err(), "unknown provider should fail to deserialize");
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ before sending requests.
 | [mcp-stateless-broker.yaml](configs/mcp-stateless-broker.yaml) | Configurable stateless MCP broker using the 2026-07-28 release candidate profile |
 | [model-to-header-routing.yaml](configs/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
 | [prompt-enrichment.yaml](configs/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
+| [token-counting.yaml](configs/token-counting.yaml) | Extracts token usage from AI inference responses (streaming SSE and non-streaming JSON) and makes counts available to downstream filters via filter metadata |
 | [token-usage-headers.yaml](configs/token-usage-headers.yaml) | Inject Praxis-Token-Input, Praxis-Token-Output, and Praxis-Token-Total headers into downstream responses when token counts are available in filter metadata |
 
 ### Anthropic

--- a/examples/configs/token-counting.yaml
+++ b/examples/configs/token-counting.yaml
@@ -1,0 +1,41 @@
+# Token Counting
+#
+# Extracts token usage from AI inference responses (streaming and
+# non-streaming) and makes counts available to downstream filters
+# via filter metadata.
+#
+# Usage:
+#   cargo run -p praxis-ai-proxy -- -c examples/configs/token-counting.yaml
+#   curl http://localhost:8080/v1/chat/completions -d '{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}'
+#
+# The filter reads the response body (streaming SSE or buffered JSON),
+# extracts provider-specific token usage, and writes unified counts
+# to filter_metadata as token.input, token.output, and token.total.
+#
+# Downstream filters like token_usage_headers can then read these
+# counts and inject them as response headers.
+
+listeners:
+  - name: default
+    address: "127.0.0.1:8080"
+    filter_chains:
+      - main
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+
+      - filter: token_count
+        provider: openai
+
+      - filter: token_usage_headers
+
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:3000"

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -13,12 +13,14 @@ pub mod agentic;
 pub mod guardrails;
 pub mod inference;
 pub mod prompt_enrich;
+mod token_count;
 mod token_usage_headers;
 
 pub use agentic::{a2a::A2aFilter, mcp::McpFilter};
 pub use guardrails::AiGuardrailsFilter;
 pub use inference::ModelToHeaderFilter;
 pub use prompt_enrich::PromptEnrichFilter;
+pub use token_count::TokenCountFilter;
 pub use token_usage_headers::TokenUsageHeadersFilter;
 
 // -----------------------------------------------------------------------------

--- a/filters/src/token_count/mod.rs
+++ b/filters/src/token_count/mod.rs
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Token usage extraction filter for AI inference responses.
+//!
+//! Parses token counts from both streaming (SSE) and non-streaming (JSON)
+//! AI provider responses and writes unified counts to [`filter_metadata`]
+//! for downstream consumers. The filter is transparent: response bodies
+//! and status codes pass through unchanged.
+//!
+//! [`filter_metadata`]: HttpFilterContext::filter_metadata
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests;
+
+use std::fmt::Write as _;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use praxis_ai_apis::token_usage::{TokenUsageProvider, extract_streaming_tokens, extract_token_usage, set_token_usage};
+use praxis_filter::{
+    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, parse_filter_config,
+};
+use serde::Deserialize;
+use tracing::{debug, trace};
+
+use crate::agentic::a2a::sse;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum bytes for non-streaming JSON body accumulation (1 MiB).
+const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576; // 1 MiB
+
+/// Default maximum scratch bytes for SSE scanner state.
+const DEFAULT_MAX_SCRATCH_BYTES: usize = 65_536; // 64 KiB
+
+/// Metadata key prefix for all `token_count` working state.
+const META_PREFIX: &str = "token_count.";
+
+/// Metadata key for the extraction mode (`sse` or `json`).
+const META_MODE: &str = "token_count.mode";
+
+/// Metadata key for accumulated input tokens (streaming).
+const META_INPUT: &str = "token_count.input";
+
+/// Metadata key for accumulated output tokens (streaming).
+const META_OUTPUT: &str = "token_count.output";
+
+/// Metadata key for hex-encoded JSON body buffer (non-streaming).
+const META_BUF_HEX: &str = "token_count.buf_hex";
+
+/// Metadata key for byte count of buffered body (non-streaming).
+const META_BUF_BYTES: &str = "token_count.buf_bytes";
+
+/// Metadata key for SSE scanner line buffer.
+const META_SSE_LINE_BUF: &str = "token_count.sse_line_buf_hex";
+
+/// Metadata key for SSE scanner data buffer.
+const META_SSE_DATA_HEX: &str = "token_count.sse_data_hex";
+
+/// Metadata key for SSE scanner `has_data` flag.
+const META_SSE_HAS_DATA: &str = "token_count.sse_has_data";
+
+/// Metadata key for SSE scanner `prev_cr` flag.
+const META_SSE_PREV_CR: &str = "token_count.sse_prev_cr";
+
+/// Metadata key for SSE scanner scratch byte count.
+const META_SSE_SCRATCH: &str = "token_count.sse_scratch_bytes";
+
+// -----------------------------------------------------------------------------
+// Configuration
+// -----------------------------------------------------------------------------
+
+/// Filter configuration for `token_count`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TokenCountConfig {
+    /// AI provider whose response format to parse.
+    provider: TokenUsageProvider,
+}
+
+// -----------------------------------------------------------------------------
+// TokenCountFilter
+// -----------------------------------------------------------------------------
+
+/// Extracts token usage from AI inference responses and writes unified
+/// counts to [`filter_metadata`].
+///
+/// Supports both streaming (SSE) and non-streaming (JSON) responses
+/// across all five providers (OpenAI, Anthropic, Google, Bedrock, Azure).
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: token_count
+/// provider: openai
+/// ```
+///
+/// [`filter_metadata`]: HttpFilterContext::filter_metadata
+pub struct TokenCountFilter {
+    /// Which provider's response format to parse.
+    provider: TokenUsageProvider,
+}
+
+impl TokenCountFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: TokenCountConfig = parse_filter_config("token_count", config)?;
+
+        Ok(Box::new(Self { provider: cfg.provider }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for TokenCountFilter {
+    fn name(&self) -> &'static str {
+        "token_count"
+    }
+
+    fn response_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        let is_success = ctx.response_header.as_ref().is_some_and(|r| r.status.is_success());
+
+        if !is_success {
+            trace!("non-success response, skipping token extraction");
+            return Ok(FilterAction::Continue);
+        }
+
+        let content_type = ctx
+            .response_header
+            .as_ref()
+            .and_then(|r| r.headers.get("content-type"))
+            .and_then(|v| v.to_str().ok());
+
+        let Some(ct) = content_type else {
+            return Ok(FilterAction::Continue);
+        };
+
+        if is_event_stream_content_type(ct) {
+            ctx.filter_metadata.insert(META_MODE.to_owned(), "sse".to_owned());
+            trace!("content-type is SSE, will extract tokens from stream events");
+        } else if is_json_content_type(ct) {
+            ctx.filter_metadata.insert(META_MODE.to_owned(), "json".to_owned());
+            trace!("content-type is JSON, will extract tokens from full body");
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let mode = ctx.get_metadata(META_MODE).map(str::to_owned);
+
+        match mode.as_deref() {
+            Some("sse") => handle_sse_body(ctx, body, end_of_stream, self.provider),
+            Some("json") => handle_json_body(ctx, body, end_of_stream, self.provider),
+            _ => {},
+        }
+
+        Ok(FilterAction::Continue)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// JSON (Non-Streaming) Path
+// -----------------------------------------------------------------------------
+
+/// Accumulate JSON body chunks and extract token usage on completion.
+fn handle_json_body(
+    ctx: &mut HttpFilterContext<'_>,
+    body: &Option<Bytes>,
+    end_of_stream: bool,
+    provider: TokenUsageProvider,
+) {
+    if let Some(chunk) = body.as_ref()
+        && !accumulate_response_hex(ctx, chunk, DEFAULT_MAX_BODY_BYTES)
+    {
+        clear_all_metadata(ctx);
+        return;
+    }
+
+    if end_of_stream {
+        let bytes = ctx.filter_metadata.get(META_BUF_HEX).and_then(|hex| decode_hex(hex));
+
+        if let Some(data) = bytes
+            && let Some(usage) = extract_token_usage(provider, &data)
+        {
+            set_token_usage(
+                ctx,
+                usage.input_tokens(),
+                usage.output_tokens(),
+                Some(usage.total_tokens()),
+            );
+            debug!(
+                input = usage.input_tokens(),
+                output = usage.output_tokens(),
+                total = usage.total_tokens(),
+                "extracted token usage from JSON response"
+            );
+        }
+
+        clear_all_metadata(ctx);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SSE (Streaming) Path
+// -----------------------------------------------------------------------------
+
+/// Process SSE body chunks and extract token usage incrementally.
+fn handle_sse_body(
+    ctx: &mut HttpFilterContext<'_>,
+    body: &Option<Bytes>,
+    end_of_stream: bool,
+    provider: TokenUsageProvider,
+) {
+    if let Some(chunk) = body.as_ref() {
+        let mut state = load_sse_scan_state(ctx);
+
+        let result = sse::scan_sse_chunk(&mut state, chunk, DEFAULT_MAX_SCRATCH_BYTES);
+
+        for payload in &result.payloads {
+            process_sse_payload(ctx, payload, provider);
+        }
+
+        if result.overflowed {
+            debug!(
+                scratch_bytes = state.scratch_bytes,
+                "SSE scratch exceeds limit, finalizing token counts"
+            );
+            finalize_streaming_counts(ctx);
+            clear_all_metadata(ctx);
+            return;
+        }
+
+        save_sse_scan_state(ctx, &state);
+    }
+
+    if end_of_stream {
+        finalize_streaming_counts(ctx);
+        clear_all_metadata(ctx);
+    }
+}
+
+/// Try to extract token usage from a single SSE data payload.
+fn process_sse_payload(ctx: &mut HttpFilterContext<'_>, payload: &[u8], provider: TokenUsageProvider) {
+    if payload == b"[DONE]" {
+        return;
+    }
+
+    if try_complete_usage(ctx, payload, provider) {
+        return;
+    }
+
+    try_partial_usage(ctx, payload, provider);
+}
+
+/// Try complete usage extraction (OpenAI, Google, Azure final events).
+fn try_complete_usage(ctx: &mut HttpFilterContext<'_>, payload: &[u8], provider: TokenUsageProvider) -> bool {
+    let Some(usage) = extract_token_usage(provider, payload) else {
+        return false;
+    };
+
+    ctx.filter_metadata
+        .insert(META_INPUT.to_owned(), usage.input_tokens().to_string());
+    ctx.filter_metadata
+        .insert(META_OUTPUT.to_owned(), usage.output_tokens().to_string());
+    trace!(
+        input = usage.input_tokens(),
+        output = usage.output_tokens(),
+        "complete token usage found in SSE event"
+    );
+    true
+}
+
+/// Try partial extraction (Anthropic, Bedrock streaming).
+fn try_partial_usage(ctx: &mut HttpFilterContext<'_>, payload: &[u8], provider: TokenUsageProvider) {
+    let Some((input, output)) = extract_streaming_tokens(provider, payload) else {
+        return;
+    };
+
+    if let Some(inp) = input {
+        merge_accumulated_count(ctx, META_INPUT, inp);
+        trace!(input = inp, "partial input tokens from SSE event");
+    }
+    if let Some(out) = output {
+        merge_accumulated_count(ctx, META_OUTPUT, out);
+        trace!(output = out, "partial output tokens from SSE event");
+    }
+}
+
+/// Merge a partial count into accumulated state via max (last-writer wins
+/// for providers that repeat counts, additive for those that don't).
+fn merge_accumulated_count(ctx: &mut HttpFilterContext<'_>, key: &str, value: u64) {
+    let existing: u64 = ctx.filter_metadata.get(key).and_then(|v| v.parse().ok()).unwrap_or(0);
+
+    let new_value = existing.max(value);
+    ctx.filter_metadata.insert(key.to_owned(), new_value.to_string());
+}
+
+/// Write accumulated streaming counts to the well-known metadata keys.
+fn finalize_streaming_counts(ctx: &mut HttpFilterContext<'_>) {
+    let input: u64 = ctx
+        .filter_metadata
+        .get(META_INPUT)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let output: u64 = ctx
+        .filter_metadata
+        .get(META_OUTPUT)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    if input > 0 || output > 0 {
+        set_token_usage(ctx, input, output, None);
+        debug!(input, output, "finalized streaming token counts");
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SSE Scanner State Persistence
+// -----------------------------------------------------------------------------
+
+/// Reconstructs scanner state from hex-encoded `filter_metadata` keys.
+fn load_sse_scan_state(ctx: &HttpFilterContext<'_>) -> sse::SseScanState {
+    let line_buf = ctx
+        .filter_metadata
+        .get(META_SSE_LINE_BUF)
+        .and_then(|hex| decode_hex(hex))
+        .unwrap_or_default();
+
+    let data_buf = ctx
+        .filter_metadata
+        .get(META_SSE_DATA_HEX)
+        .and_then(|hex| decode_hex(hex))
+        .unwrap_or_default();
+
+    let has_data = ctx.filter_metadata.get(META_SSE_HAS_DATA).is_some_and(|v| v == "true");
+
+    let prev_cr = ctx.filter_metadata.get(META_SSE_PREV_CR).is_some_and(|v| v == "true");
+
+    let scratch_bytes: usize = ctx
+        .filter_metadata
+        .get(META_SSE_SCRATCH)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    sse::SseScanState {
+        line_buf,
+        data_buf,
+        has_data,
+        prev_cr,
+        scratch_bytes,
+    }
+}
+
+/// Persists scanner state back to `filter_metadata` for the next chunk.
+fn save_sse_scan_state(ctx: &mut HttpFilterContext<'_>, state: &sse::SseScanState) {
+    set_hex_metadata(ctx, META_SSE_LINE_BUF, &state.line_buf);
+    set_hex_metadata(ctx, META_SSE_DATA_HEX, &state.data_buf);
+
+    ctx.filter_metadata.insert(
+        META_SSE_HAS_DATA.to_owned(),
+        if state.has_data { "true" } else { "false" }.to_owned(),
+    );
+    ctx.filter_metadata.insert(
+        META_SSE_PREV_CR.to_owned(),
+        if state.prev_cr { "true" } else { "false" }.to_owned(),
+    );
+    ctx.filter_metadata
+        .insert(META_SSE_SCRATCH.to_owned(), state.scratch_bytes.to_string());
+}
+
+// -----------------------------------------------------------------------------
+// Hex Encoding Utilities
+// -----------------------------------------------------------------------------
+
+/// Accumulate raw bytes as hex to avoid corruption when chunk boundaries
+/// split multibyte UTF-8 code points. Returns `false` if the byte limit
+/// was exceeded.
+fn accumulate_response_hex(ctx: &mut HttpFilterContext<'_>, chunk: &[u8], max_bytes: usize) -> bool {
+    let existing_bytes: usize = ctx
+        .filter_metadata
+        .get(META_BUF_BYTES)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    if existing_bytes.saturating_add(chunk.len()) > max_bytes {
+        debug!(
+            existing_bytes,
+            chunk_len = chunk.len(),
+            max_bytes,
+            "response body exceeds token_count capture limit"
+        );
+        return false;
+    }
+
+    let hex_buf = ctx.filter_metadata.entry(META_BUF_HEX.to_owned()).or_default();
+    for byte in chunk {
+        _ = write!(hex_buf, "{byte:02x}");
+    }
+
+    let new_total = existing_bytes + chunk.len();
+    ctx.filter_metadata
+        .insert(META_BUF_BYTES.to_owned(), new_total.to_string());
+
+    true
+}
+
+/// Inverse of the hex encoding.
+fn decode_hex(hex: &str) -> Option<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
+        return None;
+    }
+
+    hex.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let hi = hex_digit(*pair.first()?)?;
+            let lo = hex_digit(*pair.last()?)?;
+            Some(hi << 4 | lo)
+        })
+        .collect()
+}
+
+/// Supports lowercase `a`-`f` only (our encoder writes lowercase).
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Hex-encodes raw bytes into a metadata value, or removes the key if empty.
+fn set_hex_metadata(ctx: &mut HttpFilterContext<'_>, key: &str, data: &[u8]) {
+    if data.is_empty() {
+        ctx.filter_metadata.remove(key);
+    } else {
+        let mut hex = String::with_capacity(data.len() * 2);
+        for byte in data {
+            _ = write!(hex, "{byte:02x}");
+        }
+        ctx.filter_metadata.insert(key.to_owned(), hex);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Content-Type Helpers
+// -----------------------------------------------------------------------------
+
+/// Whether a content-type header value indicates `text/event-stream`.
+fn is_event_stream_content_type(ct: &str) -> bool {
+    ct.split(';')
+        .next()
+        .is_some_and(|media| media.trim().eq_ignore_ascii_case("text/event-stream"))
+}
+
+/// Whether a content-type header value indicates `application/json`.
+fn is_json_content_type(ct: &str) -> bool {
+    ct.split(';')
+        .next()
+        .is_some_and(|media| media.trim().eq_ignore_ascii_case("application/json"))
+}
+
+// -----------------------------------------------------------------------------
+// Metadata Cleanup
+// -----------------------------------------------------------------------------
+
+/// Remove all `token_count.*` working state from `filter_metadata`.
+fn clear_all_metadata(ctx: &mut HttpFilterContext<'_>) {
+    ctx.filter_metadata.retain(|key, _| !key.starts_with(META_PREFIX));
+}

--- a/filters/src/token_count/tests.rs
+++ b/filters/src/token_count/tests.rs
@@ -1,0 +1,631 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the `token_count` filter.
+
+use bytes::Bytes;
+use http::header::HeaderValue;
+use praxis_filter::{FilterAction, HttpFilter as _, Response};
+
+use super::*;
+
+// -----------------------------------------------------------------------------
+// Config Parsing
+// -----------------------------------------------------------------------------
+
+#[test]
+fn from_config_with_valid_provider() {
+    let config: serde_yaml::Value = serde_yaml::from_str("provider: openai").unwrap();
+    let filter = TokenCountFilter::from_config(&config).unwrap();
+
+    assert_eq!(filter.name(), "token_count", "filter name should match");
+}
+
+#[test]
+fn from_config_all_providers() {
+    for provider in ["openai", "anthropic", "google", "bedrock", "azure"] {
+        let yaml = format!("provider: {provider}");
+        let config: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+        let result = TokenCountFilter::from_config(&config);
+
+        assert!(result.is_ok(), "provider '{provider}' should be accepted");
+    }
+}
+
+#[test]
+fn from_config_rejects_unknown_provider() {
+    let config: serde_yaml::Value = serde_yaml::from_str("provider: unknown").unwrap();
+    let result = TokenCountFilter::from_config(&config);
+
+    assert!(result.is_err(), "unknown provider should be rejected");
+}
+
+#[test]
+fn from_config_rejects_missing_provider() {
+    let config: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let result = TokenCountFilter::from_config(&config);
+
+    assert!(result.is_err(), "missing provider should be rejected");
+}
+
+#[test]
+fn from_config_rejects_unknown_fields() {
+    let config: serde_yaml::Value = serde_yaml::from_str("provider: openai\nextra: true").unwrap();
+    let result = TokenCountFilter::from_config(&config);
+
+    assert!(result.is_err(), "unknown fields should be rejected");
+}
+
+// -----------------------------------------------------------------------------
+// on_response: Content-Type Detection
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn on_response_sets_sse_mode_for_event_stream() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("text/event-stream");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata(META_MODE),
+        Some("sse"),
+        "SSE content-type should set mode to sse"
+    );
+}
+
+#[tokio::test]
+async fn on_response_sets_json_mode_for_application_json() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("application/json");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata(META_MODE),
+        Some("json"),
+        "JSON content-type should set mode to json"
+    );
+}
+
+#[tokio::test]
+async fn on_response_handles_content_type_with_charset() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("application/json; charset=utf-8");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata(META_MODE),
+        Some("json"),
+        "JSON with charset should still set mode to json"
+    );
+}
+
+#[tokio::test]
+async fn on_response_handles_case_insensitive_content_type() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("Text/Event-Stream");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata(META_MODE),
+        Some("sse"),
+        "case-insensitive content-type should be recognized"
+    );
+}
+
+#[tokio::test]
+async fn on_response_skips_non_success_status() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_status_and_content_type(http::StatusCode::BAD_REQUEST, "application/json");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert!(
+        ctx.get_metadata(META_MODE).is_none(),
+        "non-success status should not set mode"
+    );
+}
+
+#[tokio::test]
+async fn on_response_skips_unknown_content_type() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("text/plain");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert!(
+        ctx.get_metadata(META_MODE).is_none(),
+        "unknown content-type should not set mode"
+    );
+}
+
+#[tokio::test]
+async fn on_response_skips_missing_content_type() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = crate::test_utils::make_response();
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert!(
+        ctx.get_metadata(META_MODE).is_none(),
+        "missing content-type should not set mode"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Non-Streaming JSON: End-to-End
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn json_openai_extracts_tokens() {
+    let json = br#"{"usage":{"prompt_tokens":15,"completion_tokens":42,"total_tokens":57}}"#;
+
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::OpenAi, json).await;
+
+    assert_eq!(input.as_deref(), Some("15"), "OpenAI input tokens");
+    assert_eq!(output.as_deref(), Some("42"), "OpenAI output tokens");
+    assert_eq!(total.as_deref(), Some("57"), "OpenAI total tokens");
+}
+
+#[tokio::test]
+async fn json_anthropic_extracts_tokens() {
+    let json = br#"{"usage":{"input_tokens":15,"output_tokens":42}}"#;
+
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::Anthropic, json).await;
+
+    assert_eq!(input.as_deref(), Some("15"), "Anthropic input tokens");
+    assert_eq!(output.as_deref(), Some("42"), "Anthropic output tokens");
+    assert_eq!(total.as_deref(), Some("57"), "Anthropic total tokens (computed)");
+}
+
+#[tokio::test]
+async fn json_google_extracts_tokens() {
+    let json = br#"{"usageMetadata":{"promptTokenCount":15,"candidatesTokenCount":42,"totalTokenCount":57}}"#;
+
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::Google, json).await;
+
+    assert_eq!(input.as_deref(), Some("15"), "Google input tokens");
+    assert_eq!(output.as_deref(), Some("42"), "Google output tokens");
+    assert_eq!(total.as_deref(), Some("57"), "Google total tokens");
+}
+
+#[tokio::test]
+async fn json_bedrock_converse_extracts_tokens() {
+    let json = br#"{"usage":{"inputTokens":15,"outputTokens":42,"totalTokens":57}}"#;
+
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::Bedrock, json).await;
+
+    assert_eq!(input.as_deref(), Some("15"), "Bedrock input tokens");
+    assert_eq!(output.as_deref(), Some("42"), "Bedrock output tokens");
+    assert_eq!(total.as_deref(), Some("57"), "Bedrock total tokens");
+}
+
+#[tokio::test]
+async fn json_azure_extracts_tokens() {
+    let json = br#"{"usage":{"prompt_tokens":5,"completion_tokens":10,"total_tokens":15}}"#;
+
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::Azure, json).await;
+
+    assert_eq!(input.as_deref(), Some("5"), "Azure input tokens");
+    assert_eq!(output.as_deref(), Some("10"), "Azure output tokens");
+    assert_eq!(total.as_deref(), Some("15"), "Azure total tokens");
+}
+
+#[tokio::test]
+async fn json_missing_usage_sets_nothing() {
+    let json = br#"{"id":"abc","choices":[]}"#;
+
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::OpenAi, json).await;
+
+    assert!(input.is_none(), "missing usage should not set input");
+    assert!(output.is_none(), "missing usage should not set output");
+    assert!(total.is_none(), "missing usage should not set total");
+}
+
+#[tokio::test]
+async fn json_malformed_sets_nothing() {
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::OpenAi, b"not json").await;
+
+    assert!(input.is_none(), "malformed JSON should not set input");
+    assert!(output.is_none(), "malformed JSON should not set output");
+    assert!(total.is_none(), "malformed JSON should not set total");
+}
+
+#[tokio::test]
+async fn json_empty_body_sets_nothing() {
+    let (input, output, total) = run_json_extraction(TokenUsageProvider::OpenAi, b"").await;
+
+    assert!(input.is_none(), "empty body should not set input");
+    assert!(output.is_none(), "empty body should not set output");
+    assert!(total.is_none(), "empty body should not set total");
+}
+
+#[tokio::test]
+async fn json_chunked_body_reassembled() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("application/json");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let chunk1 = br#"{"usage":{"prompt_tokens":15,"#;
+    let chunk2 = br#""completion_tokens":42,"total_tokens":57}}"#;
+
+    let mut body1 = Some(Bytes::from_static(chunk1));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+    let mut body2 = Some(Bytes::from_static(chunk2));
+    drop(filter.on_response_body(&mut ctx, &mut body2, true).unwrap());
+
+    assert_eq!(ctx.get_metadata("token.input"), Some("15"), "chunked input tokens");
+    assert_eq!(ctx.get_metadata("token.output"), Some("42"), "chunked output tokens");
+    assert_eq!(ctx.get_metadata("token.total"), Some("57"), "chunked total tokens");
+}
+
+#[tokio::test]
+async fn json_clears_working_metadata() {
+    let json = br#"{"usage":{"prompt_tokens":15,"completion_tokens":42,"total_tokens":57}}"#;
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("application/json");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let mut body = Some(Bytes::from_static(json));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    let working_keys: Vec<_> = ctx
+        .filter_metadata
+        .keys()
+        .filter(|k| k.starts_with(META_PREFIX))
+        .collect();
+
+    assert!(
+        working_keys.is_empty(),
+        "all token_count.* working metadata should be cleared after extraction"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Streaming SSE: End-to-End
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_openai_final_usage_event() {
+    let events = b"data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n";
+
+    let (input, output, total) = run_sse_extraction(TokenUsageProvider::OpenAi, events).await;
+
+    assert_eq!(input.as_deref(), Some("10"), "OpenAI SSE input tokens");
+    assert_eq!(output.as_deref(), Some("20"), "OpenAI SSE output tokens");
+    assert_eq!(total.as_deref(), Some("30"), "OpenAI SSE total tokens");
+}
+
+#[tokio::test]
+async fn sse_anthropic_accumulated_events() {
+    let events = concat!(
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":25}}}\n\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"Hi\"}}\n\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":42}}\n\n",
+    );
+
+    let (input, output, total) = run_sse_extraction(TokenUsageProvider::Anthropic, events.as_bytes()).await;
+
+    assert_eq!(
+        input.as_deref(),
+        Some("25"),
+        "Anthropic SSE input tokens from message_start"
+    );
+    assert_eq!(
+        output.as_deref(),
+        Some("42"),
+        "Anthropic SSE output tokens from message_delta"
+    );
+    assert_eq!(total.as_deref(), Some("67"), "Anthropic SSE total tokens (computed)");
+}
+
+#[tokio::test]
+async fn sse_google_final_usage_event() {
+    let events = b"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hi\"}]}}]}\n\ndata: {\"usageMetadata\":{\"promptTokenCount\":15,\"candidatesTokenCount\":42,\"totalTokenCount\":57}}\n\n";
+
+    let (input, output, total) = run_sse_extraction(TokenUsageProvider::Google, events).await;
+
+    assert_eq!(input.as_deref(), Some("15"), "Google SSE input tokens");
+    assert_eq!(output.as_deref(), Some("42"), "Google SSE output tokens");
+    assert_eq!(total.as_deref(), Some("57"), "Google SSE total tokens");
+}
+
+#[tokio::test]
+async fn sse_done_sentinel_ignored() {
+    let events =
+        b"data: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n";
+
+    let (input, output, _) = run_sse_extraction(TokenUsageProvider::OpenAi, events).await;
+
+    assert_eq!(input.as_deref(), Some("10"), "[DONE] should not overwrite usage data");
+    assert_eq!(output.as_deref(), Some("20"), "[DONE] should not overwrite usage data");
+}
+
+#[tokio::test]
+async fn sse_chunks_split_across_calls() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("text/event-stream");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let chunk1 = b"data: {\"usage\":{\"prompt_to";
+    let chunk2 = b"kens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\n";
+
+    let mut body1 = Some(Bytes::from_static(chunk1));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+    assert!(
+        ctx.get_metadata("token.input").is_none(),
+        "incomplete SSE frame should not set tokens"
+    );
+
+    let mut body2 = Some(Bytes::from_static(chunk2));
+    drop(filter.on_response_body(&mut ctx, &mut body2, true).unwrap());
+
+    assert_eq!(ctx.get_metadata("token.input"), Some("10"), "split SSE input tokens");
+    assert_eq!(ctx.get_metadata("token.output"), Some("20"), "split SSE output tokens");
+}
+
+#[tokio::test]
+async fn sse_no_usage_events_sets_nothing() {
+    let events = b"data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n";
+
+    let (input, output, total) = run_sse_extraction(TokenUsageProvider::OpenAi, events).await;
+
+    assert!(input.is_none(), "no usage events should not set input");
+    assert!(output.is_none(), "no usage events should not set output");
+    assert!(total.is_none(), "no usage events should not set total");
+}
+
+#[tokio::test]
+async fn sse_clears_working_metadata() {
+    let events = b"data: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\n";
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("text/event-stream");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let mut body = Some(Bytes::copy_from_slice(events));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    let working_keys: Vec<_> = ctx
+        .filter_metadata
+        .keys()
+        .filter(|k| k.starts_with(META_PREFIX))
+        .collect();
+
+    assert!(
+        working_keys.is_empty(),
+        "all token_count.* working metadata should be cleared after SSE extraction"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Body Mode Without on_response
+// -----------------------------------------------------------------------------
+
+#[test]
+fn on_response_body_noop_without_mode() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::GET, "/health");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"hello"));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should return Continue without mode"
+    );
+    assert!(
+        ctx.get_metadata("token.input").is_none(),
+        "should not set any token metadata without mode"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Buffer Overflow
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn json_overflow_sets_nothing() {
+    let filter = make_filter(TokenUsageProvider::OpenAi);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("application/json");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let huge_body = vec![b'x'; DEFAULT_MAX_BODY_BYTES + 1];
+    let mut body = Some(Bytes::from(huge_body));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert!(
+        ctx.get_metadata("token.input").is_none(),
+        "overflow should not set tokens"
+    );
+    let working_keys: Vec<_> = ctx
+        .filter_metadata
+        .keys()
+        .filter(|k| k.starts_with(META_PREFIX))
+        .collect();
+    assert!(working_keys.is_empty(), "overflow should clear all working metadata");
+}
+
+// -----------------------------------------------------------------------------
+// Content-Type Helpers
+// -----------------------------------------------------------------------------
+
+#[test]
+fn is_event_stream_recognizes_variants() {
+    assert!(is_event_stream_content_type("text/event-stream"), "exact match");
+    assert!(
+        is_event_stream_content_type("text/event-stream; charset=utf-8"),
+        "with charset"
+    );
+    assert!(is_event_stream_content_type("Text/Event-Stream"), "mixed case");
+    assert!(is_event_stream_content_type("TEXT/EVENT-STREAM"), "uppercase");
+    assert!(
+        !is_event_stream_content_type("application/json"),
+        "json should not match"
+    );
+}
+
+#[test]
+fn is_json_recognizes_variants() {
+    assert!(is_json_content_type("application/json"), "exact match");
+    assert!(is_json_content_type("application/json; charset=utf-8"), "with charset");
+    assert!(is_json_content_type("Application/JSON"), "mixed case");
+    assert!(!is_json_content_type("text/event-stream"), "SSE should not match");
+}
+
+// -----------------------------------------------------------------------------
+// Hex Encoding
+// -----------------------------------------------------------------------------
+
+#[test]
+fn decode_hex_roundtrips() {
+    let data = b"hello world";
+    let encoded = data.iter().fold(String::new(), |mut s, b| {
+        _ = write!(s, "{b:02x}");
+        s
+    });
+    let decoded = decode_hex(&encoded).unwrap();
+
+    assert_eq!(decoded, data, "hex roundtrip should preserve data");
+}
+
+#[test]
+fn decode_hex_rejects_odd_length() {
+    assert!(decode_hex("abc").is_none(), "odd-length hex should return None");
+}
+
+#[test]
+fn decode_hex_rejects_invalid_chars() {
+    assert!(decode_hex("zz").is_none(), "invalid hex chars should return None");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+use std::fmt::Write as _;
+
+fn make_filter(provider: TokenUsageProvider) -> TokenCountFilter {
+    TokenCountFilter { provider }
+}
+
+fn make_response_with_content_type(ct: &str) -> Response {
+    let mut resp = crate::test_utils::make_response();
+    resp.headers.insert("content-type", HeaderValue::from_str(ct).unwrap());
+    resp
+}
+
+fn make_response_with_status_and_content_type(status: http::StatusCode, ct: &str) -> Response {
+    let mut resp = Response {
+        headers: http::HeaderMap::new(),
+        status,
+    };
+    resp.headers.insert("content-type", HeaderValue::from_str(ct).unwrap());
+    resp
+}
+
+/// Run a full `on_response` -> `on_response_body` cycle for JSON extraction.
+async fn run_json_extraction(
+    provider: TokenUsageProvider,
+    body_bytes: &[u8],
+) -> (Option<String>, Option<String>, Option<String>) {
+    let filter = make_filter(provider);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("application/json");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let mut body = Some(Bytes::copy_from_slice(body_bytes));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    (
+        ctx.get_metadata("token.input").map(str::to_owned),
+        ctx.get_metadata("token.output").map(str::to_owned),
+        ctx.get_metadata("token.total").map(str::to_owned),
+    )
+}
+
+/// Run a full `on_response` -> `on_response_body` cycle for SSE extraction.
+async fn run_sse_extraction(
+    provider: TokenUsageProvider,
+    sse_bytes: &[u8],
+) -> (Option<String>, Option<String>, Option<String>) {
+    let filter = make_filter(provider);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut resp = make_response_with_content_type("text/event-stream");
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    let mut body = Some(Bytes::copy_from_slice(sse_bytes));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    (
+        ctx.get_metadata("token.input").map(str::to_owned),
+        ctx.get_metadata("token.output").map(str::to_owned),
+        ctx.get_metadata("token.total").map(str::to_owned),
+    )
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -66,6 +66,10 @@ fn register_general_ai_filters(registry: &mut praxis_filter::FilterRegistry) {
     );
     praxis_filter::register_filters!(
         @register registry,
+        http "token_count" => praxis_ai_filters::TokenCountFilter::from_config
+    );
+    praxis_filter::register_filters!(
+        @register registry,
         http "token_usage_headers" => praxis_ai_filters::TokenUsageHeadersFilter::from_config
     );
 }


### PR DESCRIPTION
Implements issue 211: a new filter that extracts token usage from AI
  inference responses across all five providers (OpenAI, Anthropic,
  Google, Bedrock, Azure). Supports both SSE streaming and JSON
  non-streaming modes via content-type detection. Reuses the existing
  SSE scanner from the A2A module and the token extraction APIs.