### PR TITLE
docs(config): add openai_stream_events to full-flow example

### DIFF
--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -91,6 +91,9 @@ filter_chains:
         database_url: "sqlite://responses.db?mode=rwc"
         responses_table: openai_responses
         conversations_table: openai_conversations
+
+      - filter: openai_stream_events
+
       - filter: openai_responses_rehydrate
 
       - filter: responses_proxy


### PR DESCRIPTION
## Summary
- Wire the `openai_stream_events` filter into the Responses API full-flow pipeline between `openai_response_store` and `openai_responses_rehydrate`

## Test plan
- [ ] Verify the full-flow config loads without errors
- [ ] Run a streaming Responses API request through the pipeline and confirm SSE events are accumulated