### PR TITLE
fix: point issue template discussions link to ai repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/praxis-proxy/praxis/discussions
+    url: https://github.com/praxis-proxy/ai/discussions
     about: Ask questions or start a discussion


### PR DESCRIPTION
## Summary

The discussions contact link in the issue template config pointed to `praxis-proxy/praxis` instead of `praxis-proxy/ai`. This fixes it to point to the correct repository's discussions.