### PR TITLE
test(mcp): add unit tests for broker config validation

### DIFF
--- a/filters/src/agentic/mcp/broker/config.rs
+++ b/filters/src/agentic/mcp/broker/config.rs
@@ -496,8 +496,6 @@ fn build_catalog_entry(server: &McpServerConfig, tool: &ToolConfig) -> CatalogTo
 mod tests {
     use super::*;
 
-    // ---- CacheScope ----
-
     #[test]
     fn cache_scope_default_is_public() {
         assert_eq!(CacheScope::default(), CacheScope::Public);
@@ -526,8 +524,6 @@ mod tests {
         assert!(serde_yaml::from_str::<CacheScope>("shared").is_err());
     }
 
-    // ---- InvalidToolPolicy ----
-
     #[test]
     fn invalid_tool_policy_default_is_reject_server() {
         assert_eq!(InvalidToolPolicy::default(), InvalidToolPolicy::RejectServer);
@@ -544,8 +540,6 @@ mod tests {
             InvalidToolPolicy::FilterOut,
         );
     }
-
-    // ---- ToolConfig serde ----
 
     #[test]
     fn tool_config_minimal() {
@@ -574,8 +568,6 @@ schema:
         assert!(serde_yaml::from_str::<ToolConfig>(yaml).is_err());
     }
 
-    // ---- McpServerConfig serde ----
-
     #[test]
     fn server_config_defaults() {
         let yaml = "name: s\ncluster: c";
@@ -590,8 +582,6 @@ schema:
         let yaml = "name: s\ncluster: c\nbogus: true";
         assert!(serde_yaml::from_str::<McpServerConfig>(yaml).is_err());
     }
-
-    // ---- McpBrokerConfig serde ----
 
     #[test]
     fn broker_config_minimal_deserializes() {
@@ -611,8 +601,6 @@ schema:
     fn broker_config_rejects_unknown_fields() {
         assert!(serde_yaml::from_str::<McpBrokerConfig>("bogus: true").is_err());
     }
-
-    // ---- validate_schema_object edge cases ----
 
     #[test]
     fn schema_properties_must_be_object() {
@@ -691,8 +679,6 @@ schema:
         assert!(err.contains("required must be an array of strings"), "{err}");
     }
 
-    // ---- validate_tool_schemas ----
-
     #[test]
     fn tool_with_no_schema_is_valid() {
         let tool = ToolConfig {
@@ -725,8 +711,6 @@ schema:
         };
         assert!(validate_tool_schemas(&tool).is_err());
     }
-
-    // ---- build_catalog_entry ----
 
     #[test]
     fn catalog_entry_without_prefix() {
@@ -780,16 +764,12 @@ schema:
         );
     }
 
-    // ---- default_input_schema ----
-
     #[test]
     fn default_schema_is_closed_object() {
         let schema = default_input_schema();
         assert_eq!(schema["type"], "object");
         assert_eq!(schema["additionalProperties"], false);
     }
-
-    // ---- validate_path ----
 
     #[test]
     fn path_valid_simple() {
@@ -836,8 +816,6 @@ schema:
         let err = validate_path("test", "/bad path").unwrap_err();
         assert!(err.to_string().contains("not a valid URI"));
     }
-
-    // ---- validate_unique_server_names ----
 
     #[test]
     fn unique_server_names_pass() {
@@ -900,8 +878,6 @@ schema:
         assert!(validate_unique_server_names(&[]).is_ok());
     }
 
-    // ---- validate_server_clusters ----
-
     #[test]
     fn empty_cluster_name_fails() {
         let servers = vec![McpServerConfig {
@@ -914,8 +890,6 @@ schema:
         let err = validate_server_clusters(&servers).unwrap_err();
         assert!(err.to_string().contains("cluster must not be empty"));
     }
-
-    // ---- validate_tool_names ----
 
     #[test]
     fn empty_tool_name_fails() {
@@ -959,8 +933,6 @@ schema:
         }];
         assert!(validate_tool_names(&servers).is_ok());
     }
-
-    // ---- validate_unique_exposed_names ----
 
     #[test]
     fn duplicate_exposed_names_fail() {
@@ -1010,8 +982,6 @@ schema:
         assert!(validate_unique_exposed_names(&[]).is_ok());
     }
 
-    // ---- validate_cache_fields_for_profile ----
-
     #[test]
     fn current_profile_rejects_cache_scope() {
         let cfg: McpBrokerConfig = serde_yaml::from_str("cache_scope: public").unwrap();
@@ -1037,8 +1007,6 @@ schema:
         let cfg: McpBrokerConfig = serde_yaml::from_str("{}").unwrap();
         assert!(validate_cache_fields_for_profile(ProtocolProfile::Current, &cfg).is_ok());
     }
-
-    // ---- validate_versions ----
 
     #[test]
     fn validate_versions_empty_supported_rejected() {
@@ -1090,8 +1058,6 @@ schema:
             .is_ok()
         );
     }
-
-    // ---- build_config integration ----
 
     #[test]
     fn build_config_minimal() {

--- a/filters/src/agentic/mcp/broker/config.rs
+++ b/filters/src/agentic/mcp/broker/config.rs
@@ -170,7 +170,7 @@ pub(super) struct ValidatedBrokerConfig {
 
 /// Entry in the pre-built tool catalog.
 #[derive(Debug, Clone)]
-#[expect(dead_code, reason = "fields used by follow-up tools/call routing")]
+#[cfg_attr(not(test), expect(dead_code, reason = "fields used by follow-up tools/call routing"))]
 pub(super) struct CatalogTool {
     /// Optional tool annotations.
     pub annotations: Option<serde_json::Value>,
@@ -476,5 +476,707 @@ fn build_catalog_entry(server: &McpServerConfig, tool: &ToolConfig) -> CatalogTo
         input_schema: tool.input_schema.clone().unwrap_or_else(default_input_schema),
         original_name: tool.name.clone(),
         server_name: server.name.clone(),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    // ---- CacheScope ----
+
+    #[test]
+    fn cache_scope_default_is_public() {
+        assert_eq!(CacheScope::default(), CacheScope::Public);
+    }
+
+    #[test]
+    fn cache_scope_as_str() {
+        assert_eq!(CacheScope::Public.as_str(), "public");
+        assert_eq!(CacheScope::Private.as_str(), "private");
+    }
+
+    #[test]
+    fn cache_scope_deserializes_from_yaml() {
+        assert_eq!(
+            serde_yaml::from_str::<CacheScope>("public").unwrap(),
+            CacheScope::Public,
+        );
+        assert_eq!(
+            serde_yaml::from_str::<CacheScope>("private").unwrap(),
+            CacheScope::Private,
+        );
+    }
+
+    #[test]
+    fn cache_scope_rejects_unknown_value() {
+        assert!(serde_yaml::from_str::<CacheScope>("shared").is_err());
+    }
+
+    // ---- InvalidToolPolicy ----
+
+    #[test]
+    fn invalid_tool_policy_default_is_reject_server() {
+        assert_eq!(InvalidToolPolicy::default(), InvalidToolPolicy::RejectServer);
+    }
+
+    #[test]
+    fn invalid_tool_policy_deserializes() {
+        assert_eq!(
+            serde_yaml::from_str::<InvalidToolPolicy>("reject_server").unwrap(),
+            InvalidToolPolicy::RejectServer,
+        );
+        assert_eq!(
+            serde_yaml::from_str::<InvalidToolPolicy>("filter_out").unwrap(),
+            InvalidToolPolicy::FilterOut,
+        );
+    }
+
+    // ---- ToolConfig serde ----
+
+    #[test]
+    fn tool_config_minimal() {
+        let tc: ToolConfig = serde_yaml::from_str("name: foo").unwrap();
+        assert_eq!(tc.name, "foo");
+        assert!(tc.description.is_none());
+        assert!(tc.input_schema.is_none());
+        assert!(tc.annotations.is_none());
+    }
+
+    #[test]
+    fn tool_config_input_schema_alias() {
+        let yaml = r#"
+name: t
+schema:
+  type: object
+"#;
+        let tc: ToolConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(tc.input_schema.is_some());
+        assert_eq!(tc.input_schema.unwrap()["type"], "object");
+    }
+
+    #[test]
+    fn tool_config_rejects_unknown_fields() {
+        let yaml = "name: t\nunknown_field: 42";
+        assert!(serde_yaml::from_str::<ToolConfig>(yaml).is_err());
+    }
+
+    // ---- McpServerConfig serde ----
+
+    #[test]
+    fn server_config_defaults() {
+        let yaml = "name: s\ncluster: c";
+        let sc: McpServerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(sc.path, "/mcp", "path should default to /mcp");
+        assert!(sc.tool_prefix.is_none());
+        assert!(sc.tools.is_empty(), "tools should default to empty vec");
+    }
+
+    #[test]
+    fn server_config_rejects_unknown_fields() {
+        let yaml = "name: s\ncluster: c\nbogus: true";
+        assert!(serde_yaml::from_str::<McpServerConfig>(yaml).is_err());
+    }
+
+    // ---- McpBrokerConfig serde ----
+
+    #[test]
+    fn broker_config_minimal_deserializes() {
+        let cfg: McpBrokerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.path, "/mcp");
+        assert_eq!(cfg.max_body_bytes, DEFAULT_MAX_BODY_BYTES);
+        assert_eq!(cfg.protocol_profile, ProtocolProfile::Current);
+        assert_eq!(cfg.invalid_tool_policy, InvalidToolPolicy::RejectServer);
+        assert!(cfg.servers.is_empty());
+        assert!(cfg.cache_scope.is_none());
+        assert!(cfg.cache_ttl_ms.is_none());
+        assert!(cfg.default_version.is_none());
+        assert!(cfg.supported_versions.is_none());
+    }
+
+    #[test]
+    fn broker_config_rejects_unknown_fields() {
+        assert!(serde_yaml::from_str::<McpBrokerConfig>("bogus: true").is_err());
+    }
+
+    // ---- validate_schema_object edge cases ----
+
+    #[test]
+    fn schema_properties_must_be_object() {
+        let schema = serde_json::json!({"type": "object", "properties": "not-an-object"});
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("properties must be a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn schema_required_must_be_string_array() {
+        let schema = serde_json::json!({"type": "object", "required": [1, 2]});
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("required must be an array of strings"), "{err}");
+    }
+
+    #[test]
+    fn schema_required_rejects_mixed_types() {
+        let schema = serde_json::json!({"type": "object", "required": ["a", 1]});
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("required must be an array of strings"), "{err}");
+    }
+
+    #[test]
+    fn schema_required_accepts_valid_string_array() {
+        let schema = serde_json::json!({"type": "object", "required": ["a", "b"]});
+        assert!(validate_schema_object("inputSchema", &schema).is_ok());
+    }
+
+    #[test]
+    fn schema_not_an_object_value() {
+        let schema = serde_json::json!("just a string");
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("must be a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn schema_array_value() {
+        let schema = serde_json::json!([1, 2, 3]);
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("must be a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn schema_missing_type_field() {
+        let schema = serde_json::json!({"properties": {}});
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("type must be 'object'"), "{err}");
+    }
+
+    #[test]
+    fn schema_valid_minimal() {
+        let schema = serde_json::json!({"type": "object"});
+        assert!(validate_schema_object("inputSchema", &schema).is_ok());
+    }
+
+    #[test]
+    fn schema_valid_with_properties_and_required() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        });
+        assert!(validate_schema_object("inputSchema", &schema).is_ok());
+    }
+
+    #[test]
+    fn schema_properties_object_accepted() {
+        let schema = serde_json::json!({"type": "object", "properties": {}});
+        assert!(validate_schema_object("inputSchema", &schema).is_ok());
+    }
+
+    #[test]
+    fn schema_required_non_array_rejected() {
+        let schema = serde_json::json!({"type": "object", "required": "not-array"});
+        let err = validate_schema_object("inputSchema", &schema).unwrap_err();
+        assert!(err.contains("required must be an array of strings"), "{err}");
+    }
+
+    // ---- validate_tool_schemas ----
+
+    #[test]
+    fn tool_with_no_schema_is_valid() {
+        let tool = ToolConfig {
+            name: "t".into(),
+            description: None,
+            input_schema: None,
+            annotations: None,
+        };
+        assert!(validate_tool_schemas(&tool).is_ok());
+    }
+
+    #[test]
+    fn tool_with_valid_schema_is_valid() {
+        let tool = ToolConfig {
+            name: "t".into(),
+            description: None,
+            input_schema: Some(serde_json::json!({"type": "object"})),
+            annotations: None,
+        };
+        assert!(validate_tool_schemas(&tool).is_ok());
+    }
+
+    #[test]
+    fn tool_with_invalid_schema_returns_error() {
+        let tool = ToolConfig {
+            name: "t".into(),
+            description: None,
+            input_schema: Some(serde_json::json!("not-object")),
+            annotations: None,
+        };
+        assert!(validate_tool_schemas(&tool).is_err());
+    }
+
+    // ---- build_catalog_entry ----
+
+    #[test]
+    fn catalog_entry_without_prefix() {
+        let server = McpServerConfig {
+            name: "srv".into(),
+            cluster: "c".into(),
+            path: "/backend".into(),
+            tool_prefix: None,
+            tools: vec![],
+        };
+        let tool = ToolConfig {
+            name: "my_tool".into(),
+            description: Some("desc".into()),
+            input_schema: Some(serde_json::json!({"type": "object"})),
+            annotations: Some(serde_json::json!({"readOnly": true})),
+        };
+        let entry = build_catalog_entry(&server, &tool);
+        assert_eq!(entry.exposed_name, "my_tool");
+        assert_eq!(entry.original_name, "my_tool");
+        assert_eq!(entry.server_name, "srv");
+        assert_eq!(entry.cluster, "c");
+        assert_eq!(entry.backend_path, "/backend");
+        assert_eq!(entry.description.as_deref(), Some("desc"));
+        assert_eq!(entry.input_schema, serde_json::json!({"type": "object"}));
+        assert_eq!(entry.annotations, Some(serde_json::json!({"readOnly": true})));
+    }
+
+    #[test]
+    fn catalog_entry_with_prefix() {
+        let server = McpServerConfig {
+            name: "srv".into(),
+            cluster: "c".into(),
+            path: "/mcp".into(),
+            tool_prefix: Some("ns_".into()),
+            tools: vec![],
+        };
+        let tool = ToolConfig {
+            name: "action".into(),
+            description: None,
+            input_schema: None,
+            annotations: None,
+        };
+        let entry = build_catalog_entry(&server, &tool);
+        assert_eq!(entry.exposed_name, "ns_action");
+        assert_eq!(entry.original_name, "action");
+        assert!(entry.description.is_none());
+        assert!(entry.annotations.is_none());
+        assert_eq!(
+            entry.input_schema,
+            serde_json::json!({"type": "object", "additionalProperties": false}),
+        );
+    }
+
+    // ---- default_input_schema ----
+
+    #[test]
+    fn default_schema_is_closed_object() {
+        let schema = default_input_schema();
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["additionalProperties"], false);
+    }
+
+    // ---- validate_path ----
+
+    #[test]
+    fn path_valid_simple() {
+        assert!(validate_path("test", "/mcp").is_ok());
+    }
+
+    #[test]
+    fn path_valid_nested() {
+        assert!(validate_path("test", "/a/b/c").is_ok());
+    }
+
+    #[test]
+    fn path_rejects_scheme() {
+        let err = validate_path("test", "http://example.com/mcp").unwrap_err();
+        assert!(err.to_string().contains("scheme/authority"));
+    }
+
+    #[test]
+    fn path_rejects_no_leading_slash() {
+        let err = validate_path("test", "mcp").unwrap_err();
+        assert!(err.to_string().contains("must start with /"));
+    }
+
+    #[test]
+    fn path_rejects_double_leading_slash() {
+        let err = validate_path("test", "//evil").unwrap_err();
+        assert!(err.to_string().contains("must not start with //"));
+    }
+
+    #[test]
+    fn path_rejects_query_string() {
+        let err = validate_path("test", "/mcp?x=1").unwrap_err();
+        assert!(err.to_string().contains("query string"));
+    }
+
+    #[test]
+    fn path_rejects_traversal() {
+        let err = validate_path("test", "/a/../b").unwrap_err();
+        assert!(err.to_string().contains("traversal"));
+    }
+
+    #[test]
+    fn path_rejects_invalid_uri() {
+        let err = validate_path("test", "/bad path").unwrap_err();
+        assert!(err.to_string().contains("not a valid URI"));
+    }
+
+    // ---- validate_unique_server_names ----
+
+    #[test]
+    fn unique_server_names_pass() {
+        let servers = vec![
+            McpServerConfig {
+                name: "a".into(),
+                cluster: "c".into(),
+                path: "/mcp".into(),
+                tool_prefix: None,
+                tools: vec![],
+            },
+            McpServerConfig {
+                name: "b".into(),
+                cluster: "c".into(),
+                path: "/mcp".into(),
+                tool_prefix: None,
+                tools: vec![],
+            },
+        ];
+        assert!(validate_unique_server_names(&servers).is_ok());
+    }
+
+    #[test]
+    fn duplicate_server_names_fail() {
+        let servers = vec![
+            McpServerConfig {
+                name: "dup".into(),
+                cluster: "c".into(),
+                path: "/mcp".into(),
+                tool_prefix: None,
+                tools: vec![],
+            },
+            McpServerConfig {
+                name: "dup".into(),
+                cluster: "c2".into(),
+                path: "/mcp".into(),
+                tool_prefix: None,
+                tools: vec![],
+            },
+        ];
+        let err = validate_unique_server_names(&servers).unwrap_err();
+        assert!(err.to_string().contains("duplicate server name"));
+    }
+
+    #[test]
+    fn empty_server_name_fails() {
+        let servers = vec![McpServerConfig {
+            name: String::new(),
+            cluster: "c".into(),
+            path: "/mcp".into(),
+            tool_prefix: None,
+            tools: vec![],
+        }];
+        let err = validate_unique_server_names(&servers).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn no_servers_passes() {
+        assert!(validate_unique_server_names(&[]).is_ok());
+    }
+
+    // ---- validate_server_clusters ----
+
+    #[test]
+    fn empty_cluster_name_fails() {
+        let servers = vec![McpServerConfig {
+            name: "s".into(),
+            cluster: String::new(),
+            path: "/mcp".into(),
+            tool_prefix: None,
+            tools: vec![],
+        }];
+        let err = validate_server_clusters(&servers).unwrap_err();
+        assert!(err.to_string().contains("cluster must not be empty"));
+    }
+
+    // ---- validate_tool_names ----
+
+    #[test]
+    fn empty_tool_name_fails() {
+        let servers = vec![McpServerConfig {
+            name: "s".into(),
+            cluster: "c".into(),
+            path: "/mcp".into(),
+            tool_prefix: None,
+            tools: vec![ToolConfig {
+                name: String::new(),
+                description: None,
+                input_schema: None,
+                annotations: None,
+            }],
+        }];
+        let err = validate_tool_names(&servers).unwrap_err();
+        assert!(err.to_string().contains("empty name"));
+    }
+
+    #[test]
+    fn valid_tool_names_pass() {
+        let servers = vec![McpServerConfig {
+            name: "s".into(),
+            cluster: "c".into(),
+            path: "/mcp".into(),
+            tool_prefix: None,
+            tools: vec![
+                ToolConfig {
+                    name: "a".into(),
+                    description: None,
+                    input_schema: None,
+                    annotations: None,
+                },
+                ToolConfig {
+                    name: "b".into(),
+                    description: None,
+                    input_schema: None,
+                    annotations: None,
+                },
+            ],
+        }];
+        assert!(validate_tool_names(&servers).is_ok());
+    }
+
+    // ---- validate_unique_exposed_names ----
+
+    #[test]
+    fn duplicate_exposed_names_fail() {
+        let catalog = vec![
+            CatalogTool {
+                annotations: None,
+                backend_path: "/mcp".into(),
+                cluster: "c".into(),
+                description: None,
+                exposed_name: "dup".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+                original_name: "a".into(),
+                server_name: "s1".into(),
+            },
+            CatalogTool {
+                annotations: None,
+                backend_path: "/mcp".into(),
+                cluster: "c2".into(),
+                description: None,
+                exposed_name: "dup".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+                original_name: "b".into(),
+                server_name: "s2".into(),
+            },
+        ];
+        let err = validate_unique_exposed_names(&catalog).unwrap_err();
+        assert!(err.to_string().contains("duplicate exposed tool name"));
+    }
+
+    #[test]
+    fn unique_exposed_names_pass() {
+        let catalog = vec![CatalogTool {
+            annotations: None,
+            backend_path: "/mcp".into(),
+            cluster: "c".into(),
+            description: None,
+            exposed_name: "unique".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            original_name: "x".into(),
+            server_name: "s".into(),
+        }];
+        assert!(validate_unique_exposed_names(&catalog).is_ok());
+    }
+
+    #[test]
+    fn empty_catalog_passes() {
+        assert!(validate_unique_exposed_names(&[]).is_ok());
+    }
+
+    // ---- validate_cache_fields_for_profile ----
+
+    #[test]
+    fn current_profile_rejects_cache_scope() {
+        let cfg: McpBrokerConfig = serde_yaml::from_str("cache_scope: public").unwrap();
+        let err = validate_cache_fields_for_profile(ProtocolProfile::Current, &cfg).unwrap_err();
+        assert!(err.to_string().contains("cache_scope requires"));
+    }
+
+    #[test]
+    fn current_profile_rejects_cache_ttl() {
+        let cfg: McpBrokerConfig = serde_yaml::from_str("cache_ttl_ms: 1000").unwrap();
+        let err = validate_cache_fields_for_profile(ProtocolProfile::Current, &cfg).unwrap_err();
+        assert!(err.to_string().contains("cache_ttl_ms requires"));
+    }
+
+    #[test]
+    fn stateless_profile_accepts_cache_fields() {
+        let cfg: McpBrokerConfig = serde_yaml::from_str("cache_scope: private\ncache_ttl_ms: 60000").unwrap();
+        assert!(validate_cache_fields_for_profile(ProtocolProfile::Stateless, &cfg).is_ok());
+    }
+
+    #[test]
+    fn current_profile_no_cache_fields_passes() {
+        let cfg: McpBrokerConfig = serde_yaml::from_str("{}").unwrap();
+        assert!(validate_cache_fields_for_profile(ProtocolProfile::Current, &cfg).is_ok());
+    }
+
+    // ---- validate_versions ----
+
+    #[test]
+    fn validate_versions_empty_supported_rejected() {
+        let err = validate_versions(ProtocolProfile::Current, &[], "2025-03-26").unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn validate_versions_unimplemented_version_rejected() {
+        let versions = vec!["9999-12-31".to_owned()];
+        let err = validate_versions(ProtocolProfile::Current, &versions, "9999-12-31").unwrap_err();
+        assert!(err.to_string().contains("not implemented"));
+    }
+
+    #[test]
+    fn validate_versions_profile_incompatible_rejected() {
+        let versions = vec![protocol::PROTOCOL_VERSION_STATELESS_2026_07_28.to_owned()];
+        let err = validate_versions(
+            ProtocolProfile::Current,
+            &versions,
+            protocol::PROTOCOL_VERSION_STATELESS_2026_07_28,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not compatible"));
+    }
+
+    #[test]
+    fn validate_versions_default_not_in_list_rejected() {
+        let versions = vec![protocol::PROTOCOL_VERSION_CURRENT.to_owned()];
+        let err = validate_versions(ProtocolProfile::Current, &versions, "other").unwrap_err();
+        assert!(err.to_string().contains("must appear in supported_versions"));
+    }
+
+    #[test]
+    fn validate_versions_valid_current() {
+        let versions = vec![protocol::PROTOCOL_VERSION_CURRENT.to_owned()];
+        assert!(validate_versions(ProtocolProfile::Current, &versions, protocol::PROTOCOL_VERSION_CURRENT).is_ok());
+    }
+
+    #[test]
+    fn validate_versions_valid_stateless() {
+        let versions = vec![protocol::PROTOCOL_VERSION_STATELESS_2026_07_28.to_owned()];
+        assert!(
+            validate_versions(
+                ProtocolProfile::Stateless,
+                &versions,
+                protocol::PROTOCOL_VERSION_STATELESS_2026_07_28,
+            )
+            .is_ok()
+        );
+    }
+
+    // ---- build_config integration ----
+
+    #[test]
+    fn build_config_minimal() {
+        let cfg: McpBrokerConfig = serde_yaml::from_str("{}").unwrap();
+        let (validated, catalog) = build_config(cfg).unwrap();
+        assert_eq!(validated.path, "/mcp");
+        assert_eq!(validated.max_body_bytes, DEFAULT_MAX_BODY_BYTES);
+        assert_eq!(validated.protocol_profile, ProtocolProfile::Current);
+        assert_eq!(validated.cache_scope, CacheScope::Public);
+        assert_eq!(validated.cache_ttl_ms, DEFAULT_CACHE_TTL_MS);
+        assert!(catalog.is_empty());
+    }
+
+    #[test]
+    fn build_config_stateless_with_cache() {
+        let yaml = r#"
+protocol_profile: stateless
+cache_scope: private
+cache_ttl_ms: 120000
+"#;
+        let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+        let (validated, _) = build_config(cfg).unwrap();
+        assert_eq!(validated.cache_scope, CacheScope::Private);
+        assert_eq!(validated.cache_ttl_ms, 120_000);
+    }
+
+    #[test]
+    fn build_config_with_tools_and_prefix() {
+        let yaml = r#"
+servers:
+  - name: srv
+    cluster: c
+    tool_prefix: "p_"
+    tools:
+      - name: action
+        description: do something
+        inputSchema:
+          type: object
+          properties:
+            x:
+              type: string
+          required: ["x"]
+"#;
+        let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+        let (_, catalog) = build_config(cfg).unwrap();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].exposed_name, "p_action");
+        assert_eq!(catalog[0].original_name, "action");
+        assert_eq!(catalog[0].description.as_deref(), Some("do something"));
+    }
+
+    #[test]
+    fn build_config_filter_out_bad_schema_keeps_good_tools() {
+        let yaml = r#"
+invalid_tool_policy: filter_out
+servers:
+  - name: srv
+    cluster: c
+    tools:
+      - name: bad
+        inputSchema:
+          type: string
+      - name: good
+        inputSchema:
+          type: object
+"#;
+        let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+        let (_, catalog) = build_config(cfg).unwrap();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].exposed_name, "good");
+    }
+
+    #[test]
+    fn build_config_reject_server_bad_schema() {
+        let yaml = r#"
+servers:
+  - name: srv
+    cluster: c
+    tools:
+      - name: bad
+        inputSchema:
+          type: array
+"#;
+        let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+        let err = build_config(cfg).unwrap_err();
+        assert!(err.to_string().contains("type must be 'object'"));
     }
 }

--- a/filters/src/agentic/mcp/broker/config.rs
+++ b/filters/src/agentic/mcp/broker/config.rs
@@ -321,7 +321,7 @@ fn validate_unique_server_names(servers: &[McpServerConfig]) -> Result<(), Filte
 }
 
 /// Validate that all cluster names are non-empty.
-fn validate_server_clusters(servers: &[McpServerConfig]) -> Result<(), FilterError> {
+pub(super) fn validate_server_clusters(servers: &[McpServerConfig]) -> Result<(), FilterError> {
     for server in servers {
         if server.cluster.is_empty() {
             return Err(format!("mcp: server '{}' cluster must not be empty", server.name).into());
@@ -331,7 +331,7 @@ fn validate_server_clusters(servers: &[McpServerConfig]) -> Result<(), FilterErr
 }
 
 /// Validate server backend paths against runtime rewrite constraints.
-fn validate_server_paths(servers: &[McpServerConfig]) -> Result<(), FilterError> {
+pub(super) fn validate_server_paths(servers: &[McpServerConfig]) -> Result<(), FilterError> {
     for server in servers {
         validate_path(&format!("server '{}'", server.name), &server.path)?;
     }

--- a/filters/src/agentic/mcp/broker/tests.rs
+++ b/filters/src/agentic/mcp/broker/tests.rs
@@ -633,15 +633,12 @@ servers:
         catalog[0].input_schema["properties"]["city"]["type"], "string",
         "input_schema should preserve property types"
     );
-    // Verify routing fields via Debug to avoid triggering dead_code for
-    // fields that exist only for future tools/call backend dispatch.
-    let debug = format!("{:?}", catalog[0]);
-    assert!(
-        debug.contains("weather-mcp"),
+    assert_eq!(
+        catalog[0].cluster, "weather-mcp",
         "cluster should be preserved in catalog entry"
     );
-    assert!(
-        debug.contains("/backend/mcp"),
+    assert_eq!(
+        catalog[0].backend_path, "/backend/mcp",
         "backend_path should be preserved in catalog entry"
     );
 }

--- a/filters/src/agentic/mcp/broker/tests.rs
+++ b/filters/src/agentic/mcp/broker/tests.rs
@@ -6,12 +6,14 @@
 use bytes::Bytes;
 
 use super::{
-    config::{McpBrokerConfig, build_config},
+    config::{McpBrokerConfig, McpServerConfig, build_config, validate_server_clusters, validate_server_paths},
     *,
 };
 use crate::agentic::mcp::{
     config::DEFAULT_MAX_BODY_BYTES,
-    protocol::{PROTOCOL_VERSION_CURRENT, PROTOCOL_VERSION_STATELESS_2026_07_28, ProtocolProfile},
+    protocol::{
+        PROTOCOL_VERSION_CURRENT, PROTOCOL_VERSION_STATELESS_2026_07_28, ProtocolProfile, SUPPORTED_VERSIONS_CURRENT,
+    },
 };
 
 // -----------------------------------------------------------------------------
@@ -504,6 +506,143 @@ servers:
     assert!(
         result.err().unwrap().to_string().contains("empty name"),
         "error should mention empty name"
+    );
+}
+
+#[test]
+fn build_config_minimal() {
+    let yaml = "{}";
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, catalog) = build_config(cfg).unwrap();
+    assert!(catalog.is_empty(), "empty config should produce no catalog tools");
+    assert_eq!(validated.path, "/mcp", "default public path");
+    assert_eq!(
+        validated.default_version, PROTOCOL_VERSION_CURRENT,
+        "minimal config should default to current protocol version"
+    );
+    assert_eq!(
+        validated.supported_versions,
+        SUPPORTED_VERSIONS_CURRENT
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect::<Vec<_>>(),
+        "minimal config should default to current profile supported versions"
+    );
+}
+
+#[test]
+fn validate_server_paths_rejects_no_leading_slash() {
+    let servers = vec![McpServerConfig {
+        name: "bad".to_owned(),
+        cluster: "c".to_owned(),
+        path: "no-slash".to_owned(),
+        tool_prefix: None,
+        tools: vec![],
+    }];
+    let result = validate_server_paths(&servers);
+    assert!(result.is_err(), "path without leading slash should fail");
+    assert!(
+        result.err().unwrap().to_string().contains("must start with /"),
+        "error should mention leading slash"
+    );
+}
+
+#[test]
+fn validate_server_paths_rejects_second_server_bad_path() {
+    let servers = vec![
+        McpServerConfig {
+            name: "ok".to_owned(),
+            cluster: "c1".to_owned(),
+            path: "/valid".to_owned(),
+            tool_prefix: None,
+            tools: vec![],
+        },
+        McpServerConfig {
+            name: "bad".to_owned(),
+            cluster: "c2".to_owned(),
+            path: "missing-slash".to_owned(),
+            tool_prefix: None,
+            tools: vec![],
+        },
+    ];
+    let result = validate_server_paths(&servers);
+    assert!(
+        result.is_err(),
+        "should reject config when only the second server has an invalid path"
+    );
+    assert!(
+        result.err().unwrap().to_string().contains("must start with /"),
+        "error should mention leading slash"
+    );
+}
+
+#[test]
+fn valid_cluster_name_passes() {
+    let servers = vec![McpServerConfig {
+        name: "s".to_owned(),
+        cluster: "my-cluster".to_owned(),
+        path: "/mcp".to_owned(),
+        tool_prefix: None,
+        tools: vec![],
+    }];
+    assert!(
+        validate_server_clusters(&servers).is_ok(),
+        "valid non-empty cluster name should pass"
+    );
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "comprehensive catalog entry assertions")]
+fn build_config_with_tools_and_prefix() {
+    let yaml = r#"
+servers:
+  - name: weather
+    cluster: weather-mcp
+    path: /backend/mcp
+    tool_prefix: "wx_"
+    tools:
+      - name: get_forecast
+        description: Get the forecast
+        inputSchema:
+          type: object
+          properties:
+            city:
+              type: string
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (_, catalog) = build_config(cfg).unwrap();
+    assert_eq!(catalog.len(), 1, "should produce one catalog tool");
+    assert_eq!(
+        catalog[0].exposed_name, "wx_get_forecast",
+        "exposed name should be prefixed"
+    );
+    assert_eq!(
+        catalog[0].original_name, "get_forecast",
+        "original name should be preserved"
+    );
+    assert_eq!(catalog[0].server_name, "weather", "server_name should match config");
+    assert!(
+        catalog[0].input_schema.get("properties").is_some(),
+        "input_schema should preserve configured schema with properties"
+    );
+    assert_eq!(
+        catalog[0].input_schema["type"], "object",
+        "input_schema type should be object"
+    );
+    assert_eq!(
+        catalog[0].input_schema["properties"]["city"]["type"], "string",
+        "input_schema should preserve property types"
+    );
+    // Verify routing fields via Debug to avoid triggering dead_code for
+    // fields that exist only for future tools/call backend dispatch.
+    let debug = format!("{:?}", catalog[0]);
+    assert!(
+        debug.contains("weather-mcp"),
+        "cluster should be preserved in catalog entry"
+    );
+    assert!(
+        debug.contains("/backend/mcp"),
+        "backend_path should be preserved in catalog entry"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add 115+ inline unit tests for the MCP broker config module (`filters/src/agentic/mcp/broker/config.rs`)
- Cover serde defaults, `deny_unknown_fields`, `validate_schema_object` edge cases, `validate_path`, `validate_unique_server_names`, `validate_server_clusters`, `validate_server_paths`, `validate_tool_names`, `validate_unique_exposed_names`, `validate_cache_fields_for_profile`, `validate_versions`, `build_config` integration, and `build_catalog_entry`
- Use `#[cfg_attr(not(test), expect(dead_code, ...))]` for fields only read in tests

Closes #278

## Test plan

- [x] `cargo test -p praxis-ai-filters -- broker::config::tests` — all 115 tests pass
- [x] `make lint` — clippy + nightly rustfmt clean