### PR TITLE
test: add unit tests to boost coverage to 95%

### DIFF
--- a/apis/src/anthropic/to_openai/mod.rs
+++ b/apis/src/anthropic/to_openai/mod.rs
@@ -276,7 +276,7 @@ fn transform_non_streaming_body(ctx: &mut HttpFilterContext<'_>, body: &mut Opti
 // -----------------------------------------------------------------------------
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::indexing_slicing, reason = "tests")]
 mod tests {
     use bytes::Bytes;
     use http::{Method, StatusCode};
@@ -337,5 +337,183 @@ mod tests {
 
         assert!(matches!(action, FilterAction::Continue), "filter should continue");
         assert_eq!(body, Some(original), "upstream error body should pass through");
+    }
+
+    // --- extract_request_metadata ---
+
+    #[test]
+    fn extract_request_metadata_streaming_true_with_model() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        let bytes = br#"{"stream":true,"model":"claude-opus-4-8"}"#;
+
+        extract_request_metadata(&mut ctx, bytes);
+
+        assert_eq!(
+            ctx.filter_metadata.get("anthropic_to_openai.streaming").unwrap(),
+            "true"
+        );
+        assert_eq!(
+            ctx.filter_metadata.get("anthropic_to_openai.model").unwrap(),
+            "claude-opus-4-8"
+        );
+    }
+
+    #[test]
+    fn extract_request_metadata_streaming_false() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        let bytes = br#"{"stream":false,"model":"gpt-4"}"#;
+
+        extract_request_metadata(&mut ctx, bytes);
+
+        assert_eq!(
+            ctx.filter_metadata.get("anthropic_to_openai.streaming").unwrap(),
+            "false"
+        );
+        assert_eq!(ctx.filter_metadata.get("anthropic_to_openai.model").unwrap(), "gpt-4");
+    }
+
+    #[test]
+    fn extract_request_metadata_invalid_json() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+
+        extract_request_metadata(&mut ctx, b"not json");
+
+        assert_eq!(
+            ctx.filter_metadata.get("anthropic_to_openai.streaming").unwrap(),
+            "false",
+            "invalid JSON should default streaming to false"
+        );
+        assert!(
+            !ctx.filter_metadata.contains_key("anthropic_to_openai.model"),
+            "invalid JSON should not set model"
+        );
+    }
+
+    // --- transform_request_body ---
+
+    #[test]
+    fn transform_request_body_none_continues() {
+        let mut body: Option<Bytes> = None;
+        let action = transform_request_body(&mut body);
+
+        assert!(matches!(action, FilterAction::Continue));
+        assert!(body.is_none());
+    }
+
+    #[test]
+    fn transform_request_body_valid_transforms() {
+        let mut body = Some(Bytes::from(
+            br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#.to_vec(),
+        ));
+        let action = transform_request_body(&mut body);
+
+        assert!(matches!(action, FilterAction::Continue));
+        assert!(body.is_some());
+        let parsed: serde_json::Value = serde_json::from_slice(body.unwrap().as_ref()).unwrap();
+        assert_eq!(parsed["messages"][0]["role"], "user");
+        assert_eq!(
+            parsed["max_completion_tokens"], 1024,
+            "max_tokens should be mapped to max_completion_tokens"
+        );
+    }
+
+    #[test]
+    fn transform_request_body_invalid_rejects() {
+        let mut body = Some(Bytes::from_static(b"not json"));
+        let action = transform_request_body(&mut body);
+
+        assert!(
+            matches!(action, FilterAction::Reject(_)),
+            "invalid body should produce a rejection"
+        );
+    }
+
+    // --- should_transform_response ---
+
+    #[test]
+    fn should_transform_response_streaming_returns_false() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        ctx.set_metadata("anthropic_to_openai.streaming", "true");
+        let mut response = make_response();
+        ctx.response_header = Some(&mut response);
+
+        assert!(
+            !should_transform_response(&ctx),
+            "streaming responses should not be transformed"
+        );
+    }
+
+    #[test]
+    fn should_transform_response_non_streaming_success() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        ctx.set_metadata("anthropic_to_openai.streaming", "false");
+        let mut response = make_response();
+        ctx.response_header = Some(&mut response);
+
+        assert!(
+            should_transform_response(&ctx),
+            "non-streaming success should be transformed"
+        );
+    }
+
+    // --- transform_non_streaming_body ---
+
+    #[test]
+    fn transform_non_streaming_body_none_is_noop() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        let mut body: Option<Bytes> = None;
+
+        transform_non_streaming_body(&mut ctx, &mut body, "gpt-4");
+
+        assert!(body.is_none());
+    }
+
+    #[test]
+    fn transform_non_streaming_body_empty_bytes_is_noop() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        let mut body = Some(Bytes::new());
+
+        transform_non_streaming_body(&mut ctx, &mut body, "gpt-4");
+
+        assert_eq!(body.as_ref().unwrap().len(), 0, "empty bytes should not be transformed");
+    }
+
+    #[test]
+    fn transform_non_streaming_body_success() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        let response_json = br#"{"id":"chatcmpl-1","model":"gpt-4","choices":[{"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#;
+        let mut body = Some(Bytes::from(response_json.to_vec()));
+
+        transform_non_streaming_body(&mut ctx, &mut body, "gpt-4");
+
+        assert!(body.is_some());
+        let parsed: serde_json::Value = serde_json::from_slice(body.unwrap().as_ref()).unwrap();
+        assert_eq!(parsed["type"], "message");
+        assert_eq!(parsed["content"][0]["text"], "Hello!");
+        assert_eq!(
+            ctx.filter_metadata.get("openai.finish_reason").unwrap(),
+            "stop",
+            "finish_reason should be stored in metadata"
+        );
+    }
+
+    #[test]
+    fn transform_non_streaming_body_invalid_json_preserves_body() {
+        let request = make_request(Method::POST, "/v1/messages");
+        let mut ctx = make_filter_context(&request);
+        let original = Bytes::from_static(b"not json");
+        let mut body = Some(original.clone());
+
+        transform_non_streaming_body(&mut ctx, &mut body, "gpt-4");
+
+        assert_eq!(body, Some(original), "body should not be modified on error");
     }
 }

--- a/apis/src/anthropic/to_openai/request.rs
+++ b/apis/src/anthropic/to_openai/request.rs
@@ -631,4 +631,225 @@ mod tests {
 
         assert_eq!(parsed["top_k"], 40, "top_k should be preserved as extra body parameter");
     }
+
+    #[test]
+    fn transform_request_non_json_body() {
+        let body = b"not json at all";
+        let result = transform_request(body);
+        assert!(result.is_err(), "non-JSON body should return Err");
+        assert!(
+            result.unwrap_err().contains("invalid JSON"),
+            "error should mention invalid JSON"
+        );
+    }
+
+    #[test]
+    fn transform_request_json_array_body() {
+        let body = b"[1,2,3]";
+        let result = transform_request(body);
+        assert!(result.is_err(), "JSON array body should return Err");
+        assert!(
+            result.unwrap_err().contains("not a JSON object"),
+            "error should mention not a JSON object"
+        );
+    }
+
+    #[test]
+    fn hoist_system_non_string_non_array_skipped() {
+        let body =
+            br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":42,"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["messages"].as_array().unwrap().len(),
+            1,
+            "non-string/non-array system should be skipped"
+        );
+        assert_eq!(parsed["messages"][0]["role"], "user");
+    }
+
+    #[test]
+    fn hoist_system_array_empty_text_skipped() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":[{"type":"text","text":""}],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["messages"].as_array().unwrap().len(),
+            1,
+            "system with single empty text block should be skipped"
+        );
+        assert_eq!(parsed["messages"][0]["role"], "user");
+    }
+
+    #[test]
+    fn convert_messages_missing_role_skipped() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert!(
+            parsed["messages"].as_array().unwrap().is_empty(),
+            "message without role should be skipped"
+        );
+    }
+
+    #[test]
+    fn convert_messages_content_not_string_or_array() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":42}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["messages"][0]["role"], "user");
+        assert_eq!(
+            parsed["messages"][0]["content"], "",
+            "non-string/non-array content should become empty string"
+        );
+    }
+
+    #[test]
+    fn thinking_block_dropped() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think..."}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert!(
+            parsed["messages"].as_array().unwrap().is_empty(),
+            "thinking blocks should be dropped entirely"
+        );
+    }
+
+    #[test]
+    fn unknown_block_type_dropped() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"custom_xyz","data":"something"}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert!(
+            parsed["messages"].as_array().unwrap().is_empty(),
+            "unknown block types should be dropped"
+        );
+    }
+
+    #[test]
+    fn tool_choice_string_none() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":"none","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["tool_choice"], "none", "string none maps to none");
+    }
+
+    #[test]
+    fn tool_choice_string_unknown_maps_to_auto() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":"foo","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["tool_choice"], "auto", "unknown string tool_choice maps to auto");
+    }
+
+    #[test]
+    fn tool_choice_object_none() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"f","description":"d","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"none"},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["tool_choice"], "none", "object-form none maps to none");
+    }
+
+    #[test]
+    fn tool_choice_object_tool_with_name() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"fn","description":"d","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"tool","name":"fn"},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["tool_choice"]["type"], "function",
+            "tool type should map to function"
+        );
+        assert_eq!(
+            parsed["tool_choice"]["function"]["name"], "fn",
+            "tool name should be preserved"
+        );
+    }
+
+    #[test]
+    fn tool_choice_object_tool_without_name_maps_to_auto() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"f","description":"d","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"tool"},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["tool_choice"], "auto",
+            "tool without name should fallback to auto"
+        );
+    }
+
+    #[test]
+    fn tool_choice_non_string_non_object_skipped() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":true,"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert!(
+            parsed.get("tool_choice").is_none(),
+            "non-string/non-object tool_choice should be skipped"
+        );
+    }
+
+    #[test]
+    fn multipart_image_and_text_produces_array_content() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"text","text":"Describe this"},{"type":"image","source":{"type":"url","url":"https://example.com/img.png"}}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let content = &parsed["messages"][0]["content"];
+        assert!(content.is_array(), "multipart content should be an array");
+        assert_eq!(content.as_array().unwrap().len(), 2, "two content parts");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image_url");
+    }
+
+    #[test]
+    fn only_tool_result_blocks_produce_tool_messages() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"result1"},{"type":"tool_result","tool_use_id":"call_2","content":"result2"}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let messages = parsed["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2, "two tool messages, no wrapper");
+        assert_eq!(messages[0]["role"], "tool");
+        assert_eq!(messages[0]["tool_call_id"], "call_1");
+        assert_eq!(messages[0]["content"], "result1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_2");
+        assert_eq!(messages[1]["content"], "result2");
+    }
+
+    #[test]
+    fn extract_tool_result_content_null() {
+        let block = json!({"type": "tool_result", "tool_use_id": "call_1", "content": null});
+        let result = extract_tool_result_content(&block);
+        assert!(result.is_empty(), "null content should return empty string");
+    }
+
+    #[test]
+    fn extract_tool_result_content_missing() {
+        let block = json!({"type": "tool_result", "tool_use_id": "call_1"});
+        let result = extract_tool_result_content(&block);
+        assert!(result.is_empty(), "missing content should return empty string");
+    }
+
+    #[test]
+    fn bash_and_text_editor_tools_filtered() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"type":"bash_20241022","name":"bash"},{"type":"text_editor_20241022","name":"text_editor"},{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{}}}],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let tools = parsed["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1, "only non-filtered tools should remain");
+        assert_eq!(tools[0]["function"]["name"], "get_weather");
+    }
 }

--- a/apis/src/anthropic/to_openai/response.rs
+++ b/apis/src/anthropic/to_openai/response.rs
@@ -263,4 +263,73 @@ mod tests {
 
         assert_eq!(parsed["usage"]["cache_read_input_tokens"], 80, "cached tokens mapped");
     }
+
+    #[test]
+    fn transform_response_non_json_body() {
+        let result = transform_response(b"not json at all", "gpt-4");
+        let err = result.err().unwrap();
+        assert!(err.contains("invalid JSON"), "error should mention invalid JSON: {err}");
+    }
+
+    #[test]
+    fn transform_response_json_array_body() {
+        let result = transform_response(b"[1,2,3]", "gpt-4");
+        let err = result.err().unwrap();
+        assert!(
+            err.contains("not a JSON object"),
+            "error should mention not a JSON object: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_id_generates_msg_prefixed_id() {
+        let body = br#"{"model":"gpt-4","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let parsed: Value = serde_json::from_slice(&tr.body).unwrap();
+
+        let id = parsed["id"].as_str().unwrap();
+        assert!(
+            id.starts_with("msg_"),
+            "generated ID should start with msg_ but got: {id}"
+        );
+    }
+
+    #[test]
+    fn empty_choices_produces_empty_content() {
+        let body =
+            br#"{"id":"chatcmpl-1","model":"gpt-4","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":0}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let parsed: Value = serde_json::from_slice(&tr.body).unwrap();
+
+        assert!(
+            parsed["content"].as_array().unwrap().is_empty(),
+            "empty choices should produce empty content"
+        );
+    }
+
+    #[test]
+    fn empty_string_content_produces_no_text_block() {
+        let body = br#"{"id":"chatcmpl-1","model":"gpt-4","choices":[{"message":{"role":"assistant","content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":0}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let parsed: Value = serde_json::from_slice(&tr.body).unwrap();
+
+        assert!(
+            parsed["content"].as_array().unwrap().is_empty(),
+            "empty content string should not produce a text block"
+        );
+    }
+
+    #[test]
+    fn invalid_tool_call_arguments_fallback_to_empty_object() {
+        let body = br#"{"id":"chatcmpl-1","model":"gpt-4","choices":[{"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"not{json"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let parsed: Value = serde_json::from_slice(&tr.body).unwrap();
+
+        assert_eq!(parsed["content"][0]["type"], "tool_use");
+        assert_eq!(
+            parsed["content"][0]["input"],
+            json!({}),
+            "invalid JSON arguments should fallback to empty object"
+        );
+    }
 }

--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -618,3 +618,69 @@ fn post_route<'a>(segments: &'a [&'a str]) -> Option<PostRoute<'a>> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_store_unavailable_returns_500_server_error() {
+        let rejection = reject_store_unavailable();
+        assert_eq!(rejection.status, 500);
+        let body: Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["message"], "Internal server error.");
+    }
+
+    #[test]
+    fn reject_store_unavailable_sets_json_content_type() {
+        let rejection = reject_store_unavailable();
+        let ct = rejection
+            .headers
+            .iter()
+            .find(|(k, _)| k == "content-type")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(ct, Some("application/json"), "should set application/json content-type");
+    }
+
+    #[test]
+    fn post_route_create_conversation() {
+        let segments = ["", "v1", "conversations"];
+        assert!(matches!(post_route(&segments), Some(PostRoute::CreateConversation)));
+    }
+
+    #[test]
+    fn post_route_update_conversation() {
+        let segments = ["", "v1", "conversations", "conv_123"];
+        assert!(matches!(
+            post_route(&segments),
+            Some(PostRoute::UpdateConversation("conv_123"))
+        ));
+    }
+
+    #[test]
+    fn post_route_create_items() {
+        let segments = ["", "v1", "conversations", "conv_123", "items"];
+        assert!(matches!(
+            post_route(&segments),
+            Some(PostRoute::CreateItems("conv_123"))
+        ));
+    }
+
+    #[test]
+    fn post_route_unmatched_returns_none() {
+        let segments = ["", "v1", "models"];
+        assert!(post_route(&segments).is_none());
+    }
+
+    #[test]
+    fn post_route_empty_id_returns_none() {
+        let segments = ["", "v1", "conversations", ""];
+        assert!(
+            post_route(&segments).is_none(),
+            "empty conversation ID should not match"
+        );
+    }
+}

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -782,3 +782,201 @@ async fn collect_conversation_messages(
     }
     Ok(messages)
 }
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // store_error_response
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn store_error_invalid_input_returns_400() {
+        let error = StoreError::InvalidInput("bad cursor".to_owned());
+        let rejection = store_error_response(&error).unwrap();
+        assert_eq!(rejection.status, 400);
+        let body: Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["message"], "bad cursor");
+    }
+
+    #[test]
+    fn store_error_database_returns_500() {
+        let error = StoreError::Database("connection lost".to_owned());
+        let rejection = store_error_response(&error).unwrap();
+        assert_eq!(rejection.status, 500);
+        let body: Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["message"], "Internal server error.");
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_item_list_params
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_params_skips_pair_without_separator() {
+        let params = parse_item_list_params(Some("noseparator&limit=5"));
+        assert_eq!(params.limit, 5);
+        assert!(params.after_item_id.is_none());
+    }
+
+    #[test]
+    fn parse_params_unknown_order_stays_default() {
+        let params = parse_item_list_params(Some("order=random"));
+        assert!(!params.ascending, "unknown order should keep default descending");
+    }
+
+    #[test]
+    fn parse_params_non_numeric_limit_uses_default() {
+        let params = parse_item_list_params(Some("limit=abc"));
+        assert_eq!(params.limit, DEFAULT_PAGE_LIMIT);
+    }
+
+    // -------------------------------------------------------------------------
+    // decode_query_component / decode_item_id_path_segment
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn decode_query_component_invalid_utf8_uses_lossy() {
+        let result = decode_query_component("%FF%FE");
+        assert!(
+            result.contains('\u{FFFD}'),
+            "invalid UTF-8 should produce replacement characters"
+        );
+    }
+
+    #[test]
+    fn decode_item_id_path_segment_invalid_utf8_returns_error() {
+        let result = decode_item_id_path_segment("%FF%FE");
+        assert!(result.is_err(), "invalid UTF-8 should return error");
+        assert!(
+            result.unwrap_err().contains("valid UTF-8"),
+            "error should mention UTF-8 requirement"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // ItemListParams::effective_limit
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn effective_limit_clamps_zero_to_one() {
+        let params = ItemListParams {
+            limit: 0,
+            ..ItemListParams::default()
+        };
+        assert_eq!(params.effective_limit(), 1);
+    }
+
+    #[test]
+    fn effective_limit_clamps_above_max() {
+        let params = ItemListParams {
+            limit: MAX_PAGE_LIMIT + 50,
+            ..ItemListParams::default()
+        };
+        assert_eq!(params.effective_limit(), MAX_PAGE_LIMIT);
+    }
+
+    #[test]
+    fn effective_limit_returns_value_within_range() {
+        let params = ItemListParams {
+            limit: 50,
+            ..ItemListParams::default()
+        };
+        assert_eq!(params.effective_limit(), 50);
+    }
+
+    // -------------------------------------------------------------------------
+    // store_error_response — catch-all variants
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn store_error_serialization_returns_500() {
+        let error = StoreError::Serialization("corrupt data".to_owned());
+        let rejection = store_error_response(&error).unwrap();
+        assert_eq!(rejection.status, 500);
+        let body: Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["message"], "Internal server error.");
+    }
+
+    #[test]
+    fn store_error_unavailable_returns_500() {
+        let error = StoreError::Unavailable("not connected".to_owned());
+        let rejection = store_error_response(&error).unwrap();
+        assert_eq!(rejection.status, 500);
+        let body: Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["message"], "Internal server error.");
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_item_list_params — additional edges
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_params_none_query_returns_defaults() {
+        let params = parse_item_list_params(None);
+        assert_eq!(params.limit, DEFAULT_PAGE_LIMIT);
+        assert!(!params.ascending);
+        assert!(params.after_item_id.is_none());
+    }
+
+    #[test]
+    fn parse_params_valid_after_parameter() {
+        let params = parse_item_list_params(Some("after=item_abc123&limit=10"));
+        assert_eq!(params.after_item_id.as_deref(), Some("item_abc123"));
+        assert_eq!(params.limit, 10);
+    }
+
+    #[test]
+    fn parse_params_asc_order() {
+        let params = parse_item_list_params(Some("order=asc"));
+        assert!(params.ascending, "order=asc should set ascending");
+    }
+
+    #[test]
+    fn parse_params_desc_order() {
+        let params = parse_item_list_params(Some("order=desc"));
+        assert!(!params.ascending, "order=desc should set descending");
+    }
+
+    #[test]
+    fn parse_params_negative_limit_uses_default() {
+        let params = parse_item_list_params(Some("limit=-5"));
+        assert_eq!(
+            params.limit, DEFAULT_PAGE_LIMIT,
+            "negative limit should not parse as u32"
+        );
+    }
+
+    #[test]
+    fn parse_params_percent_encoded_after() {
+        let params = parse_item_list_params(Some("after=item%20with+space"));
+        assert_eq!(
+            params.after_item_id.as_deref(),
+            Some("item with space"),
+            "percent-encoded and plus-encoded values should decode"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // decode_item_id_path_segment — additional cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn decode_item_id_plain_ascii_passes_through() {
+        let result = decode_item_id_path_segment("item_abc123").unwrap();
+        assert_eq!(result.as_ref(), "item_abc123");
+    }
+
+    #[test]
+    fn decode_item_id_percent_encoded_ascii() {
+        let result = decode_item_id_path_segment("item%5Fabc").unwrap();
+        assert_eq!(result.as_ref(), "item_abc", "percent-encoded underscore should decode");
+    }
+}

--- a/apis/src/openai/responses/proxy/tests.rs
+++ b/apis/src/openai/responses/proxy/tests.rs
@@ -336,6 +336,67 @@ async fn passthrough_strips_conversation_from_body() {
     assert_eq!(parsed["model"], "gpt-4.1", "other fields should be preserved");
 }
 
+#[tokio::test]
+async fn passthrough_none_body() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let mut body: Option<Bytes> = None;
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "None body should return Continue"
+    );
+    assert!(body.is_none(), "None body should remain None");
+}
+
+#[tokio::test]
+async fn passthrough_invalid_json_body() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let original = b"not valid json {{{";
+    let mut body = Some(Bytes::from_static(original));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "invalid JSON body should return Continue"
+    );
+    assert_eq!(
+        body.as_deref(),
+        Some(original.as_slice()),
+        "invalid JSON body should pass through unchanged"
+    );
+}
+
+#[tokio::test]
+async fn rebuild_non_object_request_body_passes_through() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+
+    let state = ResponsesState {
+        request_body: json!(["not", "an", "object"]),
+        ..Default::default()
+    };
+    ctx.extensions.insert(state);
+
+    let mut body = Some(Bytes::from(r#"["not","an","object"]"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "non-object request_body should continue"
+    );
+
+    let rebuilt: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert!(
+        rebuilt.is_array(),
+        "non-object request_body should pass through without modification"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/sse/frame.rs
+++ b/apis/src/openai/sse/frame.rs
@@ -586,4 +586,150 @@ mod tests {
         assert_eq!(frames2.len(), 1, "second data line with blank line should dispatch");
         assert_eq!(frames2[0].data, b"line1\nline2", "split multiline data should match");
     }
+
+    // -------------------------------------------------------------------------
+    // SseParseError Display
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn display_malformed_json() {
+        let err = SseParseError::MalformedJson {
+            event_type: "response.created".to_owned(),
+            err: "expected value at line 1 column 1".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("response.created"), "should mention the event type");
+        assert!(msg.contains("expected value"), "should include the JSON error");
+    }
+
+    #[test]
+    fn display_missing_event_type() {
+        let err = SseParseError::MissingEventType {
+            field: "data.type",
+            event_type: "response.created".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("data.type"), "should mention the missing field");
+        assert!(
+            msg.contains("response.created"),
+            "should mention the observed event type"
+        );
+    }
+
+    #[test]
+    fn display_event_type_mismatch() {
+        let err = SseParseError::EventTypeMismatch {
+            sse_event_type: "response.completed".to_owned(),
+            data_event_type: "response.output_text.delta".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("response.completed"), "should mention the SSE event type");
+        assert!(
+            msg.contains("response.output_text.delta"),
+            "should mention the payload event type"
+        );
+    }
+
+    #[test]
+    fn display_event_limit_exceeded() {
+        let err = SseParseError::EventLimitExceeded { count: 101, limit: 100 };
+        let msg = err.to_string();
+        assert!(msg.contains("101"), "should mention the count");
+        assert!(msg.contains("100"), "should mention the limit");
+    }
+
+    #[test]
+    fn display_timeout() {
+        let err = SseParseError::Timeout {
+            elapsed: Duration::from_secs(35),
+            limit: Duration::from_secs(30),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("35"), "should mention elapsed time");
+        assert!(msg.contains("30"), "should mention the limit");
+    }
+
+    #[test]
+    fn display_missing_terminal_event() {
+        let err = SseParseError::MissingTerminalEvent;
+        let msg = err.to_string();
+        assert!(msg.contains("terminal"), "should mention missing terminal event");
+    }
+
+    #[test]
+    fn display_buffer_overflow() {
+        let err = SseParseError::BufferOverflow {
+            buffered_bytes: 70_000,
+            limit: 65_536,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("70000"), "should mention buffered bytes");
+        assert!(msg.contains("65536"), "should mention the limit");
+    }
+
+    #[test]
+    fn display_event_after_terminal() {
+        let err = SseParseError::EventAfterTerminal {
+            event_type: "response.output_text.delta".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("response.output_text.delta"),
+            "should mention the event type"
+        );
+        assert!(msg.contains("terminal"), "should mention terminal context");
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_chunk_with_event_limit
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn event_limit_allows_frames_within_budget() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let chunk = b"data: one\n\ndata: two\n\n";
+        let frames = parser.parse_chunk_with_event_limit(chunk, 0, 5).unwrap();
+        assert_eq!(frames.len(), 2, "both frames should be emitted within budget");
+    }
+
+    #[test]
+    fn event_limit_exact_boundary_succeeds() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let chunk = b"data: one\n\ndata: two\n\n";
+        let frames = parser.parse_chunk_with_event_limit(chunk, 0, 2).unwrap();
+        assert_eq!(frames.len(), 2, "exactly at limit should succeed");
+    }
+
+    #[test]
+    fn event_limit_exceeded_at_boundary() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let chunk = b"data: one\n\ndata: two\n\ndata: three\n\n";
+        let result = parser.parse_chunk_with_event_limit(chunk, 0, 2);
+        assert!(
+            matches!(result, Err(SseParseError::EventLimitExceeded { count: 3, limit: 2 })),
+            "third frame should exceed limit of 2"
+        );
+    }
+
+    #[test]
+    fn event_limit_accounts_for_current_events() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let chunk = b"data: one\n\n";
+        let result = parser.parse_chunk_with_event_limit(chunk, 5, 5);
+        assert!(
+            matches!(result, Err(SseParseError::EventLimitExceeded { count: 6, limit: 5 })),
+            "current_events at limit should reject the next frame"
+        );
+    }
+
+    #[test]
+    fn event_limit_no_frames_always_succeeds() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let chunk = b"data: partial";
+        let frames = parser.parse_chunk_with_event_limit(chunk, 100, 100).unwrap();
+        assert!(
+            frames.is_empty(),
+            "no complete frames should succeed regardless of current count"
+        );
+    }
 }

--- a/apis/src/openai/sse/responses/event.rs
+++ b/apis/src/openai/sse/responses/event.rs
@@ -486,4 +486,110 @@ mod tests {
             assert!(!event.is_terminal(), "{event_type} should not be terminal");
         }
     }
+
+    /// All canonical event type strings (no aliases).
+    const ALL_CANONICAL_EVENT_TYPES: &[&str] = &[
+        "response.created",
+        "response.queued",
+        "response.in_progress",
+        "response.completed",
+        "response.incomplete",
+        "response.failed",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.content_part.added",
+        "response.content_part.done",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.output_text.annotation.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.refusal.delta",
+        "response.refusal.done",
+        "response.reasoning.delta",
+        "response.reasoning.done",
+        "response.reasoning_summary_text.delta",
+        "response.reasoning_summary_text.done",
+        "response.reasoning_summary_part.added",
+        "response.reasoning_summary_part.done",
+        "error",
+    ];
+
+    #[test]
+    fn event_type_roundtrips_for_all_canonical_variants() {
+        for event_type in ALL_CANONICAL_EVENT_TYPES {
+            let event = ResponsesEvent::from_event_type(event_type, json!({}));
+            assert_eq!(
+                event.event_type(),
+                *event_type,
+                "event_type() should roundtrip for '{event_type}'"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_variant_preserves_event_type_string() {
+        let event = ResponsesEvent::from_event_type("response.future_event.custom", json!({}));
+        assert_eq!(
+            event.event_type(),
+            "response.future_event.custom",
+            "Unknown variant should preserve the original event type"
+        );
+    }
+
+    #[test]
+    fn reasoning_text_done_alias_maps_to_reasoning_done() {
+        let event = ResponsesEvent::from_event_type("response.reasoning_text.done", json!({"text": "done"}));
+        assert!(
+            matches!(event, ResponsesEvent::ReasoningDone(_)),
+            "response.reasoning_text.done alias should map to ReasoningDone"
+        );
+        assert_eq!(
+            event.event_type(),
+            "response.reasoning.done",
+            "event_type() should return canonical name for alias"
+        );
+    }
+
+    #[test]
+    fn reasoning_text_done_alias_via_frame() {
+        let f = typed_frame("response.reasoning_text.done", json!({"text": "done"}));
+        let event = ResponsesEvent::from_frame(&f).unwrap();
+        assert!(
+            matches!(event, ResponsesEvent::ReasoningDone(_)),
+            "response.reasoning_text.done should parse via from_frame"
+        );
+    }
+
+    #[test]
+    fn canonical_event_type_maps_reasoning_text_done() {
+        assert_eq!(
+            canonical_event_type("response.reasoning_text.done"),
+            "response.reasoning.done",
+            "reasoning_text.done should canonicalize to reasoning.done"
+        );
+    }
+
+    #[test]
+    fn canonical_event_type_maps_reasoning_text_delta() {
+        assert_eq!(
+            canonical_event_type("response.reasoning_text.delta"),
+            "response.reasoning.delta",
+            "reasoning_text.delta should canonicalize to reasoning.delta"
+        );
+    }
+
+    #[test]
+    fn canonical_event_type_passes_through_non_aliases() {
+        assert_eq!(
+            canonical_event_type("response.created"),
+            "response.created",
+            "non-alias event types should pass through unchanged"
+        );
+        assert_eq!(
+            canonical_event_type("error"),
+            "error",
+            "non-alias event types should pass through unchanged"
+        );
+    }
 }

--- a/apis/src/store/tests.rs
+++ b/apis/src/store/tests.rs
@@ -1282,6 +1282,30 @@ async fn conversation_item_methods_fail_without_items_table() {
 }
 
 // -----------------------------------------------------------------------------
+// StoreError Display & Error trait
+// -----------------------------------------------------------------------------
+
+#[test]
+fn store_error_invalid_input_display() {
+    let err = StoreError::InvalidInput("bad cursor".into());
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("bad cursor"),
+        "InvalidInput Display should include the message: {msg}"
+    );
+}
+
+#[test]
+fn store_error_implements_std_error() {
+    use std::error::Error as _;
+    let err = StoreError::Database("connection lost".into());
+    assert!(
+        err.source().is_none(),
+        "StoreError should implement std::error::Error with no source"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // File-Backed Store
 // -----------------------------------------------------------------------------
 

--- a/filters/src/guardrails/tests.rs
+++ b/filters/src/guardrails/tests.rs
@@ -355,6 +355,6 @@ phase:
     )
     .unwrap();
 
-    assert!(!parsed.phase.request);
-    assert!(parsed.phase.response);
+    assert!(!parsed.phase.request, "overridden request should be false");
+    assert!(parsed.phase.response, "overridden response should be true");
 }

--- a/filters/src/inference/model_to_header.rs
+++ b/filters/src/inference/model_to_header.rs
@@ -283,4 +283,65 @@ mod tests {
 
         assert!(matches!(action, FilterAction::Continue), "on_request should be a no-op");
     }
+
+    #[tokio::test]
+    async fn on_response_delegates_to_inner() {
+        let filter = ModelToHeaderFilter::from_config(&serde_yaml::Value::Null).unwrap();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut resp = crate::test_utils::make_response();
+        ctx.response_header = Some(&mut resp);
+
+        let action = filter.on_response(&mut ctx).await.unwrap();
+
+        assert!(
+            matches!(action, FilterAction::Continue),
+            "on_response should delegate to inner and return Continue"
+        );
+    }
+
+    #[test]
+    fn response_body_access_delegates_to_inner() {
+        let filter = ModelToHeaderFilter::from_config(&serde_yaml::Value::Null).unwrap();
+        assert_eq!(
+            filter.response_body_access(),
+            BodyAccess::None,
+            "response body access should delegate to inner"
+        );
+    }
+
+    #[test]
+    fn response_body_mode_delegates_to_inner() {
+        let filter = ModelToHeaderFilter::from_config(&serde_yaml::Value::Null).unwrap();
+        assert!(
+            matches!(filter.response_body_mode(), BodyMode::Stream),
+            "response body mode should delegate to inner"
+        );
+    }
+
+    #[test]
+    fn needs_request_context_delegates_to_inner() {
+        let filter = ModelToHeaderFilter::from_config(&serde_yaml::Value::Null).unwrap();
+        // JsonBodyFieldFilter does not need request context on the
+        // response path; verify the delegate forwards the inner value.
+        assert!(
+            !filter.needs_request_context(),
+            "needs_request_context should delegate to inner and return false"
+        );
+    }
+
+    #[test]
+    fn on_response_body_delegates_to_inner() {
+        let filter = ModelToHeaderFilter::from_config(&serde_yaml::Value::Null).unwrap();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut body = Some(Bytes::from_static(b"response data"));
+
+        let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+
+        assert!(
+            matches!(action, FilterAction::Continue),
+            "on_response_body should delegate to inner and return Continue"
+        );
+    }
 }

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -161,4 +161,19 @@ filter_chains:
             "error should mention the missing chain name: {err}"
         );
     }
+
+    #[test]
+    fn default_config_source_returns_builtin_when_no_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let source = default_config_source();
+
+        std::env::set_current_dir(original).unwrap();
+        assert_eq!(
+            source, "<built-in default>",
+            "should return built-in default when praxis.yaml is absent"
+        );
+    }
 }

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -162,15 +162,32 @@ filter_chains:
         );
     }
 
+    static CWD_MUTEX: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+    struct CwdGuard(std::path::PathBuf);
+
+    impl CwdGuard {
+        fn new(path: &std::path::Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(original)
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).expect("failed to restore working directory");
+        }
+    }
+
     #[test]
     fn default_config_source_returns_builtin_when_no_yaml() {
+        let _lock = CWD_MUTEX.get_or_init(Default::default).lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        let original = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _guard = CwdGuard::new(dir.path());
 
         let source = default_config_source();
 
-        std::env::set_current_dir(original).unwrap();
         assert_eq!(
             source, "<built-in default>",
             "should return built-in default when praxis.yaml is absent"


### PR DESCRIPTION
## Summary

- Add unit tests across 12 files to increase line coverage from ~94.5% to 95.35%
- Cover previously untested code paths: error handling, edge cases, Display impls, pure helper functions
- Fix missing assert messages in guardrails tests (from #323 review feedback)

### Files changed
- `apis/src/anthropic/to_openai/{request,response,mod}.rs` — conversion error paths, tool_choice branches, metadata extraction
- `apis/src/openai/sse/{frame,responses/event}.rs` — SseParseError Display, event_type round-trip
- `apis/src/openai/conversations/{handlers,filter}.rs` — store_error_response, parse_item_list_params, reject_store_unavailable
- `apis/src/openai/responses/proxy/tests.rs` — strip_conversation_field edge cases
- `apis/src/store/tests.rs` — StoreError Display + Error trait
- `filters/src/inference/model_to_header.rs` — response-side delegate methods
- `filters/src/guardrails/tests.rs` — add missing assert messages
- `server/src/commands.rs` — default_config_source

## Test plan

- [x] `cargo test --workspace --lib` — 2035 tests pass
- [x] `make lint` — clippy + nightly rustfmt clean
- [x] `cargo llvm-cov` — coverage at 95.35%