### PR TITLE
refactor(apis): extract shared is_event_stream_content_type helper

### DIFF
--- a/apis/src/anthropic/stream_events/mod.rs
+++ b/apis/src/anthropic/stream_events/mod.rs
@@ -17,6 +17,7 @@ use serde_json::Value;
 use tracing::debug;
 
 use self::config::{AnthropicStreamEventsConfig, build_config};
+use crate::is_event_stream_content_type;
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -392,12 +393,6 @@ fn is_streaming_request(ctx: &HttpFilterContext<'_>) -> bool {
             .is_some_and(|v| v == "true")
 }
 
-/// Whether a `Content-Type` header value indicates `text/event-stream`.
-fn is_event_stream_content_type(ct: &str) -> bool {
-    ct.split(';')
-        .next()
-        .is_some_and(|media| media.trim().eq_ignore_ascii_case("text/event-stream"))
-}
 
 /// Process a single SSE event block (lines between double-newlines).
 ///

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -16,6 +16,17 @@ pub mod openai;
 pub mod store;
 pub mod token_usage;
 
+/// Whether a `Content-Type` header value indicates `text/event-stream`,
+/// ignoring parameters (e.g. `; charset=utf-8`) and ASCII case.
+pub fn is_event_stream_content_type(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .eq_ignore_ascii_case("text/event-stream")
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/store/filter.rs
+++ b/apis/src/openai/responses/store/filter.rs
@@ -65,8 +65,11 @@ use super::{
     config::{ResponseStoreConfig, StorageBackend, revalidate_postgres_host, validate_config},
     list_input_items,
 };
-use crate::store::{
-    PostgresResponseStore, ResponseRecord, ResponseStore, ResponseStoreRegistry, SqliteResponseStore, StoreError,
+use crate::{
+    is_event_stream_content_type,
+    store::{
+        PostgresResponseStore, ResponseRecord, ResponseStore, ResponseStoreRegistry, SqliteResponseStore, StoreError,
+    },
 };
 
 /// Persists Responses API responses to the configured response store backend.
@@ -545,16 +548,6 @@ fn is_json_content_type(content_type: &str) -> bool {
         .unwrap_or_default()
         .trim()
         .eq_ignore_ascii_case("application/json")
-}
-
-/// Return whether a `Content-Type` header is SSE event stream.
-fn is_event_stream_content_type(content_type: &str) -> bool {
-    content_type
-        .split(';')
-        .next()
-        .unwrap_or_default()
-        .trim()
-        .eq_ignore_ascii_case("text/event-stream")
 }
 
 /// Check response headers before enabling response body buffering.

--- a/apis/src/openai/responses/validate/mod.rs
+++ b/apis/src/openai/responses/validate/mod.rs
@@ -34,6 +34,7 @@ use tracing::{debug, trace};
 
 use self::rules::validate_request;
 use super::error::responses_error_rejection;
+use crate::is_event_stream_content_type;
 
 // -----------------------------------------------------------------------------
 // OpenaiResponsesValidateFilter
@@ -174,13 +175,7 @@ fn should_reformat_error(ctx: &HttpFilterContext<'_>) -> bool {
             .headers
             .get(http::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
-            .is_some_and(|ct| {
-                ct.split(';')
-                    .next()
-                    .unwrap_or_default()
-                    .trim()
-                    .eq_ignore_ascii_case("text/event-stream")
-            });
+            .is_some_and(is_event_stream_content_type);
         is_error && !already_sse
     })
 }

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -26,6 +26,7 @@ use std::{borrow::Cow, fmt::Write as _, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use praxis_ai_apis::is_event_stream_content_type;
 use praxis_filter::{
     BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext,
     builtins::http::{
@@ -607,12 +608,6 @@ fn clear_sse_capture_metadata(ctx: &mut HttpFilterContext<'_>) {
     ctx.filter_metadata.remove("a2a.response.cluster");
 }
 
-/// Whether a content-type header value indicates `text/event-stream`.
-fn is_event_stream_content_type(ct: &str) -> bool {
-    ct.split(';')
-        .next()
-        .is_some_and(|media| media.trim().eq_ignore_ascii_case("text/event-stream"))
-}
 
 /// Build a `JsonRpcConfig` for the shared parser with A2A-appropriate defaults.
 fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {


### PR DESCRIPTION
## Summary

- Extracts a shared `is_event_stream_content_type` helper in `praxis-ai-apis` to replace four duplicate copies of the same SSE content-type detection logic
- The helper splits on `;`, trims whitespace, and compares `text/event-stream` case-insensitively
- Consolidates private functions from `store/filter.rs`, `anthropic/stream_events`, `a2a/mod.rs`, and inline logic in `validate/mod.rs`

Follow-up to #272 per [review feedback](https://github.com/praxis-proxy/ai/pull/272#discussion_r2236236252).