### PR TITLE
ci(fmt): include test crates in rustfmt checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,16 +77,14 @@ test-integration:
 # Quality
 # -------------------------------------------------------------------
 
-AI_PKGS := -p praxis-ai-proxy -p praxis-ai-filters -p praxis-ai-apis -p xtask
-
 lint:
 	cargo clippy --workspace --all-targets -- -D warnings
-	cargo +nightly fmt $(AI_PKGS) -- --check
+	cargo +nightly fmt --all -- --check
 	cargo xtask lint-separators
 	cargo xtask lint-filter-docs
 
 fmt:
-	cargo +nightly fmt $(AI_PKGS)
+	cargo +nightly fmt --all
 
 doc:
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items

--- a/tests/integration/tests/suite/conversations_rehydrate.rs
+++ b/tests/integration/tests/suite/conversations_rehydrate.rs
@@ -254,7 +254,11 @@ impl Drop for TempDb {
     }
 }
 
-fn start_test_env() -> (praxis_test_utils::ProxyGuard, praxis_test_utils::net::backend::BackendGuard, TempDb) {
+fn start_test_env() -> (
+    praxis_test_utils::ProxyGuard,
+    praxis_test_utils::net::backend::BackendGuard,
+    TempDb,
+) {
     let echo = start_echo_backend();
     let db = TempDb::new();
     let proxy_port = free_port();

--- a/tests/integration/tests/suite/examples/openai_stream_events.rs
+++ b/tests/integration/tests/suite/examples/openai_stream_events.rs
@@ -199,7 +199,8 @@ async fn stream_events_incremental_accumulation_before_terminal() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stream_events_processes_validate_reformatted_error() {
-    let error_body = r#"{"error":{"message":"model not found","type":"invalid_request_error","code":"model_not_found"}}"#;
+    let error_body =
+        r#"{"error":{"message":"model not found","type":"invalid_request_error","code":"model_not_found"}}"#;
     let backend_guard = Backend::status(404, error_body)
         .header("content-type", "application/json")
         .start_with_shutdown();


### PR DESCRIPTION
  ## Summary

Smol PR to satisfy my OCD 😬 and save anyone else some time if they run `fmt --all` that adds rustfmt check used by `make lint` to also covers the AI test crates.

Before this, `make lint` formatted only the main AI crates and `xtask`, so integration/schema/test utility files could drift unless someone ran `cargo +nightly fmt --all --check` manually.

This also applies the rustfmt-required wrap in the OpenAI stream events integration test that exposed the gap.

Thanks!