### PR TITLE
test(xtask): fix example lint assertion message

### DIFF
--- a/xtask/src/lint_example_tests.rs
+++ b/xtask/src/lint_example_tests.rs
@@ -194,7 +194,7 @@ mod tests {
         );
         assert!(
             configs.contains(&"prompt-enrichment.yaml".to_owned()),
-            "basic-reverse-proxy.yaml should be in the config list"
+            "prompt-enrichment.yaml should be in the config list"
         );
     }
 


### PR DESCRIPTION
  ## Summary

  Fixes a stale assertion message in the example-config lint tests.

  The test checks for `prompt-enrichment.yaml`, but the failure message still referenced `basic-reverse-proxy.yaml` from the core Praxis repo. This PR updates the message so future failures point at the file the test actually checks.

  ## Validation

  - `cargo test -p xtask lint_example_tests`
  - `git diff --check`