### PR TITLE
chore(deps): update crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 to fix [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `fmt::Pointer` impl)
- Fixes `security-audit` and `dependency-check` CI failures on main

## Test plan

- [ ] CI `security-audit` job passes
- [ ] CI `dependency-check` job passes