### PR TITLE
docs: AI gateway documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![MSRV: 1.96](https://img.shields.io/badge/MSRV-1.96-brightgreen.svg)](https://blog.rust-lang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-AI features and capabilities for [Praxis](https://github.com/praxis-proxy/praxis).
+AI-native proxy server and **AI Gateway** built on the
+[Praxis](https://github.com/praxis-proxy/praxis) composable
+filter pipeline. Documentation: [docs/overview.md](docs/overview.md).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,22 +1,53 @@
 # Praxis AI Documentation
 
-AI inference filters, agentic protocol support, and provider
-API integrations built on
-[Praxis](https://github.com/praxis-proxy/praxis).
+Praxis AI is an **AI-native proxy server** and **AI Gateway**
+(AI API Gateway) for routing, managing, enriching, and
+parsing inference and agentic traffic. It builds on the
+[Praxis](https://github.com/praxis-proxy/praxis) proxy
+framework and composable filter pipeline.
+
+Run the `praxis-ai` binary for all features below. See
+[core docs](https://github.com/praxis-proxy/praxis/tree/main/docs)
+for shared proxy configuration.
+
+## Getting started
+
+- [AI Gateway overview](overview.md)
+- [Quickstart](quickstart.md)
+- [Features](features.md)
+- [Example configs](../examples/README.md)
+
+## Guides
+
+- [OpenAI Responses API](openai-responses.md)
+- [Anthropic Messages API](anthropic-messages.md)
+- [Token counting](token-counting.md)
 
 ## Architecture
 
-- [AI Inference](architecture/ai-inference.md)
-- [Agentic Protocols](architecture/agentic-protocols.md)
-- [Response Store](architecture/response-store.md)
+- [Crate layout](architecture/crate-layout.md)
+- [AI inference pipeline](architecture/ai-inference.md)
+- [Agentic protocols](architecture/agentic-protocols.md)
+- [Response store](architecture/response-store.md)
 
 ## Filters
 
-- [Filter reference](filters/)
-- [Anthropic Messages](anthropic-messages.md)
-- [Anthropic Messages replay test plan](anthropic-messages-replay-test-plan.md)
+- [Filter overview](filters/README.md)
+- [Filter reference](filters/reference.md)
+- [Extensions](filters/extensions.md)
+
+## Developing
+
+- [Getting started](developing/getting-started.md)
+- [Conventions](developing/conventions.md)
+- [Adding filters](developing/adding-filters.md)
+
+## Core operating docs
+
+TLS, security hardening, and YAML schema details live in the
+[Praxis core documentation](https://github.com/praxis-proxy/praxis/tree/main/docs/operating).
 
 ## Reference
 
-- [Example configs](../examples/README.md)
-- [Proposals](proposals/)
+- [Proposals](proposals.md)
+- [Anthropic Messages replay test plan](anthropic-messages-replay-test-plan.md)

--- a/docs/architecture/agentic-protocols.md
+++ b/docs/architecture/agentic-protocols.md
@@ -1,7 +1,10 @@
 # Agentic Protocols
 
-JSON-RPC 2.0 envelope parsing and protocol-specific
-metadata extraction for MCP and A2A agent traffic.
+**Parsing and routing** for agentic traffic on the
+[AI Gateway][overview]: JSON-RPC 2.0 envelope parsing and
+protocol-specific metadata extraction for MCP and A2A.
+
+[overview]: ../overview.md
 
 ## Overview
 
@@ -199,16 +202,10 @@ All three filters share these conventions:
 
 ## Key Files
 
-- `filter/src/builtins/http/ai/agentic/json_rpc/`:
-  JSON-RPC 2.0 envelope parser and filter
-- `filter/src/builtins/http/ai/agentic/mcp/`:
-  MCP filter, broker, envelope, protocol
-- `filter/src/builtins/http/ai/agentic/a2a/`:
-  A2A filter, task routing, SSE scanner
-- `filter/src/builtins/http/ai/agentic/mcp/broker/`:
-  MCP broker with static catalog
-- `filter/src/builtins/http/ai/agentic/a2a/task_routing.rs`:
-  in-process task route store with TTL
+- [`filter/src/builtins/http/payload_processing/json_rpc/`](https://github.com/praxis-proxy/praxis/tree/main/filter/src/builtins/http/payload_processing/json_rpc) (core):
+  JSON-RPC 2.0 envelope parser
+- `filters/src/agentic/mcp/`: MCP filter, broker, envelope
+- `filters/src/agentic/a2a/`: A2A filter, task routing, SSE scanner
 
 ## Related
 

--- a/docs/architecture/ai-inference.md
+++ b/docs/architecture/ai-inference.md
@@ -1,8 +1,11 @@
 # AI Inference
 
-Body-aware classification, routing, and enrichment
-for AI inference traffic, built on the filter
-pipeline and StreamBuffer body access pattern.
+The **routing and parsing** layer of the [AI Gateway][overview]:
+body-aware classification, enrichment, and
+upstream selection for inference traffic, built on the
+filter pipeline and StreamBuffer body access pattern.
+
+[overview]: ../overview.md
 
 ## Overview
 
@@ -150,11 +153,13 @@ OpenAI-compatible chat completion request bodies.
 Static configured messages are prepended or appended
 to the `messages` array. Uses `BodyAccess::ReadWrite`.
 
-### `credential_injection`
+### `credential_injection` (core builtin)
 
 Per-cluster API key injection with client credential
 stripping. Supports inline values and environment
-variable sources.
+variable sources. Provided by Praxis core, commonly
+paired with AI pipelines. See
+[core credential_injection docs](https://github.com/praxis-proxy/praxis/blob/main/docs/filters/http/security/credential_injection.md).
 
 ### `openai_response_store`
 
@@ -163,18 +168,12 @@ Persists non-streaming Responses API responses. See
 
 ## Key Files
 
-- `filter/src/builtins/http/ai/classifier/mod.rs`:
-  pure format classifier
-- `filter/src/builtins/http/ai/openai/responses/mod.rs`:
-  `ResponsesFormatFilter`
-- `filter/src/builtins/http/ai/inference/model_to_header.rs`:
-  `ModelToHeaderFilter`
-- `filter/src/builtins/http/ai/prompt_enrich/`:
-  prompt enrichment filter
-- `filter/src/builtins/http/ai/anthropic/`:
-  Anthropic Messages format filter
-- `filter/src/body/mode.rs`:
-  `BodyMode::StreamBuffer` definition
+- `apis/src/classifier/mod.rs`: pure format classifier
+- `apis/src/openai/responses/`: Responses format, validate, store filters
+- `filters/src/inference/model_to_header.rs`: `ModelToHeaderFilter`
+- `filters/src/prompt_enrich/`: prompt enrichment filter
+- `apis/src/anthropic/`: Anthropic Messages filters
+- [`filter/src/body/mode.rs`](https://github.com/praxis-proxy/praxis/blob/main/filter/src/body/mode.rs) (core): `BodyMode::StreamBuffer`
 
 ## Related
 

--- a/docs/architecture/crate-layout.md
+++ b/docs/architecture/crate-layout.md
@@ -1,0 +1,58 @@
+# Crate Layout
+
+Praxis AI extends the core proxy with three workspace crates.
+All AI filters implement the same `HttpFilter` trait from
+`praxis-filter` and register at startup in `server/src/lib.rs`.
+
+## Dependency flow
+
+```text
+praxis-ai-proxy (server)
+  -> praxis-ai-filters
+    -> praxis-ai-apis
+      -> praxis-filter / praxis-core / praxis-protocol (core)
+```
+
+| Crate | Role |
+| ----- | ---- |
+| `server` (`praxis-ai-proxy`) | Binary `praxis-ai`; registers AI + core filters |
+| `filters` (`praxis-ai-filters`) | MCP, A2A, guardrails, model routing, token counting, token headers |
+| `apis` (`praxis-ai-apis`) | OpenAI/Anthropic filters, classifier, store, token usage parsers |
+
+## Key modules
+
+```text
+apis/src/
+  classifier/       Request body format detection
+  openai/           Responses API, conversations, SSE
+  anthropic/        Messages API filters
+  store/            ResponseStore trait, SQLite/Postgres
+  token_usage/      Provider-specific usage extraction (library)
+
+filters/src/
+  agentic/          MCP and A2A filters
+  guardrails/       AI content guardrails (ai_guardrails)
+  inference/        Promotes model body field to header (model_to_header)
+  prompt_enrich/    Chat completion message injection
+  token_count/      Response token usage extraction
+  token_usage_headers.rs  Injects Praxis-Token-* response headers
+```
+
+## Pipeline extensions
+
+`ResponseStoreRegistry` implements `PipelineExtension` and is
+injected when pipelines are built (`server/src/pipelines.rs`).
+Filters such as `openai_response_store` and
+`openai_responses_rehydrate` access stores through
+`ctx.extensions`.
+
+## Dynamic reload
+
+Config hot-reload is inherited from Praxis core. Pipelines
+swap atomically; `ResponseStoreRegistry` is recreated per
+pipeline build.
+
+## Related
+
+- [AGENTS.md](../../AGENTS.md) - agent and contributor reference
+- [Core crate layout](https://github.com/praxis-proxy/praxis/blob/main/docs/architecture/crate-layout.md)

--- a/docs/architecture/response-store.md
+++ b/docs/architecture/response-store.md
@@ -132,20 +132,13 @@ pass-through traffic is not held.
 
 ## Key Files
 
-- `filter/src/builtins/http/ai/openai/responses/store/filter.rs`:
-  filter implementation and lifecycle
-- `filter/src/builtins/http/ai/openai/responses/store/config.rs`:
-  configuration, SSRF validation
-- `filter/src/builtins/http/ai/store/trait_def.rs`:
-  `ResponseStore` trait
-- `filter/src/builtins/http/ai/store/types.rs`:
-  `ResponseRecord`, `StoreError`
-- `filter/src/builtins/http/ai/store/sqlite.rs`:
-  SQLite backend
-- `filter/src/builtins/http/ai/store/postgres.rs`:
-  PostgreSQL backend
-- `filter/src/builtins/http/ai/store/schemas.rs`:
-  DDL generation and identifier validation
+- `apis/src/openai/responses/store/filter.rs`: store filter lifecycle
+- `apis/src/openai/responses/store/config.rs`: configuration, SSRF validation
+- `apis/src/store/mod.rs`: `ResponseStore` trait, `ResponseStoreRegistry`
+- `apis/src/store/types.rs`: `ResponseRecord`, `StoreError`
+- `apis/src/store/sqlite.rs`: SQLite backend
+- `apis/src/store/postgres.rs`: PostgreSQL backend
+- `server/src/pipelines.rs`: injects `ResponseStoreRegistry` per pipeline
 
 ## Related
 

--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -61,7 +61,7 @@ binding or protocol registration. If you need to
 bind ports below 1024, prefer one of these approaches:
 
 - Grant `CAP_NET_BIND_SERVICE` to the binary:
-  `sudo setcap cap_net_bind_service=+ep ./target/release/praxis`
+  `sudo setcap cap_net_bind_service=+ep ./target/release/praxis-ai`
 - Run behind a reverse proxy or load balancer that
   handles port 80/443.
 - Use socket activation (systemd) to pass pre-bound

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,14 +1,11 @@
 # Features
 
-Praxis AI extends the [Praxis proxy framework][praxis]
-with AI-specific filters for inference routing, provider
-APIs, token counting, guardrails, agentic protocols,
-response storage, and prompt enrichment.
+Praxis AI adds provider, agentic, and observability filters
+on the [Praxis proxy framework][praxis]. See the
+[AI Gateway overview](overview.md) for how they fit together.
 
-For base proxy features (TLS, HTTP/2, TCP, WebSocket,
-load balancing, rate limiting, compression, CORS,
-health checks, etc.), see the
-[Praxis core documentation][praxis].
+For TLS, routing, load balancing, rate limits, and other core
+filters, see [Praxis core documentation][praxis].
 
 [praxis]: https://github.com/praxis-proxy/praxis
 
@@ -20,7 +17,7 @@ health checks, etc.), see the
   header-based routing to provider-specific clusters.
   Uses StreamBuffer to inspect the body before upstream
   selection.
-- **Credential injection** (`credential_injection`):
+- **Credential injection** (`credential_injection`, core):
   per-cluster API key injection with client credential
   stripping. Supports inline values and environment
   variable sources. Pair with a source discriminator
@@ -65,6 +62,11 @@ health checks, etc.), see the
   `/v1/conversations` endpoints locally.
 - **Responses proxy** (`openai_responses_proxy`): rebuilds
   the request body from `ResponsesState` when present.
+- **Stream events** (`openai_stream_events`): accumulates
+  native Responses API SSE events for downstream filters.
+- **Tool routing** (`openai_tool_parse`): parses `tools` and
+  `tool_choice` for branch-chain routing without mutating
+  the body.
 
 ## Anthropic Messages API
 
@@ -89,22 +91,24 @@ health checks, etc.), see the
 
 ## AI Agentic
 
-- **JSON-RPC 2.0 foundation** (`json_rpc`): request
-  envelope parsing and method/id extraction for HTTP
-  POST bodies, enabling method-based routing for
-  MCP/A2A-style traffic.
-- **MCP proxying** (`mcp`): Model Context Protocol
-  broker with tool discovery and routing via the
-  filter pipeline.
-- **A2A proxying** (`a2a`): Agent-to-Agent protocol
-  support with task routing via the filter pipeline.
+- **JSON-RPC 2.0 foundation** (`json_rpc`, core): request
+  envelope parsing for MCP/A2A-style traffic.
+- **MCP proxying** (`mcp`): MCP broker with catalog and
+  session metadata; `tools/call` is not forwarded by the
+  stateless broker profile.
+- **A2A proxying** (`a2a`): task routing and SSE detection
+  for Agent-to-Agent traffic.
 
 ## Security and Observability
 
-- **AI guardrails** (`ai_guardrails`): calls an
-  external AI guardrail provider to evaluate request
-  bodies. The provider determines whether content
-  should be passed, blocked, or redacted.
+- **AI guardrails** (`ai_guardrails`): calls an external AI
+  guardrail provider to evaluate request (and eventually response)
+  bodies. The provider determines whether content should be passed,
+  blocked, or redacted. Request-side evaluation is not wired yet;
+  response-side work is tracked in
+  [#50](https://github.com/praxis-proxy/ai/issues/50).
+- **Token counting** (`token_count`): extracts usage from
+  provider responses (JSON and SSE) into filter metadata.
 - **Token usage headers** (`token_usage_headers`):
   injects `Praxis-Token-Input`, `Praxis-Token-Output`,
   and `Praxis-Token-Total` headers into downstream

--- a/docs/filters/README.md
+++ b/docs/filters/README.md
@@ -21,11 +21,17 @@ apis/src/                 Provider API filters
   token_usage/            Token counting
 
 filters/src/              Cross-provider filters
-  agentic/                MCP, A2A, JSON-RPC
+  agentic/                MCP, A2A
   guardrails/             AI content guardrails
-  inference/              Model routing, credentials
-  prompt_enrich/          Prompt injection
+  inference/              Model body field to header promotion
+  prompt_enrich/          Chat completion message injection
+  token_count/            Response token usage extraction
+  token_usage_headers.rs  Per-response token count headers
 ```
+
+Core builtins used alongside AI filters: `json_rpc`,
+`credential_injection`, `router`, `load_balancer`. See
+[Praxis core filter reference][praxis-filters].
 
 ### Provider APIs (`praxis-ai-apis`)
 
@@ -43,6 +49,8 @@ filters/src/              Cross-provider filters
 | `openai_response_store` | Persists responses to storage backend |
 | `openai_conversations` | Handles `/v1/conversations` endpoints |
 | `openai_responses_proxy` | Rebuilds request body from `ResponsesState` |
+| `openai_stream_events` | Accumulates Responses API SSE events |
+| `openai_tool_parse` | Parses tools for branch routing |
 
 ### Cross-Provider Filters (`praxis-ai-filters`)
 
@@ -50,10 +58,10 @@ filters/src/              Cross-provider filters
 |--------|-------------|
 | `a2a` | A2A protocol metadata extraction |
 | `mcp` | MCP protocol broker and routing |
-| `json_rpc` | JSON-RPC 2.0 envelope parsing |
 | `ai_guardrails` | External guardrail provider integration |
 | `model_to_header` | Promotes `model` body field to header |
 | `prompt_enrich` | Injects messages into chat completions |
+| `token_count` | Extracts token usage into filter metadata |
 | `token_usage_headers` | Token count response headers |
 
 ## Registration

--- a/docs/filters/a2a.md
+++ b/docs/filters/a2a.md
@@ -22,7 +22,7 @@ When `task_routing.enabled` is true, the filter captures task and context owners
 | `headers.task_id` | string | no | Header name for the extracted task ID (e.g. `x-praxis-a2a-task-id`). |
 | `headers.version` | string | no | Header name for A2A version (e.g. `x-praxis-a2a-version`). |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer`. |
-| `method_aliases` | object<string, string> | no | Method aliases for compatibility (slash-delimited → `PascalCase`). |
+| `method_aliases` | `object<string, string>` | no | Method aliases for compatibility (slash-delimited to `PascalCase`). |
 | `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
 | `task_routing` | TaskRoutingConfig | no | Task-ownership routing configuration. |
 | `task_routing.enabled` | bool | no | Whether task routing is enabled. |

--- a/docs/filters/ai_guardrails.md
+++ b/docs/filters/ai_guardrails.md
@@ -5,6 +5,10 @@
 
 Calls an external AI guardrail provider to evaluate request (and eventually response) bodies. The provider determines whether content should be passed, blocked, or redacted.
 
+## Configuration Notes
+
+**Implementation status:** Request-side evaluation is not wired yet; bodies are buffered via `StreamBuffer` but `on_request_body` returns `Continue` unconditionally. Response-side evaluation is tracked in <https://github.com/praxis-proxy/ai/issues/50>.
+
 ## Configuration
 
 | Field | Type | Required | Description |

--- a/docs/filters/extensions.md
+++ b/docs/filters/extensions.md
@@ -7,6 +7,32 @@ register into the shared `FilterRegistry`.
 
 [praxis]: https://github.com/praxis-proxy/praxis
 
+## filter_metadata
+
+Praxis attaches a per-request `filter_metadata` map to
+[`HttpFilterContext`][http-filter-context] from Praxis
+core. Filters store flat string key-value pairs that
+persist across all HTTP lifecycle phases on the same
+request (request, request-body, response,
+response-body).
+
+Keys use dot-prefix namespacing by convention (for
+example `token.input`, `token.output`, `a2a.method`).
+Upstream filters write values; downstream filters read
+them in later phases without coupling to each other's
+internals. Note the phase-ordering constraint: `token_count`
+writes body-derived counts in `on_response_body`, while
+`token_usage_headers` reads metadata in `on_response`, so
+those two filters cannot chain into response headers in one
+pass (see [token-counting](../token-counting.md) and
+[proposal 00214](../proposals/00214_token-usage-response-headers.md)).
+
+Custom filters can read and write `filter_metadata` via
+`ctx.filter_metadata` in `on_request`, `on_response`,
+and body hooks.
+
+[http-filter-context]: https://github.com/praxis-proxy/praxis/blob/main/filter/src/context.rs
+
 ## Auto-Discovery (Recommended)
 
 External filter crates can self-register into Praxis AI
@@ -41,7 +67,7 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = "0.1"
-praxis-proxy-filter = "0.3"
+praxis-proxy-filter = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = { package = "yaml_serde", version = "0.10" }
 ```
@@ -294,3 +320,18 @@ filter with `FilterFactory::Http(Arc::new(factory))`,
 build a minimal YAML config, and assert on status codes
 and response bodies. See `tests/integration/` for
 examples.
+
+Built-in filter reference pages are generated from source.
+After changing a filter config struct, run:
+
+```console
+cargo xtask generate-filter-docs
+```
+
+CI runs `cargo xtask lint-filter-docs` as part of `make lint`.
+Every example under `examples/configs/` must have an
+integration test (or an entry in the SKIP allowlist):
+
+```console
+cargo xtask lint-example-tests
+```

--- a/docs/filters/openai_conversations.md
+++ b/docs/filters/openai_conversations.md
@@ -14,7 +14,7 @@ All matched requests are served from the local store and never forwarded upstrea
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
 | `backend` | `sqlite` \| `postgres` | yes | Storage backend to use. |
-| `database_url` | string (secret) | yes | Database connection URL. Wrapped in [`SecretString`] to prevent accidental logging of credentials. |
+| `database_url` | string (secret) | yes | Database connection URL. Wrapped in `SecretString` to prevent accidental logging of credentials. |
 | `conversations_table` | string | no | Table name for conversation records. |
 | `items_table` | string | no | Table name for conversation item records. |
 | `ssl_mode` | SslMode | no | TLS mode for `PostgreSQL` connections. Only valid when `backend` is `postgres`. Overrides any `sslmode` parameter in the connection URL. |

--- a/docs/filters/openai_response_store.md
+++ b/docs/filters/openai_response_store.md
@@ -10,7 +10,7 @@ Persists Responses API responses to the configured response store backend.
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
 | `backend` | `sqlite` \| `postgres` | yes | Storage backend to use. |
-| `database_url` | string (secret) | yes | Database connection URL. Wrapped in [`SecretString`] to prevent accidental logging of credentials. |
+| `database_url` | string (secret) | yes | Database connection URL. Wrapped in `SecretString` to prevent accidental logging of credentials. |
 | `responses_table` | string | yes | Table name for response records. |
 | `conversations_table` | string | yes | Table name for conversation message records. |
 | `ssl_mode` | SslMode | no | TLS mode for `PostgreSQL` connections. Only valid when `backend` is `postgres`. Overrides any `sslmode` parameter in the connection URL. |

--- a/docs/filters/openai_responses_format.md
+++ b/docs/filters/openai_responses_format.md
@@ -47,3 +47,6 @@ headers:
   stream: x-praxis-ai-stream
   mode: x-praxis-responses-mode
 ```
+
+## Related examples
+- [responses-routing.yaml](../../examples/configs/openai/responses/responses-routing.yaml)

--- a/docs/filters/openai_responses_model_rewrite.md
+++ b/docs/filters/openai_responses_model_rewrite.md
@@ -18,7 +18,7 @@ Quote wildcard alias keys in YAML, such as `"gpt-4.1-*"`, so `*` is parsed as a 
 | `headers.effective_model` | string | no | Header name for the effective (post-rewrite) model value. |
 | `headers.original_model` | string | no | Header name for the original (pre-rewrite) model value. |
 | `max_body_bytes` | integer | no | Maximum request body size to buffer before parsing. |
-| `model_aliases` | object<string, string> | no | Map from client-facing model names or single-wildcard patterns to backend model names. Quote wildcard keys in YAML. Exact aliases win before wildcard aliases; wildcard aliases are matched by literal specificity. |
+| `model_aliases` | `object<string, string>` | no | Map from client-facing model names or single-wildcard patterns to backend model names. Quote wildcard keys in YAML. Exact aliases win before wildcard aliases; wildcard aliases are matched by literal specificity. |
 | `on_invalid` | `continue` \| `reject` | no | Behavior when the body is not valid JSON. |
 
 ## Examples

--- a/docs/filters/openai_responses_validate.md
+++ b/docs/filters/openai_responses_validate.md
@@ -7,7 +7,7 @@ Validates and enriches Responses API requests.
 
 ## Configuration Notes
 
-Reads classifier metadata for parameter-combination checks, then parses the body as [`serde_json::Value`] for targeted field extraction. Does not deserialize the full body into a typed struct.
+Reads classifier metadata for parameter-combination checks, then parses the body as `serde_json::Value` for targeted field extraction. Does not deserialize the full body into a typed struct.
 
 Must be placed after `openai_responses_format` in the filter chain. Skips non-Responses API requests (those not classified as `openai_responses`).
 

--- a/docs/filters/openai_stream_events.md
+++ b/docs/filters/openai_stream_events.md
@@ -7,7 +7,7 @@ Accumulates state from native Responses API SSE event streams.
 
 ## Configuration Notes
 
-All fields are optional; omitted values fall back to [`SseParserConfig`] defaults.
+All fields are optional; omitted values fall back to `SseParserConfig` defaults.
 
 ## Configuration
 

--- a/docs/filters/openai_tool_parse.md
+++ b/docs/filters/openai_tool_parse.md
@@ -25,3 +25,6 @@ filter: openai_tool_parse
 filter: openai_tool_parse
 max_body_bytes: 67108864
 ```
+
+## Related examples
+- [tool-routing.yaml](../../examples/configs/openai/responses/tool-routing.yaml)

--- a/docs/filters/openai_web_search.md
+++ b/docs/filters/openai_web_search.md
@@ -14,7 +14,7 @@ Validates configuration and constructs a search client at startup. At runtime th
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
 | `provider` | `brave` \| `tavily` \| `you` | yes | Search backend provider. |
-| `api_key` | string (secret) | no | API key for the search provider (supports `${ENV_VAR}`). Wrapped in [`SecretString`] to prevent accidental logging. |
+| `api_key` | string (secret) | no | API key for the search provider (supports `${ENV_VAR}`). Wrapped in `SecretString` to prevent accidental logging. |
 | `default_context_size` | string | no | Default search context size when the client omits it. |
 | `timeout_ms` | integer | no | Callout timeout in milliseconds. |
 | `max_body_bytes` | integer | no | Maximum request body bytes to buffer. |

--- a/docs/filters/reference.md
+++ b/docs/filters/reference.md
@@ -71,10 +71,10 @@ see the [Praxis core filter reference][core-ref].
 
 | Filter | Description |
 |--------|-------------|
-| [`token_count`](token_count.md) | Extracts token usage from AI inference responses and writes unified counts to [`filter_metadata`]. |
+| [`token_count`](token_count.md) | Extracts token usage from AI inference responses and writes unified counts to [filter_metadata](extensions.md#filter_metadata). |
 
 ### Token Usage
 
 | Filter | Description |
 |--------|-------------|
-| [`token_usage_headers`](token_usage_headers.md) | Injects `Praxis-Token-Input`, `Praxis-Token-Output`, and `Praxis-Token-Total` headers into downstream responses when token usage data is present in [`filter_metadata`]. |
+| [`token_usage_headers`](token_usage_headers.md) | Injects `Praxis-Token-Input`, `Praxis-Token-Output`, and `Praxis-Token-Total` headers into downstream responses when token usage data is present in [filter_metadata](extensions.md#filter_metadata). |

--- a/docs/filters/token_count.md
+++ b/docs/filters/token_count.md
@@ -3,7 +3,7 @@
 
 # `token_count`
 
-Extracts token usage from AI inference responses and writes unified counts to [`filter_metadata`].
+Extracts token usage from AI inference responses and writes unified counts to [filter_metadata](extensions.md#filter_metadata).
 
 ## Configuration Notes
 

--- a/docs/filters/token_usage_headers.md
+++ b/docs/filters/token_usage_headers.md
@@ -3,7 +3,7 @@
 
 # `token_usage_headers`
 
-Injects `Praxis-Token-Input`, `Praxis-Token-Output`, and `Praxis-Token-Total` headers into downstream responses when token usage data is present in [`filter_metadata`].
+Injects `Praxis-Token-Input`, `Praxis-Token-Output`, and `Praxis-Token-Total` headers into downstream responses when token usage data is present in [filter_metadata](extensions.md#filter_metadata).
 
 ## Configuration Notes
 

--- a/docs/openai-responses.md
+++ b/docs/openai-responses.md
@@ -1,0 +1,267 @@
+# OpenAI Responses API
+
+Praxis AI supports the OpenAI Responses API (`/v1/responses`)
+and related endpoints through composable filters on the
+[AI Gateway][overview]. On the gateway data plane, Responses
+traffic is **routed** (body classification and cluster
+selection), **managed** (validation and policy), **enriched**
+(stored responses, conversation history, rehydration, and
+request rebuilding from pipeline state), and **parsed** (SSE
+events, tools, token usage). Operators can run minimal
+passthrough to OpenAI or a full stateful pipeline with local
+persistence and multi-turn context.
+
+This guide shows how to wire those filters with runnable
+examples and the outcomes to expect. For OpenAI request and
+response schemas, see the
+[OpenAI Responses API reference](https://platform.openai.com/docs/api-reference/responses).
+
+[overview]: overview.md
+
+## Filters
+
+Deploy filters in pipeline order: classify first, then validate,
+enrich/store/rehydrate as needed, route upstream.
+
+| Filter | Phase | Purpose |
+| ------ | ----- | ------- |
+| `openai_conversations` | Request/response | Local `/v1/conversations` CRUD |
+| `openai_responses_format` | Request | Classify format; promote routing headers |
+| `openai_responses_validate` | Request | Parameter checks; generate IDs |
+| `openai_tool_parse` | Request | Parse tools for branch routing |
+| `openai_responses_rehydrate` | Request | Load history from `previous_response_id` |
+| `openai_responses_proxy` | Request | Rebuild body from `ResponsesState` |
+| `openai_response_store` | Request/response | Persist responses; local GET/DELETE |
+| `openai_stream_events` | Request/response | Accumulate streaming SSE events |
+| `openai_responses_model_rewrite` | Request body | Rewrite `model` field |
+
+Per-filter configuration: [filter reference](filters/reference.md).
+
+## Run an example locally
+
+Example configs under `examples/configs/openai/responses/` use
+local upstream ports (commonly `127.0.0.1:8000`). Start a stub
+or inference backend on those ports before sending traffic.
+
+```console
+cargo run -p praxis-ai-proxy -- \
+  -c examples/configs/openai/responses/request-validate.yaml
+```
+
+In another terminal, send requests to `http://127.0.0.1:8080`.
+See [examples/README.md](../examples/README.md#openai) for the
+full catalog.
+
+## Examples
+
+Each example below uses a config under
+`examples/configs/openai/`. Start the proxy with
+`-c <path>` and a stub backend on the configured upstream
+port (see [Run an example locally](#run-an-example-locally)).
+Integration tests live under
+`tests/integration/tests/suite/examples/`.
+
+### Validate and forward
+
+[request-validate.yaml](../examples/configs/openai/responses/request-validate.yaml)
+- `openai_responses_format` then `openai_responses_validate`
+before routing. Smallest **manage**-plane demo.
+
+Valid request:
+
+```console
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1","input":"Hello, world!"}'
+```
+
+**Expect:** HTTP **200** and the upstream body unchanged
+(tests use an echo backend returning `ok`).
+
+Invalid request:
+
+```console
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1","input":"test","stream":true,"background":true}'
+```
+
+**Expect:** HTTP **400** (SSE `type: error` when `stream: true`;
+JSON error otherwise). Upstream is not called.
+
+**Tests:** `openai_responses_validate.rs`
+
+### Route by body format
+
+[format-routing.yaml](../examples/configs/openai/responses/format-routing.yaml)
+- **route** plane: `openai_responses_format` promotes
+`x-praxis-ai-format`; router picks the cluster.
+
+```console
+# Responses API shape -> responses-backend cluster
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1-mini","input":"Hello"}'
+```
+
+**Expect:** HTTP **200**, response body `responses-backend`.
+
+```console
+# Chat Completions shape -> chat-backend cluster
+curl -sS -X POST http://127.0.0.1:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Hi"}]}'
+```
+
+**Expect:** HTTP **200**, response body `chat-backend`.
+
+**Tests:** `openai_responses_format.rs`
+
+### Enrichment: persist and serve locally
+
+[response-store.yaml](../examples/configs/openai/responses/response-store.yaml)
+- **enrich** plane: `openai_response_store` persists
+non-streaming POST responses and serves GET/DELETE at the
+gateway without calling upstream.
+
+```console
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1","input":"Hello"}'
+```
+
+**Expect:** HTTP **200** and the upstream Responses JSON
+returned to the client (e.g. `id`, `output`, ...). The same
+response is written to the configured store (SQLite or
+PostgreSQL).
+
+```console
+curl -sS http://127.0.0.1:8080/v1/responses/resp_abc
+```
+
+**Expect:** HTTP **200** and the stored JSON from the
+gateway - not a round trip to the inference backend.
+
+```console
+curl -sS -X DELETE http://127.0.0.1:8080/v1/responses/resp_abc
+```
+
+**Expect:** HTTP **200** and `{"id":"resp_abc","deleted":true}`.
+
+**Tests:** `openai_response_store.rs`
+
+### Enrichment: rehydrate a previous turn
+
+[rehydrate.yaml](../examples/configs/openai/responses/rehydrate.yaml)
+- **enrich** plane: validates `previous_response_id`
+against the store and loads history into pipeline state
+before forwarding.
+
+Turn 1 - seed the store:
+
+```console
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1","input":"Hello"}'
+```
+
+**Expect:** HTTP **200** and upstream Responses JSON (e.g.
+`id: resp_first`, `status: completed`).
+
+Turn 2 - follow-up with stored ID:
+
+```console
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1","input":"What next?","previous_response_id":"resp_first"}'
+```
+
+**Expect:** HTTP **200**. Rehydration succeeds when the
+stored response exists and is `completed`; the request body
+reaches upstream unchanged (`input` and
+`previous_response_id` preserved). A missing or incomplete
+stored ID is rejected by the rehydrate filter.
+
+**Tests:** `rehydrate.rs`
+
+### Example index
+
+| Goal | Example | Integration tests |
+| ---- | ------- | ----------------- |
+| Validate parameter combinations | [request-validate.yaml](../examples/configs/openai/responses/request-validate.yaml) | `openai_responses_validate.rs` |
+| Route by detected body format | [format-routing.yaml](../examples/configs/openai/responses/format-routing.yaml) | `openai_responses_format.rs` |
+| Route stateful vs stateless mode | [responses-routing.yaml](../examples/configs/openai/responses/responses-routing.yaml) | `responses_routing.rs` |
+| Persist responses; local GET/DELETE | [response-store.yaml](../examples/configs/openai/responses/response-store.yaml) | `openai_response_store.rs` |
+| Rehydrate `previous_response_id` | [rehydrate.yaml](../examples/configs/openai/responses/rehydrate.yaml) | `rehydrate.rs` |
+| Tool-based branch routing | [tool-routing.yaml](../examples/configs/openai/responses/tool-routing.yaml) | `openai_tool_parse.rs` |
+| Rewrite model before upstream | [model-rewrite.yaml](../examples/configs/openai/responses/model-rewrite.yaml) | `openai_responses_model_rewrite.rs` |
+| Accumulate streaming SSE state | [stream-events.yaml](../examples/configs/openai/responses/stream-events.yaml) | `openai_stream_events.rs` |
+| Local conversations CRUD | [conversations.yaml](../examples/configs/openai/conversations/conversations.yaml) | `openai_conversations.rs` |
+| Full multi-filter pipeline | [full-flow.yaml](../examples/configs/openai/responses/full-flow.yaml) | `session_replay.rs` |
+
+## Production passthrough to OpenAI
+
+To forward validated traffic to `api.openai.com`, add TLS upstream
+config and supply a client or injected API key. A minimal chain:
+
+```yaml
+filter_chains:
+  - name: responses
+    filters:
+      - filter: openai_responses_format
+      - filter: openai_responses_validate
+      - filter: router
+        routes:
+          - path_prefix: "/v1"
+            cluster: openai
+      - filter: load_balancer
+        clusters:
+          - name: openai
+            endpoints: ["api.openai.com:443"]
+            tls:
+              sni: "api.openai.com"
+```
+
+```console
+curl -sS -X POST http://127.0.0.1:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{"model":"gpt-4o","input":"Hello"}'
+```
+
+**Expect:** HTTP **200** and an OpenAI Responses JSON body (`id`,
+`output`, `usage`, ...) - same shape as calling the provider
+directly. Classification and validation are transparent on the
+happy path. For credential injection instead of client-supplied
+keys, see [credential-injection.yaml](../examples/configs/credential-injection.yaml).
+
+## Stateful pipeline
+
+Multi-turn traffic with storage, rehydration, and tool routing
+uses more filters. Reference implementation:
+[full-flow.yaml](../examples/configs/openai/responses/full-flow.yaml).
+
+Typical order:
+
+```text
+openai_conversations -> openai_responses_format -> openai_responses_validate
+  -> openai_tool_parse -> openai_response_store -> openai_stream_events
+  -> openai_responses_rehydrate -> openai_responses_proxy -> router -> load_balancer
+```
+
+A request is **stateful** when any of these hold:
+`previous_response_id`, non-empty `tools`, `store: true`
+(default), `background: true`, `conversation`, or `prompt.id`.
+
+**What to look for:** persisted `resp_*` IDs, local
+`GET /v1/responses/{id}`, conversation append-back, and replay
+coverage in `tests/integration/fixtures/replay/codex/responses-basic.json`.
+
+Storage design: [Response store](architecture/response-store.md).
+
+## Related
+
+- [AI inference](architecture/ai-inference.md)
+- [Token counting](token-counting.md)
+- [Filter reference](filters/reference.md)
+- [Example configs](../examples/README.md#openai)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,116 @@
+# AI Gateway
+
+Praxis AI (`praxis-ai`) is an **AI-native proxy server** and
+**AI Gateway** (also deployable as an **AI API Gateway**).
+It extends the [Praxis][praxis] composable filter pipeline
+with AI-specific filters that classify, enrich, and parse
+inference and agentic traffic between workloads and model
+or agent backends.
+
+Router, load balancer, TLS, CORS, rate limiting, and other
+core filters come from Praxis. AI filters register into the
+same YAML filter pipeline.
+
+[praxis]: https://github.com/praxis-proxy/praxis
+
+## What is an AI Gateway?
+
+An AI Gateway is a filter pipeline dedicated to inference and
+agentic workloads. Callers may be external clients, in-cluster
+applications, or outbound services; backends may be hosted
+models, provider APIs, or agent runtimes.
+
+The gateway:
+
+- **Routes** traffic to the right provider or cluster
+- **Manages** policy, credentials, rate limits, content
+  safety, and resilience
+- **Enriches** prompts and conversation state
+- **Parses** request and response bodies (JSON and SSE)
+
+Unlike routing on URL and headers alone, an AI Gateway
+classifies provider API formats from request bodies and
+applies policy in the data plane. Content safety combines
+core [`guardrails`](https://github.com/praxis-proxy/praxis/blob/main/docs/filters/http/security/guardrails.md)
+(rule and PII matching) with
+[`ai_guardrails`](features.md#security-and-observability)
+(external provider evaluation for pass, block, or redact).
+Rate limiting and credential controls use the same core
+filters as any Praxis deployment.
+
+## AI-native proxy server
+
+An **AI-native proxy server** understands AI wire formats
+incrementally: OpenAI Responses and Chat Completions,
+Anthropic Messages, and agentic JSON-RPC (MCP, A2A). It uses
+[StreamBuffer][streambuffer] body access to inspect JSON
+before upstream selection, handles streaming SSE responses,
+and shares facts across filter phases via
+[`filter_metadata`][filter-metadata].
+
+[streambuffer]: https://github.com/praxis-proxy/praxis/blob/main/docs/architecture/payload-processing.md
+[filter-metadata]: filters/extensions.md#filter_metadata
+
+## Primary use-cases
+
+- **Ingress**: API gateway for external clients and partners
+- **Egress**: Application outbound calls to provider APIs
+- **In-cluster**: Kubernetes `Service` (or similar) for
+  pod-to-model traffic
+
+```text
+  [ Client / Pod / Service ]
+            |
+            v
+     +--------------+
+     |  praxis-ai   |  classify, guard, enrich, limit, parse
+     +--------------+
+            |
+     +------+------+------+
+     v      v      v      v
+  OpenAI  Anthropic  MCP  A2A backends
+```
+
+YAML and filter chains are the same across placements; only
+listener address, TLS, and upstream clusters change per
+environment.
+
+## Route, manage, enrich, parse
+
+| Plane | What it does | Examples |
+| ----- | ------------ | -------- |
+| **Route** | Classify format; pick upstream cluster | `openai_responses_format`, `anthropic_messages_format`, `model_to_header`, `router`, branch chains |
+| **Manage** | Policy, limits, credentials, resilience | `rate_limit`, `credential_injection`, `guardrails` (core), `ai_guardrails`, `ip_acl`, health checks, circuit breaker |
+| **Enrich** | Prompts, stored state, multi-turn context | `prompt_enrich`, `openai_responses_rehydrate`, `openai_response_store`, `openai_conversations` |
+| **Parse** | Bodies, SSE, agentic metadata, usage | StreamBuffer classifiers, `token_count`, `mcp`, `a2a`, `json_rpc` |
+
+See [Features](features.md) for the full filter list.
+
+## Unified AI API Gateway
+
+A single listener can front multiple provider APIs. Classifier
+filters promote format and model facts to headers; the router
+selects the backend cluster. Example:
+[unified-gateway.yaml](../examples/configs/anthropic/unified-gateway.yaml).
+
+## Praxis core vs praxis-ai
+
+| | `praxis` | `praxis-ai` |
+| - | -------- | ----------- |
+| **Role** | General proxy framework (ingress, egress, load balancing) | AI Gateway on the same runtime |
+| **AI filters** | No | Yes (provider APIs, agentic, store, tokens) |
+| **Config** | YAML filter chains | Same format |
+
+Deploy `praxis` for non-AI or custom binaries. Deploy
+`praxis-ai` when workloads need an AI Gateway or AI API
+Gateway out of the box.
+
+## Next steps
+
+- [Quickstart](quickstart.md)
+- [Features](features.md)
+- [AI inference pipeline](architecture/ai-inference.md)
+- [OpenAI Responses API](openai-responses.md)
+- [Anthropic Messages API](anthropic-messages.md)
+- [Agentic protocols](architecture/agentic-protocols.md)
+- [Filter reference](filters/reference.md)

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -24,7 +24,7 @@ Build consensus with community members.
 > what you're bringing up is a real concern that needs to
 > be addressed, regardless of "How?" it is addressed.
 
-[GitHub Discussion]: https://github.com/praxis-proxy/praxis/discussions
+[GitHub Discussion]: https://github.com/praxis-proxy/ai/discussions
 
 ### 2. Sign-off
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,12 +66,18 @@ curl http://127.0.0.1:8080/v1/responses \
   -d '{"model": "gpt-4o", "input": "Hello"}'
 ```
 
+## Deployment
+
+The same YAML serves ingress, egress, or in-cluster
+placements; change listener address, TLS, and upstream
+clusters per environment. Filter chains stay the same.
+See [AI Gateway overview](overview.md) for use-cases.
+
 ## Next steps
 
-- [Example configs](../examples/README.md): working YAML
-  for every feature.
-- [Filters](filters/README.md): AI filters and how to
-  write your own.
-- [Praxis core](https://github.com/praxis-proxy/praxis):
-  listener, filter-chain, routing, and load-balancer
-  configuration.
+- [AI Gateway overview](overview.md)
+- [OpenAI Responses](openai-responses.md) and
+  [Anthropic Messages](anthropic-messages.md) guides
+- [Example configs](../examples/README.md)
+- [Filters](filters/README.md)
+- [Praxis core](https://github.com/praxis-proxy/praxis)

--- a/docs/token-counting.md
+++ b/docs/token-counting.md
@@ -1,0 +1,69 @@
+# Token Counting
+
+Part of the **parse** plane on the [AI Gateway][overview]:
+extract token usage from AI provider responses and write
+unified counts to filter metadata.
+
+[overview]: overview.md
+
+## `token_count` filter
+
+`token_count` inspects upstream response bodies (JSON or SSE),
+parses provider-specific usage fields, and writes
+`token.input`, `token.output`, and `token.total` to
+`filter_metadata`. Response bodies pass through unchanged.
+
+Set `provider` to match your upstream:
+
+| Value | Formats |
+| ----- | ------- |
+| `openai` | OpenAI Chat Completions, Responses API |
+| `anthropic` | Anthropic Messages (JSON and SSE) |
+| `google` | Gemini-style usage blocks |
+| `bedrock` | AWS Bedrock Converse API and Claude InvokeModel |
+| `azure` | Azure OpenAI (same JSON as OpenAI) |
+
+Example:
+
+```yaml
+filter_chains:
+  - name: ai
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/v1"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints: ["127.0.0.1:3000"]
+      - filter: token_count
+        provider: openai
+```
+
+Working config: [token-counting.yaml](../examples/configs/token-counting.yaml).
+
+## `token_usage_headers` filter
+
+`token_usage_headers` injects `Praxis-Token-Input`,
+`Praxis-Token-Output`, and `Praxis-Token-Total` when those
+metadata keys are already present. It runs in `on_response`,
+before response body chunks are processed.
+
+`token_count` writes usage in `on_response_body` after the
+body is parsed. **A single-pass pipeline cannot yet turn
+body-derived counts into client response headers.** The
+[token usage headers proposal](proposals/00214_token-usage-response-headers.md)
+documents the limitation and open options (trailers, buffering,
+or a later pipeline hook).
+
+Use `token_usage_headers` today when another filter (or an
+earlier hook) populates token metadata before `on_response`.
+Otherwise it is a no-op, as in
+[token-usage-headers.yaml](../examples/configs/token-usage-headers.yaml).
+
+## Related
+
+- [Filter reference](filters/reference.md)
+- [Features](features.md#security-and-observability)
+- [Proposal 00214](proposals/00214_token-usage-response-headers.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,12 +13,17 @@ Configs use local ports (`3000`, `3001`, ...) for
 upstreams — start a real backend or stub on those ports
 before sending requests.
 
+**Model routing:** `model-to-header-routing.yaml` uses the
+AI `model_to_header` filter. `ai-inference-body-based-routing.yaml`
+uses the core `json_body_field` filter for the same pattern.
+
 ## Configs
 
 ### General
 
 | File | Description |
 | ------ | ------------- |
+| [ai-guardrails.yaml](configs/ai-guardrails.yaml) | ai_guardrails filter with NeMo provider config (request evaluation not yet wired) |
 | [a2a-agent-card-routing.yaml](configs/a2a-agent-card-routing.yaml) | Routes agent card discovery requests to dedicated backends |
 | [a2a-classifier-routing.yaml](configs/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, context ID, task ID, and streaming detection |
 | [a2a-task-routing.yaml](configs/a2a-task-routing.yaml) | Captures task and context ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up requests back to the backend cluster that created the task or owns the context |
@@ -39,7 +44,7 @@ before sending requests.
 | [messages-protocol.yaml](configs/anthropic/messages-protocol.yaml) | Routes Anthropic Messages API requests to a native `/v1/messages` backend |
 | [messages-to-openai.yaml](configs/anthropic/messages-to-openai.yaml) | Transforms Anthropic Messages API requests and responses for Chat Completions-compatible inference backends |
 | [request-validate.yaml](configs/anthropic/request-validate.yaml) | Rejects empty, malformed, or non-object JSON request bodies |
-| [unified-gateway.yaml](configs/anthropic/unified-gateway.yaml) | Routes traffic by classifier-promoted headers so a single listener handles Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses requests |
+| [unified-gateway.yaml](configs/anthropic/unified-gateway.yaml) | Unified AI API Gateway: one listener routes Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses by classifier-promoted headers |
 
 ### OpenAI
 

--- a/examples/configs/ai-guardrails.yaml
+++ b/examples/configs/ai-guardrails.yaml
@@ -1,0 +1,45 @@
+# AI Guardrails
+#
+# Buffers request bodies and is intended to call an external AI
+# guardrail provider (NeMo) before routing. The provider determines
+# whether content should be passed, blocked, or redacted.
+#
+# Implementation status: request-side evaluation is not wired yet;
+# bodies pass through unconditionally. Deploy a NeMo Guardrails
+# service at the configured endpoint before enabling blocking
+# behavior once integration ships.
+#
+# Example request:
+#
+#   curl -X POST http://localhost:8080/v1/chat/completions \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}'
+
+listeners:
+  - name: gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [guardrails, routing]
+
+filter_chains:
+  - name: guardrails
+    filters:
+      - filter: ai_guardrails
+        provider:
+          type: nemo
+          endpoint: "http://127.0.0.1:8000/v1/guardrail/checks"
+          timeout_ms: 5000
+        phase:
+          request: true
+          response: false
+
+  - name: routing
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:3000"

--- a/filters/src/agentic/a2a/config.rs
+++ b/filters/src/agentic/a2a/config.rs
@@ -264,7 +264,7 @@ pub(crate) struct A2aConfig {
     #[serde(default = "default_max_body_bytes")]
     pub max_body_bytes: usize,
 
-    /// Method aliases for compatibility (slash-delimited → `PascalCase`).
+    /// Method aliases for compatibility (slash-delimited to `PascalCase`).
     #[serde(default)]
     pub method_aliases: BTreeMap<String, String>,
 

--- a/filters/src/guardrails/filter.rs
+++ b/filters/src/guardrails/filter.rs
@@ -25,6 +25,11 @@ const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576;
 /// eventually response) bodies. The provider determines whether
 /// content should be passed, blocked, or redacted.
 ///
+/// **Implementation status:** Request-side evaluation is not wired
+/// yet; bodies are buffered via `StreamBuffer` but `on_request_body`
+/// returns `Continue` unconditionally. Response-side evaluation is
+/// tracked in <https://github.com/praxis-proxy/ai/issues/50>.
+///
 /// # YAML configuration
 ///
 /// ```yaml

--- a/filters/src/guardrails/mod.rs
+++ b/filters/src/guardrails/mod.rs
@@ -3,6 +3,7 @@
 
 //! AI guardrails filter: calls external content safety providers
 //! (e.g. `NeMo` Guardrails) to evaluate request and response bodies.
+//! Request-side evaluation is not wired yet.
 
 mod config;
 mod filter;

--- a/tests/integration/tests/suite/examples/ai_guardrails.rs
+++ b/tests/integration/tests/suite/examples/ai_guardrails.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the AI guardrails example configuration.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{free_port, http_send, json_post, parse_body, parse_status, start_echo_backend, start_proxy};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ai_guardrails_config_parses() {
+    let config = super::load_example_config(
+        "ai-guardrails.yaml",
+        29920,
+        HashMap::from([("127.0.0.1:3000", 29921_u16)]),
+    );
+
+    assert_eq!(config.listeners.len(), 1, "should have 1 listener");
+    assert_eq!(&*config.listeners[0].name, "gateway", "listener name should be gateway");
+}
+
+#[test]
+fn ai_guardrails_passes_chat_request_through() {
+    let backend_guard = start_echo_backend();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+
+    let config = super::load_example_config(
+        "ai-guardrails.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3000", backend_port)]),
+    );
+
+    let proxy = start_proxy(&config);
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "request should reach backend");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("backend should echo valid JSON");
+    assert_eq!(parsed["model"], "gpt-4o", "body should pass through unchanged");
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -8,6 +8,7 @@ mod test_utils;
 pub use test_utils::load_example_config;
 
 mod agentic_routing;
+mod ai_guardrails;
 mod anthropic_messages;
 mod credential_injection;
 mod full_flow;

--- a/xtask/src/filter_docs.rs
+++ b/xtask/src/filter_docs.rs
@@ -1431,7 +1431,7 @@ fn render_map_type(segment: &syn::PathSegment, enums: &BTreeMap<String, EnumInfo
         .first()
         .map_or_else(|| "string".to_owned(), |t| render_type(t, enums));
     let value = args.get(1).map_or_else(|| "any".to_owned(), |t| render_type(t, enums));
-    format!("object<{key}, {value}>")
+    format!("`object<{key}, {value}>`")
 }
 
 /// Render the inner type argument or a fallback.
@@ -1545,12 +1545,12 @@ fn config_notes(doc: &str) -> Vec<String> {
 
 /// Normalize one config doc paragraph into prose, dropping fenced code.
 fn normalize_config_note(paragraph: &str) -> Option<String> {
-    normalize_doc_prose(paragraph)
+    normalize_doc_prose(paragraph).map(|note| fix_broken_md_links(&note))
 }
 
 /// Normalize one field doc comment into safe table-cell prose.
 fn normalize_field_doc(doc: &str) -> String {
-    normalize_doc_prose(doc).unwrap_or_default().replace('|', "\\|")
+    fix_broken_md_links(&normalize_doc_prose(doc).unwrap_or_default()).replace('|', "\\|")
 }
 
 /// Normalize doc comment prose, dropping fenced code and reference definitions.
@@ -1588,17 +1588,113 @@ fn render_filter_doc(entry: &FilterEntry) -> String {
     writeln!(out).unwrap();
 
     if !entry.filter.description.is_empty() {
-        writeln!(out, "{}", entry.filter.description).unwrap();
+        writeln!(out, "{}", fix_broken_md_links(&entry.filter.description)).unwrap();
     }
     for description in &entry.filter.extra_descriptions {
         writeln!(out).unwrap();
-        writeln!(out, "{description}").unwrap();
+        writeln!(out, "{}", fix_broken_md_links(description)).unwrap();
     }
 
     render_config_notes(&mut out, &entry.filter.config_notes);
     render_config_table(&mut out, &entry.filter.fields);
     render_yaml_examples(&mut out, &entry.filter.yaml_examples);
+    render_related_examples(&mut out, &workspace_root(), &entry.filter.name);
     out
+}
+
+/// Return a markdown link for rustdoc intradoc symbols that have a
+/// stable docs target. Unmapped symbols fall back to inline code.
+fn intradoc_link_target(symbol: &str) -> Option<&'static str> {
+    match symbol {
+        "filter_metadata" => Some("[filter_metadata](extensions.md#filter_metadata)"),
+        _ => None,
+    }
+}
+
+/// Replace broken intradoc links like `` [`Name`] `` with inline code
+/// or a mapped markdown link when a stable target exists.
+fn fix_broken_md_links(text: &str) -> String {
+    let mut result = text.to_owned();
+    let mut search_from = 0;
+    while let Some(tail) = result.get(search_from..)
+        && let Some(rel_start) = tail.find("[`")
+    {
+        let start = search_from + rel_start;
+        let Some(end_tail) = result.get(start..) else {
+            break;
+        };
+        let Some(rel_end) = end_tail.find("`]") else {
+            break;
+        };
+        let end = start + rel_end + 2;
+        if result.get(end..).is_some_and(|rest| rest.starts_with('(')) {
+            search_from = end;
+            continue;
+        }
+        let Some(inner) = result.get(start + 2..end.saturating_sub(2)) else {
+            break;
+        };
+        let inner = inner.to_owned();
+        let suffix = result.get(end..).unwrap_or("").to_owned();
+        let prefix = result.get(..start).unwrap_or("");
+        let replacement = intradoc_link_target(&inner).map_or_else(|| format!("`{inner}`"), str::to_owned);
+        result = format!("{prefix}{replacement}{suffix}");
+        search_from = start.saturating_add(replacement.len());
+    }
+    result
+}
+
+/// List example config paths that reference the given filter.
+fn discover_example_paths(root: &Path, filter_name: &str) -> Vec<String> {
+    let examples_dir = root.join("examples/configs");
+    let mut yaml_files = Vec::new();
+    collect_yaml_files(&examples_dir, &mut yaml_files);
+    let mut matches = Vec::new();
+    for path in yaml_files {
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let matches_filter = content.lines().any(|line| {
+            line.trim()
+                .strip_prefix("filter:")
+                .is_some_and(|rest| rest.trim() == filter_name)
+        });
+        if matches_filter && let Ok(rel) = path.strip_prefix(root) {
+            matches.push(rel.display().to_string().replace('\\', "/"));
+        }
+    }
+    matches.sort();
+    matches
+}
+
+/// Recursively collect `.yaml` files under `dir`.
+fn collect_yaml_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_yaml_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "yaml") {
+            out.push(path);
+        }
+    }
+}
+
+/// Append links to example configs that use this filter.
+fn render_related_examples(out: &mut String, root: &Path, filter_name: &str) {
+    let examples = discover_example_paths(root, filter_name);
+    if examples.is_empty() {
+        return;
+    }
+    writeln!(out).unwrap();
+    writeln!(out, "## Related examples").unwrap();
+    for path in examples {
+        let link = format!("../../{path}");
+        let label = path.rsplit('/').next().unwrap_or(&path);
+        writeln!(out, "- [{label}]({link})").unwrap();
+    }
 }
 
 /// Render configuration notes if present.
@@ -1727,7 +1823,8 @@ fn render_category_section(out: &mut String, category: &str, filters: &[&FilterE
     writeln!(out, "|--------|-------------|").unwrap();
     for f in filters {
         let link = format!("{}.md", f.filter.name);
-        writeln!(out, "| [`{}`]({link}) | {} |", f.filter.name, f.filter.description).unwrap();
+        let description = fix_broken_md_links(&f.filter.description);
+        writeln!(out, "| [`{}`]({link}) | {description} |", f.filter.name).unwrap();
     }
 }
 
@@ -1987,7 +2084,7 @@ mod tests {
         let doc = "Protocol versions accepted during negotiation.\nEvery entry must be implemented by this build (present in\n[`protocol::SUPPORTED_VERSIONS`]). Defaults to the versions\nthis build implements.";
         assert_eq!(
             normalize_field_doc(doc),
-            "Protocol versions accepted during negotiation. Every entry must be implemented by this build (present in [`protocol::SUPPORTED_VERSIONS`]). Defaults to the versions this build implements."
+            "Protocol versions accepted during negotiation. Every entry must be implemented by this build (present in `protocol::SUPPORTED_VERSIONS`). Defaults to the versions this build implements."
         );
     }
 
@@ -1996,8 +2093,27 @@ mod tests {
         let doc = "Uses [`Thing`] for validation.\n\n[`Thing`]: crate::Thing";
         assert_eq!(
             normalize_field_doc(doc),
-            "Uses [`Thing`] for validation.",
+            "Uses `Thing` for validation.",
             "reference definitions should not render inside table cells"
+        );
+    }
+
+    #[test]
+    fn fix_broken_md_links_maps_filter_metadata() {
+        let text = "Writes counts to [`filter_metadata`] for downstream filters.";
+        assert_eq!(
+            fix_broken_md_links(text),
+            "Writes counts to [filter_metadata](extensions.md#filter_metadata) for downstream filters."
+        );
+    }
+
+    #[test]
+    fn fix_broken_md_links_preserves_existing_links() {
+        let text = "See [`Thing`](https://example.com) for details.";
+        assert_eq!(
+            fix_broken_md_links(text),
+            "See [`Thing`](https://example.com) for details.",
+            "already-linked references must not be rewritten"
         );
     }
 
@@ -2126,7 +2242,7 @@ mod tests {
         let ty: syn::Type = syn::parse_str("BTreeMap<String, String>").unwrap();
         assert_eq!(
             render_type(&ty, &BTreeMap::new()),
-            "object<string, string>",
+            "`object<string, string>`",
             "maps should render as YAML object shapes"
         );
     }

--- a/xtask/src/lint_example_tests.rs
+++ b/xtask/src/lint_example_tests.rs
@@ -14,30 +14,10 @@ use clap::Parser;
 /// requirement. Each entry must have a justification. Shrink this list over
 /// time by adding tests.
 const SKIP: &[&str] = &[
-    // TODO(migration): add integration tests for all AI example configs.
-    // All configs are skipped until tests/integration is re-enabled.
-    "a2a-classifier-routing.yaml",
-    "a2a-task-routing.yaml",
+    // Uses core `json_body_field`; covered by praxis core examples/tests.
     "ai-inference-body-based-routing.yaml",
-    "anthropic/messages-protocol.yaml",
-    "anthropic/messages-to-openai.yaml",
-    "anthropic/request-validate.yaml",
-    "anthropic/unified-gateway.yaml",
-    "credential-injection.yaml",
-    "json-rpc-routing.yaml",
-    "mcp-classifier-routing.yaml",
+    // Integration test uses inline YAML; example uses multi-chain X-AI-Model routing.
     "model-to-header-routing.yaml",
-    "openai/conversations/conversations.yaml",
-    "openai/responses/format-routing.yaml",
-    "openai/responses/full-flow.yaml",
-    "openai/responses/model-rewrite.yaml",
-    "openai/responses/rehydrate.yaml",
-    "openai/responses/request-validate.yaml",
-    "openai/responses/response-store.yaml",
-    "openai/responses/responses-proxy.yaml",
-    "openai/responses/responses-routing.yaml",
-    "prompt-enrichment.yaml",
-    "token-usage-headers.yaml",
 ];
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Expand docs hub with guides (OpenAI Responses, token counting), architecture pages, and filter cross-links
- Add `ai-guardrails` example with integration test; shrink `lint-example-tests` SKIP list


## Test plan
- [ ] Conventions CI (signoff, signed commits, no AI authorship)
- [ ] `make lint` / `cargo xtask lint-example-tests`
- [ ] Integration tests for new `ai-guardrails` example