### PR TITLE
test: add unit tests for remaining config modules

### DIFF
--- a/apis/src/anthropic/messages_format/config.rs
+++ b/apis/src/anthropic/messages_format/config.rs
@@ -128,3 +128,140 @@ pub(crate) fn build_config(cfg: AnthropicMessagesFormatConfig) -> Result<Anthrop
 
     Ok(cfg)
 }
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    // -- Serde defaults -------------------------------------------------------
+
+    #[test]
+    fn serde_defaults_anthropic_messages_format_config() {
+        let cfg: AnthropicMessagesFormatConfig = serde_yaml::from_str("{}").unwrap();
+
+        assert_eq!(cfg.max_body_bytes, 1_048_576, "default should be 1 MiB");
+        assert_eq!(cfg.on_invalid, OnInvalidBehavior::Continue);
+    }
+
+    #[test]
+    fn default_max_body_bytes_is_1_mib() {
+        assert_eq!(DEFAULT_MAX_BODY_BYTES, 1_048_576);
+    }
+
+    #[test]
+    fn anthropic_messages_format_headers_defaults() {
+        let h = AnthropicMessagesFormatHeaders::default();
+        assert_eq!(h.format.as_deref(), Some("x-praxis-ai-format"));
+        assert_eq!(h.model.as_deref(), Some("x-praxis-ai-model"));
+        assert_eq!(h.stream.as_deref(), Some("x-praxis-ai-stream"));
+    }
+
+    // -- deny_unknown_fields --------------------------------------------------
+
+    #[test]
+    fn deny_unknown_fields_anthropic_messages_format_config() {
+        let res = serde_yaml::from_str::<AnthropicMessagesFormatConfig>(
+            r#"
+bogus: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deny_unknown_fields_anthropic_messages_format_headers() {
+        let res = serde_yaml::from_str::<AnthropicMessagesFormatHeaders>(
+            r#"
+format: x-test
+extra: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    // -- build_config ---------------------------------------------------------
+
+    #[test]
+    fn build_config_minimal_ok() {
+        let cfg: AnthropicMessagesFormatConfig = serde_yaml::from_str("{}").unwrap();
+        assert!(build_config(cfg).is_ok());
+    }
+
+    #[test]
+    fn build_config_zero_max_body_bytes_rejected() {
+        let cfg = AnthropicMessagesFormatConfig {
+            on_invalid: OnInvalidBehavior::default_continue(),
+            max_body_bytes: 0,
+            headers: AnthropicMessagesFormatHeaders::default(),
+        };
+        let err = build_config(cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("must be greater than 0"),
+            "expected 'must be greater than 0' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_config_invalid_header_name_rejected() {
+        let cfg = AnthropicMessagesFormatConfig {
+            on_invalid: OnInvalidBehavior::default_continue(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            headers: AnthropicMessagesFormatHeaders {
+                format: Some("not a valid header!".into()),
+                model: default_model_header(),
+                stream: default_stream_header(),
+            },
+        };
+        let err = build_config(cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid HTTP header name"),
+            "expected invalid header error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_config_valid_custom_headers_ok() {
+        let cfg = AnthropicMessagesFormatConfig {
+            on_invalid: OnInvalidBehavior::default_continue(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            headers: AnthropicMessagesFormatHeaders {
+                format: Some("x-custom-format".into()),
+                model: Some("x-custom-model".into()),
+                stream: Some("x-custom-stream".into()),
+            },
+        };
+        assert!(build_config(cfg).is_ok());
+    }
+
+    // -- null header disables promotion ---------------------------------------
+
+    #[test]
+    fn null_header_disables_promotion() {
+        let cfg: AnthropicMessagesFormatConfig = serde_yaml::from_str(
+            r#"
+headers:
+  format: null
+  model: null
+  stream: null
+"#,
+        )
+        .unwrap();
+
+        assert!(cfg.headers.format.is_none());
+        assert!(cfg.headers.model.is_none());
+        assert!(cfg.headers.stream.is_none());
+        assert!(build_config(cfg).is_ok());
+    }
+}

--- a/apis/src/openai/responses/config.rs
+++ b/apis/src/openai/responses/config.rs
@@ -132,3 +132,140 @@ pub(crate) fn build_config(cfg: ResponsesFormatConfig) -> Result<ResponsesFormat
 
     Ok(cfg)
 }
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    // -- Serde defaults -------------------------------------------------------
+
+    #[test]
+    fn serde_defaults_responses_format_config() {
+        let cfg: ResponsesFormatConfig = serde_yaml::from_str("{}").unwrap();
+
+        assert_eq!(cfg.max_body_bytes, DEFAULT_JSON_BODY_MAX_BYTES);
+        assert_eq!(cfg.on_invalid, OnInvalidBehavior::Continue);
+    }
+
+    #[test]
+    fn responses_format_headers_defaults() {
+        let h = ResponsesFormatHeaders::default();
+        assert_eq!(h.format.as_deref(), Some("x-praxis-ai-format"));
+        assert_eq!(h.model.as_deref(), Some("x-praxis-ai-model"));
+        assert_eq!(h.stream.as_deref(), Some("x-praxis-ai-stream"));
+        assert_eq!(h.mode.as_deref(), Some("x-praxis-responses-mode"));
+    }
+
+    // -- deny_unknown_fields --------------------------------------------------
+
+    #[test]
+    fn deny_unknown_fields_responses_format_config() {
+        let res = serde_yaml::from_str::<ResponsesFormatConfig>(
+            r#"
+bogus: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deny_unknown_fields_responses_format_headers() {
+        let res = serde_yaml::from_str::<ResponsesFormatHeaders>(
+            r#"
+format: x-test
+extra: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    // -- build_config ---------------------------------------------------------
+
+    #[test]
+    fn build_config_minimal_ok() {
+        let cfg: ResponsesFormatConfig = serde_yaml::from_str("{}").unwrap();
+        assert!(build_config(cfg).is_ok());
+    }
+
+    #[test]
+    fn build_config_zero_max_body_bytes_rejected() {
+        let cfg = ResponsesFormatConfig {
+            on_invalid: OnInvalidBehavior::default_continue(),
+            max_body_bytes: 0,
+            headers: ResponsesFormatHeaders::default(),
+        };
+        let err = build_config(cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("must be greater than 0"),
+            "expected 'must be greater than 0' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_config_invalid_header_name_rejected() {
+        let cfg = ResponsesFormatConfig {
+            on_invalid: OnInvalidBehavior::default_continue(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            headers: ResponsesFormatHeaders {
+                format: Some("not a valid header!".into()),
+                model: default_model_header(),
+                stream: default_stream_header(),
+                mode: default_mode_header(),
+            },
+        };
+        let err = build_config(cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid HTTP header name"),
+            "expected invalid header error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_config_valid_custom_headers_ok() {
+        let cfg = ResponsesFormatConfig {
+            on_invalid: OnInvalidBehavior::default_continue(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            headers: ResponsesFormatHeaders {
+                format: Some("x-custom-format".into()),
+                model: Some("x-custom-model".into()),
+                stream: Some("x-custom-stream".into()),
+                mode: Some("x-custom-mode".into()),
+            },
+        };
+        assert!(build_config(cfg).is_ok());
+    }
+
+    // -- null header disables promotion ---------------------------------------
+
+    #[test]
+    fn null_header_disables_promotion() {
+        let cfg: ResponsesFormatConfig = serde_yaml::from_str(
+            r#"
+headers:
+  format: null
+  model: null
+  stream: null
+  mode: null
+"#,
+        )
+        .unwrap();
+
+        assert!(cfg.headers.format.is_none());
+        assert!(cfg.headers.model.is_none());
+        assert!(cfg.headers.stream.is_none());
+        assert!(cfg.headers.mode.is_none());
+        assert!(build_config(cfg).is_ok());
+    }
+}

--- a/apis/src/openai/responses/model_rewrite/config.rs
+++ b/apis/src/openai/responses/model_rewrite/config.rs
@@ -195,3 +195,294 @@ fn validate_header_name(field: &str, name: Option<&str>) -> Result<(), FilterErr
     }
     Ok(())
 }
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    // -- Serde defaults -------------------------------------------------------
+
+    #[test]
+    fn serde_defaults_model_rewrite_config() {
+        let cfg: ModelRewriteConfig = serde_yaml::from_str(
+            r#"
+default_model: "llama-3.3-70b"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.default_model.as_deref(), Some("llama-3.3-70b"));
+        assert_eq!(cfg.max_body_bytes, DEFAULT_JSON_BODY_MAX_BYTES);
+        assert_eq!(cfg.on_invalid, OnInvalidBehavior::Continue);
+        assert!(cfg.model_aliases.is_empty());
+    }
+
+    #[test]
+    fn on_invalid_behavior_defaults_to_continue() {
+        let b = OnInvalidBehavior::default();
+        assert_eq!(b, OnInvalidBehavior::Continue);
+    }
+
+    #[test]
+    fn model_rewrite_headers_defaults() {
+        let h = ModelRewriteHeaders::default();
+        assert_eq!(h.effective_model.as_deref(), Some("x-praxis-ai-effective-model"));
+        assert_eq!(h.original_model.as_deref(), Some("x-praxis-ai-original-model"));
+    }
+
+    // -- OnInvalidBehavior serde ----------------------------------------------
+
+    #[test]
+    fn on_invalid_behavior_serde_continue() {
+        let b: OnInvalidBehavior = serde_yaml::from_str("continue").unwrap();
+        assert_eq!(b, OnInvalidBehavior::Continue);
+    }
+
+    #[test]
+    fn on_invalid_behavior_serde_reject() {
+        let b: OnInvalidBehavior = serde_yaml::from_str("reject").unwrap();
+        assert_eq!(b, OnInvalidBehavior::Reject);
+    }
+
+    // -- deny_unknown_fields --------------------------------------------------
+
+    #[test]
+    fn deny_unknown_fields_model_rewrite_config() {
+        let res = serde_yaml::from_str::<ModelRewriteConfig>(
+            r#"
+default_model: "test"
+bogus: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deny_unknown_fields_model_rewrite_headers() {
+        let res = serde_yaml::from_str::<ModelRewriteHeaders>(
+            r#"
+effective_model: x-test
+extra: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    // -- validate_config ------------------------------------------------------
+
+    #[test]
+    fn validate_no_default_model_no_aliases_rejected() {
+        let cfg = ModelRewriteConfig {
+            default_model: None,
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            model_aliases: HashMap::new(),
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("at least one"),
+            "expected 'at least one' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_empty_default_model_rejected() {
+        let cfg = ModelRewriteConfig {
+            default_model: Some(String::new()),
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            model_aliases: HashMap::new(),
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "expected 'must not be empty' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_whitespace_only_default_model_rejected() {
+        let cfg = ModelRewriteConfig {
+            default_model: Some("   ".into()),
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            model_aliases: HashMap::new(),
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "expected 'must not be empty' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_default_model_only_ok() {
+        let cfg = ModelRewriteConfig {
+            default_model: Some("llama-3.3-70b".into()),
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            model_aliases: HashMap::new(),
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        assert!(validate_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_aliases_only_ok() {
+        let mut aliases = HashMap::new();
+        aliases.insert("gpt-4".into(), "llama-3.3-70b".into());
+        let cfg = ModelRewriteConfig {
+            default_model: None,
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            model_aliases: aliases,
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        assert!(validate_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_both_default_model_and_aliases_ok() {
+        let mut aliases = HashMap::new();
+        aliases.insert("gpt-4".into(), "llama-3.3-70b".into());
+        let cfg = ModelRewriteConfig {
+            default_model: Some("default-model".into()),
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            model_aliases: aliases,
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        assert!(validate_config(&cfg).is_ok());
+    }
+
+    // -- validate_aliases -----------------------------------------------------
+
+    #[test]
+    fn validate_aliases_empty_source_rejected() {
+        let mut aliases = HashMap::new();
+        aliases.insert(String::new(), "target".into());
+        let err = validate_aliases(&aliases).unwrap_err();
+        assert!(
+            err.to_string().contains("source name must not be empty"),
+            "expected empty source error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_aliases_multiple_wildcards_rejected() {
+        let mut aliases = HashMap::new();
+        aliases.insert("gpt-*-*".into(), "target".into());
+        let err = validate_aliases(&aliases).unwrap_err();
+        assert!(
+            err.to_string().contains("at most one '*'"),
+            "expected wildcard error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_aliases_empty_target_rejected() {
+        let mut aliases = HashMap::new();
+        aliases.insert("gpt-4".into(), String::new());
+        let err = validate_aliases(&aliases).unwrap_err();
+        assert!(
+            err.to_string().contains("target"),
+            "expected empty target error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_aliases_single_wildcard_ok() {
+        let mut aliases = HashMap::new();
+        aliases.insert("gpt-4.1-*".into(), "qwen-2.5-72b".into());
+        assert!(validate_aliases(&aliases).is_ok());
+    }
+
+    #[test]
+    fn validate_aliases_exact_alias_ok() {
+        let mut aliases = HashMap::new();
+        aliases.insert("codex-mini-latest".into(), "llama-3.3-70b".into());
+        assert!(validate_aliases(&aliases).is_ok());
+    }
+
+    // -- validate_header_name -------------------------------------------------
+
+    #[test]
+    fn validate_header_name_none_ok() {
+        assert!(validate_header_name("test", None).is_ok());
+    }
+
+    #[test]
+    fn validate_header_name_empty_rejected() {
+        let err = validate_header_name("test", Some("")).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "expected empty header error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_header_name_invalid_rejected() {
+        let err = validate_header_name("test", Some("not a valid header!")).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid HTTP header name"),
+            "expected invalid header error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_header_name_valid_accepted() {
+        assert!(validate_header_name("test", Some("x-custom-header")).is_ok());
+    }
+
+    // -- validate_config: max_body_bytes --------------------------------------
+
+    #[test]
+    fn validate_zero_max_body_bytes_rejected() {
+        let cfg = ModelRewriteConfig {
+            default_model: Some("test-model".into()),
+            headers: ModelRewriteHeaders::default(),
+            max_body_bytes: 0,
+            model_aliases: HashMap::new(),
+            on_invalid: OnInvalidBehavior::Continue,
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("must be greater than 0"),
+            "expected 'must be greater than 0' error, got: {err}"
+        );
+    }
+
+    // -- null header disables promotion ---------------------------------------
+
+    #[test]
+    fn null_header_disables_promotion() {
+        let cfg: ModelRewriteConfig = serde_yaml::from_str(
+            r#"
+default_model: "test"
+headers:
+  effective_model: null
+  original_model: null
+"#,
+        )
+        .unwrap();
+
+        assert!(cfg.headers.effective_model.is_none());
+        assert!(cfg.headers.original_model.is_none());
+        assert!(validate_config(&cfg).is_ok());
+    }
+}

--- a/filters/src/prompt_enrich/config.rs
+++ b/filters/src/prompt_enrich/config.rs
@@ -155,3 +155,229 @@ pub(super) fn message_to_value(msg: &MessageConfig) -> serde_json::Value {
         "content": msg.content,
     })
 }
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    // -- Serde defaults -------------------------------------------------------
+
+    #[test]
+    fn serde_defaults_prompt_enrich_config() {
+        let cfg: PromptEnrichConfig = serde_yaml::from_str(
+            r#"
+prepend:
+  - role: system
+    content: hello
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.max_body_bytes, DEFAULT_JSON_BODY_MAX_BYTES);
+        assert_eq!(cfg.on_invalid, InvalidBodyBehavior::Continue);
+        assert!(cfg.append.is_empty());
+    }
+
+    #[test]
+    fn invalid_body_behavior_defaults_to_continue() {
+        let b = InvalidBodyBehavior::default();
+        assert_eq!(b, InvalidBodyBehavior::Continue);
+    }
+
+    // -- MessageRole serde ----------------------------------------------------
+
+    #[test]
+    fn message_role_serde_system() {
+        let r: MessageRole = serde_yaml::from_str("system").unwrap();
+        assert_eq!(r, MessageRole::System);
+    }
+
+    #[test]
+    fn message_role_serde_user() {
+        let r: MessageRole = serde_yaml::from_str("user").unwrap();
+        assert_eq!(r, MessageRole::User);
+    }
+
+    #[test]
+    fn message_role_serde_unknown_rejected() {
+        let res = serde_yaml::from_str::<MessageRole>("admin");
+        assert!(res.is_err());
+    }
+
+    // -- InvalidBodyBehavior serde --------------------------------------------
+
+    #[test]
+    fn invalid_body_behavior_serde_continue() {
+        let b: InvalidBodyBehavior = serde_yaml::from_str("continue").unwrap();
+        assert_eq!(b, InvalidBodyBehavior::Continue);
+    }
+
+    #[test]
+    fn invalid_body_behavior_serde_reject() {
+        let b: InvalidBodyBehavior = serde_yaml::from_str("reject").unwrap();
+        assert_eq!(b, InvalidBodyBehavior::Reject);
+    }
+
+    // -- deny_unknown_fields --------------------------------------------------
+
+    #[test]
+    fn deny_unknown_fields_prompt_enrich_config() {
+        let res = serde_yaml::from_str::<PromptEnrichConfig>(
+            r#"
+prepend:
+  - role: system
+    content: hello
+unknown_field: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deny_unknown_fields_message_config() {
+        let res = serde_yaml::from_str::<MessageConfig>(
+            r#"
+role: system
+content: hello
+extra: true
+"#,
+        );
+        assert!(res.is_err());
+    }
+
+    // -- validate_config ------------------------------------------------------
+
+    #[test]
+    fn validate_empty_prepend_and_append_rejected() {
+        let cfg = PromptEnrichConfig {
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            on_invalid: InvalidBodyBehavior::Continue,
+            prepend: vec![],
+            append: vec![],
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("at least one"),
+            "expected 'at least one' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_prepend_only_ok() {
+        let cfg = PromptEnrichConfig {
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            on_invalid: InvalidBodyBehavior::Continue,
+            prepend: vec![MessageConfig {
+                role: MessageRole::System,
+                content: "hello".into(),
+            }],
+            append: vec![],
+        };
+        assert!(validate_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_append_only_ok() {
+        let cfg = PromptEnrichConfig {
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            on_invalid: InvalidBodyBehavior::Continue,
+            prepend: vec![],
+            append: vec![MessageConfig {
+                role: MessageRole::User,
+                content: "cite sources".into(),
+            }],
+        };
+        assert!(validate_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_empty_content_rejected() {
+        let cfg = PromptEnrichConfig {
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            on_invalid: InvalidBodyBehavior::Continue,
+            prepend: vec![MessageConfig {
+                role: MessageRole::System,
+                content: String::new(),
+            }],
+            append: vec![],
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("content"),
+            "expected 'content' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_prepend_with_user_role_rejected() {
+        let cfg = PromptEnrichConfig {
+            max_body_bytes: DEFAULT_JSON_BODY_MAX_BYTES,
+            on_invalid: InvalidBodyBehavior::Continue,
+            prepend: vec![MessageConfig {
+                role: MessageRole::User,
+                content: "not allowed".into(),
+            }],
+            append: vec![],
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("system"),
+            "expected 'system' role error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_zero_max_body_bytes_rejected() {
+        let cfg = PromptEnrichConfig {
+            max_body_bytes: 0,
+            on_invalid: InvalidBodyBehavior::Continue,
+            prepend: vec![MessageConfig {
+                role: MessageRole::System,
+                content: "hello".into(),
+            }],
+            append: vec![],
+        };
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("must be greater than 0"),
+            "expected 'must be greater than 0' error, got: {err}"
+        );
+    }
+
+    // -- message_to_value -----------------------------------------------------
+
+    #[test]
+    fn message_to_value_system() {
+        let msg = MessageConfig {
+            role: MessageRole::System,
+            content: "be helpful".into(),
+        };
+        let v = message_to_value(&msg);
+        assert_eq!(v["role"], "system");
+        assert_eq!(v["content"], "be helpful");
+    }
+
+    #[test]
+    fn message_to_value_user() {
+        let msg = MessageConfig {
+            role: MessageRole::User,
+            content: "cite sources".into(),
+        };
+        let v = message_to_value(&msg);
+        assert_eq!(v["role"], "user");
+        assert_eq!(v["content"], "cite sources");
+    }
+}


### PR DESCRIPTION
## Summary

- Add inline unit tests for 4 config modules that had zero test coverage:
  - `filters/src/prompt_enrich/config.rs` — 17 tests (serde defaults, MessageRole, InvalidBodyBehavior, deny_unknown_fields, validate_config, message_to_value)
  - `apis/src/openai/responses/model_rewrite/config.rs` — 24 tests (serde defaults, OnInvalidBehavior, ModelRewriteHeaders, deny_unknown_fields, validate_config, validate_aliases, validate_header_name)
  - `apis/src/openai/responses/config.rs` — 9 tests (serde defaults, ResponsesFormatHeaders, deny_unknown_fields, build_config)
  - `apis/src/anthropic/messages_format/config.rs` — 10 tests (serde defaults, DEFAULT_MAX_BODY_BYTES, headers, deny_unknown_fields, build_config)

Closes #283

## Test plan

- [x] `cargo test -p praxis-ai-filters -- prompt_enrich::config::tests` — all 17 tests pass
- [x] `cargo test -p praxis-ai-apis -- openai::responses::model_rewrite::config::tests` — all 24 tests pass
- [x] `cargo test -p praxis-ai-apis -- openai::responses::config::tests` — all 9 tests pass
- [x] `cargo test -p praxis-ai-apis -- anthropic::messages_format::config::tests` — all 10 tests pass
- [x] `make lint` — clippy + nightly rustfmt clean