### PR TITLE
docs: use language-neutral type names in generated filter docs

### DIFF
--- a/docs/filters/a2a.md
+++ b/docs/filters/a2a.md
@@ -17,17 +17,17 @@ Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method,
 | `headers.streaming` | string | no | Header name for streaming detection (e.g. `x-praxis-a2a-streaming`). |
 | `headers.task_id` | string | no | Header name for the extracted task ID (e.g. `x-praxis-a2a-task-id`). |
 | `headers.version` | string | no | Header name for A2A version (e.g. `x-praxis-a2a-version`). |
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer`. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer`. |
 | `method_aliases` | object<string, string> | no | Method aliases for compatibility (slash-delimited → `PascalCase`). |
 | `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
 | `task_routing` | TaskRoutingConfig | no | Task-ownership routing configuration. |
 | `task_routing.enabled` | bool | no | Whether task routing is enabled. |
-| `task_routing.max_response_body_bytes` | usize | no | Maximum response body bytes to buffer for task route capture. |
+| `task_routing.max_response_body_bytes` | integer | no | Maximum response body bytes to buffer for task route capture. |
 | `task_routing.on_lookup_miss` | `continue` | no | Behavior when a task route lookup misses. |
 | `task_routing.route_cluster_header` | string | no | Internal header name injected on task route hit. |
 | `task_routing.store` | `local` | no | Storage backend for task routes. |
-| `task_routing.terminal_ttl_seconds` | u64 | no | TTL in seconds for terminal task routes (0 = remove immediately). |
-| `task_routing.ttl_seconds` | u64 | no | TTL in seconds for non-terminal task routes. |
+| `task_routing.terminal_ttl_seconds` | integer | no | TTL in seconds for terminal task routes (0 = remove immediately). |
+| `task_routing.ttl_seconds` | integer | no | TTL in seconds for non-terminal task routes. |
 
 ## Examples
 

--- a/docs/filters/anthropic_messages_format.md
+++ b/docs/filters/anthropic_messages_format.md
@@ -10,7 +10,7 @@ Classifies Anthropic Messages API requests and promotes routing facts to headers
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
 | `on_invalid` | `continue` \| `reject` \| `error` | no | Behavior when the body cannot be classified. |
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `headers` | AnthropicMessagesFormatHeaders | no | Header names for promoted classification facts. |
 | `headers.format` | string | no | Header name for the detected format. |
 | `headers.model` | string | no | Header name for the extracted model value. |

--- a/docs/filters/anthropic_stream_events.md
+++ b/docs/filters/anthropic_stream_events.md
@@ -13,7 +13,7 @@ Arms automatically when an upstream classifier or transform filter sets `anthrop
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_partial_event_bytes` | usize | no | Maximum incomplete SSE event bytes retained between chunks. |
+| `max_partial_event_bytes` | integer | no | Maximum incomplete SSE event bytes retained between chunks. |
 
 ## Examples
 

--- a/docs/filters/anthropic_to_openai.md
+++ b/docs/filters/anthropic_to_openai.md
@@ -9,7 +9,7 @@ Transforms Anthropic Messages API requests to Chat Completions-compatible reques
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 
 ## Examples
 

--- a/docs/filters/anthropic_validate.md
+++ b/docs/filters/anthropic_validate.md
@@ -9,7 +9,7 @@ Validates Anthropic Messages request bodies for proxy-owned JSON envelope requir
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 
 ## Example
 

--- a/docs/filters/mcp.md
+++ b/docs/filters/mcp.md
@@ -32,10 +32,10 @@ Supports two protocol profiles: `current` (session-based, default) and `stateles
 | `headers.name` | string | no | Header name for the tool/resource/prompt name (e.g. `x-praxis-mcp-name`). |
 | `headers.protocol_version` | string | no | Header name for the MCP protocol version (e.g. `x-praxis-mcp-protocol-version`). |
 | `headers.session_present` | string | no | Header name for MCP session presence (e.g. `x-praxis-mcp-session-present`). |
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer`. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer`. |
 | `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
 | `cache_scope` | `public` \| `private` | no | Cache scope for stateless responses. Requires `protocol_profile: stateless`. |
-| `cache_ttl_ms` | u64 | no | Cache TTL in milliseconds for stateless responses. Requires `protocol_profile: stateless`. |
+| `cache_ttl_ms` | integer | no | Cache TTL in milliseconds for stateless responses. Requires `protocol_profile: stateless`. |
 | `default_version` | string | no | Fallback MCP protocol version. When omitted, derived from the profile. |
 | `invalid_tool_policy` | `reject_server` \| `filter_out` | no | Behavior when a tool has an invalid schema. |
 | `path` | string | no | Public MCP path handled by Praxis. |

--- a/docs/filters/openai_responses_format.md
+++ b/docs/filters/openai_responses_format.md
@@ -18,7 +18,7 @@ Use with branch chains to route stateful and stateless requests to different clu
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
 | `on_invalid` | `continue` \| `reject` \| `error` | no | Behavior when the body cannot be classified. |
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `headers` | ResponsesFormatHeaders | no | Header names for promoted classification facts. |
 | `headers.format` | string | no | Header name for the detected format (e.g. `openai_responses`, `openai_chat_completions`). |
 | `headers.model` | string | no | Header name for the extracted model value. |

--- a/docs/filters/openai_responses_model_rewrite.md
+++ b/docs/filters/openai_responses_model_rewrite.md
@@ -17,7 +17,7 @@ Quote wildcard alias keys in YAML, such as `"gpt-4.1-*"`, so `*` is parsed as a 
 | `headers` | ModelRewriteHeaders | no | Header names for promoted model values. |
 | `headers.effective_model` | string | no | Header name for the effective (post-rewrite) model value. |
 | `headers.original_model` | string | no | Header name for the original (pre-rewrite) model value. |
-| `max_body_bytes` | usize | no | Maximum request body size to buffer before parsing. |
+| `max_body_bytes` | integer | no | Maximum request body size to buffer before parsing. |
 | `model_aliases` | object<string, string> | no | Map from client-facing model names or single-wildcard patterns to backend model names. Quote wildcard keys in YAML. Exact aliases win before wildcard aliases; wildcard aliases are matched by literal specificity. |
 | `on_invalid` | `continue` \| `reject` | no | Behavior when the body is not valid JSON. |
 

--- a/docs/filters/openai_stream_events.md
+++ b/docs/filters/openai_stream_events.md
@@ -13,10 +13,10 @@ All fields are optional; omitted values fall back to [`SseParserConfig`] default
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_buffer_bytes` | usize | no | Maximum bytes buffered for incomplete SSE lines/data across chunk boundaries. Default: 10 MiB. |
-| `max_events` | usize | no | Maximum number of SSE events before the parser errors. Default: 100,000. |
-| `timeout_secs` | u64 | no | Maximum seconds from first chunk to stream completion. Default: 300 (5 minutes). |
-| `max_tool_call_argument_bytes` | usize | no | Maximum bytes accumulated per function-call argument string from `function_call_arguments.delta` events. Default: 1 MiB. |
+| `max_buffer_bytes` | integer | no | Maximum bytes buffered for incomplete SSE lines/data across chunk boundaries. Default: 10 MiB. |
+| `max_events` | integer | no | Maximum number of SSE events before the parser errors. Default: 100,000. |
+| `timeout_secs` | integer | no | Maximum seconds from first chunk to stream completion. Default: 300 (5 minutes). |
+| `max_tool_call_argument_bytes` | integer | no | Maximum bytes accumulated per function-call argument string from `function_call_arguments.delta` events. Default: 1 MiB. |
 
 ## Example
 

--- a/docs/filters/prompt_enrich.md
+++ b/docs/filters/prompt_enrich.md
@@ -17,7 +17,7 @@ In chains that also use `json_body_field` or `model_to_header`, place `prompt_en
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_body_bytes` | usize | no | Maximum request body size to buffer before parsing. |
+| `max_body_bytes` | integer | no | Maximum request body size to buffer before parsing. |
 | `on_invalid` | `continue` \| `reject` | no | Behavior when the body is not valid JSON or lacks a `messages` array. |
 | `prepend` | MessageConfig[] | no | Messages to prepend at the beginning of the `messages` array. |
 | `prepend[].role` | `system` \| `user` | yes | Role for the injected message. |

--- a/docs/filters/responses_proxy.md
+++ b/docs/filters/responses_proxy.md
@@ -15,7 +15,7 @@ When no `ResponsesState` exists (non-Responses requests, or requests without `pr
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 
 ## Examples
 

--- a/docs/filters/tool_parse.md
+++ b/docs/filters/tool_parse.md
@@ -9,7 +9,7 @@ Parses tool definitions and `tool_choice` from Responses API request bodies and 
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
+| `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 
 ## Examples
 

--- a/xtask/src/filter_docs.rs
+++ b/xtask/src/filter_docs.rs
@@ -2432,14 +2432,23 @@ mod tests {
     #[test]
     fn numeric_types_render_language_neutral() {
         let enums = BTreeMap::new();
-        let u64_ty: syn::Type = syn::parse_str("u64").unwrap();
-        assert_eq!(render_type(&u64_ty, &enums), "integer", "unsigned integers");
-        let usize_ty: syn::Type = syn::parse_str("usize").unwrap();
-        assert_eq!(render_type(&usize_ty, &enums), "integer", "usize");
-        let i32_ty: syn::Type = syn::parse_str("i32").unwrap();
-        assert_eq!(render_type(&i32_ty, &enums), "integer", "signed integers");
-        let f64_ty: syn::Type = syn::parse_str("f64").unwrap();
-        assert_eq!(render_type(&f64_ty, &enums), "number", "floats");
+        for (rust_ty, expected) in [
+            ("u8", "integer"),
+            ("u16", "integer"),
+            ("u32", "integer"),
+            ("u64", "integer"),
+            ("usize", "integer"),
+            ("i8", "integer"),
+            ("i16", "integer"),
+            ("i32", "integer"),
+            ("i64", "integer"),
+            ("isize", "integer"),
+            ("f32", "number"),
+            ("f64", "number"),
+        ] {
+            let ty: syn::Type = syn::parse_str(rust_ty).unwrap();
+            assert_eq!(render_type(&ty, &enums), expected, "{rust_ty}");
+        }
     }
 
     /// Build a sample [`FilterEntry`] for rendering tests.

--- a/xtask/src/filter_docs.rs
+++ b/xtask/src/filter_docs.rs
@@ -1367,9 +1367,9 @@ fn render_type_path(tp: &syn::TypePath, enums: &BTreeMap<String, EnumInfo>) -> S
         "String" => "string".to_owned(),
         "SecretString" => "string (secret)".to_owned(),
         "Value" => "any".to_owned(),
-        "bool" | "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" | "f32" | "f64" => {
-            ident
-        },
+        "bool" => ident,
+        "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" => "integer".to_owned(),
+        "f32" | "f64" => "number".to_owned(),
         other => enums
             .get(other)
             .map_or_else(|| other.to_owned(), |info| render_enum_type(info, enums)),
@@ -2071,7 +2071,7 @@ mod tests {
     fn render_filter_doc_has_field_row() {
         let result = render_filter_doc(&sample_filter_entry());
         assert!(
-            result.contains("| `timeout_ms` | u64 | yes | Max time in milliseconds. |"),
+            result.contains("| `timeout_ms` | integer | yes | Max time in milliseconds. |"),
             "should have field row"
         );
         assert!(
@@ -2091,7 +2091,7 @@ mod tests {
         let result = render_filter_doc(&entry);
 
         assert!(
-            result.contains("| `timeout_ms` | u64 | yes | Maximum allowed time. Use `0 \\| 1` only in tests. |"),
+            result.contains("| `timeout_ms` | integer | yes | Maximum allowed time. Use `0 \\| 1` only in tests. |"),
             "field table rows should render prose without fenced doctests"
         );
         assert!(
@@ -2429,6 +2429,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn numeric_types_render_language_neutral() {
+        let enums = BTreeMap::new();
+        let u64_ty: syn::Type = syn::parse_str("u64").unwrap();
+        assert_eq!(render_type(&u64_ty, &enums), "integer", "unsigned integers");
+        let usize_ty: syn::Type = syn::parse_str("usize").unwrap();
+        assert_eq!(render_type(&usize_ty, &enums), "integer", "usize");
+        let i32_ty: syn::Type = syn::parse_str("i32").unwrap();
+        assert_eq!(render_type(&i32_ty, &enums), "integer", "signed integers");
+        let f64_ty: syn::Type = syn::parse_str("f64").unwrap();
+        assert_eq!(render_type(&f64_ty, &enums), "number", "floats");
+    }
+
     /// Build a sample [`FilterEntry`] for rendering tests.
     fn sample_filter_entry() -> FilterEntry {
         FilterEntry {
@@ -2441,7 +2454,7 @@ mod tests {
                 config_notes: vec![],
                 fields: vec![FieldInfo {
                     name: "timeout_ms".to_owned(),
-                    type_str: "u64".to_owned(),
+                    type_str: "integer".to_owned(),
                     doc: "Max time in milliseconds.".to_owned(),
                     required: RequiredKind::Yes,
                 }],


### PR DESCRIPTION
## Summary

Port of https://github.com/praxis-proxy/praxis/pull/751 to the AI repo. Replaces Rust-specific type names (`u64`, `usize`, `f64`, etc.) with language-neutral equivalents (`integer`, `number`) in the xtask filter-doc generator and regenerates all filter documentation. Adds a `numeric_types_render_language_neutral` test to cover the mapping.

## Test plan

- [x] `cargo test -p xtask -- numeric_types_render_language_neutral` passes
- [x] `make lint` passes (clippy, fmt, lint-filter-docs)
- [x] `make build` passes
- [x] No Rust type names remain in generated `docs/filters/*.md`