### PR TITLE
test(guardrails): add unit tests for config validation

### DIFF
--- a/filters/src/guardrails/config.rs
+++ b/filters/src/guardrails/config.rs
@@ -24,7 +24,10 @@ pub(super) struct AiGuardrailsConfig {
     pub provider: ProviderConfig,
 
     /// Which phases to evaluate.
-    #[expect(dead_code, reason = "read once provider evaluation is wired (#578)")]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "read once provider evaluation is wired (#578)")
+    )]
     #[serde(default)]
     pub phase: PhaseConfig,
 }
@@ -58,15 +61,21 @@ pub(super) struct ProviderConfig {
 #[serde(deny_unknown_fields)]
 pub(super) struct PhaseConfig {
     /// Evaluate client requests before forwarding to the upstream.
-    #[expect(
-        dead_code,
-        reason = "read by on_request_body once provider evaluation is wired (#578)"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "read by on_request_body once provider evaluation is wired (#578)"
+        )
     )]
     #[serde(default = "default_true")]
     pub request: bool,
 
     /// Evaluate upstream responses before forwarding to the client.
-    #[expect(dead_code, reason = "read once response-side evaluation is implemented (#580)")]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "read once response-side evaluation is implemented (#580)")
+    )]
     #[serde(default)]
     pub response: bool,
 }

--- a/filters/src/guardrails/mod.rs
+++ b/filters/src/guardrails/mod.rs
@@ -10,7 +10,13 @@ pub(crate) mod providers;
 
 #[cfg(test)]
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
-#[allow(clippy::unwrap_used, reason = "tests")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
 mod tests;
 
 pub use filter::AiGuardrailsFilter;

--- a/filters/src/guardrails/tests.rs
+++ b/filters/src/guardrails/tests.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-use super::filter::AiGuardrailsFilter;
+use super::{
+    config::{AiGuardrailsConfig, PhaseConfig, ProviderType},
+    filter::AiGuardrailsFilter,
+};
 
 // =============================================================================
 // General config
@@ -190,12 +193,12 @@ provider:
     .unwrap();
 
     let filter = AiGuardrailsFilter::from_config(&yaml).unwrap();
-    assert!(
-        matches!(
-            filter.request_body_mode(),
-            praxis_filter::body::BodyMode::StreamBuffer { max_bytes: Some(_) }
-        ),
-        "body mode should be StreamBuffer"
+    assert_eq!(
+        filter.request_body_mode(),
+        praxis_filter::body::BodyMode::StreamBuffer {
+            max_bytes: Some(1_048_576)
+        },
+        "body mode should be StreamBuffer with 1 MiB limit"
     );
 }
 
@@ -241,4 +244,117 @@ provider:
         matches!(action, praxis_filter::FilterAction::Continue),
         "stub provider should pass through"
     );
+}
+
+// =============================================================================
+// ProviderType serde
+// =============================================================================
+
+#[test]
+fn provider_type_nemo_parses() {
+    let parsed: ProviderType = serde_yaml::from_str(r#""nemo""#).unwrap();
+    assert_eq!(parsed, ProviderType::Nemo);
+}
+
+#[test]
+fn provider_type_unknown_rejected() {
+    let result: Result<ProviderType, _> = serde_yaml::from_str(r#""openai""#);
+    assert!(result.is_err(), "unknown provider type should fail");
+}
+
+// =============================================================================
+// PhaseConfig
+// =============================================================================
+
+#[test]
+fn phase_config_default() {
+    let phase = PhaseConfig::default();
+    assert!(phase.request, "default request should be true");
+    assert!(!phase.response, "default response should be false");
+}
+
+#[test]
+fn phase_config_custom_values() {
+    let parsed: PhaseConfig = serde_yaml::from_str(
+        "
+request: false
+response: true
+",
+    )
+    .unwrap();
+    assert!(!parsed.request, "request should be false");
+    assert!(parsed.response, "response should be true");
+}
+
+#[test]
+fn phase_config_omitted_uses_defaults() {
+    let parsed: PhaseConfig = serde_yaml::from_str("{}").unwrap();
+    assert!(parsed.request, "omitted request should default to true");
+    assert!(!parsed.response, "omitted response should default to false");
+}
+
+#[test]
+fn phase_config_unknown_field_rejected() {
+    let result: Result<PhaseConfig, _> = serde_yaml::from_str(
+        "
+request: true
+unknown: 42
+",
+    );
+    assert!(result.is_err(), "unknown fields should fail with deny_unknown_fields");
+}
+
+// =============================================================================
+// AiGuardrailsConfig serde
+// =============================================================================
+
+#[test]
+fn guardrails_config_minimal_valid() {
+    let parsed: AiGuardrailsConfig = serde_yaml::from_str(
+        r#"
+provider:
+  type: nemo
+  endpoint: "http://nemo:8000/v1/guardrail/checks"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(parsed.provider.provider_type, ProviderType::Nemo);
+}
+
+#[test]
+fn guardrails_config_missing_provider_rejected() {
+    let result: Result<AiGuardrailsConfig, _> = serde_yaml::from_str("{}");
+    assert!(result.is_err(), "missing provider should fail");
+}
+
+#[test]
+fn guardrails_config_unknown_field_rejected() {
+    let result: Result<AiGuardrailsConfig, _> = serde_yaml::from_str(
+        r#"
+provider:
+  type: nemo
+  endpoint: "http://nemo:8000/v1/guardrail/checks"
+bogus: true
+"#,
+    );
+    assert!(result.is_err(), "unknown fields should fail with deny_unknown_fields");
+}
+
+#[test]
+fn guardrails_config_with_phase_overrides() {
+    let parsed: AiGuardrailsConfig = serde_yaml::from_str(
+        r#"
+provider:
+  type: nemo
+  endpoint: "http://nemo:8000/v1/guardrail/checks"
+phase:
+  request: false
+  response: true
+"#,
+    )
+    .unwrap();
+
+    assert!(!parsed.phase.request);
+    assert!(parsed.phase.response);
 }


### PR DESCRIPTION
## Summary

- Add inline unit tests for the guardrails config module (`filters/src/guardrails/config.rs`)
- Cover ProviderType serde, PhaseConfig defaults/custom/deny_unknown_fields, AiGuardrailsConfig serde
- Strengthen existing `body_mode_is_stream_buffer` test to assert exact `max_bytes` value
- Use `#[cfg_attr(not(test), expect(dead_code, ...))]` for fields only read in tests

Closes #282

## Test plan

- [x] `cargo test -p praxis-ai-filters -- guardrails` — all tests pass
- [x] `make lint` — clippy + nightly rustfmt clean