### PR TITLE
ci: bump coverage threshold from 93% to 94%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ coverage-check:
 		--output-path coverage.json
 	@LINE_PCT=$$(jq '.data[0].totals.lines.percent' coverage.json); \
 	echo "Line coverage: $${LINE_PCT}%"; \
-	if [ $$(echo "$${LINE_PCT} < 93" | bc -l) -eq 1 ]; then \
-		echo "FAIL: coverage $${LINE_PCT}% is below 93% threshold"; \
+	if [ $$(echo "$${LINE_PCT} < 94" | bc -l) -eq 1 ]; then \
+		echo "FAIL: coverage $${LINE_PCT}% is below 94% threshold"; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
Raise the `coverage-check` Makefile target threshold from 93% to 94%.
Current workspace line coverage sits at ~94.4%, so this passes comfortably.