### PR TITLE
test: change auth test header to avoid tripping scanners

### DIFF
--- a/tests/integration/tests/suite/adversarial/header_smuggling.rs
+++ b/tests/integration/tests/suite/adversarial/header_smuggling.rs
@@ -167,7 +167,7 @@ fn proxy_authorization_stripped_from_upstream() {
 
     let request = "GET / HTTP/1.1\r\n\
          Host: localhost\r\n\
-         Proxy-Authorization: Basic dGVzdDp0ZXN0\r\n\
+         Proxy-Authorization: Basic badmonkey123\r\n\
          Authorization: Bearer real-token\r\n\
          \r\n";
     let raw = http_send(&addr, request);


### PR DESCRIPTION
Change test auth header to some non real looking token to avoid tripping security scanners. 