### PR TITLE
feat(filter): add openai_stream_events SSE accumulator filter

### DIFF
--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -108,6 +108,10 @@ pub(crate) mod test_utils {
             @register registry,
             http "openai_responses_rehydrate" => crate::openai::RehydrateFilter::from_config
         );
+        praxis_filter::register_filters!(
+            @register registry,
+            http "openai_stream_events" => crate::openai::OpenaiStreamEventsFilter::from_config
+        );
         registry
     }
 }

--- a/apis/src/openai/mod.rs
+++ b/apis/src/openai/mod.rs
@@ -16,5 +16,5 @@ pub(crate) mod translation;
 pub use conversations::OpenaiConversationsFilter;
 pub use responses::{
     ModelRewriteFilter, OpenaiResponsesValidateFilter, RehydrateFilter, ResponseStoreFilter, ResponsesFormatFilter,
-    proxy::ResponsesProxyFilter,
+    proxy::ResponsesProxyFilter, stream_events::OpenaiStreamEventsFilter,
 };

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -21,13 +21,9 @@ mod config;
 pub(crate) mod error;
 pub(crate) mod model_rewrite;
 pub(crate) mod proxy;
-#[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on modules")]
-#[allow(
-    dead_code,
-    reason = "state infrastructure for upcoming Responses API filter consumers (#354)"
-)]
 pub(crate) mod state;
 pub(crate) mod store;
+pub(crate) mod stream_events;
 
 pub use model_rewrite::ModelRewriteFilter;
 pub use store::ResponseStoreFilter;

--- a/apis/src/openai/responses/state.rs
+++ b/apis/src/openai/responses/state.rs
@@ -19,6 +19,10 @@
 /// callers.
 ///
 /// [`RequestExtensions`]: praxis_filter::RequestExtensions
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "fields used incrementally as more filters are ported")
+)]
 pub(crate) struct ResponsesState {
     /// Truncation strategy for managing context window limits.
     ///
@@ -244,6 +248,7 @@ fn extract_bool_or(body: &serde_json::Value, field: &str, default: bool) -> bool
 // -----------------------------------------------------------------------------
 
 #[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Dispatches parsed SSE events to mutate [`ResponsesState`].
+//!
+//! Terminal events (`response.completed`, `response.incomplete`,
+//! `response.failed`) are authoritative — their payloads overwrite
+//! any incrementally accumulated state. Incremental events
+//! (`output_item.added`, `function_call_arguments.done`) provide
+//! fallback state in case the terminal event is missing.
+
+use praxis_filter::HttpFilterContext;
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use super::StreamEventsState;
+use crate::openai::{responses::state::ResponsesState, sse::responses::ResponsesEvent};
+
+/// Process a single SSE event, updating `ResponsesState` in
+/// extensions and per-filter accumulation state.
+pub(super) fn accumulate_event(
+    ctx: &mut HttpFilterContext<'_>,
+    filter_state: &mut StreamEventsState,
+    event: &ResponsesEvent,
+) {
+    match event {
+        ResponsesEvent::ResponseCompleted(payload)
+        | ResponsesEvent::ResponseIncomplete(payload)
+        | ResponsesEvent::ResponseFailed(payload) => {
+            handle_terminal_event(ctx, payload, event);
+        },
+
+        ResponsesEvent::OutputItemAdded(payload) => {
+            handle_output_item_added(ctx, payload);
+        },
+        ResponsesEvent::OutputItemDone(payload) => {
+            handle_output_item_done(ctx, payload);
+        },
+
+        ResponsesEvent::FunctionCallArgumentsDelta(payload) => {
+            handle_function_call_delta(filter_state, payload);
+        },
+        ResponsesEvent::FunctionCallArgumentsDone(payload) => {
+            handle_function_call_done(ctx, filter_state, payload);
+        },
+
+        ResponsesEvent::Error(payload) => {
+            warn!(error = %payload, "streaming error event received");
+        },
+
+        ResponsesEvent::Unknown { event_type, .. } => {
+            debug!(event_type, "unknown SSE event type (forward-compat)");
+        },
+
+        _ => {},
+    }
+}
+
+/// Overwrite `ResponsesState` from a terminal event's authoritative payload.
+fn handle_terminal_event(ctx: &mut HttpFilterContext<'_>, payload: &Value, event: &ResponsesEvent) {
+    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
+
+    let response = payload.get("response").unwrap_or(payload);
+
+    response.clone_into(&mut state.response_object);
+
+    if let Some(Value::Array(output)) = response.get("output") {
+        output.clone_into(&mut state.output_items);
+    }
+
+    if let Some(usage) = response.get("usage")
+        && !usage.is_null()
+    {
+        usage.clone_into(&mut state.usage);
+    }
+
+    let status = match event {
+        ResponsesEvent::ResponseCompleted(_) => "completed",
+        ResponsesEvent::ResponseIncomplete(_) => "incomplete",
+        ResponsesEvent::ResponseFailed(_) => "failed",
+        _ => "unknown",
+    };
+    ctx.set_metadata("responses.status", status.to_owned());
+
+    debug!(status, "terminal event received, ResponsesState updated");
+}
+
+/// Push a new output item to the incremental accumulator.
+fn handle_output_item_added(ctx: &mut HttpFilterContext<'_>, payload: &Value) {
+    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
+
+    if let Some(item) = payload.get("item") {
+        state.output_items.push(item.clone());
+    }
+}
+
+/// Replace an existing output item by index or id, or append if new.
+fn handle_output_item_done(ctx: &mut HttpFilterContext<'_>, payload: &Value) {
+    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
+
+    let Some(item) = payload.get("item") else {
+        return;
+    };
+
+    if let Some(idx) = payload
+        .get("output_index")
+        .and_then(Value::as_u64)
+        .and_then(|v| usize::try_from(v).ok())
+        && let Some(slot) = state.output_items.get_mut(idx)
+    {
+        item.clone_into(slot);
+        return;
+    }
+
+    if let Some(id) = item.get("id").and_then(Value::as_str)
+        && let Some(existing) = state
+            .output_items
+            .iter_mut()
+            .find(|i| i.get("id").and_then(Value::as_str) == Some(id))
+    {
+        item.clone_into(existing);
+        return;
+    }
+
+    state.output_items.push(item.clone());
+}
+
+/// Append a function-call argument delta to the running buffer.
+fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Value) {
+    let Some(key) = tool_call_key(payload) else {
+        return;
+    };
+    let Some(delta) = payload.get("delta").and_then(Value::as_str) else {
+        return;
+    };
+
+    filter_state.tool_call_args.entry(key).or_default().push_str(delta);
+}
+
+/// Finalize a function call from accumulated deltas and push to `tool_calls`.
+fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut StreamEventsState, payload: &Value) {
+    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
+
+    let Some(key) = tool_call_key(payload) else {
+        return;
+    };
+
+    let arguments = filter_state
+        .tool_call_args
+        .remove(&key)
+        .or_else(|| payload.get("arguments").and_then(Value::as_str).map(ToOwned::to_owned))
+        .unwrap_or_default();
+
+    let Some(item) = find_output_item_mut(&mut state.output_items, payload) else {
+        warn!(
+            key,
+            "dropping function-call arguments.done without matching output item"
+        );
+        return;
+    };
+
+    let Some(tool_call) = complete_function_call_item(item, &arguments) else {
+        warn!(
+            key,
+            "dropping function-call arguments.done for non-function output item"
+        );
+        return;
+    };
+
+    upsert_tool_call(&mut state.tool_calls, tool_call);
+}
+
+/// Build the stable key used by argument delta/done events.
+fn tool_call_key(payload: &Value) -> Option<String> {
+    payload
+        .get("item_id")
+        .and_then(Value::as_str)
+        .map(|item_id| format!("item:{item_id}"))
+        .or_else(|| {
+            payload
+                .get("output_index")
+                .and_then(Value::as_u64)
+                .map(|output_index| format!("index:{output_index}"))
+        })
+}
+
+/// Find the output item targeted by a function-call arguments event.
+fn find_output_item_mut<'a>(output_items: &'a mut [Value], payload: &Value) -> Option<&'a mut Value> {
+    if let Some(item_id) = payload.get("item_id").and_then(Value::as_str)
+        && let Some(index) = output_items
+            .iter()
+            .position(|item| item.get("id").and_then(Value::as_str) == Some(item_id))
+    {
+        return output_items.get_mut(index);
+    }
+
+    let output_index = payload
+        .get("output_index")
+        .and_then(Value::as_u64)
+        .and_then(|v| usize::try_from(v).ok())?;
+    output_items.get_mut(output_index)
+}
+
+/// Apply finalized arguments to an existing function-call item.
+fn complete_function_call_item(item: &mut Value, arguments: &str) -> Option<Value> {
+    let obj = item.as_object_mut()?;
+    if obj.get("type").and_then(Value::as_str) != Some("function_call") {
+        return None;
+    }
+
+    obj.insert("arguments".to_owned(), Value::String(arguments.to_owned()));
+    if !matches!(
+        obj.get("status").and_then(Value::as_str),
+        Some("completed" | "incomplete")
+    ) {
+        obj.insert("status".to_owned(), Value::String("completed".to_owned()));
+    }
+
+    Some(item.clone())
+}
+
+/// Insert or replace a completed function-call item.
+fn upsert_tool_call(tool_calls: &mut Vec<Value>, tool_call: Value) {
+    let id = tool_call.get("id").and_then(Value::as_str);
+    let call_id = tool_call.get("call_id").and_then(Value::as_str);
+
+    if let Some(existing) = tool_calls.iter_mut().find(|existing| {
+        let existing_id = existing.get("id").and_then(Value::as_str);
+        let existing_call_id = existing.get("call_id").and_then(Value::as_str);
+        id.is_some_and(|id| existing_id == Some(id)) || call_id.is_some_and(|call_id| existing_call_id == Some(call_id))
+    }) {
+        tool_call.clone_into(existing);
+        return;
+    }
+
+    tool_calls.push(tool_call);
+}

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -147,7 +147,7 @@ fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Va
     buf.push_str(delta);
 }
 
-/// Finalize a function call from accumulated deltas and push to `tool_calls`.
+/// Finalize a function call from the done event's payload and push to `tool_calls`.
 fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut StreamEventsState, payload: &Value) {
     let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
 
@@ -155,10 +155,12 @@ fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut
         return;
     };
 
-    let arguments = filter_state
-        .tool_call_args
-        .remove(&key)
-        .or_else(|| payload.get("arguments").and_then(Value::as_str).map(ToOwned::to_owned))
+    let accumulated = filter_state.tool_call_args.remove(&key);
+    let arguments = payload
+        .get("arguments")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or(accumulated)
         .unwrap_or_default();
 
     let Some(item) = find_output_item_mut(&mut state.output_items, payload) else {

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -134,7 +134,17 @@ fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Va
         return;
     };
 
-    filter_state.tool_call_args.entry(key).or_default().push_str(delta);
+    let buf = filter_state.tool_call_args.entry(key.clone()).or_default();
+    if buf.len().saturating_add(delta.len()) > filter_state.max_tool_call_argument_bytes {
+        warn!(
+            key,
+            limit = filter_state.max_tool_call_argument_bytes,
+            "accumulated tool-call arguments exceed max_tool_call_argument_bytes, dropping"
+        );
+        filter_state.tool_call_args.remove(&key);
+        return;
+    }
+    buf.push_str(delta);
 }
 
 /// Finalize a function call from accumulated deltas and push to `tool_calls`.

--- a/apis/src/openai/responses/stream_events/config.rs
+++ b/apis/src/openai/responses/stream_events/config.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use praxis_filter::{FilterError, body::MAX_JSON_BODY_BYTES};
 use serde::Deserialize;
 
 use crate::openai::sse::SseParserConfig;
@@ -40,7 +41,31 @@ pub(crate) struct StreamEventsConfig {
 /// Default cap for accumulated function-call argument bytes (1 MiB).
 const DEFAULT_MAX_TOOL_CALL_ARGUMENT_BYTES: usize = 1024 * 1024;
 
+/// Filter name used in validation error messages.
+const FILTER_NAME: &str = "openai_stream_events";
+
 impl StreamEventsConfig {
+    /// Validate explicitly set values. Omitted fields use safe defaults.
+    pub(crate) fn validate(&self) -> Result<(), FilterError> {
+        if let Some(v) = self.max_buffer_bytes {
+            reject_zero(v, "max_buffer_bytes")?;
+            reject_above_max(v, "max_buffer_bytes")?;
+        }
+        if let Some(v) = self.max_events {
+            reject_zero(v, "max_events")?;
+        }
+        if let Some(v) = self.timeout_secs
+            && v == 0
+        {
+            return Err(format!("{FILTER_NAME}: 'timeout_secs' must be greater than 0").into());
+        }
+        if let Some(v) = self.max_tool_call_argument_bytes {
+            reject_zero(v, "max_tool_call_argument_bytes")?;
+            reject_above_max(v, "max_tool_call_argument_bytes")?;
+        }
+        Ok(())
+    }
+
     /// Convert to the internal parser config, applying defaults for
     /// any omitted fields.
     pub(crate) fn to_parser_config(&self) -> SseParserConfig {
@@ -57,4 +82,20 @@ impl StreamEventsConfig {
         self.max_tool_call_argument_bytes
             .unwrap_or(DEFAULT_MAX_TOOL_CALL_ARGUMENT_BYTES)
     }
+}
+
+/// Reject a zero value for a named configuration field.
+fn reject_zero(value: usize, field: &str) -> Result<(), FilterError> {
+    if value == 0 {
+        return Err(format!("{FILTER_NAME}: '{field}' must be greater than 0").into());
+    }
+    Ok(())
+}
+
+/// Reject a byte-cap value that exceeds `MAX_JSON_BODY_BYTES` (64 MiB).
+fn reject_above_max(value: usize, field: &str) -> Result<(), FilterError> {
+    if value > MAX_JSON_BODY_BYTES {
+        return Err(format!("{FILTER_NAME}: {field} ({value}) exceeds maximum ({MAX_JSON_BODY_BYTES})").into());
+    }
+    Ok(())
 }

--- a/apis/src/openai/responses/stream_events/config.rs
+++ b/apis/src/openai/responses/stream_events/config.rs
@@ -30,7 +30,15 @@ pub(crate) struct StreamEventsConfig {
     /// Default: 300 (5 minutes).
     #[serde(default)]
     pub timeout_secs: Option<u64>,
+
+    /// Maximum bytes accumulated per function-call argument string
+    /// from `function_call_arguments.delta` events. Default: 1 MiB.
+    #[serde(default)]
+    pub max_tool_call_argument_bytes: Option<usize>,
 }
+
+/// Default cap for accumulated function-call argument bytes (1 MiB).
+const DEFAULT_MAX_TOOL_CALL_ARGUMENT_BYTES: usize = 1024 * 1024;
 
 impl StreamEventsConfig {
     /// Convert to the internal parser config, applying defaults for
@@ -42,5 +50,11 @@ impl StreamEventsConfig {
             max_events: self.max_events.unwrap_or(defaults.max_events),
             timeout: self.timeout_secs.map_or(defaults.timeout, Duration::from_secs),
         }
+    }
+
+    /// Resolved cap for per-tool-call accumulated argument bytes.
+    pub(crate) fn max_tool_call_argument_bytes(&self) -> usize {
+        self.max_tool_call_argument_bytes
+            .unwrap_or(DEFAULT_MAX_TOOL_CALL_ARGUMENT_BYTES)
     }
 }

--- a/apis/src/openai/responses/stream_events/config.rs
+++ b/apis/src/openai/responses/stream_events/config.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! YAML-facing configuration for the `openai_stream_events` filter.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::openai::sse::SseParserConfig;
+
+/// Configuration for the `openai_stream_events` filter.
+///
+/// All fields are optional; omitted values fall back to
+/// [`SseParserConfig`] defaults.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StreamEventsConfig {
+    /// Maximum bytes buffered for incomplete SSE lines/data across
+    /// chunk boundaries. Default: 10 MiB.
+    #[serde(default)]
+    pub max_buffer_bytes: Option<usize>,
+
+    /// Maximum number of SSE events before the parser errors.
+    /// Default: 100,000.
+    #[serde(default)]
+    pub max_events: Option<usize>,
+
+    /// Maximum seconds from first chunk to stream completion.
+    /// Default: 300 (5 minutes).
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
+impl StreamEventsConfig {
+    /// Convert to the internal parser config, applying defaults for
+    /// any omitted fields.
+    pub(crate) fn to_parser_config(&self) -> SseParserConfig {
+        let defaults = SseParserConfig::default();
+        SseParserConfig {
+            max_buffer_bytes: self.max_buffer_bytes.unwrap_or(defaults.max_buffer_bytes),
+            max_events: self.max_events.unwrap_or(defaults.max_events),
+            timeout: self.timeout_secs.map_or(defaults.timeout, Duration::from_secs),
+        }
+    }
+}

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -3,16 +3,17 @@
 
 //! Accumulates state from native Responses API SSE event streams.
 //!
-//! Parses backend SSE chunks using [`ResponsesSseParser`], dispatches
+//! Parses backend SSE chunks using [`SseFrameParser`], dispatches
 //! typed events to update [`ResponsesState`] in request extensions.
-//! The filter is read-only: it observes body chunks without modifying
-//! them.
+//! The response body passes through unchanged.
 //!
-//! [`ResponsesSseParser`]: crate::openai::sse::responses::ResponsesSseParser
+//! [`SseFrameParser`]: crate::openai::sse::SseFrameParser
 //! [`ResponsesState`]: super::state::ResponsesState
 
 mod accumulator;
 mod config;
+
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -22,12 +23,35 @@ use praxis_filter::{
 use tracing::{debug, trace, warn};
 
 use self::{accumulator::accumulate_event, config::StreamEventsConfig};
-use crate::openai::sse::{SseParserConfig, responses::ResponsesSseParser};
+use crate::openai::sse::{SseFrameParser, SseParseError, SseParserConfig, responses::ResponsesEvent};
+
+/// Completion state observed while parsing a Responses SSE stream.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CompletionState {
+    /// No completion signal has been observed.
+    Open,
+    /// A terminal lifecycle event was observed.
+    TerminalLifecycle,
+    /// A stream-level error event was observed.
+    Error,
+}
 
 /// Per-request parser and accumulation state.
 pub(super) struct StreamEventsState {
-    /// Layered SSE parser that converts raw bytes into typed events.
-    parser: ResponsesSseParser,
+    /// Byte-level SSE frame parser.
+    frame_parser: SseFrameParser,
+    /// Number of non-sentinel events parsed so far.
+    event_count: usize,
+    /// Maximum allowed event count.
+    max_events: usize,
+    /// Maximum allowed wall-clock time.
+    timeout: Duration,
+    /// Timestamp of first chunk.
+    started_at: Option<Instant>,
+    /// Timestamp when a terminal state was first observed.
+    completed_at: Option<Instant>,
+    /// Stream completion state (`Open` / `TerminalLifecycle` / `Error`).
+    completion_state: CompletionState,
     /// Accumulated function-call argument deltas, keyed by item id or output index.
     tool_call_args: std::collections::HashMap<String, String>,
     /// Cap on accumulated bytes per tool-call argument string.
@@ -61,6 +85,7 @@ impl OpenaiStreamEventsFilter {
     /// Returns [`FilterError`] if the YAML config is invalid.
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         let cfg: StreamEventsConfig = parse_filter_config("openai_stream_events", config)?;
+        cfg.validate()?;
         Ok(Box::new(Self {
             parser_config: cfg.to_parser_config(),
             max_tool_call_argument_bytes: cfg.max_tool_call_argument_bytes(),
@@ -102,10 +127,30 @@ impl HttpFilter for OpenaiStreamEventsFilter {
         if is_responses && is_streaming {
             trace!("arming stream_events for streaming Responses API request");
             ctx.insert_filter_state(StreamEventsState {
-                parser: ResponsesSseParser::new(&self.parser_config),
+                frame_parser: SseFrameParser::new(self.parser_config.max_buffer_bytes),
+                event_count: 0,
+                max_events: self.parser_config.max_events,
+                timeout: self.parser_config.timeout,
+                started_at: None,
+                completed_at: None,
+                completion_state: CompletionState::Open,
                 tool_call_args: std::collections::HashMap::new(),
                 max_tool_call_argument_bytes: self.max_tool_call_argument_bytes,
             });
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if !Self::is_armed(ctx) {
+            return Ok(FilterAction::Continue);
+        }
+
+        if !is_success_sse_response(ctx) {
+            debug!("disarming stream_events: response is not 2xx text/event-stream");
+            ctx.remove_filter_state::<StreamEventsState>();
+            return Ok(FilterAction::Continue);
         }
 
         Ok(FilterAction::Continue)
@@ -122,9 +167,7 @@ impl HttpFilter for OpenaiStreamEventsFilter {
             return Ok(FilterAction::Continue);
         }
 
-        if let Some(bytes) = body.as_ref() {
-            process_chunk(ctx, bytes);
-        }
+        process_chunk(ctx, body);
 
         if end_of_stream {
             validate_stream_end(ctx);
@@ -134,34 +177,140 @@ impl HttpFilter for OpenaiStreamEventsFilter {
     }
 }
 
-/// Parse an SSE chunk and dispatch events to the accumulator.
-fn process_chunk(ctx: &mut HttpFilterContext<'_>, bytes: &Bytes) {
+/// Parse SSE frames and accumulate state without modifying the body.
+fn process_chunk(ctx: &mut HttpFilterContext<'_>, body: &Option<Bytes>) {
+    let Some(bytes) = body.as_ref() else {
+        return;
+    };
+
     let Some(mut state) = ctx.remove_filter_state::<StreamEventsState>() else {
         return;
     };
-    match state.parser.parse_chunk(bytes) {
-        Ok(events) => {
-            for event in &events {
-                accumulate_event(ctx, &mut state, event);
-            }
-        },
-        Err(e) => {
-            warn!(error = %e, "SSE parse error in stream_events");
-            ctx.set_metadata("responses.stream_parse_error", "true".to_owned());
-        },
+
+    let now = Instant::now();
+    state.started_at.get_or_insert(now);
+
+    if let Err(e) = parse_and_accumulate(&mut state, ctx, bytes, now) {
+        warn!(error = %e, "SSE parse error in stream_events");
+        ctx.set_metadata("responses.stream_parse_error", "true".to_owned());
     }
+
     ctx.insert_filter_state(state);
+}
+
+/// Parse frames from raw bytes and accumulate events.
+fn parse_and_accumulate(
+    state: &mut StreamEventsState,
+    ctx: &mut HttpFilterContext<'_>,
+    bytes: &Bytes,
+    now: Instant,
+) -> Result<(), SseParseError> {
+    check_timeout(state, now)?;
+
+    let frames = state.frame_parser.parse_chunk_with_counted_event_limit(
+        bytes,
+        state.event_count,
+        state.max_events,
+        |frame| frame.data != b"[DONE]",
+    )?;
+
+    for frame in &frames {
+        if frame.data == b"[DONE]" {
+            continue;
+        }
+
+        state.event_count += 1;
+        let event = ResponsesEvent::from_frame(frame)?;
+        record_completion(state, &event, now)?;
+        accumulate_event(ctx, state, &event);
+    }
+
+    Ok(())
+}
+
+/// Check whether the stream has exceeded its wall-clock timeout.
+fn check_timeout(state: &StreamEventsState, now: Instant) -> Result<(), SseParseError> {
+    let Some(started_at) = state.started_at else {
+        return Ok(());
+    };
+    let elapsed = now.duration_since(started_at);
+    if elapsed > state.timeout {
+        return Err(SseParseError::Timeout {
+            elapsed,
+            limit: state.timeout,
+        });
+    }
+    Ok(())
+}
+
+/// Record whether an event signals stream completion.
+fn record_completion(state: &mut StreamEventsState, event: &ResponsesEvent, now: Instant) -> Result<(), SseParseError> {
+    if matches!(event, ResponsesEvent::Error(_)) {
+        if state.completion_state == CompletionState::Error {
+            return Err(SseParseError::EventAfterTerminal {
+                event_type: event.event_type().to_owned(),
+            });
+        }
+        mark_complete(state, CompletionState::Error, now);
+        return Ok(());
+    }
+
+    if state.completion_state != CompletionState::Open {
+        return Err(SseParseError::EventAfterTerminal {
+            event_type: event.event_type().to_owned(),
+        });
+    }
+
+    if event.is_terminal() {
+        mark_complete(state, CompletionState::TerminalLifecycle, now);
+    }
+
+    Ok(())
+}
+
+/// Record the first terminal-state timestamp while allowing stronger
+/// states to replace weaker ones.
+fn mark_complete(state: &mut StreamEventsState, new_state: CompletionState, now: Instant) {
+    state.completion_state = new_state;
+    state.completed_at.get_or_insert(now);
 }
 
 /// Check that the SSE stream terminated with a terminal event.
 fn validate_stream_end(ctx: &mut HttpFilterContext<'_>) {
-    if let Some(state) = ctx.get_filter_state::<StreamEventsState>()
-        && let Err(e) = state.parser.validate_complete()
-    {
-        warn!(error = %e, "stream did not terminate cleanly");
-        ctx.set_metadata("responses.stream_incomplete", "true".to_owned());
+    if let Some(state) = ctx.get_filter_state::<StreamEventsState>() {
+        let checked_at = state.completed_at.unwrap_or_else(Instant::now);
+        if let Err(e) = check_timeout(state, checked_at) {
+            warn!(error = %e, "stream did not terminate cleanly");
+            ctx.set_metadata("responses.stream_incomplete", "true".to_owned());
+        } else if state.completion_state == CompletionState::Open {
+            warn!("stream did not terminate cleanly: missing terminal event");
+            ctx.set_metadata("responses.stream_incomplete", "true".to_owned());
+        }
     }
     debug!("stream_events processing complete");
+}
+
+/// Whether the response is a successful `text/event-stream` response.
+fn is_success_sse_response(ctx: &HttpFilterContext<'_>) -> bool {
+    let Some(resp) = ctx.response_header.as_ref() else {
+        return true;
+    };
+
+    if !resp.status.is_success() {
+        return false;
+    }
+
+    resp.headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(is_event_stream_content_type)
+}
+
+/// Whether a `Content-Type` header value indicates `text/event-stream`.
+fn is_event_stream_content_type(ct: &str) -> bool {
+    ct.split(';')
+        .next()
+        .is_some_and(|media| media.trim().eq_ignore_ascii_case("text/event-stream"))
 }
 
 #[cfg(test)]

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Accumulates state from native Responses API SSE event streams.
+//!
+//! Parses backend SSE chunks using [`ResponsesSseParser`], dispatches
+//! typed events to update [`ResponsesState`] in request extensions.
+//! The filter is read-only: it observes body chunks without modifying
+//! them.
+//!
+//! [`ResponsesSseParser`]: crate::openai::sse::responses::ResponsesSseParser
+//! [`ResponsesState`]: super::state::ResponsesState
+
+mod accumulator;
+mod config;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use praxis_filter::{
+    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, parse_filter_config,
+};
+use tracing::{debug, trace, warn};
+
+use self::{accumulator::accumulate_event, config::StreamEventsConfig};
+use crate::openai::sse::{SseParserConfig, responses::ResponsesSseParser};
+
+/// Per-request parser and accumulation state.
+pub(super) struct StreamEventsState {
+    /// Layered SSE parser that converts raw bytes into typed events.
+    parser: ResponsesSseParser,
+    /// Accumulated function-call argument deltas, keyed by item id or output index.
+    tool_call_args: std::collections::HashMap<String, String>,
+}
+
+/// Accumulates state from native Responses API SSE event streams.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: openai_stream_events
+/// # All fields optional:
+/// # max_buffer_bytes: 10485760
+/// # max_events: 100000
+/// # timeout_secs: 300
+/// ```
+pub struct OpenaiStreamEventsFilter {
+    /// Configuration for the SSE frame parser.
+    parser_config: SseParserConfig,
+}
+
+impl OpenaiStreamEventsFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: StreamEventsConfig = parse_filter_config("openai_stream_events", config)?;
+        Ok(Box::new(Self {
+            parser_config: cfg.to_parser_config(),
+        }))
+    }
+
+    /// Whether per-request parser state has been installed.
+    fn is_armed(ctx: &HttpFilterContext<'_>) -> bool {
+        ctx.get_filter_state::<StreamEventsState>().is_some()
+    }
+}
+
+#[async_trait]
+impl HttpFilter for OpenaiStreamEventsFilter {
+    fn name(&self) -> &'static str {
+        "openai_stream_events"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::None
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    fn response_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        let is_responses = ctx.get_metadata("openai_responses_format.format") == Some("openai_responses");
+        let is_streaming = ctx.get_metadata("openai_responses_format.stream") == Some("true");
+
+        if is_responses && is_streaming {
+            trace!("arming stream_events for streaming Responses API request");
+            ctx.insert_filter_state(StreamEventsState {
+                parser: ResponsesSseParser::new(&self.parser_config),
+                tool_call_args: std::collections::HashMap::new(),
+            });
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !Self::is_armed(ctx) {
+            debug!("stream_events not armed, passing through");
+            return Ok(FilterAction::Continue);
+        }
+
+        if let Some(bytes) = body.as_ref() {
+            process_chunk(ctx, bytes);
+        }
+
+        if end_of_stream {
+            validate_stream_end(ctx);
+        }
+
+        Ok(FilterAction::Continue)
+    }
+}
+
+/// Parse an SSE chunk and dispatch events to the accumulator.
+fn process_chunk(ctx: &mut HttpFilterContext<'_>, bytes: &Bytes) {
+    let Some(mut state) = ctx.remove_filter_state::<StreamEventsState>() else {
+        return;
+    };
+    match state.parser.parse_chunk(bytes) {
+        Ok(events) => {
+            for event in &events {
+                accumulate_event(ctx, &mut state, event);
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "SSE parse error in stream_events");
+            ctx.set_metadata("responses.stream_parse_error", "true".to_owned());
+        },
+    }
+    ctx.insert_filter_state(state);
+}
+
+/// Check that the SSE stream terminated with a terminal event.
+fn validate_stream_end(ctx: &mut HttpFilterContext<'_>) {
+    if let Some(state) = ctx.get_filter_state::<StreamEventsState>()
+        && let Err(e) = state.parser.validate_complete()
+    {
+        warn!(error = %e, "stream did not terminate cleanly");
+        ctx.set_metadata("responses.stream_incomplete", "true".to_owned());
+    }
+    debug!("stream_events processing complete");
+}
+
+#[cfg(test)]
+mod tests;

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -30,6 +30,8 @@ pub(super) struct StreamEventsState {
     parser: ResponsesSseParser,
     /// Accumulated function-call argument deltas, keyed by item id or output index.
     tool_call_args: std::collections::HashMap<String, String>,
+    /// Cap on accumulated bytes per tool-call argument string.
+    max_tool_call_argument_bytes: usize,
 }
 
 /// Accumulates state from native Responses API SSE event streams.
@@ -42,10 +44,13 @@ pub(super) struct StreamEventsState {
 /// # max_buffer_bytes: 10485760
 /// # max_events: 100000
 /// # timeout_secs: 300
+/// # max_tool_call_argument_bytes: 1048576
 /// ```
 pub struct OpenaiStreamEventsFilter {
     /// Configuration for the SSE frame parser.
     parser_config: SseParserConfig,
+    /// Cap on accumulated bytes per tool-call argument string.
+    max_tool_call_argument_bytes: usize,
 }
 
 impl OpenaiStreamEventsFilter {
@@ -58,6 +63,7 @@ impl OpenaiStreamEventsFilter {
         let cfg: StreamEventsConfig = parse_filter_config("openai_stream_events", config)?;
         Ok(Box::new(Self {
             parser_config: cfg.to_parser_config(),
+            max_tool_call_argument_bytes: cfg.max_tool_call_argument_bytes(),
         }))
     }
 
@@ -98,6 +104,7 @@ impl HttpFilter for OpenaiStreamEventsFilter {
             ctx.insert_filter_state(StreamEventsState {
                 parser: ResponsesSseParser::new(&self.parser_config),
                 tool_call_args: std::collections::HashMap::new(),
+                max_tool_call_argument_bytes: self.max_tool_call_argument_bytes,
             });
         }
 

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::too_many_lines,
+    unused_must_use,
+    reason = "tests"
+)]
+
+use bytes::Bytes;
+use praxis_filter::{FilterAction, HttpFilter};
+use serde_json::json;
+
+use super::{OpenaiStreamEventsFilter, StreamEventsState};
+use crate::{
+    openai::responses::state::ResponsesState,
+    test_utils::{make_filter_context, make_request},
+};
+
+fn make_filter() -> Box<dyn HttpFilter> {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    OpenaiStreamEventsFilter::from_config(&yaml).unwrap()
+}
+
+fn make_armed_context() -> (Box<dyn HttpFilter>, praxis_filter::HttpFilterContext<'static>) {
+    let filter = make_filter();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+    ctx.current_filter_id = Some(0);
+    (filter, ctx)
+}
+
+#[test]
+fn default_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = OpenaiStreamEventsFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "openai_stream_events");
+}
+
+#[test]
+fn custom_config_overrides_apply() {
+    let yaml: serde_yaml::Value =
+        serde_yaml::from_str("max_buffer_bytes: 1048576\nmax_events: 500\ntimeout_secs: 60").unwrap();
+    let filter = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(filter.is_ok(), "custom config should parse");
+}
+
+#[test]
+fn unknown_config_field_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("bogus_field: true").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(result.is_err(), "unknown fields should be rejected");
+}
+
+#[tokio::test]
+async fn arms_for_streaming_responses_request() {
+    let (filter, mut ctx) = make_armed_context();
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert!(
+        ctx.get_filter_state::<StreamEventsState>().is_some(),
+        "filter should be armed"
+    );
+}
+
+#[tokio::test]
+async fn does_not_arm_for_non_streaming() {
+    let filter = make_filter();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "false".to_owned());
+    ctx.current_filter_id = Some(0);
+
+    let _action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        ctx.get_filter_state::<StreamEventsState>().is_none(),
+        "filter should not arm for non-streaming"
+    );
+}
+
+#[tokio::test]
+async fn does_not_arm_for_non_responses_format() {
+    let filter = make_filter();
+    let req = make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_chat_completions".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+    ctx.current_filter_id = Some(0);
+
+    let _action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        ctx.get_filter_state::<StreamEventsState>().is_none(),
+        "filter should not arm for non-responses format"
+    );
+}
+
+#[test]
+fn unarmed_filter_passes_through_body() {
+    let filter = make_filter();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.current_filter_id = Some(0);
+
+    let mut body = Some(Bytes::from("data: {}\n\n"));
+    let action = filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert!(body.is_some(), "body should not be consumed");
+}
+
+fn make_sse_chunk(event_type: &str, data: &serde_json::Value) -> Bytes {
+    let mut obj = data.clone();
+    obj.as_object_mut()
+        .unwrap()
+        .entry("type")
+        .or_insert_with(|| serde_json::Value::String(event_type.to_owned()));
+    let data_str = serde_json::to_string(&obj).unwrap();
+    Bytes::from(format!("event: {event_type}\ndata: {data_str}\n\n"))
+}
+
+fn make_done_chunk() -> Bytes {
+    Bytes::from("data: [DONE]\n\n")
+}
+
+#[tokio::test]
+async fn terminal_event_writes_response_object() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let response_payload = json!({
+        "id": "resp_123",
+        "object": "response",
+        "status": "completed",
+        "model": "gpt-4o",
+        "created_at": 1_700_000_000,
+        "output": [
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Hello"}]}
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    });
+
+    let mut body = Some(make_sse_chunk("response.completed", &response_payload));
+    filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.response_object["id"], "resp_123");
+    assert_eq!(state.output_items.len(), 1);
+    assert_eq!(state.usage["total_tokens"], 15);
+    assert_eq!(ctx.get_metadata("responses.status"), Some("completed"),);
+}
+
+#[tokio::test]
+async fn output_item_added_accumulates_incrementally() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({"type": "message", "role": "assistant", "id": "item_1"});
+    let payload = json!({"item": item});
+
+    let mut body = Some(make_sse_chunk("response.output_item.added", &payload));
+    filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.output_items.len(), 1);
+    assert_eq!(state.output_items[0]["id"], "item_1");
+}
+
+#[tokio::test]
+async fn terminal_event_overwrites_incremental_output() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({"item": {"type": "message", "id": "item_1"}});
+    let mut body1 = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut body1, false).unwrap();
+    assert_eq!(ctx.extensions.get::<ResponsesState>().unwrap().output_items.len(), 1);
+
+    let completed = json!({
+        "id": "resp_123",
+        "status": "completed",
+        "model": "gpt-4o",
+        "created_at": 1_700_000_000,
+        "output": [
+            {"type": "message", "id": "item_final_1"},
+            {"type": "message", "id": "item_final_2"}
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    });
+    let mut body2 = Some(make_sse_chunk("response.completed", &completed));
+    filter.on_response_body(&mut ctx, &mut body2, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(
+        state.output_items.len(),
+        2,
+        "terminal event should overwrite incremental output"
+    );
+    assert_eq!(state.output_items[0]["id"], "item_final_1");
+}
+
+#[tokio::test]
+async fn function_call_accumulation() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_item_1",
+            "call_id": "call_1",
+            "name": "get_weather",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut item_body = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut item_body, false).unwrap();
+
+    let delta1 = json!({"item_id": "fc_item_1", "output_index": 0, "delta": "{\"city\":"});
+    let mut b1 = Some(make_sse_chunk("response.function_call_arguments.delta", &delta1));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let delta2 = json!({"item_id": "fc_item_1", "output_index": 0, "delta": "\"NYC\"}"});
+    let mut b2 = Some(make_sse_chunk("response.function_call_arguments.delta", &delta2));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let done = json!({
+        "item_id": "fc_item_1",
+        "output_index": 0,
+        "arguments": "{\"city\":\"NYC\"}"
+    });
+    let mut b3 = Some(make_sse_chunk("response.function_call_arguments.done", &done));
+    filter.on_response_body(&mut ctx, &mut b3, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.tool_calls.len(), 1);
+    assert_eq!(state.tool_calls[0]["id"], "fc_item_1");
+    assert_eq!(state.tool_calls[0]["call_id"], "call_1");
+    assert_eq!(state.tool_calls[0]["name"], "get_weather");
+    assert_eq!(state.tool_calls[0]["arguments"], "{\"city\":\"NYC\"}");
+    assert_eq!(state.tool_calls[0]["status"], "completed");
+    assert_eq!(state.output_items[0]["arguments"], "{\"city\":\"NYC\"}");
+}
+
+#[tokio::test]
+async fn missing_state_does_not_panic() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let completed = json!({
+        "id": "resp_123",
+        "status": "completed",
+        "model": "gpt-4o",
+        "created_at": 1_700_000_000,
+        "output": [],
+        "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    });
+    let mut body = Some(make_sse_chunk("response.completed", &completed));
+    let result = filter.on_response_body(&mut ctx, &mut body, false);
+    assert!(result.is_ok(), "should not panic with missing ResponsesState");
+    assert!(
+        ctx.extensions.get::<ResponsesState>().is_some(),
+        "should have created ResponsesState"
+    );
+}
+
+#[tokio::test]
+async fn eos_validates_stream_completeness() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let completed =
+        json!({"id": "resp_1", "status": "completed", "model": "m", "created_at": 0, "output": [], "usage": {}});
+    let mut b1 = Some(make_sse_chunk("response.completed", &completed));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let mut b2 = Some(make_done_chunk());
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let mut empty = None;
+    filter.on_response_body(&mut ctx, &mut empty, true).unwrap();
+    assert!(
+        ctx.get_metadata("responses.stream_parse_error").is_none(),
+        "DONE sentinel should not set parse-error metadata"
+    );
+    assert!(
+        ctx.get_metadata("responses.stream_incomplete").is_none(),
+        "complete stream should not set incomplete flag"
+    );
+}
+
+#[tokio::test]
+async fn eos_without_terminal_sets_incomplete() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let delta = json!({"text": "hi"});
+    let mut b1 = Some(make_sse_chunk("response.output_text.delta", &delta));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let mut empty = None;
+    filter.on_response_body(&mut ctx, &mut empty, true).unwrap();
+    assert_eq!(
+        ctx.get_metadata("responses.stream_incomplete"),
+        Some("true"),
+        "missing terminal should set incomplete flag"
+    );
+}
+
+#[test]
+fn body_passes_through_unchanged() {
+    let (filter, mut ctx) = make_armed_context();
+    ctx.insert_filter_state(StreamEventsState {
+        parser: crate::openai::sse::responses::ResponsesSseParser::new(&crate::openai::sse::SseParserConfig::default()),
+        tool_call_args: std::collections::HashMap::new(),
+    });
+
+    let original = Bytes::from("event: response.created\ndata: {\"type\":\"response.created\",\"id\":\"r1\"}\n\n");
+    let mut body = Some(original.clone());
+    filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    assert_eq!(
+        body.as_ref().unwrap(),
+        &original,
+        "read-only filter must not modify body bytes"
+    );
+}
+
+#[test]
+fn parse_error_sets_metadata() {
+    let (filter, mut ctx) = make_armed_context();
+    ctx.insert_filter_state(StreamEventsState {
+        parser: crate::openai::sse::responses::ResponsesSseParser::new(&crate::openai::sse::SseParserConfig {
+            max_buffer_bytes: 10,
+            max_events: 100_000,
+            timeout: std::time::Duration::from_secs(300),
+        }),
+        tool_call_args: std::collections::HashMap::new(),
+    });
+
+    let large_chunk =
+        Bytes::from("event: response.created\ndata: {\"id\": \"resp_overflow_test_with_a_very_long_payload\"}\n\n");
+    let mut body = Some(large_chunk);
+    filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    assert_eq!(
+        ctx.get_metadata("responses.stream_parse_error"),
+        Some("true"),
+        "parse error should set metadata flag"
+    );
+}
+
+#[tokio::test]
+async fn output_item_done_replaces_by_index() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let added = json!({"item": {"type": "message", "id": "item_1", "content": []}});
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &added));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let done = json!({
+        "output_index": 0,
+        "item": {"type": "message", "id": "item_1", "content": [{"type": "output_text", "text": "final"}]}
+    });
+    let mut b2 = Some(make_sse_chunk("response.output_item.done", &done));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.output_items.len(), 1, "should replace, not append");
+    assert!(
+        state.output_items[0]["content"][0]["text"] == "final",
+        "should have updated content"
+    );
+}
+
+#[tokio::test]
+async fn terminal_incomplete_sets_status() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let payload = json!({
+        "id": "resp_inc",
+        "status": "incomplete",
+        "model": "gpt-4o",
+        "created_at": 1_700_000_000,
+        "output": [{"type": "message", "id": "item_1"}],
+        "usage": {"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+        "incomplete_details": {"reason": "max_output_tokens"}
+    });
+    let mut body = Some(make_sse_chunk("response.incomplete", &payload));
+    filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.response_object["id"], "resp_inc");
+    assert_eq!(state.output_items.len(), 1);
+    assert_eq!(ctx.get_metadata("responses.status"), Some("incomplete"));
+}
+
+#[tokio::test]
+async fn terminal_failed_sets_status() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let payload = json!({
+        "id": "resp_fail",
+        "status": "failed",
+        "model": "gpt-4o",
+        "created_at": 1_700_000_000,
+        "output": [],
+        "usage": {"input_tokens": 5, "output_tokens": 0, "total_tokens": 5},
+        "error": {"code": "server_error", "message": "internal failure"}
+    });
+    let mut body = Some(make_sse_chunk("response.failed", &payload));
+    filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.response_object["id"], "resp_fail");
+    assert_eq!(state.output_items.len(), 0);
+    assert_eq!(ctx.get_metadata("responses.status"), Some("failed"));
+}
+
+#[tokio::test]
+async fn output_item_done_replaces_by_id() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let added = json!({"item": {"type": "message", "id": "item_A", "content": []}});
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &added));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let done = json!({
+        "item": {"type": "message", "id": "item_A", "content": [{"type": "output_text", "text": "replaced"}]}
+    });
+    let mut b2 = Some(make_sse_chunk("response.output_item.done", &done));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.output_items.len(), 1, "should replace by id, not append");
+    assert_eq!(state.output_items[0]["content"][0]["text"], "replaced");
+}
+
+#[tokio::test]
+async fn upsert_tool_call_dedup() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_dup",
+            "call_id": "call_dup",
+            "name": "search",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let done1 = json!({"item_id": "fc_dup", "output_index": 0, "arguments": "{\"q\":\"v1\"}"});
+    let mut b2 = Some(make_sse_chunk("response.function_call_arguments.done", &done1));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    assert_eq!(ctx.extensions.get::<ResponsesState>().unwrap().tool_calls.len(), 1);
+
+    let done2 = json!({"item_id": "fc_dup", "output_index": 0, "arguments": "{\"q\":\"v2\"}"});
+    let mut b3 = Some(make_sse_chunk("response.function_call_arguments.done", &done2));
+    filter.on_response_body(&mut ctx, &mut b3, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.tool_calls.len(), 1, "should replace, not append duplicate");
+    assert_eq!(state.tool_calls[0]["arguments"], "{\"q\":\"v2\"}");
+}
+
+#[tokio::test]
+async fn function_call_done_without_prior_deltas() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_no_delta",
+            "call_id": "call_nd",
+            "name": "get_time",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let done = json!({
+        "item_id": "fc_no_delta",
+        "output_index": 0,
+        "arguments": "{\"tz\":\"UTC\"}"
+    });
+    let mut b2 = Some(make_sse_chunk("response.function_call_arguments.done", &done));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.tool_calls.len(), 1);
+    assert_eq!(
+        state.tool_calls[0]["arguments"], "{\"tz\":\"UTC\"}",
+        "should use payload arguments when no deltas were accumulated"
+    );
+}
+
+#[tokio::test]
+async fn unknown_event_type_ignored() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let payload = json!({"some_field": "some_value"});
+    let mut body = Some(make_sse_chunk("response.future_event_type", &payload));
+    let result = filter.on_response_body(&mut ctx, &mut body, false);
+
+    assert!(result.is_ok(), "unknown event type should not error");
+    assert!(body.is_some(), "body should pass through unchanged");
+}
+
+#[tokio::test]
+async fn error_event_does_not_mutate_state() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let payload = json!({"code": "server_error", "message": "something broke"});
+    let mut body = Some(make_sse_chunk("error", &payload));
+    let result = filter.on_response_body(&mut ctx, &mut body, false);
+
+    assert!(result.is_ok(), "error event should not fail the filter");
+    assert!(
+        ctx.extensions.get::<ResponsesState>().is_none(),
+        "error event should not create ResponsesState"
+    );
+}

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -13,9 +13,9 @@ use bytes::Bytes;
 use praxis_filter::{FilterAction, HttpFilter};
 use serde_json::json;
 
-use super::{OpenaiStreamEventsFilter, StreamEventsState};
+use super::{CompletionState, OpenaiStreamEventsFilter, StreamEventsState};
 use crate::{
-    openai::responses::state::ResponsesState,
+    openai::{responses::state::ResponsesState, sse::SseFrameParser},
     test_utils::{make_filter_context, make_request},
 };
 
@@ -54,6 +54,51 @@ fn unknown_config_field_rejected() {
     let yaml: serde_yaml::Value = serde_yaml::from_str("bogus_field: true").unwrap();
     let result = OpenaiStreamEventsFilter::from_config(&yaml);
     assert!(result.is_err(), "unknown fields should be rejected");
+}
+
+#[test]
+fn zero_max_buffer_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_buffer_bytes: 0").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero max_buffer_bytes should be rejected");
+}
+
+#[test]
+fn zero_max_events_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_events: 0").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero max_events should be rejected");
+}
+
+#[test]
+fn zero_timeout_secs_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("timeout_secs: 0").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero timeout_secs should be rejected");
+}
+
+#[test]
+fn zero_max_tool_call_argument_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_tool_call_argument_bytes: 0").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero max_tool_call_argument_bytes should be rejected");
+}
+
+#[test]
+fn oversized_max_buffer_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_buffer_bytes: 100000000").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(result.is_err(), "max_buffer_bytes above 64 MiB should be rejected");
+}
+
+#[test]
+fn oversized_max_tool_call_argument_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_tool_call_argument_bytes: 100000000").unwrap();
+    let result = OpenaiStreamEventsFilter::from_config(&yaml);
+    assert!(
+        result.is_err(),
+        "max_tool_call_argument_bytes above 64 MiB should be rejected"
+    );
 }
 
 #[tokio::test]
@@ -316,7 +361,13 @@ async fn eos_without_terminal_sets_incomplete() {
 fn body_passes_through_unchanged() {
     let (filter, mut ctx) = make_armed_context();
     ctx.insert_filter_state(StreamEventsState {
-        parser: crate::openai::sse::responses::ResponsesSseParser::new(&crate::openai::sse::SseParserConfig::default()),
+        frame_parser: SseFrameParser::new(10_485_760),
+        event_count: 0,
+        max_events: 100_000,
+        timeout: std::time::Duration::from_secs(300),
+        started_at: None,
+        completed_at: None,
+        completion_state: CompletionState::Open,
         tool_call_args: std::collections::HashMap::new(),
         max_tool_call_argument_bytes: 1024 * 1024,
     });
@@ -326,9 +377,9 @@ fn body_passes_through_unchanged() {
     filter.on_response_body(&mut ctx, &mut body, false).unwrap();
 
     assert_eq!(
-        body.as_ref().unwrap(),
-        &original,
-        "read-only filter must not modify body bytes"
+        body.as_ref().unwrap().as_ref(),
+        original.as_ref(),
+        "body should pass through unchanged in ReadOnly mode"
     );
 }
 
@@ -336,11 +387,13 @@ fn body_passes_through_unchanged() {
 fn parse_error_sets_metadata() {
     let (filter, mut ctx) = make_armed_context();
     ctx.insert_filter_state(StreamEventsState {
-        parser: crate::openai::sse::responses::ResponsesSseParser::new(&crate::openai::sse::SseParserConfig {
-            max_buffer_bytes: 10,
-            max_events: 100_000,
-            timeout: std::time::Duration::from_secs(300),
-        }),
+        frame_parser: SseFrameParser::new(10),
+        event_count: 0,
+        max_events: 100_000,
+        timeout: std::time::Duration::from_secs(300),
+        started_at: None,
+        completed_at: None,
+        completion_state: CompletionState::Open,
         tool_call_args: std::collections::HashMap::new(),
         max_tool_call_argument_bytes: 1024 * 1024,
     });
@@ -517,6 +570,44 @@ async fn function_call_done_without_prior_deltas() {
 }
 
 #[tokio::test]
+async fn done_payload_wins_over_accumulated_deltas() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_diff",
+            "call_id": "call_diff",
+            "name": "lookup",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let delta = json!({"item_id": "fc_diff", "output_index": 0, "delta": "{\"from\":\"delta\"}"});
+    let mut b2 = Some(make_sse_chunk("response.function_call_arguments.delta", &delta));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let done = json!({
+        "item_id": "fc_diff",
+        "output_index": 0,
+        "arguments": "{\"from\":\"done_payload\"}"
+    });
+    let mut b3 = Some(make_sse_chunk("response.function_call_arguments.done", &done));
+    filter.on_response_body(&mut ctx, &mut b3, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(
+        state.tool_calls[0]["arguments"], "{\"from\":\"done_payload\"}",
+        "done-event arguments should take precedence over accumulated deltas"
+    );
+}
+
+#[tokio::test]
 async fn unknown_event_type_ignored() {
     let (filter, mut ctx) = make_armed_context();
     filter.on_request(&mut ctx).await.unwrap();
@@ -542,6 +633,55 @@ async fn error_event_does_not_mutate_state() {
     assert!(
         ctx.extensions.get::<ResponsesState>().is_none(),
         "error event should not create ResponsesState"
+    );
+}
+
+#[tokio::test]
+async fn error_after_terminal_lifecycle_is_accepted() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let completed =
+        json!({"id": "resp_1", "status": "completed", "model": "m", "created_at": 0, "output": [], "usage": {}});
+    let mut b1 = Some(make_sse_chunk("response.completed", &completed));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let error = json!({"code": "server_error", "message": "late error"});
+    let mut b2 = Some(make_sse_chunk("error", &error));
+    let result = filter.on_response_body(&mut ctx, &mut b2, false);
+
+    assert!(
+        result.is_ok(),
+        "first error after terminal lifecycle should be accepted"
+    );
+    assert!(
+        ctx.get_metadata("responses.stream_parse_error").is_none(),
+        "accepted error should not set parse error"
+    );
+}
+
+#[tokio::test]
+async fn second_error_after_terminal_is_rejected() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let completed =
+        json!({"id": "resp_1", "status": "completed", "model": "m", "created_at": 0, "output": [], "usage": {}});
+    let mut b1 = Some(make_sse_chunk("response.completed", &completed));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let error1 = json!({"code": "server_error", "message": "first error"});
+    let mut b2 = Some(make_sse_chunk("error", &error1));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let error2 = json!({"code": "server_error", "message": "second error"});
+    let mut b3 = Some(make_sse_chunk("error", &error2));
+    filter.on_response_body(&mut ctx, &mut b3, false).unwrap();
+
+    assert_eq!(
+        ctx.get_metadata("responses.stream_parse_error"),
+        Some("true"),
+        "second error event should be rejected as EventAfterTerminal"
     );
 }
 
@@ -621,5 +761,117 @@ async fn tool_call_argument_bytes_within_limit() {
         state.tool_call_args.get("item:fc_ok").unwrap(),
         "{\"k\":\"v\"}",
         "within-limit deltas should accumulate normally"
+    );
+}
+
+#[tokio::test]
+async fn on_response_disarms_for_non_2xx_status() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+    assert!(ctx.get_filter_state::<StreamEventsState>().is_some());
+
+    let resp = Box::leak(Box::new(crate::test_utils::make_response()));
+    resp.status = http::StatusCode::BAD_REQUEST;
+    resp.headers.insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("application/json"),
+    );
+    ctx.response_header = Some(resp);
+
+    filter.on_response(&mut ctx).await.unwrap();
+
+    assert!(
+        ctx.get_filter_state::<StreamEventsState>().is_none(),
+        "filter should be disarmed for non-2xx response"
+    );
+}
+
+#[tokio::test]
+async fn on_response_disarms_for_non_sse_content_type() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let resp = Box::leak(Box::new(crate::test_utils::make_response()));
+    resp.headers.insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("application/json"),
+    );
+    ctx.response_header = Some(resp);
+
+    filter.on_response(&mut ctx).await.unwrap();
+
+    assert!(
+        ctx.get_filter_state::<StreamEventsState>().is_none(),
+        "filter should be disarmed for non-SSE content type"
+    );
+}
+
+#[tokio::test]
+async fn on_response_stays_armed_for_sse_with_charset() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let resp = Box::leak(Box::new(crate::test_utils::make_response()));
+    resp.headers.insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("text/event-stream; charset=utf-8"),
+    );
+    ctx.response_header = Some(resp);
+
+    filter.on_response(&mut ctx).await.unwrap();
+
+    assert!(
+        ctx.get_filter_state::<StreamEventsState>().is_some(),
+        "filter should stay armed for text/event-stream with charset parameter"
+    );
+}
+
+#[tokio::test]
+async fn disarmed_filter_passes_error_body_through() {
+    let (filter, mut ctx) = make_armed_context();
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let resp = Box::leak(Box::new(crate::test_utils::make_response()));
+    resp.status = http::StatusCode::BAD_REQUEST;
+    resp.headers.insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("application/json"),
+    );
+    ctx.response_header = Some(resp);
+    filter.on_response(&mut ctx).await.unwrap();
+
+    let error_json = r#"{"error":{"message":"bad request","type":"invalid_request_error"}}"#;
+    let mut body = Some(Bytes::from(error_json));
+    filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+
+    assert_eq!(
+        body.as_ref().unwrap().as_ref(),
+        error_json.as_bytes(),
+        "error body should pass through unchanged after disarming"
+    );
+}
+
+#[tokio::test]
+async fn on_response_preserves_content_length_when_not_armed() {
+    let filter = make_filter();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.current_filter_id = Some(0);
+
+    let resp = Box::leak(Box::new(crate::test_utils::make_response()));
+    resp.headers
+        .insert(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("1234"));
+    ctx.response_header = Some(resp);
+
+    filter.on_response(&mut ctx).await.unwrap();
+
+    assert!(
+        ctx.response_header
+            .as_ref()
+            .unwrap()
+            .headers
+            .get(http::header::CONTENT_LENGTH)
+            .is_some(),
+        "Content-Length should be preserved when filter is not armed"
     );
 }

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -318,6 +318,7 @@ fn body_passes_through_unchanged() {
     ctx.insert_filter_state(StreamEventsState {
         parser: crate::openai::sse::responses::ResponsesSseParser::new(&crate::openai::sse::SseParserConfig::default()),
         tool_call_args: std::collections::HashMap::new(),
+        max_tool_call_argument_bytes: 1024 * 1024,
     });
 
     let original = Bytes::from("event: response.created\ndata: {\"type\":\"response.created\",\"id\":\"r1\"}\n\n");
@@ -341,6 +342,7 @@ fn parse_error_sets_metadata() {
             timeout: std::time::Duration::from_secs(300),
         }),
         tool_call_args: std::collections::HashMap::new(),
+        max_tool_call_argument_bytes: 1024 * 1024,
     });
 
     let large_chunk =
@@ -540,5 +542,84 @@ async fn error_event_does_not_mutate_state() {
     assert!(
         ctx.extensions.get::<ResponsesState>().is_none(),
         "error event should not create ResponsesState"
+    );
+}
+
+#[tokio::test]
+async fn tool_call_argument_bytes_cap_enforced() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_tool_call_argument_bytes: 20").unwrap();
+    let filter = OpenaiStreamEventsFilter::from_config(&yaml).unwrap();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+    ctx.current_filter_id = Some(0);
+
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_big",
+            "call_id": "call_big",
+            "name": "big_fn",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let delta1 = json!({"item_id": "fc_big", "output_index": 0, "delta": "0123456789"});
+    let mut b2 = Some(make_sse_chunk("response.function_call_arguments.delta", &delta1));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let delta2 = json!({"item_id": "fc_big", "output_index": 0, "delta": "0123456789X"});
+    let mut b3 = Some(make_sse_chunk("response.function_call_arguments.delta", &delta2));
+    filter.on_response_body(&mut ctx, &mut b3, false).unwrap();
+
+    let state = ctx.remove_filter_state::<StreamEventsState>().unwrap();
+    assert!(
+        !state.tool_call_args.contains_key("item:fc_big"),
+        "exceeding max_tool_call_argument_bytes should drop the accumulator entry"
+    );
+}
+
+#[tokio::test]
+async fn tool_call_argument_bytes_within_limit() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_tool_call_argument_bytes: 50").unwrap();
+    let filter = OpenaiStreamEventsFilter::from_config(&yaml).unwrap();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+    ctx.current_filter_id = Some(0);
+
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_ok",
+            "call_id": "call_ok",
+            "name": "small_fn",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut b1 = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut b1, false).unwrap();
+
+    let delta = json!({"item_id": "fc_ok", "output_index": 0, "delta": "{\"k\":\"v\"}"});
+    let mut b2 = Some(make_sse_chunk("response.function_call_arguments.delta", &delta));
+    filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
+
+    let state = ctx.remove_filter_state::<StreamEventsState>().unwrap();
+    assert_eq!(
+        state.tool_call_args.get("item:fc_ok").unwrap(),
+        "{\"k\":\"v\"}",
+        "within-limit deltas should accumulate normally"
     );
 }

--- a/apis/src/openai/sse/mod.rs
+++ b/apis/src/openai/sse/mod.rs
@@ -4,7 +4,7 @@
 //! SSE parsing for OpenAI streaming APIs.
 //!
 //! - [`frame::SseFrameParser`] — byte-level SSE chunk reassembly
-//! - [`responses::ResponsesSseParser`] — typed Responses API event parser
+//! - [`responses::ResponsesEvent`] — typed Responses API event enum
 
 #![cfg_attr(not(test), allow(dead_code, reason = "used by filter implementations"))]
 

--- a/apis/src/openai/sse/responses/mod.rs
+++ b/apis/src/openai/sse/responses/mod.rs
@@ -7,4 +7,3 @@ mod event;
 mod parser;
 
 pub(crate) use event::ResponsesEvent;
-pub(crate) use parser::ResponsesSseParser;

--- a/apis/src/openai/sse/responses/mod.rs
+++ b/apis/src/openai/sse/responses/mod.rs
@@ -6,7 +6,5 @@
 mod event;
 mod parser;
 
-#[expect(unused_imports, reason = "used by filter implementations in production")]
 pub(crate) use event::ResponsesEvent;
-#[expect(unused_imports, reason = "used by filter implementations in production")]
 pub(crate) use parser::ResponsesSseParser;

--- a/docs/filters/openai_response_store.md
+++ b/docs/filters/openai_response_store.md
@@ -3,7 +3,7 @@
 
 # `openai_response_store`
 
-Persists non-streaming Responses API responses to the configured response store backend.
+Persists Responses API responses to the configured response store backend. Supports both buffered (non-streaming) and streaming responses. Streaming exchanges are persisted at end-of-stream using accumulated `ResponsesState` from the `openai_stream_events` filter.
 
 ## Configuration
 

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -107,4 +107,4 @@ filter_chains:
         clusters:
           - name: "inference-backend"
             endpoints:
-              - "127.0.0.1:3001"
+              - "127.0.0.1:8000"

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -107,4 +107,4 @@ filter_chains:
         clusters:
           - name: "inference-backend"
             endpoints:
-              - "127.0.0.1:8000"
+              - "127.0.0.1:3001"

--- a/examples/configs/openai/responses/stream-events.yaml
+++ b/examples/configs/openai/responses/stream-events.yaml
@@ -1,0 +1,72 @@
+# Streaming Event Accumulation
+#
+# Demonstrates the `openai_stream_events` filter, which observes
+# SSE chunks from the backend without modification, accumulates
+# state (response object, output items, tool calls, usage), and
+# writes it to ResponsesState metadata. The `openai_response_store`
+# filter then persists the accumulated state at end-of-stream.
+#
+# This is a minimal pipeline focused on streaming accumulation
+# and persistence. Response body filters run in reverse config
+# order, so the store is listed before stream_events while
+# stream_events still parses final chunks before store persistence.
+# For a complete setup with multi-turn conversation support
+# (rehydrate, responses_proxy), see
+# full-flow.yaml.
+#
+# Example requests:
+#
+#   # Streaming with persistence (store defaults to true)
+#   curl -N http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"Qwen/Qwen3-0.6B","input":"Say hello","stream":true}'
+#
+#   # Non-streaming (still persisted via the buffered path)
+#   curl http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"Qwen/Qwen3-0.6B","input":"Say hello"}'
+#
+#   # Retrieve stored response
+#   curl http://localhost:8080/v1/responses/<response-id>
+#
+# Requires the ai-inference feature:
+#   cargo build -p praxis --features ai-inference
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [responses-pipeline]
+
+filter_chains:
+  - name: responses-pipeline
+    filters:
+      - filter: openai_responses_format
+        on_invalid: reject
+        headers:
+          format: x-praxis-ai-format
+          model: x-praxis-ai-model
+          stream: x-praxis-ai-stream
+          mode: x-praxis-responses-mode
+
+      - filter: openai_responses_validate
+
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "sqlite://responses.db?mode=rwc"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+
+      - filter: openai_stream_events
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            headers:
+              x-praxis-ai-format: "openai_responses"
+            cluster: "inference-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "inference-backend"
+            endpoints:
+              - "127.0.0.1:8000"

--- a/examples/configs/openai/responses/stream-events.yaml
+++ b/examples/configs/openai/responses/stream-events.yaml
@@ -57,6 +57,7 @@ filter_chains:
         conversations_table: openai_conversations
 
       - filter: openai_stream_events
+        # max_tool_call_argument_bytes: 1048576
 
       - filter: router
         routes:

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -94,7 +94,7 @@ fn register_anthropic_filters(registry: &mut praxis_filter::FilterRegistry) {
     );
 }
 
-/// Register OpenAI-specific filters.
+/// Register OpenAI Responses API request-path filters.
 fn register_openai_filters(registry: &mut praxis_filter::FilterRegistry) {
     praxis_filter::register_filters!(
         @register registry,
@@ -114,11 +114,20 @@ fn register_openai_filters(registry: &mut praxis_filter::FilterRegistry) {
     );
     praxis_filter::register_filters!(
         @register registry,
+        http "openai_responses_rehydrate" => praxis_ai_apis::openai::RehydrateFilter::from_config
+    );
+    register_openai_response_filters(registry);
+}
+
+/// Register OpenAI Responses API response-path and persistence filters.
+fn register_openai_response_filters(registry: &mut praxis_filter::FilterRegistry) {
+    praxis_filter::register_filters!(
+        @register registry,
         http "openai_response_store" => praxis_ai_apis::openai::ResponseStoreFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "openai_responses_rehydrate" => praxis_ai_apis::openai::RehydrateFilter::from_config
+        http "openai_stream_events" => praxis_ai_apis::openai::OpenaiStreamEventsFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -19,6 +19,7 @@ mod openai_response_store_postgres;
 mod openai_responses_format;
 mod openai_responses_model_rewrite;
 mod openai_responses_validate;
+mod openai_stream_events;
 mod prompt_enrichment;
 mod rehydrate;
 mod responses_proxy;

--- a/tests/integration/tests/suite/examples/openai_stream_events.rs
+++ b/tests/integration/tests/suite/examples/openai_stream_events.rs
@@ -119,6 +119,84 @@ async fn stream_events_accumulates_state_and_persists_response_to_sqlite() {
     cleanup_sqlite_files(&db_path);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_events_incremental_accumulation_before_terminal() {
+    let sse_body = [
+        "event: response.output_item.added\n",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,",
+        "\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",",
+        "\"name\":\"get_weather\",\"arguments\":\"\",\"status\":\"in_progress\"}}\n\n",
+        "event: response.function_call_arguments.delta\n",
+        "data: {\"type\":\"response.function_call_arguments.delta\",",
+        "\"item_id\":\"fc_1\",\"output_index\":0,\"delta\":\"{\\\"city\\\":\"}\n\n",
+        "event: response.function_call_arguments.delta\n",
+        "data: {\"type\":\"response.function_call_arguments.delta\",",
+        "\"item_id\":\"fc_1\",\"output_index\":0,\"delta\":\"\\\"NYC\\\"}\"}\n\n",
+        "event: response.function_call_arguments.done\n",
+        "data: {\"type\":\"response.function_call_arguments.done\",",
+        "\"item_id\":\"fc_1\",\"output_index\":0,",
+        "\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\"}\n\n",
+        &format!(
+            "event: response.completed\ndata: {{\"type\":\"response.completed\",\"response\":{RESPONSE_JSON}}}\n\n"
+        ),
+        "event: done\ndata: [DONE]\n\n",
+    ]
+    .concat();
+
+    let backend_guard = Backend::fixed(&sse_body)
+        .header("content-type", "text/event-stream")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let (db_url, db_path) = temp_sqlite_url("stream_events_incr");
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/stream-events.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", &db_url),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/responses",
+            r#"{"model":"gpt-4.1","input":"Hello streaming","stream":true}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200);
+
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("function_call_arguments.done"),
+        "response should contain function_call_arguments.done event: {body}"
+    );
+    assert!(
+        body.contains("response.completed"),
+        "response should contain response.completed event: {body}"
+    );
+
+    let pool = sqlx::SqlitePool::connect(&db_url)
+        .await
+        .expect("should connect to test database");
+    let sql = format!("SELECT id FROM {RESPONSES_TABLE} WHERE id = ?");
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+        .bind("resp_stream_example")
+        .fetch_one(&pool)
+        .await
+        .expect("terminal response should still be persisted after incremental events");
+    pool.close().await;
+
+    let id: String = row.get("id");
+    assert_eq!(id, "resp_stream_example");
+
+    drop(proxy);
+    cleanup_sqlite_files(&db_path);
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/tests/integration/tests/suite/examples/openai_stream_events.rs
+++ b/tests/integration/tests/suite/examples/openai_stream_events.rs
@@ -197,6 +197,49 @@ async fn stream_events_incremental_accumulation_before_terminal() {
     cleanup_sqlite_files(&db_path);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_events_processes_validate_reformatted_error() {
+    let error_body = r#"{"error":{"message":"model not found","type":"invalid_request_error","code":"model_not_found"}}"#;
+    let backend_guard = Backend::status(404, error_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let (db_url, db_path) = temp_sqlite_url("stream_events_err");
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/stream-events.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", &db_url),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/responses",
+            r#"{"model":"nonexistent","input":"Hello","stream":true}"#,
+        ),
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "validate filter reformats 404 to 200 SSE for streaming requests"
+    );
+
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("model not found") || body.contains("model_not_found"),
+        "error details should be preserved through validate+stream_events: {body}"
+    );
+
+    drop(proxy);
+    cleanup_sqlite_files(&db_path);
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/tests/integration/tests/suite/examples/openai_stream_events.rs
+++ b/tests/integration/tests/suite/examples/openai_stream_events.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the streaming Responses API example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    Backend, example_config_path, free_port, http_send, json_post, parse_body, parse_header, parse_status, patch_yaml,
+    start_proxy,
+};
+use sqlx::Row as _;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const RESPONSE_JSON: &str = r#"{"id":"resp_stream_example","created_at":1000,"model":"gpt-4.1","object":"response","status":"completed","input":"Hello streaming","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi from stream"}]}]}"#;
+
+const RESPONSES_TABLE: &str = "openai_responses";
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_events_accumulates_state_and_persists_response_to_sqlite() {
+    let sse_body = format!(
+        "event: response.completed\ndata: {{\"type\":\"response.completed\",\"response\":{RESPONSE_JSON}}}\n\n\
+         event: done\ndata: [DONE]\n\n"
+    );
+    let backend_guard = Backend::fixed(&sse_body)
+        .header("content-type", "text/event-stream")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let (db_url, db_path) = temp_sqlite_url("stream_events");
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/stream-events.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", &db_url),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/responses",
+            r#"{"model":"gpt-4.1","input":"Hello streaming","stream":true}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "streaming request should return 200");
+    assert_eq!(
+        parse_header(&raw, "content-type").as_deref(),
+        Some("text/event-stream"),
+        "streaming response should keep text/event-stream content type"
+    );
+
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("data:"),
+        "streaming response body should contain SSE data lines: {body}"
+    );
+    assert!(
+        body.contains("response.completed"),
+        "streaming response body should contain response.completed event: {body}"
+    );
+
+    let pool = sqlx::SqlitePool::connect(&db_url)
+        .await
+        .expect("should connect to test database");
+    let sql = format!("SELECT id, tenant_id, created_at, model, input, messages FROM {RESPONSES_TABLE} WHERE id = ?");
+    let row: sqlx::sqlite::SqliteRow = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+        .bind("resp_stream_example")
+        .fetch_one(&pool)
+        .await
+        .expect("streamed response should be persisted in database");
+    pool.close().await;
+
+    let id: String = row.get("id");
+    let tenant_id: String = row.get("tenant_id");
+    let created_at: i64 = row.get("created_at");
+    let model: String = row.get("model");
+
+    assert_eq!(id, "resp_stream_example", "persisted id should match stream");
+    assert_eq!(tenant_id, "default", "default tenant should be used");
+    assert_eq!(created_at, 1000, "persisted created_at should match stream");
+    assert_eq!(model, "gpt-4.1", "persisted model should match stream");
+
+    let input_raw: String = row.get("input");
+    let input: serde_json::Value = serde_json::from_str(&input_raw).expect("input column should be valid JSON");
+    assert_eq!(
+        input,
+        serde_json::json!("Hello streaming"),
+        "persisted input should match terminal response"
+    );
+
+    let messages_raw: String = row.get("messages");
+    let messages: serde_json::Value =
+        serde_json::from_str(&messages_raw).expect("messages column should be valid JSON");
+    let items = messages.as_array().expect("messages should be an array");
+    assert_eq!(
+        items.len(),
+        2,
+        "messages should include normalized input plus output for rehydration"
+    );
+    assert_eq!(
+        items[0],
+        serde_json::json!({"type": "message", "role": "user", "content": "Hello streaming"}),
+        "string input should be normalized as a user message"
+    );
+    assert_eq!(items[1]["type"], "message", "output item should be preserved");
+
+    drop(proxy);
+    cleanup_sqlite_files(&db_path);
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn temp_sqlite_url(test_name: &str) -> (String, std::path::PathBuf) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let db_path = std::env::temp_dir().join(format!("praxis_integ_{test_name}_{}_{nanos}.db", std::process::id()));
+    (format!("sqlite://{}?mode=rwc", db_path.display()), db_path)
+}
+
+fn cleanup_sqlite_files(db_path: &std::path::Path) {
+    drop(std::fs::remove_file(db_path));
+    drop(std::fs::remove_file(format!("{}-shm", db_path.display())));
+    drop(std::fs::remove_file(format!("{}-wal", db_path.display())));
+}

--- a/tests/integration/tests/suite/examples/openai_stream_events.rs
+++ b/tests/integration/tests/suite/examples/openai_stream_events.rs
@@ -35,7 +35,7 @@ async fn stream_events_accumulates_state_and_persists_response_to_sqlite() {
     let proxy_port = free_port();
 
     let (db_url, db_path) = temp_sqlite_url("stream_events");
-    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/stream-events.yaml"))
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/stream-events.yaml"))
         .expect("example config should exist");
     let patched = patch_yaml(
         &yaml.replace("sqlite://responses.db?mode=rwc", &db_url),


### PR DESCRIPTION
## Summary

- Adds `openai_stream_events` read-only filter that observes Responses API SSE events and accumulates state into `ResponsesState` (response object, output items, tool calls, usage)
- Terminal events (`response.completed/incomplete/failed`) overwrite incrementally accumulated state per the terminal-wins principle
- The store filter's `persist_from_streaming_state` consumes the accumulated state at end-of-stream for streaming persistence
- Includes 24 unit tests covering all accumulator paths, example config, integration test, and docs update

## Test plan

- [x] `make lint` passes (clippy + nightly fmt)
- [x] All unit tests pass (`cargo test -p praxis-ai-apis -- stream_events`)
- [x] Coverage audit: 84% line coverage on accumulator, 100% on config
- [x] Integration test scaffold for streaming SSE with backend

Closes #292 