### PR TITLE
fix(container): restore container image builds

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -16,5 +16,4 @@ Makefile
 tests/
 xtask/
 examples/
-!examples/configs/operations/container-default.yaml
 benchmarks/

--- a/Containerfile
+++ b/Containerfile
@@ -53,7 +53,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 COPY apis/src ./apis/src
 COPY filters/src ./filters/src
 COPY server/src ./server/src
-COPY examples ./examples
 
 RUN find apis/src filters/src server/src \
     -name '*.rs' -exec touch {} +


### PR DESCRIPTION
## Summary

  Fixes the AI container build by removing a stale `examples/` copy from the builder stage.

```
[1/2] STEP 16/18: COPY examples ./examples
Error: building at STEP "COPY examples ./examples": no items matching glob "/tmp/praxis-ai-container-check/examples" copied (1 filtered out using /tmp/praxis-ai-container-check/.containerignore): no such file or directory
make: *** [Makefile:53: container] Error 125
```

  `.containerignore` excludes `examples/`, but the `Containerfile` still tried to `COPY examples ./examples`. The only re-include rule pointed at `examples/configs/operations/container-default.yaml`, which does not exist on main, so the container build failed before the image could finish building.

  This removes the unused examples copy and the dead re-include rule. The runtime image does not consume examples, and the builder stage does not need them.

  ## Validation

  - `git diff --check`
  - `make container`
