### PR TITLE
fix(apis): percent-decode SQLite path before traversal check in response-store

### DIFF
--- a/apis/src/openai/responses/store/config.rs
+++ b/apis/src/openai/responses/store/config.rs
@@ -120,7 +120,10 @@ fn validate_sqlite_database_url(database_url: &str) -> Result<(), FilterError> {
     }
 
     let path = sqlite_file_path(database_url).unwrap_or(database_url);
-    if has_dot_dot_traversal(path) {
+    let path = percent_decode_str(path)
+        .decode_utf8()
+        .map_err(|e| format!("openai_response_store: database_url path must be valid UTF-8: {e}"))?;
+    if has_dot_dot_traversal(&path) {
         return Err("openai_response_store: database_url must not contain '..' path traversal".into());
     }
     Ok(())

--- a/apis/src/openai/responses/store/tests.rs
+++ b/apis/src/openai/responses/store/tests.rs
@@ -97,6 +97,24 @@ conversations_table: conversations
 }
 
 #[test]
+fn database_url_encoded_slash_traversal_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite://..%2F..%2Fetc%2Fresponses.db?mode=rwc"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(
+        result.is_err(),
+        "database_url with percent-encoded slash traversal should be rejected"
+    );
+}
+
+#[test]
 fn missing_backend_rejected() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"


### PR DESCRIPTION
## Summary

The response-store SQLite URL validator checked `has_dot_dot_traversal` on the raw URL path without percent-decoding, unlike the conversations validator. A URL like `sqlite://..%2F..%2Fetc%2Fresponses.db` bypassed the traversal guard because the raw string lacks literal `..` separators.

This patch percent-decodes the extracted SQLite file path before the traversal check, matching the conversations validator, and adds a regression test for the encoded-slash traversal pattern.

Closes #268

## Changes

- `apis/src/openai/responses/store/config.rs`: add `percent_decode_str` + `decode_utf8` before `has_dot_dot_traversal` in `validate_sqlite_database_url`
- `apis/src/openai/responses/store/tests.rs`: add `database_url_encoded_slash_traversal_rejected` test for `sqlite://..%2F..%2Fetc%2Fresponses.db?mode=rwc`

## Test plan

- [x] `cargo test -p praxis-ai-apis -- database_url_encoded` passes (both existing `%2e%2e` and new `%2F` tests)
- [x] `make lint` passes (clippy + nightly fmt)
- [x] `make build` passes