### PR TITLE
feat(a2a): route task traffic by context ownership

### DIFF
--- a/docs/filters/a2a.md
+++ b/docs/filters/a2a.md
@@ -5,6 +5,10 @@
 
 Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method, family, task ID, streaming detection, and version to request headers, filter results, and durable metadata for routing.
 
+## Configuration Notes
+
+When `task_routing.enabled` is true, the filter captures task and context ownership from backend responses and uses it to route follow-up requests. Task-owner routing sends `GetTask`, `CancelTask`, `SubscribeToTask`, and push-notification config methods back to the backend that created the task. Context-owner routing sends `ListTasks`, `SendMessage`, and `SendStreamingMessage` requests carrying a known `contextId` back to the backend that owns the context. Task-ID routes take precedence over context-ID routes. Context routes always use `ttl_seconds`; a completed task does not evict the context route.
+
 ## Configuration
 
 | Field | Type | Required | Description |
@@ -24,7 +28,7 @@ Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method,
 | `task_routing.enabled` | bool | no | Whether task routing is enabled. |
 | `task_routing.max_response_body_bytes` | integer | no | Maximum response body bytes to buffer for task route capture. |
 | `task_routing.on_lookup_miss` | `continue` | no | Behavior when a task route lookup misses. |
-| `task_routing.route_cluster_header` | string | no | Internal header name injected on task route hit. |
+| `task_routing.route_cluster_header` | string | no | Internal header name injected on task or context route hit. |
 | `task_routing.store` | `local` | no | Storage backend for task routes. |
 | `task_routing.terminal_ttl_seconds` | integer | no | TTL in seconds for terminal task routes (0 = remove immediately). |
 | `task_routing.ttl_seconds` | integer | no | TTL in seconds for non-terminal task routes. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ before sending requests.
 | ------ | ------------- |
 | [a2a-agent-card-routing.yaml](configs/a2a-agent-card-routing.yaml) | Routes agent card discovery requests to dedicated backends |
 | [a2a-classifier-routing.yaml](configs/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, context ID, task ID, and streaming detection |
-| [a2a-task-routing.yaml](configs/a2a-task-routing.yaml) | Captures task ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up task operations back to the backend cluster that created the task |
+| [a2a-task-routing.yaml](configs/a2a-task-routing.yaml) | Captures task and context ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up requests back to the backend cluster that created the task or owns the context |
 | [ai-inference-body-based-routing.yaml](configs/ai-inference-body-based-routing.yaml) | Routes LLM API requests to different backends based on the `model` field in the JSON request body |
 | [credential-injection.yaml](configs/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |
 | [json-rpc-routing.yaml](configs/json-rpc-routing.yaml) | Routes JSON-RPC 2.0 requests to different backends based on the "method" field in the JSON request body |
@@ -29,7 +29,7 @@ before sending requests.
 | [mcp-stateless-broker.yaml](configs/mcp-stateless-broker.yaml) | Configurable stateless MCP broker using the 2026-07-28 release candidate profile |
 | [model-to-header-routing.yaml](configs/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
 | [prompt-enrichment.yaml](configs/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
-| [token-counting.yaml](configs/token-counting.yaml) | Extracts token usage from AI inference responses (streaming SSE and non-streaming JSON) and makes counts available to downstream filters via filter metadata |
+| [token-counting.yaml](configs/token-counting.yaml) | Extracts token usage from AI inference responses (streaming and non-streaming) and makes counts available to downstream filters via filter metadata |
 | [token-usage-headers.yaml](configs/token-usage-headers.yaml) | Inject Praxis-Token-Input, Praxis-Token-Output, and Praxis-Token-Total headers into downstream responses when token counts are available in filter metadata |
 
 ### Anthropic
@@ -47,14 +47,15 @@ before sending requests.
 | ------ | ------------- |
 | [conversations.yaml](configs/openai/conversations/conversations.yaml) | Local /v1/conversations endpoints for conversation lifecycle, backed by the ConversationItemStore |
 | [format-routing.yaml](configs/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |
-| [full-flow.yaml](configs/openai/responses/full-flow.yaml) | Combines format classification, request validation, and backend routing into a single pipeline |
+| [full-flow.yaml](configs/openai/responses/full-flow.yaml) | Combines conversations, format classification, request validation, and backend routing into a single pipeline |
 | [model-rewrite.yaml](configs/openai/responses/model-rewrite.yaml) | Rewrites or injects the top-level `model` field in Responses API request bodies before forwarding to the inference backend |
 | [rehydrate.yaml](configs/openai/responses/rehydrate.yaml) | Validates `previous_response_id` by fetching the stored response, confirming its status is completed, and promoting the ID to filter metadata |
 | [request-validate.yaml](configs/openai/responses/request-validate.yaml) | Validates Responses API requests and rejects invalid parameter combinations |
 | [response-store.yaml](configs/openai/responses/response-store.yaml) | Persists non-streaming Responses API responses to a database and serves stored data via GET endpoints and handles DELETE /v1/responses/{id} locally |
 | [responses-proxy.yaml](configs/openai/responses/responses-proxy.yaml) | Proxies OpenAI Responses API requests to a native /v1/responses backend |
 | [responses-routing.yaml](configs/openai/responses/responses-routing.yaml) | Routes Responses API traffic by detected mode |
-| [tool-routing.yaml](configs/openai/responses/tool-routing.yaml) | Branches request processing by tool composition using filter results from tool_parse |
+| [stream-events.yaml](configs/openai/responses/stream-events.yaml) | Demonstrates the `openai_stream_events` filter, which observes SSE chunks from the backend without modification, accumulates state (response object, output items, tool calls, usage), and writes it to ResponsesState metadata |
+| [tool-routing.yaml](configs/openai/responses/tool-routing.yaml) | Demonstrates using `tool_parse` to route Responses API requests by their tool composition |
 
 ### Payload Processing
 

--- a/examples/configs/a2a-task-routing.yaml
+++ b/examples/configs/a2a-task-routing.yaml
@@ -1,25 +1,30 @@
-# A2A Task Routing
+# A2A Task and Context-Owner Routing
 #
-# Captures task ownership from SendMessage JSON responses and
+# Captures task and context ownership from SendMessage JSON responses and
 # SendStreamingMessage / SubscribeToTask SSE responses, then routes
-# follow-up task operations back to the backend cluster that created
-# the task.
+# follow-up requests back to the backend cluster that created the task or
+# owns the context.
 #
 # This example uses `local` storage mode. This is useful for development and
-# testing or single-instance deployments of Praxis, but multi-replica task routing
+# testing or single-instance deployments of Praxis, but multi-replica routing
 # requires an external state store (e.g. Valkey).
 #
 # Flow:
 # 1. SendMessage and SendStreamingMessage are routed to agent-a by
 #    static router rules.
-# 2. The a2a filter captures task IDs from JSON response bodies
-#    (SendMessage) and SSE data frames (SendStreamingMessage,
-#    SubscribeToTask), recording task_id -> cluster_name in a
-#    local in-process store.
+# 2. The a2a filter captures task IDs and context IDs from JSON response
+#    bodies (SendMessage) and SSE data frames (SendStreamingMessage,
+#    SubscribeToTask), recording:
+#      - task_id -> cluster_name
+#      - context_id -> cluster_name
+#    in local in-process stores.
 # 3. Follow-up GetTask, CancelTask, SubscribeToTask, or push-notification
 #    config calls with a known task ID inject x-praxis-a2a-route-cluster,
 #    which the router matches to select the owning cluster.
-# 4. Unknown task IDs follow the static fallback route.
+# 4. ListTasks, SendMessage, or SendStreamingMessage carrying a known
+#    contextId are also routed to the owning cluster via context-owner
+#    routing. Task ID routes take precedence over context ID routes.
+# 5. Unknown task IDs and context IDs follow the static fallback route.
 
 listeners:
   - name: a2a
@@ -35,6 +40,7 @@ filter_chains:
         headers:
           method: x-praxis-a2a-method
           family: x-praxis-a2a-family
+          context_id: x-praxis-a2a-context-id
           task_id: x-praxis-a2a-task-id
           streaming: x-praxis-a2a-streaming
         task_routing:

--- a/filters/src/agentic/a2a/config.rs
+++ b/filters/src/agentic/a2a/config.rs
@@ -79,7 +79,7 @@ pub(crate) struct TaskRoutingConfig {
     )]
     pub on_lookup_miss: OnLookupMiss,
 
-    /// Internal header name injected on task route hit.
+    /// Internal header name injected on task or context route hit.
     #[serde(default = "default_route_cluster_header")]
     pub route_cluster_header: String,
 

--- a/filters/src/agentic/a2a/envelope.rs
+++ b/filters/src/agentic/a2a/envelope.rs
@@ -163,6 +163,12 @@ impl A2aMethod {
                 | Self::DeleteTaskPushNotificationConfig
         )
     }
+
+    /// Whether a follow-up request with this method should be routed
+    /// by stored context ownership when no task route applies.
+    pub(crate) fn is_context_routable(&self) -> bool {
+        matches!(self, Self::SendMessage | Self::SendStreamingMessage | Self::ListTasks)
+    }
 }
 
 impl A2aFamily {

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -40,7 +40,7 @@ use tracing::{debug, trace};
 use self::{
     config::{A2aConfig, build_config},
     envelope::{A2aEnvelope, extract_a2a_envelope},
-    task_routing::LocalTaskRouteStore,
+    task_routing::{LocalTaskRouteStore, RouteSource, attempt_route_lookup},
 };
 
 // -----------------------------------------------------------------------------
@@ -50,6 +50,16 @@ use self::{
 /// Extracts A2A protocol metadata from JSON-RPC request bodies and promotes
 /// method, family, task ID, streaming detection, and version to request headers,
 /// filter results, and durable metadata for routing.
+///
+/// When `task_routing.enabled` is true, the filter captures task and context
+/// ownership from backend responses and uses it to route follow-up requests.
+/// Task-owner routing sends `GetTask`, `CancelTask`, `SubscribeToTask`, and
+/// push-notification config methods back to the backend that created the task.
+/// Context-owner routing sends `ListTasks`, `SendMessage`, and
+/// `SendStreamingMessage` requests carrying a known `contextId` back to the
+/// backend that owns the context. Task-ID routes take precedence over
+/// context-ID routes. Context routes always use `ttl_seconds`; a completed
+/// task does not evict the context route.
 ///
 /// # YAML
 ///
@@ -302,45 +312,79 @@ impl HttpFilter for A2aFilter {
 // Private Utilities
 // -----------------------------------------------------------------------------
 
-/// Look up a task route and inject the route cluster header on hit.
-#[expect(clippy::too_many_lines, reason = "sequential lookup-inject-trace pipeline")]
+/// Look up a task or context route and inject the route cluster header on hit.
+///
+/// Task routes take precedence over context routes. For task-routable methods,
+/// only the task ID is consulted. For context-routable methods, the context ID
+/// is consulted. Because the method sets are disjoint in the current A2A spec,
+/// both lookups cannot apply in practice — but the ordering guarantees task
+/// wins if both IDs are ever simultaneously present.
+#[expect(clippy::too_many_lines, reason = "sequential lookup-classify-trace pipeline")]
 fn lookup_task_route(
     ctx: &mut HttpFilterContext<'_>,
     a2a_envelope: &A2aEnvelope,
     store: &LocalTaskRouteStore,
     config: &A2aConfig,
 ) {
-    if !a2a_envelope.method.is_task_routable() {
+    let task_id = if a2a_envelope.method.is_task_routable() {
+        a2a_envelope.task_id.as_deref()
+    } else {
+        None
+    };
+
+    let context_id = if a2a_envelope.method.is_context_routable() {
+        a2a_envelope.context_id.as_deref()
+    } else {
+        None
+    };
+
+    if task_id.is_none() && context_id.is_none() {
         return;
     }
 
-    let Some(task_id) = &a2a_envelope.task_id else {
-        return;
-    };
+    let has_task_id = task_id.is_some();
+    let has_context_id = context_id.is_some();
 
-    if let Some(cluster) = store.get_by_task_id(task_id) {
+    if let Some((cluster, source)) = attempt_route_lookup(store, task_id, context_id) {
         ctx.extra_request_headers.push((
             Cow::Owned(config.task_routing.route_cluster_header.clone()),
             (*cluster).to_owned(),
         ));
-        ctx.set_metadata("a2a.route_decision", "task_route_hit");
+
+        let decision = match source {
+            RouteSource::Task => "task_route_hit",
+            RouteSource::Context => "context_route_hit",
+        };
+        ctx.set_metadata("a2a.route_decision", decision);
+        ctx.set_metadata("a2a.route_source", source.as_str());
         ctx.set_metadata("a2a.route_cluster", &*cluster);
+
         debug!(
-            has_task_id = true,
-            task_id_len = task_id.len(),
+            has_task_id,
+            task_id_len = task_id.map_or(0, str::len),
+            has_context_id,
+            context_id_len = context_id.map_or(0, str::len),
             lookup_hit = true,
+            route_source = source.as_str(),
             cluster = %cluster,
             method = a2a_envelope.method.as_str(),
-            "task route lookup hit"
+            "route lookup hit"
         );
     } else {
-        ctx.set_metadata("a2a.route_decision", "task_route_miss");
+        let miss = if has_task_id {
+            "task_route_miss"
+        } else {
+            "context_route_miss"
+        };
+        ctx.set_metadata("a2a.route_decision", miss);
         debug!(
-            has_task_id = true,
-            task_id_len = task_id.len(),
+            has_task_id,
+            task_id_len = task_id.map_or(0, str::len),
+            has_context_id,
+            context_id_len = context_id.map_or(0, str::len),
             lookup_hit = false,
             method = a2a_envelope.method.as_str(),
-            "task route lookup miss"
+            "route lookup miss"
         );
     }
 }
@@ -370,7 +414,12 @@ fn try_capture_from_buffer(
     }
 }
 
-/// Uses terminal TTL when the task state is final.
+/// Store task and context routes extracted from a response body.
+///
+/// Task routes use `terminal_ttl_seconds` when the task is done; context routes
+/// always use `ttl_seconds` because a completed task does not end the context —
+/// later messages or `ListTasks` calls in the same context still need routing.
+#[expect(clippy::too_many_lines, reason = "sequential extract-store-log pipeline")]
 fn store_task_route(
     value: &serde_json::Value,
     cluster: &str,
@@ -381,7 +430,7 @@ fn store_task_route(
         return;
     };
 
-    let ttl = task_routing::route_ttl(extracted.terminal, config);
+    let task_ttl = task_routing::route_ttl(extracted.terminal, config);
 
     if extracted.terminal && config.terminal_ttl_seconds == 0 {
         store.remove(&extracted.task_id);
@@ -392,13 +441,27 @@ fn store_task_route(
             "terminal task route removed (terminal_ttl_seconds=0)"
         );
     } else {
-        store.put(&extracted.task_id, cluster, ttl);
+        store.put(&extracted.task_id, cluster, task_ttl);
         debug!(
             has_task_id = true,
             task_id_len = extracted.task_id.len(),
             cluster = %cluster,
             terminal = extracted.terminal,
             "stored task route from response"
+        );
+    }
+
+    // Context routes always use the normal TTL. A completed task does not
+    // signal context completion; the same context may receive further messages
+    // or ListTasks queries.
+    if let Some(ctx_id) = &extracted.context_id {
+        let ctx_ttl = std::time::Duration::from_secs(config.ttl_seconds);
+        store.put_context(ctx_id, cluster, ctx_ttl);
+        debug!(
+            has_context_id = true,
+            context_id_len = ctx_id.len(),
+            cluster = %cluster,
+            "stored context route from response"
         );
     }
 }

--- a/filters/src/agentic/a2a/task_routing.rs
+++ b/filters/src/agentic/a2a/task_routing.rs
@@ -24,8 +24,34 @@ const MAX_ID_LEN: usize = 256;
 /// Maximum number of task route entries before inserts are rejected.
 const MAX_TASK_ROUTES: usize = 50_000;
 
+/// Maximum number of context route entries before inserts are rejected.
+const MAX_CONTEXT_ROUTES: usize = 50_000;
+
 /// Minimum interval between proactive eviction sweeps.
 const EVICTION_INTERVAL: Duration = Duration::from_secs(30);
+
+// -----------------------------------------------------------------------------
+// RouteSource
+// -----------------------------------------------------------------------------
+
+/// Which store produced a route match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RouteSource {
+    /// Route was resolved from the task-ID store.
+    Task,
+    /// Route was resolved from the context-ID store.
+    Context,
+}
+
+impl RouteSource {
+    /// String representation for tracing and metadata.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Task => "task",
+            Self::Context => "context",
+        }
+    }
+}
 
 // -----------------------------------------------------------------------------
 // TaskRoute
@@ -53,6 +79,9 @@ pub(crate) struct ExtractedTaskRoute {
 
     /// Task ID from the response.
     pub task_id: String,
+
+    /// Context ID from the response, when present.
+    pub context_id: Option<String>,
 }
 
 // -----------------------------------------------------------------------------
@@ -67,8 +96,17 @@ pub(crate) struct LocalTaskRouteStore {
     /// Task ID → cluster mappings.
     tasks: RwLock<HashMap<String, TaskRoute>>,
 
-    /// Timestamp of the last proactive eviction sweep.
-    last_eviction: Mutex<Instant>,
+    /// Context ID → cluster mappings.
+    ///
+    /// Kept as a separate lock so task and context operations are independent
+    /// and cannot deadlock each other.
+    contexts: RwLock<HashMap<String, TaskRoute>>,
+
+    /// Timestamp of the last proactive task eviction sweep.
+    last_task_eviction: Mutex<Instant>,
+
+    /// Timestamp of the last proactive context eviction sweep.
+    last_context_eviction: Mutex<Instant>,
 }
 
 impl LocalTaskRouteStore {
@@ -76,9 +114,13 @@ impl LocalTaskRouteStore {
     pub(crate) fn new() -> Self {
         Self {
             tasks: RwLock::new(HashMap::new()),
-            last_eviction: Mutex::new(Instant::now()),
+            contexts: RwLock::new(HashMap::new()),
+            last_task_eviction: Mutex::new(Instant::now()),
+            last_context_eviction: Mutex::new(Instant::now()),
         }
     }
+
+    // ---- Task routes ----
 
     /// Look up a cluster by task ID. Returns `None` if absent or expired.
     /// Lazily removes expired entries on miss.
@@ -133,7 +175,7 @@ impl LocalTaskRouteStore {
         };
 
         let mut tasks = self.tasks.write().expect("task route store lock poisoned");
-        self.maybe_evict(&mut tasks);
+        maybe_evict_map(&mut tasks, &self.last_task_eviction);
 
         if tasks.len() >= MAX_TASK_ROUTES && !tasks.contains_key(task_id) {
             tracing::warn!(
@@ -159,26 +201,102 @@ impl LocalTaskRouteStore {
             .remove(task_id);
     }
 
-    /// Sweep expired entries if [`EVICTION_INTERVAL`] has elapsed.
-    fn maybe_evict(&self, tasks: &mut HashMap<String, TaskRoute>) {
-        if let Ok(mut last) = self.last_eviction.try_lock() {
-            if last.elapsed() < EVICTION_INTERVAL {
-                return;
+    // ---- Context routes ----
+
+    /// Look up a cluster by context ID. Returns `None` if absent or expired.
+    /// Lazily removes expired entries on miss.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock is poisoned.
+    #[expect(clippy::expect_used, reason = "poisoned lock is unrecoverable")]
+    pub(crate) fn get_by_context_id(&self, context_id: &str) -> Option<Arc<str>> {
+        let expired = {
+            let contexts = self.contexts.read().expect("context route store lock poisoned");
+            match contexts.get(context_id) {
+                Some(r) if Instant::now() < r.expires_at => return Some(Arc::clone(&r.cluster)),
+                Some(_) => true,
+                None => false,
             }
-            let before = tasks.len();
-            let now = Instant::now();
-            tasks.retain(|_, r| now < r.expires_at);
-            let evicted = before.saturating_sub(tasks.len());
-            if evicted > 0 {
-                tracing::debug!(
-                    evicted,
-                    remaining = tasks.len(),
-                    "task route store: evicted expired entries"
-                );
+        };
+
+        if expired {
+            let mut contexts = self.contexts.write().expect("context route store lock poisoned");
+            if contexts.get(context_id).is_some_and(|r| Instant::now() >= r.expires_at) {
+                contexts.remove(context_id);
             }
-            *last = Instant::now();
         }
+        None
     }
+
+    /// Store a context route mapping with the given TTL.
+    ///
+    /// Applies the same ID validation rules as [`Self::put`].
+    /// Context routes use a separate capacity limit ([`MAX_CONTEXT_ROUTES`])
+    /// and a separate eviction clock from task routes, so the two maps
+    /// cannot interfere.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock is poisoned.
+    #[expect(clippy::expect_used, reason = "poisoned lock is unrecoverable")]
+    pub(crate) fn put_context(&self, context_id: &str, cluster: &str, ttl: Duration) {
+        if !validate_id(context_id) {
+            return;
+        }
+
+        let route = TaskRoute {
+            cluster: Arc::from(cluster),
+            expires_at: Instant::now() + ttl,
+        };
+
+        let mut contexts = self.contexts.write().expect("context route store lock poisoned");
+        maybe_evict_map(&mut contexts, &self.last_context_eviction);
+
+        if contexts.len() >= MAX_CONTEXT_ROUTES && !contexts.contains_key(context_id) {
+            tracing::warn!(
+                limit = MAX_CONTEXT_ROUTES,
+                "context route store: capacity reached, insert rejected"
+            );
+            return;
+        }
+
+        contexts.insert(context_id.to_owned(), route);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Route Resolution Helper
+// -----------------------------------------------------------------------------
+
+/// Resolve a route by checking `task_id` first (higher precedence), then
+/// `context_id`. Used by the request-side lookup and directly testable
+/// to verify task-over-context precedence without method-classification guards.
+///
+/// Semantics: if `task_id` is `Some`, only the task store is consulted —
+/// a miss does **not** fall through to the context store. This mirrors
+/// the A2A spec rule that task-routable methods are not context-routable:
+/// supplying a `task_id` implies the caller already determined this is a
+/// task-routable method, so context routing would be semantically wrong on
+/// miss. When `task_id` is `None`, only `context_id` is consulted.
+///
+/// Returns `None` when neither ID has a live route.
+pub(crate) fn attempt_route_lookup(
+    store: &LocalTaskRouteStore,
+    task_id: Option<&str>,
+    context_id: Option<&str>,
+) -> Option<(Arc<str>, RouteSource)> {
+    if let Some(tid) = task_id {
+        // Task lookup only: task-routable methods are not context-routable,
+        // so a miss here should not silently consult the context store.
+        return store.get_by_task_id(tid).map(|c| (c, RouteSource::Task));
+    }
+    if let Some(cid) = context_id
+        && let Some(cluster) = store.get_by_context_id(cid)
+    {
+        return Some((cluster, RouteSource::Context));
+    }
+    None
 }
 
 // -----------------------------------------------------------------------------
@@ -232,9 +350,12 @@ fn extract_from_task_object(task: &Value) -> Option<ExtractedTaskRoute> {
         .and_then(Value::as_str)
         .is_some_and(is_terminal_state);
 
+    let context_id = extract_context_id_from_object(task);
+
     Some(ExtractedTaskRoute {
         task_id: task_id.to_owned(),
         terminal,
+        context_id,
     })
 }
 
@@ -252,9 +373,13 @@ fn extract_from_status_update(update: &Value) -> Option<ExtractedTaskRoute> {
         .and_then(Value::as_str)
         .is_some_and(is_terminal_state);
 
+    // A2A v1.0 TaskStatusUpdateEvent includes contextId per spec.
+    let context_id = extract_context_id_from_object(update);
+
     Some(ExtractedTaskRoute {
         task_id: task_id.to_owned(),
         terminal,
+        context_id,
     })
 }
 
@@ -268,10 +393,22 @@ fn extract_from_artifact_update(update: &Value) -> Option<ExtractedTaskRoute> {
         return None;
     }
 
+    // A2A v1.0 TaskArtifactUpdateEvent includes contextId per spec.
+    let context_id = extract_context_id_from_object(update);
+
     Some(ExtractedTaskRoute {
         task_id: task_id.to_owned(),
         terminal: false,
+        context_id,
     })
+}
+
+/// Extract and validate the `contextId` field from a JSON object.
+fn extract_context_id_from_object(obj: &Value) -> Option<String> {
+    obj.get("contextId")
+        .and_then(Value::as_str)
+        .filter(|id| validate_id(id))
+        .map(str::to_owned)
 }
 
 /// Compute the TTL to use for a task route entry.
@@ -308,6 +445,26 @@ fn validate_id(id: &str) -> bool {
     !id.is_empty() && id.len() <= MAX_ID_LEN && !contains_control_chars(id)
 }
 
+/// Sweep expired entries if [`EVICTION_INTERVAL`] has elapsed.
+///
+/// Accepts a mutable reference to the map (caller already holds write lock)
+/// and a separate eviction timer so task and context evictions are independent.
+fn maybe_evict_map(map: &mut HashMap<String, TaskRoute>, last_eviction: &Mutex<Instant>) {
+    if let Ok(mut last) = last_eviction.try_lock() {
+        if last.elapsed() < EVICTION_INTERVAL {
+            return;
+        }
+        let before = map.len();
+        let now = Instant::now();
+        map.retain(|_, r| now < r.expires_at);
+        let evicted = before.saturating_sub(map.len());
+        if evicted > 0 {
+            tracing::debug!(evicted, remaining = map.len(), "route store: evicted expired entries");
+        }
+        *last = Instant::now();
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -327,7 +484,7 @@ mod tests {
 
     use super::*;
 
-    // ---- Store Tests ----
+    // ---- Store Tests: Task Routes ----
 
     #[test]
     fn local_store_put_then_get_task_route() {
@@ -437,7 +594,7 @@ mod tests {
         sleep(Duration::from_millis(200));
 
         // Force eviction by setting last_eviction far in the past.
-        *store.last_eviction.lock().unwrap() = Instant::now() - EVICTION_INTERVAL - Duration::from_secs(1);
+        *store.last_task_eviction.lock().unwrap() = Instant::now() - EVICTION_INTERVAL - Duration::from_secs(1);
         store.put("fresh", "agent-b", Duration::from_secs(3600));
 
         let remaining = store.tasks.read().unwrap().len();
@@ -466,10 +623,172 @@ mod tests {
         );
     }
 
+    // ---- Store Tests: Context Routes ----
+
+    #[test]
+    fn local_store_put_then_get_context_route() {
+        let store = LocalTaskRouteStore::new();
+        store.put_context("ctx-1", "agent-a", Duration::from_secs(60));
+
+        let cluster = store.get_by_context_id("ctx-1");
+        assert_eq!(
+            cluster.as_deref(),
+            Some("agent-a"),
+            "stored context route should be retrievable"
+        );
+    }
+
+    #[test]
+    fn local_store_context_route_expiry_misses_and_removes_entry() {
+        let store = LocalTaskRouteStore::new();
+        store.put_context("ctx-1", "agent-a", Duration::from_millis(50));
+
+        sleep(Duration::from_millis(200));
+
+        let cluster = store.get_by_context_id("ctx-1");
+        assert!(cluster.is_none(), "expired context route should miss");
+
+        let still_present = store.contexts.read().unwrap().contains_key("ctx-1");
+        assert!(!still_present, "expired context entry should be lazily removed");
+    }
+
+    #[test]
+    fn local_store_rejects_control_char_context_id() {
+        let store = LocalTaskRouteStore::new();
+        let bad_id = "ctx\n-1";
+        store.put_context(bad_id, "agent-a", Duration::from_secs(60));
+
+        assert!(
+            store.get_by_context_id(bad_id).is_none(),
+            "context ID with control chars should not be stored"
+        );
+    }
+
+    #[test]
+    fn local_store_rejects_too_long_context_id() {
+        let store = LocalTaskRouteStore::new();
+        let long_id = "c".repeat(257);
+        store.put_context(&long_id, "agent-a", Duration::from_secs(60));
+
+        assert!(
+            store.get_by_context_id(&long_id).is_none(),
+            "context ID exceeding 256 bytes should not be stored"
+        );
+    }
+
+    #[test]
+    fn local_store_replaces_existing_context_route() {
+        let store = LocalTaskRouteStore::new();
+        store.put_context("ctx-1", "agent-a", Duration::from_secs(60));
+        store.put_context("ctx-1", "agent-b", Duration::from_secs(60));
+
+        assert_eq!(
+            store.get_by_context_id("ctx-1").as_deref(),
+            Some("agent-b"),
+            "later put_context should replace earlier route"
+        );
+    }
+
+    #[test]
+    fn local_store_task_and_context_routes_are_independent() {
+        let store = LocalTaskRouteStore::new();
+        store.put("task-1", "agent-a", Duration::from_secs(60));
+        store.put_context("task-1", "agent-b", Duration::from_secs(60));
+
+        assert_eq!(
+            store.get_by_task_id("task-1").as_deref(),
+            Some("agent-a"),
+            "task store should be independent of context store"
+        );
+        assert_eq!(
+            store.get_by_context_id("task-1").as_deref(),
+            Some("agent-b"),
+            "context store should be independent of task store"
+        );
+    }
+
+    #[test]
+    fn local_store_capacity_applies_to_context_routes() {
+        let store = LocalTaskRouteStore::new();
+        for i in 0..MAX_CONTEXT_ROUTES {
+            store.put_context(&format!("ctx-{i}"), "agent-a", Duration::from_secs(3600));
+        }
+
+        store.put_context("overflow", "agent-a", Duration::from_secs(3600));
+        assert!(
+            store.get_by_context_id("overflow").is_none(),
+            "context insert should be rejected when store is at capacity"
+        );
+        assert_eq!(
+            store.contexts.read().unwrap().len(),
+            MAX_CONTEXT_ROUTES,
+            "context store size should not exceed MAX_CONTEXT_ROUTES"
+        );
+    }
+
+    // ---- Precedence Tests ----
+
+    #[test]
+    fn attempt_route_lookup_task_wins_over_context() {
+        let store = LocalTaskRouteStore::new();
+        store.put("task-1", "agent-a", Duration::from_secs(60));
+        store.put_context("ctx-1", "agent-b", Duration::from_secs(60));
+
+        let result = attempt_route_lookup(&store, Some("task-1"), Some("ctx-1"));
+        assert!(result.is_some(), "should find a route");
+        let (cluster, source) = result.unwrap();
+        assert_eq!(cluster.as_ref(), "agent-a", "task route should win over context route");
+        assert_eq!(source, RouteSource::Task, "source should be task");
+    }
+
+    #[test]
+    fn attempt_route_lookup_falls_through_to_context_when_no_task_id() {
+        let store = LocalTaskRouteStore::new();
+        store.put_context("ctx-1", "agent-a", Duration::from_secs(60));
+
+        let result = attempt_route_lookup(&store, None, Some("ctx-1"));
+        assert!(result.is_some(), "should find context route");
+        let (cluster, source) = result.unwrap();
+        assert_eq!(cluster.as_ref(), "agent-a");
+        assert_eq!(source, RouteSource::Context);
+    }
+
+    #[test]
+    fn attempt_route_lookup_task_miss_does_not_fall_through_to_context() {
+        let store = LocalTaskRouteStore::new();
+        // A live context route exists, but we pass a task_id that misses.
+        store.put_context("ctx-1", "agent-a", Duration::from_secs(60));
+
+        // Supplying task_id signals a task-routable method. Task-routable
+        // methods are not context-routable, so a task miss must NOT silently
+        // consult the context store. In practice both IDs are never set at
+        // the same time (method sets are disjoint), but the helper encodes
+        // this semantics explicitly so it is directly testable.
+        let result = attempt_route_lookup(&store, Some("task-missing"), Some("ctx-1"));
+        assert!(
+            result.is_none(),
+            "task miss should not fall through to context when task_id was supplied"
+        );
+    }
+
+    #[test]
+    fn attempt_route_lookup_both_missing_returns_none() {
+        let store = LocalTaskRouteStore::new();
+        let result = attempt_route_lookup(&store, Some("no-task"), Some("no-ctx"));
+        assert!(result.is_none(), "both absent should return None");
+    }
+
+    #[test]
+    fn attempt_route_lookup_neither_id_returns_none() {
+        let store = LocalTaskRouteStore::new();
+        let result = attempt_route_lookup(&store, None, None);
+        assert!(result.is_none(), "no IDs should return None");
+    }
+
     // ---- Response Extraction Tests ----
 
     #[test]
-    fn extract_task_route_from_result_task() {
+    fn extract_task_route_from_result_task_includes_context_id() {
         let json = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -484,11 +803,16 @@ mod tests {
 
         let route = extract_task_route(&json).expect("should extract route");
         assert_eq!(route.task_id, "task-123");
+        assert_eq!(
+            route.context_id.as_deref(),
+            Some("ctx-123"),
+            "contextId should be captured"
+        );
         assert!(!route.terminal, "TASK_STATE_WORKING is not terminal");
     }
 
     #[test]
-    fn extract_task_route_from_direct_result_task() {
+    fn extract_task_route_from_direct_result_includes_context_id() {
         let json = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -501,11 +825,38 @@ mod tests {
 
         let route = extract_task_route(&json).expect("should extract route");
         assert_eq!(route.task_id, "task-456");
+        assert_eq!(
+            route.context_id.as_deref(),
+            Some("ctx-456"),
+            "contextId should be captured"
+        );
         assert!(route.terminal, "TASK_STATE_COMPLETED is terminal");
     }
 
     #[test]
-    fn message_only_response_does_not_create_route() {
+    fn extract_task_route_without_context_id_keeps_existing_task_behavior() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "id": "task-no-ctx",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract route");
+        assert_eq!(route.task_id, "task-no-ctx");
+        assert!(
+            route.context_id.is_none(),
+            "missing contextId should leave context_id as None"
+        );
+        assert!(!route.terminal);
+    }
+
+    #[test]
+    fn message_only_response_does_not_create_task_or_context_route() {
         let json = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -521,6 +872,139 @@ mod tests {
         assert!(
             extract_task_route(&json).is_none(),
             "message-only response should not produce a route"
+        );
+    }
+
+    #[test]
+    fn status_update_without_context_keeps_task_only_behavior() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "statusUpdate": {
+                    "taskId": "task-su-1",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from statusUpdate");
+        assert_eq!(route.task_id, "task-su-1");
+        assert!(
+            route.context_id.is_none(),
+            "statusUpdate without contextId should have None context_id"
+        );
+        assert!(!route.terminal);
+    }
+
+    #[test]
+    fn artifact_update_without_context_keeps_task_only_behavior() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "artifactUpdate": {
+                    "taskId": "task-au-1",
+                    "artifact": {"artifactId": "a1", "parts": []}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from artifactUpdate");
+        assert_eq!(route.task_id, "task-au-1");
+        assert!(
+            route.context_id.is_none(),
+            "artifactUpdate without contextId should have None context_id"
+        );
+        assert!(!route.terminal);
+    }
+
+    #[test]
+    fn status_update_with_context_id_captures_context_route() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "statusUpdate": {
+                    "taskId": "task-su-ctx",
+                    "contextId": "ctx-su-1",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from statusUpdate");
+        assert_eq!(route.task_id, "task-su-ctx");
+        assert_eq!(
+            route.context_id.as_deref(),
+            Some("ctx-su-1"),
+            "statusUpdate contextId should be captured"
+        );
+    }
+
+    #[test]
+    fn artifact_update_with_context_id_captures_context_route() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "artifactUpdate": {
+                    "taskId": "task-au-ctx",
+                    "contextId": "ctx-au-1",
+                    "artifact": {"artifactId": "a1", "parts": []}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from artifactUpdate");
+        assert_eq!(route.task_id, "task-au-ctx");
+        assert_eq!(
+            route.context_id.as_deref(),
+            Some("ctx-au-1"),
+            "artifactUpdate contextId should be captured"
+        );
+    }
+
+    #[test]
+    fn context_id_with_control_chars_not_extracted() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "id": "task-1",
+                    "contextId": "ctx\n-bad",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should still extract task");
+        assert!(
+            route.context_id.is_none(),
+            "contextId with control chars should not be extracted"
+        );
+    }
+
+    #[test]
+    fn context_id_too_long_not_extracted() {
+        let long_ctx = "c".repeat(257);
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "id": "task-1",
+                    "contextId": long_ctx,
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should still extract task");
+        assert!(
+            route.context_id.is_none(),
+            "contextId exceeding 256 bytes should not be extracted"
         );
     }
 
@@ -562,6 +1046,28 @@ mod tests {
 
         let ttl = route_ttl(true, &config);
         assert_eq!(ttl, Duration::from_secs(300), "terminal tasks should use terminal TTL");
+    }
+
+    #[test]
+    fn context_route_uses_normal_ttl_for_terminal_task() {
+        let store = LocalTaskRouteStore::new();
+        let normal_ttl = Duration::from_millis(500);
+        let terminal_ttl = Duration::from_millis(50);
+
+        store.put("task-1", "agent-a", terminal_ttl);
+        store.put_context("ctx-1", "agent-a", normal_ttl);
+
+        sleep(Duration::from_millis(200));
+
+        assert!(
+            store.get_by_task_id("task-1").is_none(),
+            "task route should expire after terminal TTL"
+        );
+        assert_eq!(
+            store.get_by_context_id("ctx-1").as_deref(),
+            Some("agent-a"),
+            "context route should survive past terminal TTL using normal TTL"
+        );
     }
 
     #[test]

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -1617,6 +1617,11 @@ async fn task_route_miss_continues_without_route_cluster_header() {
         !headers.contains_key("x-praxis-a2a-route-cluster"),
         "task route miss should not inject route cluster header"
     );
+    assert_eq!(
+        ctx.get_metadata("a2a.route_decision"),
+        Some("task_route_miss"),
+        "task miss should record task_route_miss, not generic route_miss"
+    );
 }
 
 #[tokio::test]
@@ -1850,6 +1855,477 @@ async fn mixed_case_sse_content_type_skips_capture() {
 }
 
 // -----------------------------------------------------------------------------
+// Context Route Lookup Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "exhaustive routing assertions")]
+async fn context_route_hit_injects_route_cluster_header_for_list_tasks() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put_context("ctx-list", "agent-a", std::time::Duration::from_secs(60));
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{"contextId":"ctx-list"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("x-praxis-a2a-route-cluster"),
+        Some(&"agent-a"),
+        "ListTasks context route hit should inject route cluster header"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.route_decision"),
+        Some("context_route_hit"),
+        "route_decision should reflect context hit"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.route_source"),
+        Some("context"),
+        "route_source should be context"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.route_cluster"),
+        Some("agent-a"),
+        "route_cluster metadata should be set"
+    );
+}
+
+#[tokio::test]
+async fn context_route_hit_injects_route_cluster_header_for_send_message() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put_context("ctx-msg", "agent-a", std::time::Duration::from_secs(60));
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"contextId":"ctx-msg","role":"ROLE_USER","parts":[]}}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("x-praxis-a2a-route-cluster"),
+        Some(&"agent-a"),
+        "SendMessage context route hit should inject route cluster header"
+    );
+    assert_eq!(ctx.get_metadata("a2a.route_decision"), Some("context_route_hit"));
+}
+
+#[tokio::test]
+async fn context_route_hit_injects_route_cluster_header_for_send_streaming_message() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put_context("ctx-stream", "agent-a", std::time::Duration::from_secs(60));
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":{"contextId":"ctx-stream","role":"ROLE_USER","parts":[]}}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("x-praxis-a2a-route-cluster"),
+        Some(&"agent-a"),
+        "SendStreamingMessage context route hit should inject route cluster header"
+    );
+    assert_eq!(ctx.get_metadata("a2a.route_decision"), Some("context_route_hit"));
+}
+
+#[tokio::test]
+async fn context_route_miss_continues_without_route_header() {
+    let filter = make_task_routing_filter();
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{"contextId":"ctx-missing"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert!(
+        !headers.contains_key("x-praxis-a2a-route-cluster"),
+        "context route miss should not inject route cluster header"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.route_decision"),
+        Some("context_route_miss"),
+        "context miss should record context_route_miss"
+    );
+}
+
+#[tokio::test]
+async fn task_route_hit_takes_precedence_over_context_route_hit() {
+    // Seed both a task route and a context route with different clusters.
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put("task-prec", "agent-task", std::time::Duration::from_secs(60));
+    store.put_context("ctx-prec", "agent-context", std::time::Duration::from_secs(60));
+
+    // Call the route resolution helper directly with both IDs to prove
+    // task wins over context regardless of method classification.
+    let result = super::task_routing::attempt_route_lookup(store, Some("task-prec"), Some("ctx-prec"));
+    assert!(result.is_some(), "should find a route");
+    let (cluster, source) = result.unwrap();
+    assert_eq!(
+        cluster.as_ref(),
+        "agent-task",
+        "task route should win over context route"
+    );
+    assert_eq!(source, super::task_routing::RouteSource::Task, "source should be task");
+}
+
+#[tokio::test]
+async fn context_route_not_used_for_non_context_methods() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    // Seed a context route, but GetTask is task-routable, not context-routable.
+    store.put_context("ctx-1", "agent-a", std::time::Duration::from_secs(60));
+
+    // GetTask with no task mapping should miss (context not consulted).
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"no-task"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert!(
+        !headers.contains_key("x-praxis-a2a-route-cluster"),
+        "task-routable methods should not fall back to context routing"
+    );
+}
+
+#[tokio::test]
+async fn classifier_only_unchanged_when_task_routing_disabled() {
+    // Classifier-only config: task_routing is not enabled.
+    let filter = make_default_filter();
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{"contextId":"ctx-123"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    // No task_routing.enabled means no route lookup attempted.
+    assert_eq!(
+        ctx.get_metadata("a2a.route_decision"),
+        None,
+        "classifier-only mode should not set route_decision"
+    );
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-a2a-route-cluster"),
+        "classifier-only mode should not inject route cluster header"
+    );
+}
+
+#[tokio::test]
+async fn context_route_hit_records_bounded_metadata() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put_context("ctx-meta", "agent-b", std::time::Duration::from_secs(60));
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{"contextId":"ctx-meta"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    drop(filter.on_request_body(&mut ctx, &mut body, true).await.unwrap());
+
+    assert_eq!(ctx.get_metadata("a2a.route_decision"), Some("context_route_hit"));
+    assert_eq!(ctx.get_metadata("a2a.route_source"), Some("context"));
+    assert_eq!(ctx.get_metadata("a2a.route_cluster"), Some("agent-b"));
+    assert_eq!(
+        ctx.get_metadata("a2a.context_id"),
+        Some("ctx-meta"),
+        "classifier-promoted context_id should still be in metadata"
+    );
+}
+
+#[tokio::test]
+async fn context_id_with_control_chars_is_not_promoted_and_does_not_route() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    // Seed a route for a clean ID.
+    store.put_context("ctx-clean", "agent-a", std::time::Duration::from_secs(60));
+
+    let body_str = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ListTasks\",\"params\":{\"contextId\":\"ctx\\n-bad\"}}";
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-a2a-route-cluster"),
+        "context ID with control chars should not route"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.context_id"),
+        None,
+        "context ID with control chars should not be promoted"
+    );
+}
+
+#[tokio::test]
+async fn too_long_context_id_is_not_promoted_and_does_not_route() {
+    let filter = make_task_routing_filter();
+    let long_ctx = "c".repeat(257);
+    let body_str = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{{"contextId":"{long_ctx}"}}}}"#);
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-a2a-route-cluster"),
+        "too-long context ID should not route"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Context Response Body Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_streaming_task_response_stores_task_and_context_routes() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-ctx-1","contextId":"ctx-resp-1","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let mut body = Some(Bytes::from(json));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-ctx-1").as_deref(),
+        Some("agent-a"),
+        "task route should be stored"
+    );
+    assert_eq!(
+        store.get_by_context_id("ctx-resp-1").as_deref(),
+        Some("agent-a"),
+        "context route should be stored alongside task route"
+    );
+}
+
+#[tokio::test]
+async fn terminal_task_zero_ttl_removes_task_but_keeps_context_route() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "terminal_ttl_seconds": 0}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-term","contextId":"ctx-term","status":{"state":"TASK_STATE_COMPLETED"}}}}"#;
+    let mut body = Some(Bytes::from(json));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert!(
+        store.get_by_task_id("task-term").is_none(),
+        "terminal task with ttl=0 should have task route removed"
+    );
+    assert_eq!(
+        store.get_by_context_id("ctx-term").as_deref(),
+        Some("agent-a"),
+        "context route must survive even when the task route is removed at terminal_ttl=0"
+    );
+}
+
+#[tokio::test]
+async fn completed_task_context_uses_normal_ttl() {
+    // Seeding a terminal task response should store context with normal TTL, not terminal TTL.
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "ttl_seconds": 3600, "terminal_ttl_seconds": 1}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-norml-ctx","contextId":"ctx-norml","status":{"state":"TASK_STATE_COMPLETED"}}}}"#;
+    let mut body = Some(Bytes::from(json));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    // Wait long enough for terminal TTL (1s) to expire.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Task route should be expired (terminal_ttl=1s).
+    assert!(
+        store.get_by_task_id("task-norml-ctx").is_none(),
+        "task route should have expired at terminal TTL"
+    );
+    // Context route should still be live (normal TTL=3600s).
+    assert_eq!(
+        store.get_by_context_id("ctx-norml").as_deref(),
+        Some("agent-a"),
+        "context route should still be live (uses normal TTL, not terminal TTL)"
+    );
+}
+
+#[tokio::test]
+async fn split_json_response_with_context_stores_context_route() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-split-ctx","contextId":"ctx-split","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let (chunk1, chunk2) = json.split_at(50);
+
+    let mut body1 = Some(Bytes::from(chunk1.to_owned()));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+    assert!(
+        store.get_by_context_id("ctx-split").is_none(),
+        "incomplete JSON should not capture"
+    );
+
+    let mut body2 = Some(Bytes::from(chunk2.to_owned()));
+    drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+
+    assert_eq!(
+        store.get_by_context_id("ctx-split").as_deref(),
+        Some("agent-a"),
+        "context route should be captured once JSON completes"
+    );
+}
+
+#[tokio::test]
+async fn oversized_response_does_not_store_context_route() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "max_response_body_bytes": 32}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let large_json = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"task":{{"id":"task-big-ctx","contextId":"ctx-big","status":{{"state":"TASK_STATE_WORKING"}}}},"padding":"{}"}}}}"#,
+        "x".repeat(64)
+    );
+    let mut body = Some(Bytes::from(large_json));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert!(
+        store.get_by_context_id("ctx-big").is_none(),
+        "oversized response should not store context route"
+    );
+}
+
+#[tokio::test]
+async fn invalid_json_response_does_not_store_context_route() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let mut body = Some(Bytes::from("not valid json"));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert!(
+        store.get_by_context_id("anything").is_none(),
+        "invalid JSON should not store context route"
+    );
+}
+
+#[tokio::test]
+async fn sse_task_event_with_context_stores_context_route() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-sse-ctx\",\"contextId\":\"ctx-sse-1\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-sse-ctx").as_deref(),
+        Some("agent-a"),
+        "SSE task event should capture task route"
+    );
+    assert_eq!(
+        store.get_by_context_id("ctx-sse-1").as_deref(),
+        Some("agent-a"),
+        "SSE task event should also capture context route when contextId present"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Task Routable Method Tests
 // -----------------------------------------------------------------------------
 
@@ -1882,6 +2358,48 @@ fn non_task_routable_methods() {
         assert!(
             !method.is_task_routable(),
             "{} should not be task-routable",
+            method.as_str()
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Context Routable Method Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn context_routable_methods() {
+    let routable = [
+        A2aMethod::SendMessage,
+        A2aMethod::SendStreamingMessage,
+        A2aMethod::ListTasks,
+    ];
+    for method in &routable {
+        assert!(
+            method.is_context_routable(),
+            "{} should be context-routable",
+            method.as_str()
+        );
+    }
+}
+
+#[test]
+fn non_context_routable_methods() {
+    let non_routable = [
+        A2aMethod::GetTask,
+        A2aMethod::CancelTask,
+        A2aMethod::SubscribeToTask,
+        A2aMethod::CreateTaskPushNotificationConfig,
+        A2aMethod::GetTaskPushNotificationConfig,
+        A2aMethod::ListTaskPushNotificationConfigs,
+        A2aMethod::DeleteTaskPushNotificationConfig,
+        A2aMethod::GetExtendedAgentCard,
+        A2aMethod::Unknown("custom".to_owned()),
+    ];
+    for method in &non_routable {
+        assert!(
+            !method.is_context_routable(),
+            "{} should not be context-routable",
             method.as_str()
         );
     }

--- a/tests/integration/tests/suite/a2a.rs
+++ b/tests/integration/tests/suite/a2a.rs
@@ -772,6 +772,207 @@ fn a2a_spoofed_context_id_header_rejected() {
 }
 
 // -----------------------------------------------------------------------------
+// Context Owner Routing Tests (Integration 1–6)
+// -----------------------------------------------------------------------------
+
+/// Integration 1: Context captured from SendMessage response, then ListTasks
+/// routes by context.
+#[test]
+fn a2a_context_captured_from_send_message_then_list_tasks_routes_by_context() {
+    let json_body = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-ctx-1","contextId":"ctx-int-1","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let agent_a_guard = Backend::fixed(json_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_context_owner_routing_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    // Step 1: SendMessage routed to agent-a (by static rule), response stores context.
+    let send_body =
+        r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"role":"ROLE_USER","parts":[]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "SendMessage should succeed");
+
+    // Step 2: ListTasks with ctx-int-1 must route to agent-a (not fallback agent-b).
+    let list_body = r#"{"jsonrpc":"2.0","id":2,"method":"ListTasks","params":{"contextId":"ctx-int-1"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", list_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "ListTasks should route to agent-a (which owns ctx-int-1), not fallback agent-b"
+    );
+}
+
+/// Integration 2: Context captured from SendMessage response, then SendMessage
+/// in same context routes by context.
+#[test]
+fn a2a_context_captured_from_send_message_then_send_message_in_same_context_routes() {
+    let json_body = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-ctx-2","contextId":"ctx-int-2","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let agent_a_guard = Backend::fixed(json_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_context_owner_routing_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    // First SendMessage creates task/context on agent-a.
+    let send_body1 =
+        r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"role":"ROLE_USER","parts":[]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body1, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "first SendMessage should succeed");
+
+    // Second SendMessage in same context must route to agent-a via context routing.
+    let send_body2 = r#"{"jsonrpc":"2.0","id":2,"method":"SendMessage","params":{"message":{"contextId":"ctx-int-2","role":"ROLE_USER","parts":[]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body2, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "second SendMessage in same context should route to agent-a via context routing"
+    );
+}
+
+/// Integration 3: Context miss continues.
+#[test]
+fn a2a_context_miss_follows_fallback_route() {
+    let agent_a_guard = start_backend_with_shutdown("agent-a");
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_context_owner_routing_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    // No prior context mapping for ctx-missing.
+    let list_body = r#"{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{"contextId":"ctx-missing"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", list_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "agent-b",
+        "unknown context should follow fallback route to agent-b"
+    );
+}
+
+// Integration 4: Task route beats context route.
+//
+// Validated at the unit level in `task_route_hit_takes_precedence_over_context_route_hit`.
+// An integration-level test is not meaningful because the methods that carry task_id
+// (GetTask, CancelTask, etc.) do not also carry contextId; the route stores are populated
+// separately. Unit coverage is authoritative for this requirement.
+
+/// Integration 5: Terminal task with context keeps context route.
+#[test]
+fn a2a_terminal_task_with_context_keeps_context_route() {
+    let json_body = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-final","contextId":"ctx-final","status":{"state":"TASK_STATE_COMPLETED"}}}}"#;
+    let agent_a_guard = Backend::fixed(json_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    // Use terminal_ttl_seconds=0 so the task route is removed immediately.
+    let yaml = a2a_context_owner_routing_zero_terminal_ttl_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    // SendMessage returns a terminal task with context.
+    let send_body =
+        r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"role":"ROLE_USER","parts":[]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "SendMessage should succeed");
+
+    // GetTask for the now-removed task should fall through (task route gone).
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-final"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "agent-b",
+        "GetTask for terminal task with ttl=0 should fall through to fallback"
+    );
+
+    // ListTasks with ctx-final should still route to agent-a (context route survived).
+    let list_body = r#"{"jsonrpc":"2.0","id":3,"method":"ListTasks","params":{"contextId":"ctx-final"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", list_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "ListTasks for ctx-final should still route to agent-a (context route survived task removal)"
+    );
+}
+
+/// Integration 6: Streaming task event with context stores context route.
+#[test]
+fn a2a_streaming_task_event_with_context_stores_context_route() {
+    let sse_body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-sse-ctx\",\"contextId\":\"ctx-sse-int\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_context_owner_routing_yaml(proxy_port, sse_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":{"role":"ROLE_USER","parts":[]}}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    read_until_timeout(&mut stream, &mut response);
+    let raw = String::from_utf8_lossy(&response);
+
+    assert_eq!(parse_status(&raw), 200, "SendStreamingMessage should succeed");
+    assert!(
+        raw.contains("text/event-stream"),
+        "SSE content-type should reach client"
+    );
+
+    // Verify SSE body passes through unchanged.
+    let response_body = parse_body(&raw);
+    assert_eq!(
+        response_body, sse_body,
+        "SSE response body should pass through unchanged"
+    );
+
+    // ListTasks with ctx-sse-int should route to agent-a (context captured from SSE event).
+    let list_body = r#"{"jsonrpc":"2.0","id":2,"method":"ListTasks","params":{"contextId":"ctx-sse-int"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", list_body, &[]);
+    let raw = http_send(&format!("127.0.0.1:{proxy_port}"), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        sse_body,
+        "ListTasks should route to agent-a after SSE event captured context route"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -1170,6 +1371,118 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+/// Context-owner routing config with standard TTLs.
+///
+/// Initial SendMessage/SendStreamingMessage route to agent-a by static rule.
+/// Context/task route hits route to the owning cluster.
+/// Fallback goes to agent-b.
+fn a2a_context_owner_routing_yaml(proxy_port: u16, agent_a_port: u16, agent_b_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          task_id: x-praxis-a2a-task-id
+          streaming: x-praxis-a2a-streaming
+        task_routing:
+          enabled: true
+          route_cluster_header: x-praxis-a2a-route-cluster
+          ttl_seconds: 3600
+          terminal_ttl_seconds: 300
+          max_response_body_bytes: 65536
+      - filter: router
+        routes:
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-a"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-b"
+            cluster: "agent-b"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-method: "SendMessage"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-streaming: "true"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            cluster: "agent-b"
+      - filter: load_balancer
+        clusters:
+          - name: "agent-a"
+            endpoints:
+              - "127.0.0.1:{agent_a_port}"
+          - name: "agent-b"
+            endpoints:
+              - "127.0.0.1:{agent_b_port}"
+"#,
+    )
+}
+
+/// Context-owner routing config with `terminal_ttl_seconds: 0` to test
+/// that task routes are immediately removed while context routes survive.
+fn a2a_context_owner_routing_zero_terminal_ttl_yaml(proxy_port: u16, agent_a_port: u16, agent_b_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          task_id: x-praxis-a2a-task-id
+        task_routing:
+          enabled: true
+          route_cluster_header: x-praxis-a2a-route-cluster
+          ttl_seconds: 3600
+          terminal_ttl_seconds: 0
+          max_response_body_bytes: 65536
+      - filter: router
+        routes:
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-a"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-b"
+            cluster: "agent-b"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-method: "SendMessage"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            cluster: "agent-b"
+      - filter: load_balancer
+        clusters:
+          - name: "agent-a"
+            endpoints:
+              - "127.0.0.1:{agent_a_port}"
+          - name: "agent-b"
+            endpoints:
+              - "127.0.0.1:{agent_b_port}"
 "#,
     )
 }


### PR DESCRIPTION
  ## Summary

  Adds local A2A context-owner routing on top of the existing local task-routing flow.

  A2A defines `contextId` as the standard way to logically group related tasks and messages ([A2A specification](https://github.com/a2aproject/A2A/blob/main/docs/specification.md)). Before this PR, Praxis could learn ownership for individual task IDs, but context-level follow-up requests such as `ListTasks` or another `SendMessage` in the same context still had to fall back to static routing. This PR teaches the local route store to remember which backend owns a context whenever that context is observed in task responses or streaming task events.

  In practical terms, the flow is:

  1. A client sends `SendMessage` or `SendStreamingMessage`.
  2. Praxis routes the initial request to `agent-a`.
  3. `agent-a` returns or streams a task/event containing `contextId: ctx-123`.
  4. Praxis stores `ctx-123 -> agent-a`.
  5. Later, the client sends `ListTasks` or another message for `ctx-123`.
  6. Praxis routes that request back to `agent-a` instead of the static fallback backend.
  
  Task ID routes still take precedence over context routes.

  This PR adds:

  - local `contextId -> cluster` route storage
  - context capture from non-streaming JSON task responses
  - context capture from streaming SSE task/status/artifact events
  - context-based routing for:
    - `ListTasks`
    - `SendMessage`
    - `SendStreamingMessage`
  - task-over-context route precedence
  - terminal-task handling where task routes may expire/remove but context ownership remains
  - docs and example updates for task + context-owner routing
  - unit, integration, schema, lint, and generated-doc coverage

  ## Scope

  This is local in-process routing only.

  It does not add Redis/Valkey, distributed context ownership, or multi-replica state sharing. Those remain follow-up work.

  ## Validation

  - `cargo test -p praxis-ai-filters a2a` — 280 passed
  - `cargo test -p praxis-tests-integration --test suite a2a` — 60 passed
  - `cargo test -p praxis-tests-schema` — 90 passed
  - `cargo clippy --workspace --all-targets -- -D warnings` — clean
  - `cargo +nightly fmt --all --check` — clean
  - `cargo xtask lint-filter-docs` — clean
  - `cargo xtask lint-example-tests` — clean
  - `cargo xtask sync-example-readme` — clean
  - `git diff --check` — clean

Note: `examples/README.md` was regenerated with `cargo xtask sync-example-readme` after rebase.
