### PR TITLE
docs: fix stale local documentation links

### DIFF
--- a/docs/architecture/agentic-protocols.md
+++ b/docs/architecture/agentic-protocols.md
@@ -213,5 +213,5 @@ All three filters share these conventions:
 ## Related
 
 - [AI Inference](ai-inference.md)
-- [Payload Processing](payload-processing.md)
-- [Architecture Overview](overview.md)
+- [Response Store](response-store.md)
+- [Features](../features.md)

--- a/docs/architecture/ai-inference.md
+++ b/docs/architecture/ai-inference.md
@@ -192,4 +192,4 @@ build.
 
 - [Response Store](response-store.md)
 - [Agentic Protocols](agentic-protocols.md)
-- [Payload Processing](payload-processing.md)
+- [Features](../features.md)

--- a/docs/architecture/response-store.md
+++ b/docs/architecture/response-store.md
@@ -149,5 +149,5 @@ pass-through traffic is not held.
 
 ## Related
 
-- [Payload Processing](payload-processing.md)
 - [AI Inference](ai-inference.md)
+- [Features](../features.md)

--- a/docs/developing/conventions.md
+++ b/docs/developing/conventions.md
@@ -63,7 +63,8 @@ write comments that restate what names already convey.
    in `tests/integration/tests/suite/examples/`
 5. Update `examples/README.md` to list any new or
    renamed example configs
-6. Significant changes need to be [benchmarked].
+6. Significant changes need benchmark or load-test evidence
+   appropriate to the affected filter path.
 
 This is not optional. A feature without tests and an
 example is not complete.
@@ -84,8 +85,6 @@ assert_eq!(status, 403);
 assert_eq!(status, 403, "ACL should block loopback");
 ```
 
-[benchmarked]:../benchmarks.md
-
 ### RFC Conformance
 
 When implementing protocol-level behavior (HTTP semantics,
@@ -103,12 +102,12 @@ and verify conformance against them.
   ```
 - When in doubt about an edge case, the RFC is the
   authority, not other proxy implementations.
-- Add dedicated conformance tests when implementing
-  RFC-specified behavior. These live in
-  `tests/conformance/`.
+- Add dedicated integration or schema tests when implementing
+  RFC-specified behavior. Keep protocol-specific coverage near
+  the affected filter or test suite.
 
-See also [HTTP Correctness](../architecture/http-correctness.md)
-for what Praxis enforces vs what Pingora handles.
+When protocol behavior depends on core proxy behavior, document
+the boundary in the relevant architecture doc or PR description.
 
 ### Rules, Practices & Lints
 

--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -46,10 +46,12 @@ produce a warning. All crates enforce
 `#![deny(unsafe_code)]` and Clippy runs with
 `-D warnings` (zero tolerance).
 
-See the [crate layout](../architecture/crate-layout.md) for workspace
-structure and crate dependencies.
-See [security-hardening.md](../operating/security-hardening.md) for
-deployment guidance.
+The workspace is split across `apis`, `filters`, `server`,
+`tests`, and `xtask`; shared dependencies are managed from the
+root `Cargo.toml`.
+
+See [SECURITY.md](../../SECURITY.md) for supported versions and
+vulnerability reporting.
 
 ## Security: Binding Low Ports
 
@@ -148,4 +150,6 @@ options.
 
 ## Performance & Benchmarking
 
-See [benchmarks.md](../benchmarks.md).
+Include benchmark or load-test evidence in PRs that materially
+affect request processing, storage, streaming, or protocol parsing
+costs.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,9 +68,10 @@ curl http://127.0.0.1:8080/v1/responses \
 
 ## Next steps
 
-- [Configuration](operating/configuration.md): filter
-  chains, routing, load balancing, and all options.
-- [Example configs](../examples/configs/): working YAML
+- [Example configs](../examples/README.md): working YAML
   for every feature.
 - [Filters](filters/README.md): AI filters and how to
   write your own.
+- [Praxis core](https://github.com/praxis-proxy/praxis):
+  listener, filter-chain, routing, and load-balancer
+  configuration.


### PR DESCRIPTION
##  Summary

  Fixes dead local documentation links left over from the repo migration. Updates developing docs, quickstart, and architecture “Related” sections to point at existing docs or replace missing references with inline guidance.

##  Validation

  - Local markdown link scan: broken=0
