### PR TITLE
docs(a2a): add agent-card routing example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,8 @@ before sending requests.
 
 | File | Description |
 | ------ | ------------- |
-| [a2a-classifier-routing.yaml](configs/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, task ID, and streaming detection |
+| [a2a-agent-card-routing.yaml](configs/a2a-agent-card-routing.yaml) | Routes agent card discovery requests to dedicated backends |
+| [a2a-classifier-routing.yaml](configs/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, context ID, task ID, and streaming detection |
 | [a2a-task-routing.yaml](configs/a2a-task-routing.yaml) | Captures task ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up task operations back to the backend cluster that created the task |
 | [ai-inference-body-based-routing.yaml](configs/ai-inference-body-based-routing.yaml) | Routes LLM API requests to different backends based on the `model` field in the JSON request body |
 | [credential-injection.yaml](configs/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |

--- a/examples/configs/a2a-agent-card-routing.yaml
+++ b/examples/configs/a2a-agent-card-routing.yaml
@@ -1,0 +1,48 @@
+# A2A Agent Card Routing
+#
+# Routes agent card discovery requests to dedicated backends.
+# Public discovery uses exact path matching; extended discovery
+# routes by the classifier's promoted x-praxis-a2a-method header.
+#
+# on_invalid: continue allows GET requests without a JSON-RPC body to
+# pass through to path-based routing.
+
+listeners:
+  - name: a2a
+    address: "127.0.0.1:8080"
+    filter_chains: [a2a-agent-card-routing]
+
+filter_chains:
+  - name: a2a-agent-card-routing
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          family: x-praxis-a2a-family
+
+      - filter: router
+        routes:
+          - path: "/.well-known/agent-card.json"
+            cluster: "public-agent-card"
+
+          - path_prefix: "/"
+            headers:
+              x-praxis-a2a-method: "GetExtendedAgentCard"
+            cluster: "extended-agent-card"
+
+          - path_prefix: "/"
+            cluster: "default"
+
+      - filter: load_balancer
+        clusters:
+          - name: "public-agent-card"
+            endpoints:
+              - "127.0.0.1:9001"
+          - name: "extended-agent-card"
+            endpoints:
+              - "127.0.0.1:9002"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:9000"

--- a/tests/integration/tests/suite/examples/agentic_routing.rs
+++ b/tests/integration/tests/suite/examples/agentic_routing.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    Backend, free_port, http_send, json_post, load_example_config, parse_body, parse_status,
+    Backend, free_port, http_get, http_send, json_post, load_example_config, parse_body, parse_status,
     start_backend_with_shutdown, start_proxy,
 };
 
@@ -613,6 +613,116 @@ fn a2a_task_routing_example_unknown_task_follows_fallback() {
     );
 }
 
+#[test]
+fn a2a_agent_card_routing_routes_public_card() {
+    let public_guard = start_backend_with_shutdown("public-agent-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-agent-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/.well-known/agent-card.json", Some("localhost"));
+    assert_eq!(status, 200, "public agent card GET should return 200");
+    assert_eq!(
+        body, "public-agent-card-response",
+        "GET /.well-known/agent-card.json should route to public-agent-card cluster"
+    );
+}
+
+#[test]
+fn a2a_agent_card_routing_falls_through_on_path_suffix() {
+    let public_guard = start_backend_with_shutdown("public-agent-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-agent-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/.well-known/agent-card.json-extra", Some("localhost"));
+    assert_eq!(status, 200, "path with suffix should return 200");
+    assert_eq!(
+        body, "default-response",
+        "path suffix past .json must not match the exact route"
+    );
+}
+
+#[test]
+fn a2a_agent_card_routing_routes_get_extended_agent_card() {
+    let public_guard = start_backend_with_shutdown("public-agent-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-agent-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/a2a/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"GetExtendedAgentCard","params":{}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "GetExtendedAgentCard should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "extended-agent-card-response",
+        "GetExtendedAgentCard should route to extended-agent-card cluster"
+    );
+}
+
+#[test]
+fn a2a_agent_card_routing_default_fallback_for_send_message() {
+    let public_guard = start_backend_with_shutdown("public-agent-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-agent-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/a2a/",
+            r#"{"jsonrpc":"2.0","id":2,"method":"SendMessage","params":{"message":"Hello"}}"#,
+        ),
+    );
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "SendMessage with no card route should return 200"
+    );
+    assert_eq!(
+        parse_body(&raw),
+        "default-response",
+        "SendMessage should fall through to default cluster"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
@@ -671,5 +781,22 @@ fn mcp_json_post(path: &str, body: &str, headers: &[(&str, &str)]) -> String {
          \r\n\
          {body}",
         body.len(),
+    )
+}
+
+fn load_agent_card_example_config(
+    proxy_port: u16,
+    public_port: u16,
+    extended_port: u16,
+    default_port: u16,
+) -> praxis_core::config::Config {
+    load_example_config(
+        "a2a-agent-card-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", public_port),
+            ("127.0.0.1:9002", extended_port),
+            ("127.0.0.1:9000", default_port),
+        ]),
     )
 }


### PR DESCRIPTION
  ## Summary

  Adds an A2A agent-card routing example using existing filters only.

  This is an examples/tests-only PR. It does not change A2A classifier behavior, task routing, MCP behavior, or core pipeline behavior.

  The new example demonstrates both common A2A agent-card discovery paths:

  - public discovery via `GET /.well-known/agent-card.json`
  - extended discovery via JSON-RPC `GetExtendedAgentCard`

  ## What This Adds

  - `examples/configs/a2a-agent-card-routing.yaml`
  - README entry for the new example config
  - integration coverage proving:
    - `GET /.well-known/agent-card.json` routes to the public agent-card backend
    - `GET /.well-known/agent-card.json-extra` does not match the exact route and falls through to default
    - `POST /a2a/` with `GetExtendedAgentCard` routes by promoted `x-praxis-a2a-method`
    - `POST /a2a/` with `SendMessage` falls through to default

  ## Design

  The public agent-card route uses exact path matching:

  ```yaml
  - path: "/.well-known/agent-card.json"
    cluster: "public-agent-card"
  ```

  The extended card route uses the existing A2A classifier. The classifier promotes the JSON-RPC method to x-praxis-a2a-method, and the router matches that header:

```yaml
  headers:
    x-praxis-a2a-method: "GetExtendedAgentCard"
```

  `on_invalid: continue` allows non-JSON GET requests to pass through to path-based routing.

  ## A2A Spec Alignment

  This example follows A2A Agent Card discovery semantics. Public discovery uses the standard well-known URI, `GET /.well-known/agent-card.json`, and extended discovery routes the A2A `GetExtendedAgentCard` operation separately so deployments can send public and authenticated/extended card traffic to different backends.

  This PR only demonstrates routing. The backend remains responsible for returning a valid `AgentCard`, enforcing authentication for extended cards, serving over HTTPS where appropriate, and handling cache/signature policy.

  Reference: [A2A Agent Discovery / Well-Known URI](https://github.com/a2aproject/A2A/blob/main/docs/specification.md#143-well-known-uri-registration)

  ## Validation

  - cargo test -p praxis-tests-integration --test suite agentic_routing
  - cargo test -p praxis-tests-schema
  - cargo clippy --workspace --all-targets -- -D warnings
  - cargo +nightly fmt --all --check
  - cargo xtask lint-example-tests
  - cargo xtask sync-example-readme
  - git diff --check
