### PR TITLE
feat(rehydrate): add max_history_bytes and max_history_items caps

### DIFF
--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -58,32 +58,57 @@ const PREV_USAGE_TOTAL_KEY: &str = "responses.previous_usage_total_tokens";
 /// ```yaml
 /// filter: openai_responses_rehydrate
 /// ```
-pub struct RehydrateFilter;
+pub struct RehydrateFilter {
+    /// Maximum serialized byte size of stored conversation history.
+    max_history_bytes: usize,
+    /// Optional cap on the number of stored history items.
+    max_history_items: Option<usize>,
+}
 
 impl RehydrateFilter {
     /// Create a filter from YAML config.
     ///
-    /// This filter has no configuration fields.
-    ///
     /// # Errors
     ///
-    /// Returns [`FilterError`] if the YAML config contains unknown fields.
+    /// Returns [`FilterError`] if the YAML config contains unknown
+    /// fields, or `max_history_bytes` / `max_history_items` is zero.
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         let empty = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
         let cfg = if config.is_null() { &empty } else { config };
-        let _validated: RehydrateConfig = parse_filter_config("openai_responses_rehydrate", cfg)?;
-        Ok(Box::new(Self))
+        let validated: RehydrateConfig = parse_filter_config("openai_responses_rehydrate", cfg)?;
+        if validated.max_history_bytes == 0 {
+            return Err(FilterError::from(
+                "openai_responses_rehydrate: max_history_bytes must be greater than 0",
+            ));
+        }
+        if validated.max_history_items == Some(0) {
+            return Err(FilterError::from(
+                "openai_responses_rehydrate: max_history_items must be greater than 0",
+            ));
+        }
+        Ok(Box::new(Self {
+            max_history_bytes: validated.max_history_bytes,
+            max_history_items: validated.max_history_items,
+        }))
     }
 }
 
-/// Empty YAML configuration for [`RehydrateFilter`].
+/// YAML configuration for [`RehydrateFilter`].
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
-#[expect(
-    clippy::empty_structs_with_brackets,
-    reason = "serde cannot deserialize a map into a unit struct"
-)]
-struct RehydrateConfig {}
+struct RehydrateConfig {
+    /// Maximum serialized byte size of stored conversation history.
+    #[serde(default = "default_max_history_bytes")]
+    max_history_bytes: usize,
+    /// Optional cap on the number of stored history items.
+    #[serde(default)]
+    max_history_items: Option<usize>,
+}
+
+/// Default maximum byte size for stored conversation history (2 MiB).
+fn default_max_history_bytes() -> usize {
+    2_097_152 // 2 MiB
+}
 
 #[async_trait]
 impl HttpFilter for RehydrateFilter {
@@ -133,7 +158,7 @@ impl HttpFilter for RehydrateFilter {
             .get_metadata("openai_responses_format.stream")
             .is_some_and(|v| v == "true");
 
-        rehydrate(ctx, body, streaming).await
+        rehydrate(ctx, body, streaming, self.max_history_bytes, self.max_history_items).await
     }
 }
 
@@ -151,6 +176,42 @@ fn is_responses_cancel_path(path: &str) -> bool {
     !response_id.is_empty() && !response_id.contains('/')
 }
 
+/// Reject the request when stored conversation history exceeds configured limits.
+fn enforce_history_limits(
+    stored: &[Value],
+    max_history_bytes: usize,
+    max_history_items: Option<usize>,
+    streaming: bool,
+) -> Result<(), FilterAction> {
+    if let Some(max) = max_history_items {
+        let count = stored.len();
+        if count > max {
+            return Err(reject_too_large(
+                &format!(
+                    "stored conversation history contains {count} items, \
+                   exceeding the {max} item limit; \
+                   compact or shorten the conversation before continuing"
+                ),
+                streaming,
+            ));
+        }
+    }
+
+    let byte_size = serde_json::to_string(stored).map_or(0, |s| s.len());
+    if byte_size > max_history_bytes {
+        return Err(reject_too_large(
+            &format!(
+                "stored conversation history is {byte_size} bytes, \
+               exceeding the {max_history_bytes} byte limit; \
+               compact or shorten the conversation before continuing"
+            ),
+            streaming,
+        ));
+    }
+
+    Ok(())
+}
+
 /// Parse body, resolve rehydration source (`previous_response_id` or
 /// `conversation`), and populate [`ResponsesState`] with the full
 /// conversation history.
@@ -161,37 +222,46 @@ async fn rehydrate(
     ctx: &mut HttpFilterContext<'_>,
     body: &Option<Bytes>,
     streaming: bool,
+    max_history_bytes: usize,
+    max_history_items: Option<usize>,
 ) -> Result<FilterAction, FilterError> {
     let Some(bytes) = body.as_ref() else {
         return Ok(FilterAction::Release);
     };
-
     let (parsed_body, prev_id) = match parse_body_and_extract_id(bytes, streaming) {
         Ok((body, Some(id))) => (body, id),
         Ok((body, None)) => return rehydrate_from_conversation(ctx, body, streaming).await,
         Err(action) => return Ok(action),
     };
-
     let tenant_id = ctx
         .get_metadata(TENANT_METADATA_KEY)
         .unwrap_or(DEFAULT_TENANT_ID)
         .to_owned();
-
-    let record = match fetch_previous_response(ctx, &tenant_id, &prev_id, streaming).await {
+    let record = match fetch_and_validate_previous(ctx, &tenant_id, &prev_id, streaming).await {
         Ok(r) => r,
         Err(action) => return Ok(action),
     };
-
-    if let Err(action) = validate_response_status(&record, streaming) {
-        return Ok(action);
-    }
-
-    populate_state_and_usage_metadata(ctx, parsed_body, &record);
-
+    let state = match build_state(parsed_body, &record, max_history_bytes, max_history_items, streaming) {
+        Ok(s) => s,
+        Err(action) => return Ok(action),
+    };
+    write_previous_usage_metadata(ctx, state.previous_usage.as_ref());
+    ctx.extensions.insert(state);
     debug!(previous_response_id = %prev_id, "previous response validated, state populated");
     ctx.set_metadata("responses.previous_response_id", prev_id);
-
     Ok(FilterAction::Release)
+}
+
+/// Fetch the previous response and validate its status in one step.
+async fn fetch_and_validate_previous(
+    ctx: &HttpFilterContext<'_>,
+    tenant_id: &str,
+    prev_id: &str,
+    streaming: bool,
+) -> Result<ResponseRecord, FilterAction> {
+    let record = fetch_previous_response(ctx, tenant_id, prev_id, streaming).await?;
+    validate_response_status(&record, streaming)?;
+    Ok(record)
 }
 
 /// Rehydrate from a stored conversation when no `previous_response_id`
@@ -282,37 +352,27 @@ fn conversation_messages_for_rehydrate(record: &ConversationRecord) -> Vec<Value
     record.messages.as_array().cloned().unwrap_or_default()
 }
 
-/// Insert rehydrated request state and promote previous usage metadata.
-fn populate_state_and_usage_metadata(ctx: &mut HttpFilterContext<'_>, parsed_body: Value, record: &ResponseRecord) {
-    let previous_tools = collect_mcp_tool_listings(record);
-
-    let previous_usage = record.response_object.get("usage").filter(|usage| !usage.is_null());
-    write_previous_usage_metadata(ctx, previous_usage);
-
-    ctx.extensions.insert(build_state(
-        parsed_body,
-        record,
-        previous_tools,
-        previous_usage.cloned(),
-    ));
-}
-
-/// Build [`ResponsesState`] by prepending stored messages before the current input.
-// TODO(#697): enforce a max rehydrated history size.
+/// Build [`ResponsesState`] by resolving stored messages, enforcing
+/// history limits, and prepending conversation history before
+/// current input.
 fn build_state(
     parsed_body: Value,
     record: &ResponseRecord,
-    previous_tools: Vec<Value>,
-    previous_usage: Option<Value>,
-) -> ResponsesState {
-    let mut state = ResponsesState::from_request_body(parsed_body);
+    max_history_bytes: usize,
+    max_history_items: Option<usize>,
+    streaming: bool,
+) -> Result<ResponsesState, FilterAction> {
     let stored = stored_messages_for_rehydrate(record);
+    enforce_history_limits(&stored, max_history_bytes, max_history_items, streaming)?;
+    let previous_tools = collect_mcp_tool_listings(record);
+    let previous_usage = record.response_object.get("usage").filter(|u| !u.is_null()).cloned();
     let replay = replay_messages_from_stored(&stored);
+    let mut state = ResponsesState::from_request_body(parsed_body);
     state.messages.splice(0..0, replay);
     state.persisted_messages.splice(0..0, stored);
     state.previous_tools = previous_tools;
     state.previous_usage = previous_usage;
-    state
+    Ok(state)
 }
 
 /// Return stored history, reconstructing from public fields for
@@ -551,6 +611,16 @@ fn reject_invalid(message: &str, streaming: bool) -> FilterAction {
 /// Build a 500 rejection with a Responses API error body.
 fn reject_server_error(message: &str, streaming: bool) -> FilterAction {
     FilterAction::Reject(responses_error_rejection(500, "server_error", message, streaming))
+}
+
+/// Build a 413 rejection with a Responses API error body.
+fn reject_too_large(message: &str, streaming: bool) -> FilterAction {
+    FilterAction::Reject(responses_error_rejection(
+        413,
+        "invalid_request_error",
+        message,
+        streaming,
+    ))
 }
 
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -91,12 +91,7 @@ impl RehydrateFilter {
         Ok(Box::new(Self { limiter }))
     }
 
-    /// Parse body, resolve rehydration source (`previous_response_id` or
-    /// `conversation`), and populate [`ResponsesState`] with the full
-    /// conversation history.
-    ///
-    /// `previous_response_id` takes precedence when both fields are
-    /// present.
+    /// Resolve rehydration source and populate [`ResponsesState`].
     async fn rehydrate(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -113,7 +108,7 @@ impl RehydrateFilter {
         }
     }
 
-    /// Rehydrate from a stored response via `previous_response_id`.
+    /// Rehydrate from a stored response.
     async fn rehydrate_from_response(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -143,8 +138,7 @@ impl RehydrateFilter {
         Ok(FilterAction::Release)
     }
 
-    /// Rehydrate from a stored conversation when no `previous_response_id`
-    /// is present.
+    /// Rehydrate from a stored conversation.
     async fn rehydrate_from_conversation(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -262,19 +256,25 @@ fn is_responses_cancel_path(path: &str) -> bool {
 // HistoryLimiter
 // -----------------------------------------------------------------------------
 
-/// Enforces byte-size and item-count caps on stored conversation history.
-///
-/// Constructed once from filter config and passed into the stored-message
-/// extraction functions so limits are checked *before* cloning.
+/// Byte-size and item-count caps on stored conversation history.
 struct HistoryLimiter {
-    /// Maximum serialized byte size of stored conversation history.
+    /// Maximum serialized byte size.
     pub(super) max_bytes: usize,
-    /// Optional cap on the number of stored history items.
+    /// Optional item-count cap.
     pub(super) max_items: Option<usize>,
 }
 
+impl Default for HistoryLimiter {
+    fn default() -> Self {
+        Self {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        }
+    }
+}
+
 impl HistoryLimiter {
-    /// Reject when `items` exceeds the configured byte-size or item-count cap.
+    /// Reject when `items` exceeds configured caps.
     fn check(&self, items: &[Value], streaming: bool) -> Result<(), FilterAction> {
         if let Some(max) = self.max_items {
             let count = items.len();
@@ -311,9 +311,7 @@ impl HistoryLimiter {
 // Stored message extraction
 // -----------------------------------------------------------------------------
 
-/// Extract stored messages from a response record, checking limits
-/// before cloning. Falls back to reconstruction from public fields
-/// for records created before hidden messages were persisted.
+/// Stored messages from a response record, checking limits before cloning.
 fn stored_messages_for_response(
     record: &ResponseRecord,
     limiter: &HistoryLimiter,
@@ -326,8 +324,7 @@ fn stored_messages_for_response(
     reconstruct_messages_from_public_response(record, limiter, streaming)
 }
 
-/// Extract stored messages from a conversation record, checking
-/// limits before cloning.
+/// Stored messages from a conversation record, checking limits before cloning.
 fn stored_messages_for_conversation(
     record: &ConversationRecord,
     limiter: &HistoryLimiter,
@@ -411,8 +408,7 @@ async fn fetch_conversation(
     })
 }
 
-/// Build [`ResponsesState`] from already-resolved stored messages and
-/// prepend conversation history before current input.
+/// Assemble [`ResponsesState`] from resolved stored messages.
 fn build_state(
     parsed_body: Value,
     stored: Vec<Value>,

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -91,6 +91,97 @@ impl RehydrateFilter {
             max_history_items: validated.max_history_items,
         }))
     }
+
+    /// Parse body, resolve rehydration source (`previous_response_id` or
+    /// `conversation`), and populate [`ResponsesState`] with the full
+    /// conversation history.
+    ///
+    /// `previous_response_id` takes precedence when both fields are
+    /// present.
+    async fn rehydrate(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &Option<Bytes>,
+        streaming: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let Some(bytes) = body.as_ref() else {
+            return Ok(FilterAction::Release);
+        };
+        match parse_body_and_extract_id(bytes, streaming) {
+            Ok((body, Some(id))) => self.rehydrate_from_response(ctx, body, id, streaming).await,
+            Ok((body, None)) => self.rehydrate_from_conversation(ctx, body, streaming).await,
+            Err(action) => Ok(action),
+        }
+    }
+
+    /// Rehydrate from a stored response via `previous_response_id`.
+    async fn rehydrate_from_response(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        parsed_body: Value,
+        prev_id: String,
+        streaming: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let tenant_id = ctx
+            .get_metadata(TENANT_METADATA_KEY)
+            .unwrap_or(DEFAULT_TENANT_ID)
+            .to_owned();
+        let record = match fetch_and_validate_previous(ctx, &tenant_id, &prev_id, streaming).await {
+            Ok(r) => r,
+            Err(action) => return Ok(action),
+        };
+        let state = match build_state(
+            parsed_body,
+            &record,
+            self.max_history_bytes,
+            self.max_history_items,
+            streaming,
+        ) {
+            Ok(s) => s,
+            Err(action) => return Ok(action),
+        };
+        write_previous_usage_metadata(ctx, state.previous_usage.as_ref());
+        ctx.extensions.insert(state);
+        debug!(previous_response_id = %prev_id, "previous response validated, state populated");
+        ctx.set_metadata("responses.previous_response_id", prev_id);
+        Ok(FilterAction::Release)
+    }
+
+    /// Rehydrate from a stored conversation when no `previous_response_id`
+    /// is present.
+    async fn rehydrate_from_conversation(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        parsed_body: Value,
+        streaming: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let conv_id = match resolve_conversation_id(&parsed_body, streaming) {
+            Ok(id) => id,
+            Err(action) => return Ok(action),
+        };
+        let tenant_id = ctx
+            .get_metadata(TENANT_METADATA_KEY)
+            .unwrap_or(DEFAULT_TENANT_ID)
+            .to_owned();
+        let record = match fetch_conversation(ctx, &tenant_id, &conv_id, streaming).await {
+            Ok(r) => r,
+            Err(action) => return Ok(action),
+        };
+        let state = match build_state(
+            parsed_body,
+            &record,
+            self.max_history_bytes,
+            self.max_history_items,
+            streaming,
+        ) {
+            Ok(s) => s,
+            Err(action) => return Ok(action),
+        };
+        write_previous_usage_metadata(ctx, state.previous_usage.as_ref());
+        ctx.extensions.insert(state);
+        debug!(conversation_id = %conv_id, "conversation rehydrated, state populated");
+        Ok(FilterAction::Release)
+    }
 }
 
 /// YAML configuration for [`RehydrateFilter`].
@@ -158,7 +249,7 @@ impl HttpFilter for RehydrateFilter {
             .get_metadata("openai_responses_format.stream")
             .is_some_and(|v| v == "true");
 
-        rehydrate(ctx, body, streaming, self.max_history_bytes, self.max_history_items).await
+        self.rehydrate(ctx, body, streaming).await
     }
 }
 
@@ -197,7 +288,7 @@ fn enforce_history_limits(
         }
     }
 
-    let byte_size = serde_json::to_string(stored).map_or(0, |s| s.len());
+    let byte_size = serde_json::to_string(stored).map_or(usize::MAX, |s| s.len());
     if byte_size > max_history_bytes {
         return Err(reject_too_large(
             &format!(
@@ -212,44 +303,42 @@ fn enforce_history_limits(
     Ok(())
 }
 
-/// Parse body, resolve rehydration source (`previous_response_id` or
-/// `conversation`), and populate [`ResponsesState`] with the full
-/// conversation history.
-///
-/// `previous_response_id` takes precedence when both fields are
-/// present.
-async fn rehydrate(
-    ctx: &mut HttpFilterContext<'_>,
-    body: &Option<Bytes>,
-    streaming: bool,
-    max_history_bytes: usize,
-    max_history_items: Option<usize>,
-) -> Result<FilterAction, FilterError> {
-    let Some(bytes) = body.as_ref() else {
-        return Ok(FilterAction::Release);
-    };
-    let (parsed_body, prev_id) = match parse_body_and_extract_id(bytes, streaming) {
-        Ok((body, Some(id))) => (body, id),
-        Ok((body, None)) => return rehydrate_from_conversation(ctx, body, streaming).await,
-        Err(action) => return Ok(action),
-    };
-    let tenant_id = ctx
-        .get_metadata(TENANT_METADATA_KEY)
-        .unwrap_or(DEFAULT_TENANT_ID)
-        .to_owned();
-    let record = match fetch_and_validate_previous(ctx, &tenant_id, &prev_id, streaming).await {
-        Ok(r) => r,
-        Err(action) => return Ok(action),
-    };
-    let state = match build_state(parsed_body, &record, max_history_bytes, max_history_items, streaming) {
-        Ok(s) => s,
-        Err(action) => return Ok(action),
-    };
-    write_previous_usage_metadata(ctx, state.previous_usage.as_ref());
-    ctx.extensions.insert(state);
-    debug!(previous_response_id = %prev_id, "previous response validated, state populated");
-    ctx.set_metadata("responses.previous_response_id", prev_id);
-    Ok(FilterAction::Release)
+// -----------------------------------------------------------------------------
+// RehydrationSource
+// -----------------------------------------------------------------------------
+
+/// Common interface for records that supply stored conversation history.
+trait RehydrationSource {
+    /// Extract stored messages for rehydration.
+    fn stored_messages(&self) -> Vec<Value>;
+    /// Recover MCP tool listings from stored history.
+    fn mcp_tool_listings(&self) -> Vec<Value> {
+        vec![]
+    }
+    /// Extract token usage from the previous response.
+    fn previous_usage(&self) -> Option<Value> {
+        None
+    }
+}
+
+impl RehydrationSource for ResponseRecord {
+    fn stored_messages(&self) -> Vec<Value> {
+        stored_messages_for_rehydrate(self)
+    }
+
+    fn mcp_tool_listings(&self) -> Vec<Value> {
+        collect_mcp_tool_listings(self)
+    }
+
+    fn previous_usage(&self) -> Option<Value> {
+        self.response_object.get("usage").filter(|u| !u.is_null()).cloned()
+    }
+}
+
+impl RehydrationSource for ConversationRecord {
+    fn stored_messages(&self) -> Vec<Value> {
+        conversation_messages_for_rehydrate(self)
+    }
 }
 
 /// Fetch the previous response and validate its status in one step.
@@ -264,46 +353,23 @@ async fn fetch_and_validate_previous(
     Ok(record)
 }
 
-/// Rehydrate from a stored conversation when no `previous_response_id`
-/// is present.
-async fn rehydrate_from_conversation(
-    ctx: &mut HttpFilterContext<'_>,
-    parsed_body: Value,
-    streaming: bool,
-) -> Result<FilterAction, FilterError> {
-    let has_conversation_field = parsed_body.get("conversation").is_some();
-    let Some(conv_id) = extract_conversation_id(&parsed_body) else {
-        if has_conversation_field {
-            return Ok(FilterAction::Reject(responses_error_rejection(
+/// Resolve the conversation ID from the request body, returning a
+/// `Release` when no conversation field is present or a `Reject`
+/// when the field is malformed.
+fn resolve_conversation_id(body: &Value, streaming: bool) -> Result<String, FilterAction> {
+    let has_field = body.get("conversation").is_some();
+    extract_conversation_id(body).ok_or_else(|| {
+        if has_field {
+            FilterAction::Reject(responses_error_rejection(
                 400,
                 "invalid_request_error",
                 "invalid conversation value: expected a string ID or {\"id\": \"...\"}",
                 streaming,
-            )));
+            ))
+        } else {
+            FilterAction::Release
         }
-        return Ok(FilterAction::Release);
-    };
-
-    let tenant_id = ctx
-        .get_metadata(TENANT_METADATA_KEY)
-        .unwrap_or(DEFAULT_TENANT_ID)
-        .to_owned();
-
-    let record = match fetch_conversation(ctx, &tenant_id, &conv_id, streaming).await {
-        Ok(r) => r,
-        Err(action) => return Ok(action),
-    };
-
-    let stored = conversation_messages_for_rehydrate(&record);
-    let replay = replay_messages_from_stored(&stored);
-    let mut state = ResponsesState::from_request_body(parsed_body);
-    state.messages.splice(0..0, replay);
-    state.persisted_messages.splice(0..0, stored);
-    ctx.extensions.insert(state);
-
-    debug!(conversation_id = %conv_id, "conversation rehydrated, state populated");
-
-    Ok(FilterAction::Release)
+    })
 }
 
 /// Extract a conversation ID from the request body.
@@ -357,15 +423,15 @@ fn conversation_messages_for_rehydrate(record: &ConversationRecord) -> Vec<Value
 /// current input.
 fn build_state(
     parsed_body: Value,
-    record: &ResponseRecord,
+    source: &impl RehydrationSource,
     max_history_bytes: usize,
     max_history_items: Option<usize>,
     streaming: bool,
 ) -> Result<ResponsesState, FilterAction> {
-    let stored = stored_messages_for_rehydrate(record);
+    let stored = source.stored_messages();
     enforce_history_limits(&stored, max_history_bytes, max_history_items, streaming)?;
-    let previous_tools = collect_mcp_tool_listings(record);
-    let previous_usage = record.response_object.get("usage").filter(|u| !u.is_null()).cloned();
+    let previous_tools = source.mcp_tool_listings();
+    let previous_usage = source.previous_usage();
     let replay = replay_messages_from_stored(&stored);
     let mut state = ResponsesState::from_request_body(parsed_body);
     state.messages.splice(0..0, replay);

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -59,10 +59,8 @@ const PREV_USAGE_TOTAL_KEY: &str = "responses.previous_usage_total_tokens";
 /// filter: openai_responses_rehydrate
 /// ```
 pub struct RehydrateFilter {
-    /// Maximum serialized byte size of stored conversation history.
-    max_history_bytes: usize,
-    /// Optional cap on the number of stored history items.
-    max_history_items: Option<usize>,
+    /// Enforces byte-size and item-count caps on stored conversation history.
+    limiter: HistoryLimiter,
 }
 
 impl RehydrateFilter {
@@ -86,10 +84,11 @@ impl RehydrateFilter {
                 "openai_responses_rehydrate: max_history_items must be greater than 0",
             ));
         }
-        Ok(Box::new(Self {
-            max_history_bytes: validated.max_history_bytes,
-            max_history_items: validated.max_history_items,
-        }))
+        let limiter = HistoryLimiter {
+            max_bytes: validated.max_history_bytes,
+            max_items: validated.max_history_items,
+        };
+        Ok(Box::new(Self { limiter }))
     }
 
     /// Parse body, resolve rehydration source (`previous_response_id` or
@@ -130,13 +129,7 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let state = match build_state(
-            parsed_body,
-            &record,
-            self.max_history_bytes,
-            self.max_history_items,
-            streaming,
-        ) {
+        let state = match build_state(parsed_body, &record, &self.limiter, streaming) {
             Ok(s) => s,
             Err(action) => return Ok(action),
         };
@@ -167,13 +160,7 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let state = match build_state(
-            parsed_body,
-            &record,
-            self.max_history_bytes,
-            self.max_history_items,
-            streaming,
-        ) {
+        let state = match build_state(parsed_body, &record, &self.limiter, streaming) {
             Ok(s) => s,
             Err(action) => return Ok(action),
         };
@@ -188,7 +175,7 @@ impl RehydrateFilter {
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RehydrateConfig {
-    /// Maximum serialized byte size of stored conversation history.
+    /// Maximum serialized byte size of stored conversation history. Default: 2,097,152 (2 MiB).
     #[serde(default = "default_max_history_bytes")]
     max_history_bytes: usize,
     /// Optional cap on the number of stored history items.
@@ -267,40 +254,53 @@ fn is_responses_cancel_path(path: &str) -> bool {
     !response_id.is_empty() && !response_id.contains('/')
 }
 
-/// Reject the request when stored conversation history exceeds configured limits.
-fn enforce_history_limits(
-    stored: &[Value],
-    max_history_bytes: usize,
-    max_history_items: Option<usize>,
-    streaming: bool,
-) -> Result<(), FilterAction> {
-    if let Some(max) = max_history_items {
-        let count = stored.len();
-        if count > max {
+// -----------------------------------------------------------------------------
+// HistoryLimiter
+// -----------------------------------------------------------------------------
+
+/// Enforces byte-size and item-count caps on stored conversation history.
+///
+/// Constructed once from filter config and passed into [`RehydrationSource`]
+/// so limits are checked *before* cloning the stored messages.
+struct HistoryLimiter {
+    /// Maximum serialized byte size of stored conversation history.
+    pub(super) max_bytes: usize,
+    /// Optional cap on the number of stored history items.
+    pub(super) max_items: Option<usize>,
+}
+
+impl HistoryLimiter {
+    /// Reject when `items` exceeds the configured byte-size or item-count cap.
+    fn check(&self, items: &[Value], streaming: bool) -> Result<(), FilterAction> {
+        if let Some(max) = self.max_items {
+            let count = items.len();
+            if count > max {
+                return Err(reject_too_large(
+                    &format!(
+                        "stored conversation history contains {count} items, \
+                       exceeding the {max} item limit; \
+                       compact or shorten the conversation before continuing"
+                    ),
+                    streaming,
+                ));
+            }
+        }
+
+        let byte_size = serde_json::to_string(items).map_or(usize::MAX, |s| s.len());
+        if byte_size > self.max_bytes {
             return Err(reject_too_large(
                 &format!(
-                    "stored conversation history contains {count} items, \
-                   exceeding the {max} item limit; \
-                   compact or shorten the conversation before continuing"
+                    "stored conversation history is {byte_size} bytes, \
+                   exceeding the {} byte limit; \
+                   compact or shorten the conversation before continuing",
+                    self.max_bytes
                 ),
                 streaming,
             ));
         }
-    }
 
-    let byte_size = serde_json::to_string(stored).map_or(usize::MAX, |s| s.len());
-    if byte_size > max_history_bytes {
-        return Err(reject_too_large(
-            &format!(
-                "stored conversation history is {byte_size} bytes, \
-               exceeding the {max_history_bytes} byte limit; \
-               compact or shorten the conversation before continuing"
-            ),
-            streaming,
-        ));
+        Ok(())
     }
-
-    Ok(())
 }
 
 // -----------------------------------------------------------------------------
@@ -309,8 +309,9 @@ fn enforce_history_limits(
 
 /// Common interface for records that supply stored conversation history.
 trait RehydrationSource {
-    /// Extract stored messages for rehydration.
-    fn stored_messages(&self) -> Vec<Value>;
+    /// Extract stored messages for rehydration, enforcing history limits
+    /// before cloning.
+    fn stored_messages(&self, limiter: &HistoryLimiter, streaming: bool) -> Result<Vec<Value>, FilterAction>;
     /// Recover MCP tool listings from stored history.
     fn mcp_tool_listings(&self) -> Vec<Value> {
         vec![]
@@ -322,8 +323,12 @@ trait RehydrationSource {
 }
 
 impl RehydrationSource for ResponseRecord {
-    fn stored_messages(&self) -> Vec<Value> {
-        stored_messages_for_rehydrate(self)
+    fn stored_messages(&self, limiter: &HistoryLimiter, streaming: bool) -> Result<Vec<Value>, FilterAction> {
+        if let Some(messages) = self.messages.as_array().filter(|a| !a.is_empty()) {
+            limiter.check(messages, streaming)?;
+            return Ok(messages.clone());
+        }
+        reconstruct_messages_from_public_response(self, limiter, streaming)
     }
 
     fn mcp_tool_listings(&self) -> Vec<Value> {
@@ -336,8 +341,11 @@ impl RehydrationSource for ResponseRecord {
 }
 
 impl RehydrationSource for ConversationRecord {
-    fn stored_messages(&self) -> Vec<Value> {
-        conversation_messages_for_rehydrate(self)
+    fn stored_messages(&self, limiter: &HistoryLimiter, streaming: bool) -> Result<Vec<Value>, FilterAction> {
+        let empty: &[Value] = &[];
+        let messages = self.messages.as_array().map_or(empty, Vec::as_slice);
+        limiter.check(messages, streaming)?;
+        Ok(messages.to_vec())
     }
 }
 
@@ -413,23 +421,16 @@ async fn fetch_conversation(
     })
 }
 
-/// Extract messages from a conversation record for rehydration.
-fn conversation_messages_for_rehydrate(record: &ConversationRecord) -> Vec<Value> {
-    record.messages.as_array().cloned().unwrap_or_default()
-}
-
 /// Build [`ResponsesState`] by resolving stored messages, enforcing
 /// history limits, and prepending conversation history before
 /// current input.
 fn build_state(
     parsed_body: Value,
     source: &impl RehydrationSource,
-    max_history_bytes: usize,
-    max_history_items: Option<usize>,
+    limiter: &HistoryLimiter,
     streaming: bool,
 ) -> Result<ResponsesState, FilterAction> {
-    let stored = source.stored_messages();
-    enforce_history_limits(&stored, max_history_bytes, max_history_items, streaming)?;
+    let stored = source.stored_messages(limiter, streaming)?;
     let previous_tools = source.mcp_tool_listings();
     let previous_usage = source.previous_usage();
     let replay = replay_messages_from_stored(&stored);
@@ -443,16 +444,11 @@ fn build_state(
 
 /// Return stored history, reconstructing from public fields for
 /// records created before hidden messages were persisted.
-fn stored_messages_for_rehydrate(record: &ResponseRecord) -> Vec<Value> {
-    if let Some(messages) = record.messages.as_array().filter(|messages| !messages.is_empty()) {
-        return messages.clone();
-    }
-
-    reconstruct_messages_from_public_response(record)
-}
-
-/// Reconstruct previous input/output items from public stored fields.
-fn reconstruct_messages_from_public_response(record: &ResponseRecord) -> Vec<Value> {
+fn reconstruct_messages_from_public_response(
+    record: &ResponseRecord,
+    limiter: &HistoryLimiter,
+    streaming: bool,
+) -> Result<Vec<Value>, FilterAction> {
     let mut messages = Vec::new();
 
     append_stored_input_items(&mut messages, record.input.clone());
@@ -461,7 +457,8 @@ fn reconstruct_messages_from_public_response(record: &ResponseRecord) -> Vec<Val
         append_stored_output_items(&mut messages, output);
     }
 
-    messages
+    limiter.check(&messages, streaming)?;
+    Ok(messages)
 }
 
 /// Append stored response input as Responses API item params.

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -59,8 +59,10 @@ const PREV_USAGE_TOTAL_KEY: &str = "responses.previous_usage_total_tokens";
 /// filter: openai_responses_rehydrate
 /// ```
 pub struct RehydrateFilter {
-    /// Enforces byte-size and item-count caps on stored conversation history.
-    limiter: HistoryLimiter,
+    /// Maximum serialized byte size of stored conversation history.
+    max_history_bytes: usize,
+    /// Optional cap on the number of stored history items.
+    max_history_items: Option<usize>,
 }
 
 impl RehydrateFilter {
@@ -84,14 +86,18 @@ impl RehydrateFilter {
                 "openai_responses_rehydrate: max_history_items must be greater than 0",
             ));
         }
-        let limiter = HistoryLimiter {
-            max_bytes: validated.max_history_bytes,
-            max_items: validated.max_history_items,
-        };
-        Ok(Box::new(Self { limiter }))
+        Ok(Box::new(Self {
+            max_history_bytes: validated.max_history_bytes,
+            max_history_items: validated.max_history_items,
+        }))
     }
 
-    /// Resolve rehydration source and populate [`ResponsesState`].
+    /// Parse body, resolve rehydration source (`previous_response_id` or
+    /// `conversation`), and populate [`ResponsesState`] with the full
+    /// conversation history.
+    ///
+    /// `previous_response_id` takes precedence when both fields are
+    /// present.
     async fn rehydrate(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -124,10 +130,11 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let stored = match stored_messages_for_response(&record, &self.limiter, streaming) {
-            Ok(s) => s,
-            Err(action) => return Ok(action),
-        };
+        let stored =
+            match stored_messages_for_response(&record, self.max_history_bytes, self.max_history_items, streaming) {
+                Ok(s) => s,
+                Err(action) => return Ok(action),
+            };
         let previous_tools = collect_mcp_tool_listings(&record);
         let previous_usage = record.response_object.get("usage").filter(|u| !u.is_null()).cloned();
         let state = build_state(parsed_body, stored, previous_tools, previous_usage);
@@ -138,7 +145,8 @@ impl RehydrateFilter {
         Ok(FilterAction::Release)
     }
 
-    /// Rehydrate from a stored conversation.
+    /// Rehydrate from a stored conversation when no `previous_response_id`
+    /// is present.
     async fn rehydrate_from_conversation(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -157,7 +165,12 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let stored = match stored_messages_for_conversation(&record, &self.limiter, streaming) {
+        let stored = match stored_messages_for_conversation(
+            &record,
+            self.max_history_bytes,
+            self.max_history_items,
+            streaming,
+        ) {
             Ok(s) => s,
             Err(action) => return Ok(action),
         };
@@ -252,59 +265,40 @@ fn is_responses_cancel_path(path: &str) -> bool {
     !response_id.is_empty() && !response_id.contains('/')
 }
 
-// -----------------------------------------------------------------------------
-// HistoryLimiter
-// -----------------------------------------------------------------------------
-
-/// Byte-size and item-count caps on stored conversation history.
-struct HistoryLimiter {
-    /// Maximum serialized byte size.
-    pub(super) max_bytes: usize,
-    /// Optional item-count cap.
-    pub(super) max_items: Option<usize>,
-}
-
-impl Default for HistoryLimiter {
-    fn default() -> Self {
-        Self {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        }
-    }
-}
-
-impl HistoryLimiter {
-    /// Reject when `items` exceeds configured caps.
-    fn check(&self, items: &[Value], streaming: bool) -> Result<(), FilterAction> {
-        if let Some(max) = self.max_items {
-            let count = items.len();
-            if count > max {
-                return Err(reject_too_large(
-                    &format!(
-                        "stored conversation history contains {count} items, \
-                       exceeding the {max} item limit; \
-                       compact or shorten the conversation before continuing"
-                    ),
-                    streaming,
-                ));
-            }
-        }
-
-        let byte_size = serde_json::to_string(items).map_or(usize::MAX, |s| s.len());
-        if byte_size > self.max_bytes {
+/// Reject when `items` exceeds the configured byte-size or item-count cap.
+fn check_history_limits(
+    items: &[Value],
+    max_bytes: usize,
+    max_items: Option<usize>,
+    streaming: bool,
+) -> Result<(), FilterAction> {
+    if let Some(max) = max_items {
+        let count = items.len();
+        if count > max {
             return Err(reject_too_large(
                 &format!(
-                    "stored conversation history is {byte_size} bytes, \
-                   exceeding the {} byte limit; \
-                   compact or shorten the conversation before continuing",
-                    self.max_bytes
+                    "stored conversation history contains {count} items, \
+                   exceeding the {max} item limit; \
+                   compact or shorten the conversation before continuing"
                 ),
                 streaming,
             ));
         }
-
-        Ok(())
     }
+
+    let byte_size = serde_json::to_string(items).map_or(usize::MAX, |s| s.len());
+    if byte_size > max_bytes {
+        return Err(reject_too_large(
+            &format!(
+                "stored conversation history is {byte_size} bytes, \
+               exceeding the {max_bytes} byte limit; \
+               compact or shorten the conversation before continuing"
+            ),
+            streaming,
+        ));
+    }
+
+    Ok(())
 }
 
 // -----------------------------------------------------------------------------
@@ -314,25 +308,27 @@ impl HistoryLimiter {
 /// Stored messages from a response record, checking limits before cloning.
 fn stored_messages_for_response(
     record: &ResponseRecord,
-    limiter: &HistoryLimiter,
+    max_bytes: usize,
+    max_items: Option<usize>,
     streaming: bool,
 ) -> Result<Vec<Value>, FilterAction> {
     if let Some(messages) = record.messages.as_array().filter(|a| !a.is_empty()) {
-        limiter.check(messages, streaming)?;
+        check_history_limits(messages, max_bytes, max_items, streaming)?;
         return Ok(messages.clone());
     }
-    reconstruct_messages_from_public_response(record, limiter, streaming)
+    reconstruct_messages_from_public_response(record, max_bytes, max_items, streaming)
 }
 
 /// Stored messages from a conversation record, checking limits before cloning.
 fn stored_messages_for_conversation(
     record: &ConversationRecord,
-    limiter: &HistoryLimiter,
+    max_bytes: usize,
+    max_items: Option<usize>,
     streaming: bool,
 ) -> Result<Vec<Value>, FilterAction> {
     let empty: &[Value] = &[];
     let messages = record.messages.as_array().map_or(empty, Vec::as_slice);
-    limiter.check(messages, streaming)?;
+    check_history_limits(messages, max_bytes, max_items, streaming)?;
     Ok(messages.to_vec())
 }
 
@@ -408,7 +404,7 @@ async fn fetch_conversation(
     })
 }
 
-/// Assemble [`ResponsesState`] from resolved stored messages.
+/// Build [`ResponsesState`] by prepending stored messages before the current input.
 fn build_state(
     parsed_body: Value,
     stored: Vec<Value>,
@@ -428,7 +424,8 @@ fn build_state(
 /// records created before hidden messages were persisted.
 fn reconstruct_messages_from_public_response(
     record: &ResponseRecord,
-    limiter: &HistoryLimiter,
+    max_bytes: usize,
+    max_items: Option<usize>,
     streaming: bool,
 ) -> Result<Vec<Value>, FilterAction> {
     let mut messages = Vec::new();
@@ -439,7 +436,7 @@ fn reconstruct_messages_from_public_response(
         append_stored_output_items(&mut messages, output);
     }
 
-    limiter.check(&messages, streaming)?;
+    check_history_limits(&messages, max_bytes, max_items, streaming)?;
     Ok(messages)
 }
 

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -129,10 +129,13 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let state = match build_state(parsed_body, &record, &self.limiter, streaming) {
+        let stored = match stored_messages_for_response(&record, &self.limiter, streaming) {
             Ok(s) => s,
             Err(action) => return Ok(action),
         };
+        let previous_tools = collect_mcp_tool_listings(&record);
+        let previous_usage = record.response_object.get("usage").filter(|u| !u.is_null()).cloned();
+        let state = build_state(parsed_body, stored, previous_tools, previous_usage);
         write_previous_usage_metadata(ctx, state.previous_usage.as_ref());
         ctx.extensions.insert(state);
         debug!(previous_response_id = %prev_id, "previous response validated, state populated");
@@ -160,10 +163,11 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let state = match build_state(parsed_body, &record, &self.limiter, streaming) {
+        let stored = match stored_messages_for_conversation(&record, &self.limiter, streaming) {
             Ok(s) => s,
             Err(action) => return Ok(action),
         };
+        let state = build_state(parsed_body, stored, vec![], None);
         write_previous_usage_metadata(ctx, state.previous_usage.as_ref());
         ctx.extensions.insert(state);
         debug!(conversation_id = %conv_id, "conversation rehydrated, state populated");
@@ -260,8 +264,8 @@ fn is_responses_cancel_path(path: &str) -> bool {
 
 /// Enforces byte-size and item-count caps on stored conversation history.
 ///
-/// Constructed once from filter config and passed into [`RehydrationSource`]
-/// so limits are checked *before* cloning the stored messages.
+/// Constructed once from filter config and passed into the stored-message
+/// extraction functions so limits are checked *before* cloning.
 struct HistoryLimiter {
     /// Maximum serialized byte size of stored conversation history.
     pub(super) max_bytes: usize,
@@ -304,49 +308,35 @@ impl HistoryLimiter {
 }
 
 // -----------------------------------------------------------------------------
-// RehydrationSource
+// Stored message extraction
 // -----------------------------------------------------------------------------
 
-/// Common interface for records that supply stored conversation history.
-trait RehydrationSource {
-    /// Extract stored messages for rehydration, enforcing history limits
-    /// before cloning.
-    fn stored_messages(&self, limiter: &HistoryLimiter, streaming: bool) -> Result<Vec<Value>, FilterAction>;
-    /// Recover MCP tool listings from stored history.
-    fn mcp_tool_listings(&self) -> Vec<Value> {
-        vec![]
-    }
-    /// Extract token usage from the previous response.
-    fn previous_usage(&self) -> Option<Value> {
-        None
-    }
-}
-
-impl RehydrationSource for ResponseRecord {
-    fn stored_messages(&self, limiter: &HistoryLimiter, streaming: bool) -> Result<Vec<Value>, FilterAction> {
-        if let Some(messages) = self.messages.as_array().filter(|a| !a.is_empty()) {
-            limiter.check(messages, streaming)?;
-            return Ok(messages.clone());
-        }
-        reconstruct_messages_from_public_response(self, limiter, streaming)
-    }
-
-    fn mcp_tool_listings(&self) -> Vec<Value> {
-        collect_mcp_tool_listings(self)
-    }
-
-    fn previous_usage(&self) -> Option<Value> {
-        self.response_object.get("usage").filter(|u| !u.is_null()).cloned()
-    }
-}
-
-impl RehydrationSource for ConversationRecord {
-    fn stored_messages(&self, limiter: &HistoryLimiter, streaming: bool) -> Result<Vec<Value>, FilterAction> {
-        let empty: &[Value] = &[];
-        let messages = self.messages.as_array().map_or(empty, Vec::as_slice);
+/// Extract stored messages from a response record, checking limits
+/// before cloning. Falls back to reconstruction from public fields
+/// for records created before hidden messages were persisted.
+fn stored_messages_for_response(
+    record: &ResponseRecord,
+    limiter: &HistoryLimiter,
+    streaming: bool,
+) -> Result<Vec<Value>, FilterAction> {
+    if let Some(messages) = record.messages.as_array().filter(|a| !a.is_empty()) {
         limiter.check(messages, streaming)?;
-        Ok(messages.to_vec())
+        return Ok(messages.clone());
     }
+    reconstruct_messages_from_public_response(record, limiter, streaming)
+}
+
+/// Extract stored messages from a conversation record, checking
+/// limits before cloning.
+fn stored_messages_for_conversation(
+    record: &ConversationRecord,
+    limiter: &HistoryLimiter,
+    streaming: bool,
+) -> Result<Vec<Value>, FilterAction> {
+    let empty: &[Value] = &[];
+    let messages = record.messages.as_array().map_or(empty, Vec::as_slice);
+    limiter.check(messages, streaming)?;
+    Ok(messages.to_vec())
 }
 
 /// Fetch the previous response and validate its status in one step.
@@ -421,25 +411,21 @@ async fn fetch_conversation(
     })
 }
 
-/// Build [`ResponsesState`] by resolving stored messages, enforcing
-/// history limits, and prepending conversation history before
-/// current input.
+/// Build [`ResponsesState`] from already-resolved stored messages and
+/// prepend conversation history before current input.
 fn build_state(
     parsed_body: Value,
-    source: &impl RehydrationSource,
-    limiter: &HistoryLimiter,
-    streaming: bool,
-) -> Result<ResponsesState, FilterAction> {
-    let stored = source.stored_messages(limiter, streaming)?;
-    let previous_tools = source.mcp_tool_listings();
-    let previous_usage = source.previous_usage();
+    stored: Vec<Value>,
+    previous_tools: Vec<Value>,
+    previous_usage: Option<Value>,
+) -> ResponsesState {
     let replay = replay_messages_from_stored(&stored);
     let mut state = ResponsesState::from_request_body(parsed_body);
     state.messages.splice(0..0, replay);
     state.persisted_messages.splice(0..0, stored);
     state.previous_tools = previous_tools;
     state.previous_usage = previous_usage;
-    Ok(state)
+    state
 }
 
 /// Return stored history, reconstructing from public fields for

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -39,10 +39,7 @@ fn unknown_field_rejected() {
 #[test]
 fn body_access_is_read_only() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     assert_eq!(
         filter.request_body_access(),
@@ -58,10 +55,7 @@ fn body_access_is_read_only() {
 #[tokio::test]
 async fn skips_non_post_request() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -74,10 +68,7 @@ async fn skips_non_post_request() {
 #[tokio::test]
 async fn skips_non_responses_format() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -94,10 +85,7 @@ async fn skips_non_responses_format() {
 #[tokio::test]
 async fn continues_on_non_end_of_stream() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -113,10 +101,7 @@ async fn continues_on_non_end_of_stream() {
 #[tokio::test]
 async fn skips_cancel_request_without_parsing_empty_body() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/resp_123/cancel");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -142,10 +127,7 @@ async fn skips_cancel_request_without_parsing_empty_body() {
 #[tokio::test]
 async fn passthrough_when_no_previous_response_id() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -172,10 +154,7 @@ async fn passthrough_when_no_previous_response_id() {
 #[tokio::test]
 async fn passthrough_when_previous_response_id_is_null() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -205,10 +184,7 @@ async fn validates_previous_response_and_sets_metadata() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -353,10 +329,7 @@ async fn rejects_when_previous_response_not_found() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -377,10 +350,7 @@ async fn rejects_when_status_not_completed() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -401,10 +371,7 @@ async fn rejects_when_status_incomplete() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -425,10 +392,7 @@ async fn rejects_when_status_failed() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -446,10 +410,7 @@ async fn rejects_when_status_failed() {
 #[tokio::test]
 async fn rejects_when_store_unavailable() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -468,10 +429,7 @@ async fn rejects_when_store_not_registered() {
     let registry = ResponseStoreRegistry::new();
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -489,10 +447,7 @@ async fn rejects_when_store_not_registered() {
 #[tokio::test]
 async fn rejects_invalid_json_body() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -509,10 +464,7 @@ async fn rejects_invalid_json_body() {
 #[tokio::test]
 async fn rejects_non_string_previous_response_id() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -532,10 +484,7 @@ async fn rejects_when_store_fetch_fails() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -556,10 +505,7 @@ async fn rejects_when_conversation_store_fails() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -600,10 +546,7 @@ async fn extracts_mcp_tools_from_previous_response() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -653,10 +596,7 @@ async fn no_previous_tools_when_output_has_no_mcp_items() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -703,10 +643,7 @@ async fn extracts_mcp_tools_from_multiple_servers() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -785,10 +722,7 @@ async fn deduplicates_mcp_tools_independent_of_tool_order() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -851,10 +785,7 @@ async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -915,10 +846,7 @@ async fn large_mcp_tool_listing_is_preserved_in_state() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -959,10 +887,7 @@ async fn extracts_usage_from_previous_response() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1009,10 +934,7 @@ async fn no_usage_metadata_when_usage_missing() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1056,10 +978,7 @@ async fn extracts_partial_usage_fields() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1127,10 +1046,7 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1331,122 +1247,12 @@ async fn from_config_with_custom_limits() {
 }
 
 #[test]
-fn from_config_rejects_zero_max_history_bytes() {
-    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_bytes: 0").unwrap();
-    let result = RehydrateFilter::from_config(&yaml);
-    assert!(result.is_err(), "max_history_bytes: 0 should be rejected");
-}
+fn from_config_rejects_zero_limits() {
+    let yaml = serde_yaml::from_str::<serde_yaml::Value>("max_history_bytes: 0").unwrap();
+    assert!(RehydrateFilter::from_config(&yaml).is_err());
 
-#[test]
-fn from_config_rejects_zero_max_history_items() {
-    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_items: 0").unwrap();
-    let result = RehydrateFilter::from_config(&yaml);
-    assert!(result.is_err(), "max_history_items: 0 should be rejected");
-}
-
-#[tokio::test]
-async fn rejects_stored_history_exceeding_byte_limit_streaming() {
-    let user_content = "A".repeat(500);
-    let assistant_content = "B".repeat(500);
-    let messages = json!([
-        {"role": "user", "content": user_content},
-        {"role": "assistant", "content": assistant_content}
-    ]);
-    let store = MockStore::with_completed_response("resp_big_stream", json!("Hello"), messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: 64,
-            max_items: None,
-        },
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    ctx.set_metadata("openai_responses_format.stream", "true");
-    let mut body = Some(Bytes::from(
-        r#"{"input":"Hi","previous_response_id":"resp_big_stream","stream":true}"#,
-    ));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(r.status, 413, "should reject with 413 for oversized history");
-            let ct = r.headers.iter().find(|(k, _)| k == "content-type");
-            assert_eq!(
-                ct.map(|(_, v)| v.as_str()),
-                Some("text/event-stream"),
-                "streaming rejection should use SSE content type"
-            );
-            let body_bytes = r.body.unwrap();
-            let body_str = std::str::from_utf8(&body_bytes).unwrap();
-            assert!(
-                body_str.starts_with("event: error\n"),
-                "streaming rejection should be an SSE error event: {body_str}"
-            );
-        },
-        other => panic!("expected Reject, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn allows_history_at_exact_byte_limit() {
-    let messages = json!([
-        {"role": "user", "content": "Hi"}
-    ]);
-    let serialized_size = serde_json::to_string(messages.as_array().unwrap()).unwrap().len();
-    let store = MockStore::with_completed_response("resp_exact", json!("Hi"), messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: serialized_size,
-            max_items: None,
-        },
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"Next","previous_response_id":"resp_exact"}"#));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    assert!(
-        matches!(action, FilterAction::Release),
-        "history at exact byte limit should pass, not reject"
-    );
-}
-
-#[tokio::test]
-async fn allows_history_at_exact_item_limit() {
-    let messages = json!([
-        {"role": "user", "content": "Hello"},
-        {"role": "assistant", "content": "Hi"}
-    ]);
-    let store = MockStore::with_completed_response("resp_exact_items", json!("Hello"), messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: Some(2),
-        },
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(
-        r#"{"input":"Next","previous_response_id":"resp_exact_items"}"#,
-    ));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    assert!(
-        matches!(action, FilterAction::Release),
-        "history at exact item limit should pass, not reject"
-    );
+    let yaml = serde_yaml::from_str::<serde_yaml::Value>("max_history_items: 0").unwrap();
+    assert!(RehydrateFilter::from_config(&yaml).is_err());
 }
 
 #[tokio::test]
@@ -1582,10 +1388,7 @@ async fn rehydrates_from_conversation_string_id() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1631,10 +1434,7 @@ async fn rehydrates_from_conversation_object_form() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1689,10 +1489,7 @@ async fn previous_response_id_takes_precedence_over_conversation() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1729,10 +1526,7 @@ async fn rejects_when_conversation_not_found() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1755,10 +1549,7 @@ async fn tenant_mismatch_rejects_conversation() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1790,10 +1581,7 @@ async fn rejects_malformed_conversation_empty_object() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1814,10 +1602,7 @@ async fn rejects_malformed_conversation_numeric() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1838,10 +1623,7 @@ async fn empty_conversation_produces_valid_state() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1872,10 +1654,7 @@ async fn empty_conversation_produces_valid_state() {
 #[tokio::test]
 async fn conversation_rehydration_requires_store_registry() {
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1897,10 +1676,7 @@ async fn conversation_null_messages_treated_as_empty() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: None,
-        },
+        limiter: HistoryLimiter::default(),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -12,6 +12,13 @@ use crate::store::{
     ConversationRecord, ResponseRecord, ResponseStore, ResponseStoreRegistry, SqliteResponseStore, StoreError,
 };
 
+fn default_filter() -> RehydrateFilter {
+    RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    }
+}
+
 // -----------------------------------------------------------------------------
 // from_config
 // -----------------------------------------------------------------------------
@@ -38,9 +45,7 @@ fn unknown_field_rejected() {
 
 #[test]
 fn body_access_is_read_only() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     assert_eq!(
         filter.request_body_access(),
         BodyAccess::ReadOnly,
@@ -54,9 +59,7 @@ fn body_access_is_read_only() {
 
 #[tokio::test]
 async fn skips_non_post_request() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let mut body = Some(Bytes::from(r#"{"input":"test"}"#));
@@ -67,9 +70,7 @@ async fn skips_non_post_request() {
 
 #[tokio::test]
 async fn skips_non_responses_format() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_chat_completions");
@@ -84,9 +85,7 @@ async fn skips_non_responses_format() {
 
 #[tokio::test]
 async fn continues_on_non_end_of_stream() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let mut body = Some(Bytes::from(r#"{"input":"partial"}"#));
@@ -100,9 +99,7 @@ async fn continues_on_non_end_of_stream() {
 
 #[tokio::test]
 async fn skips_cancel_request_without_parsing_empty_body() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/resp_123/cancel");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -126,9 +123,7 @@ async fn skips_cancel_request_without_parsing_empty_body() {
 
 #[tokio::test]
 async fn passthrough_when_no_previous_response_id() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -153,9 +148,7 @@ async fn passthrough_when_no_previous_response_id() {
 
 #[tokio::test]
 async fn passthrough_when_previous_response_id_is_null() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -183,9 +176,7 @@ async fn validates_previous_response_and_sets_metadata() {
     let store = MockStore::with_completed_response("resp_prev", json!("Hello"), messages);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -328,9 +319,7 @@ async fn rejects_when_previous_response_not_found() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -349,9 +338,7 @@ async fn rejects_when_status_not_completed() {
     let store = MockStore::with_status("resp_123", "in_progress");
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -370,9 +357,7 @@ async fn rejects_when_status_incomplete() {
     let store = MockStore::with_status("resp_123", "incomplete");
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -391,9 +376,7 @@ async fn rejects_when_status_failed() {
     let store = MockStore::with_status("resp_123", "failed");
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -409,9 +392,7 @@ async fn rejects_when_status_failed() {
 
 #[tokio::test]
 async fn rejects_when_store_unavailable() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -428,9 +409,7 @@ async fn rejects_when_store_unavailable() {
 async fn rejects_when_store_not_registered() {
     let registry = ResponseStoreRegistry::new();
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -446,9 +425,7 @@ async fn rejects_when_store_not_registered() {
 
 #[tokio::test]
 async fn rejects_invalid_json_body() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -463,9 +440,7 @@ async fn rejects_invalid_json_body() {
 
 #[tokio::test]
 async fn rejects_non_string_previous_response_id() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -483,9 +458,7 @@ async fn rejects_when_store_fetch_fails() {
     let store = MockStore::failing();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -504,9 +477,7 @@ async fn rejects_when_conversation_store_fails() {
     let store = MockStore::failing();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -545,9 +516,7 @@ async fn extracts_mcp_tools_from_previous_response() {
     let store = MockStore::with_output_and_usage("resp_mcp", output, usage);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -595,9 +564,7 @@ async fn no_previous_tools_when_output_has_no_mcp_items() {
     let store = MockStore::with_output_and_usage("resp_no_mcp", output, usage);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -642,9 +609,7 @@ async fn extracts_mcp_tools_from_multiple_servers() {
     let store = MockStore::with_output_and_usage("resp_multi", output, Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -721,9 +686,7 @@ async fn deduplicates_mcp_tools_independent_of_tool_order() {
     };
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -784,9 +747,7 @@ async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
     };
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -845,9 +806,7 @@ async fn large_mcp_tool_listing_is_preserved_in_state() {
     let store = MockStore::with_output_and_usage("resp_big", output, Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -886,9 +845,7 @@ async fn extracts_usage_from_previous_response() {
     let store = MockStore::with_output_and_usage("resp_usage", output, usage.clone());
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -933,9 +890,7 @@ async fn no_usage_metadata_when_usage_missing() {
     let store = MockStore::with_output_and_usage("resp_no_usage", output, Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -977,9 +932,7 @@ async fn extracts_partial_usage_fields() {
     let store = MockStore::with_output_and_usage("resp_partial", output, usage);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1045,9 +998,7 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
     };
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1114,10 +1065,8 @@ async fn rejects_stored_history_exceeding_byte_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: 64,
-            max_items: None,
-        },
+        max_history_bytes: 64,
+        max_history_items: None,
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1153,10 +1102,8 @@ async fn rejects_stored_history_exceeding_item_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: Some(3),
-        },
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(3),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1189,10 +1136,8 @@ async fn allows_history_within_limits() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: Some(10),
-        },
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(10),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1286,10 +1231,8 @@ async fn rejects_fallback_reconstruction_exceeding_byte_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: 64,
-            max_items: None,
-        },
+        max_history_bytes: 64,
+        max_history_items: None,
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1345,10 +1288,8 @@ async fn rejects_fallback_reconstruction_exceeding_item_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: Some(3),
-        },
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(3),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1387,9 +1328,7 @@ async fn rehydrates_from_conversation_string_id() {
     let store = MockStore::with_conversation("conv_abc", messages);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1433,9 +1372,7 @@ async fn rehydrates_from_conversation_object_form() {
     let store = MockStore::with_conversation("conv_obj", messages);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1488,9 +1425,7 @@ async fn previous_response_id_takes_precedence_over_conversation() {
     );
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1525,9 +1460,7 @@ async fn rejects_when_conversation_not_found() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1548,9 +1481,7 @@ async fn tenant_mismatch_rejects_conversation() {
     let store = MockStore::with_conversation("conv_abc", json!([{"role": "user", "content": "hello"}]));
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1580,9 +1511,7 @@ async fn rejects_malformed_conversation_empty_object() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1601,9 +1530,7 @@ async fn rejects_malformed_conversation_numeric() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1622,9 +1549,7 @@ async fn empty_conversation_produces_valid_state() {
     let store = MockStore::with_conversation("conv_empty", json!([]));
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1653,9 +1578,7 @@ async fn empty_conversation_produces_valid_state() {
 
 #[tokio::test]
 async fn conversation_rehydration_requires_store_registry() {
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -1675,9 +1598,7 @@ async fn conversation_null_messages_treated_as_empty() {
     let store = MockStore::with_conversation("conv_null_msgs", Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        limiter: HistoryLimiter::default(),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1719,10 +1640,8 @@ async fn rejects_conversation_history_exceeding_byte_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: 64,
-            max_items: None,
-        },
+        max_history_bytes: 64,
+        max_history_items: None,
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1763,10 +1682,8 @@ async fn rejects_conversation_history_exceeding_item_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: Some(3),
-        },
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(3),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1801,10 +1718,8 @@ async fn allows_conversation_history_within_limits() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        limiter: HistoryLimiter {
-            max_bytes: default_max_history_bytes(),
-            max_items: Some(10),
-        },
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(10),
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -1699,6 +1699,128 @@ async fn conversation_null_messages_treated_as_empty() {
 }
 
 // -----------------------------------------------------------------------------
+// Conversation History Limits
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_conversation_history_exceeding_byte_limit() {
+    let user_content = "A".repeat(500);
+    let assistant_content = "B".repeat(500);
+    let messages = json!([
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": assistant_content}
+    ]);
+    let store = MockStore::with_conversation("conv_big", messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: 64,
+        max_history_items: None,
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_big"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(
+                r.status, 413,
+                "should reject with 413 for oversized conversation history"
+            );
+            let body_bytes = r.body.unwrap();
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.contains("byte limit"),
+                "rejection body should mention byte limit: {body_str}"
+            );
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejects_conversation_history_exceeding_item_limit() {
+    let messages = json!([
+        {"role": "user", "content": "Turn 1"},
+        {"role": "assistant", "content": "Reply 1"},
+        {"role": "user", "content": "Turn 2"},
+        {"role": "assistant", "content": "Reply 2"},
+        {"role": "user", "content": "Turn 3"}
+    ]);
+    let store = MockStore::with_conversation("conv_many", messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(3),
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_many"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 413, "should reject with 413 for too many conversation items");
+            let body_bytes = r.body.unwrap();
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.contains("item limit"),
+                "rejection body should mention item limit: {body_str}"
+            );
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn allows_conversation_history_within_limits() {
+    let messages = json!([
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"}
+    ]);
+    let store = MockStore::with_conversation("conv_ok", messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(10),
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4.1","input":"Next","conversation":"conv_ok"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release when conversation history is within limits"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.messages.len(),
+        3,
+        "messages should contain 2 stored + 1 current input"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -39,8 +39,10 @@ fn unknown_field_rejected() {
 #[test]
 fn body_access_is_read_only() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     assert_eq!(
         filter.request_body_access(),
@@ -56,8 +58,10 @@ fn body_access_is_read_only() {
 #[tokio::test]
 async fn skips_non_post_request() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -70,8 +74,10 @@ async fn skips_non_post_request() {
 #[tokio::test]
 async fn skips_non_responses_format() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -88,8 +94,10 @@ async fn skips_non_responses_format() {
 #[tokio::test]
 async fn continues_on_non_end_of_stream() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -105,8 +113,10 @@ async fn continues_on_non_end_of_stream() {
 #[tokio::test]
 async fn skips_cancel_request_without_parsing_empty_body() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/resp_123/cancel");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -132,8 +142,10 @@ async fn skips_cancel_request_without_parsing_empty_body() {
 #[tokio::test]
 async fn passthrough_when_no_previous_response_id() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -160,8 +172,10 @@ async fn passthrough_when_no_previous_response_id() {
 #[tokio::test]
 async fn passthrough_when_previous_response_id_is_null() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -191,8 +205,10 @@ async fn validates_previous_response_and_sets_metadata() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -337,8 +353,10 @@ async fn rejects_when_previous_response_not_found() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -359,8 +377,10 @@ async fn rejects_when_status_not_completed() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -381,8 +401,10 @@ async fn rejects_when_status_incomplete() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -403,8 +425,10 @@ async fn rejects_when_status_failed() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -422,8 +446,10 @@ async fn rejects_when_status_failed() {
 #[tokio::test]
 async fn rejects_when_store_unavailable() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -442,8 +468,10 @@ async fn rejects_when_store_not_registered() {
     let registry = ResponseStoreRegistry::new();
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -461,8 +489,10 @@ async fn rejects_when_store_not_registered() {
 #[tokio::test]
 async fn rejects_invalid_json_body() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -479,8 +509,10 @@ async fn rejects_invalid_json_body() {
 #[tokio::test]
 async fn rejects_non_string_previous_response_id() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -500,8 +532,10 @@ async fn rejects_when_store_fetch_fails() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -522,8 +556,10 @@ async fn rejects_when_conversation_store_fails() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -564,8 +600,10 @@ async fn extracts_mcp_tools_from_previous_response() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -615,8 +653,10 @@ async fn no_previous_tools_when_output_has_no_mcp_items() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -663,8 +703,10 @@ async fn extracts_mcp_tools_from_multiple_servers() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -743,8 +785,10 @@ async fn deduplicates_mcp_tools_independent_of_tool_order() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -807,8 +851,10 @@ async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -869,8 +915,10 @@ async fn large_mcp_tool_listing_is_preserved_in_state() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -911,8 +959,10 @@ async fn extracts_usage_from_previous_response() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -959,8 +1009,10 @@ async fn no_usage_metadata_when_usage_missing() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1004,8 +1056,10 @@ async fn extracts_partial_usage_fields() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1073,8 +1127,10 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1142,8 +1198,10 @@ async fn rejects_stored_history_exceeding_byte_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: 64,
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: 64,
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1179,8 +1237,10 @@ async fn rejects_stored_history_exceeding_item_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(3),
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: Some(3),
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1213,8 +1273,10 @@ async fn allows_history_within_limits() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(10),
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: Some(10),
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1239,11 +1301,33 @@ async fn allows_history_within_limits() {
     );
 }
 
-#[test]
-fn from_config_with_custom_limits() {
-    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_bytes: 1048576\nmax_history_items: 200").unwrap();
+#[tokio::test]
+async fn from_config_with_custom_limits() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_bytes: 2097152\nmax_history_items: 2").unwrap();
     let filter = RehydrateFilter::from_config(&yaml).unwrap();
     assert_eq!(filter.name(), "openai_responses_rehydrate");
+
+    let messages = json!([
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "third"}
+    ]);
+    let store = MockStore::with_completed_response("resp_cfg", json!("hello"), messages);
+    let registry = setup_registry(store);
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"next","previous_response_id":"resp_cfg"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 413, "configured item limit of 2 should reject 3-item history");
+        },
+        other => panic!("expected Reject for custom max_history_items=2, got {other:?}"),
+    }
 }
 
 #[test]
@@ -1272,8 +1356,10 @@ async fn rejects_stored_history_exceeding_byte_limit_streaming() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: 64,
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: 64,
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1315,8 +1401,10 @@ async fn allows_history_at_exact_byte_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: serialized_size,
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: serialized_size,
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1341,8 +1429,10 @@ async fn allows_history_at_exact_item_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(2),
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: Some(2),
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1359,6 +1449,125 @@ async fn allows_history_at_exact_item_limit() {
     );
 }
 
+#[tokio::test]
+async fn rejects_fallback_reconstruction_exceeding_byte_limit() {
+    let large_input = "X".repeat(500);
+    let large_output = json!([
+        {"type": "message", "content": [{"type": "output_text", "text": "Y".repeat(500)}]}
+    ]);
+    let mut records = std::collections::HashMap::new();
+    records.insert(
+        "resp_fallback".to_owned(),
+        ResponseRecord {
+            id: "resp_fallback".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1000,
+            model: "gpt-4.1".to_owned(),
+            response_object: json!({
+                "id": "resp_fallback",
+                "status": "completed",
+                "output": large_output,
+            }),
+            input: json!(large_input),
+            messages: json!([]),
+        },
+    );
+    let store = MockStore {
+        records,
+        conversations: std::collections::HashMap::new(),
+        should_fail: false,
+    };
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        limiter: HistoryLimiter {
+            max_bytes: 64,
+            max_items: None,
+        },
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_fallback"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(
+                r.status, 413,
+                "fallback reconstruction exceeding byte limit should reject with 413"
+            );
+        },
+        other => panic!("expected Reject for oversized fallback reconstruction, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejects_fallback_reconstruction_exceeding_item_limit() {
+    let input = json!([
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "a"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "b"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "c"}]}
+    ]);
+    let output = json!([
+        {"type": "message", "content": [{"type": "output_text", "text": "r1"}]},
+        {"type": "message", "content": [{"type": "output_text", "text": "r2"}]}
+    ]);
+    let mut records = std::collections::HashMap::new();
+    records.insert(
+        "resp_items".to_owned(),
+        ResponseRecord {
+            id: "resp_items".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1000,
+            model: "gpt-4.1".to_owned(),
+            response_object: json!({
+                "id": "resp_items",
+                "status": "completed",
+                "output": output,
+            }),
+            input,
+            messages: json!([]),
+        },
+    );
+    let store = MockStore {
+        records,
+        conversations: std::collections::HashMap::new(),
+        should_fail: false,
+    };
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: Some(3),
+        },
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_items"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(
+                r.status, 413,
+                "fallback reconstruction exceeding item limit should reject with 413"
+            );
+            let body_bytes = r.body.unwrap();
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.contains("item limit"),
+                "rejection body should mention item limit: {body_str}"
+            );
+        },
+        other => panic!("expected Reject for oversized fallback reconstruction, got {other:?}"),
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Conversation Rehydration
 // -----------------------------------------------------------------------------
@@ -1373,8 +1582,10 @@ async fn rehydrates_from_conversation_string_id() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1420,8 +1631,10 @@ async fn rehydrates_from_conversation_object_form() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1476,8 +1689,10 @@ async fn previous_response_id_takes_precedence_over_conversation() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1514,8 +1729,10 @@ async fn rejects_when_conversation_not_found() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1538,8 +1755,10 @@ async fn tenant_mismatch_rejects_conversation() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1571,8 +1790,10 @@ async fn rejects_malformed_conversation_empty_object() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1593,8 +1814,10 @@ async fn rejects_malformed_conversation_numeric() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1615,8 +1838,10 @@ async fn empty_conversation_produces_valid_state() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1647,8 +1872,10 @@ async fn empty_conversation_produces_valid_state() {
 #[tokio::test]
 async fn conversation_rehydration_requires_store_registry() {
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1670,8 +1897,10 @@ async fn conversation_null_messages_treated_as_empty() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1714,8 +1943,10 @@ async fn rejects_conversation_history_exceeding_byte_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: 64,
-        max_history_items: None,
+        limiter: HistoryLimiter {
+            max_bytes: 64,
+            max_items: None,
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1756,8 +1987,10 @@ async fn rejects_conversation_history_exceeding_item_limit() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(3),
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: Some(3),
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1792,8 +2025,10 @@ async fn allows_conversation_history_within_limits() {
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(10),
+        limiter: HistoryLimiter {
+            max_bytes: default_max_history_bytes(),
+            max_items: Some(10),
+        },
     };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -38,7 +38,10 @@ fn unknown_field_rejected() {
 
 #[test]
 fn body_access_is_read_only() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     assert_eq!(
         filter.request_body_access(),
         BodyAccess::ReadOnly,
@@ -52,7 +55,10 @@ fn body_access_is_read_only() {
 
 #[tokio::test]
 async fn skips_non_post_request() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let mut body = Some(Bytes::from(r#"{"input":"test"}"#));
@@ -63,7 +69,10 @@ async fn skips_non_post_request() {
 
 #[tokio::test]
 async fn skips_non_responses_format() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_chat_completions");
@@ -78,7 +87,10 @@ async fn skips_non_responses_format() {
 
 #[tokio::test]
 async fn continues_on_non_end_of_stream() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let mut body = Some(Bytes::from(r#"{"input":"partial"}"#));
@@ -92,7 +104,10 @@ async fn continues_on_non_end_of_stream() {
 
 #[tokio::test]
 async fn skips_cancel_request_without_parsing_empty_body() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/resp_123/cancel");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -116,7 +131,10 @@ async fn skips_cancel_request_without_parsing_empty_body() {
 
 #[tokio::test]
 async fn passthrough_when_no_previous_response_id() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -141,7 +159,10 @@ async fn passthrough_when_no_previous_response_id() {
 
 #[tokio::test]
 async fn passthrough_when_previous_response_id_is_null() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -169,7 +190,10 @@ async fn validates_previous_response_and_sets_metadata() {
     let store = MockStore::with_completed_response("resp_prev", json!("Hello"), messages);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -312,7 +336,10 @@ async fn rejects_when_previous_response_not_found() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -331,7 +358,10 @@ async fn rejects_when_status_not_completed() {
     let store = MockStore::with_status("resp_123", "in_progress");
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -350,7 +380,10 @@ async fn rejects_when_status_incomplete() {
     let store = MockStore::with_status("resp_123", "incomplete");
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -369,7 +402,10 @@ async fn rejects_when_status_failed() {
     let store = MockStore::with_status("resp_123", "failed");
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -385,7 +421,10 @@ async fn rejects_when_status_failed() {
 
 #[tokio::test]
 async fn rejects_when_store_unavailable() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -402,7 +441,10 @@ async fn rejects_when_store_unavailable() {
 async fn rejects_when_store_not_registered() {
     let registry = ResponseStoreRegistry::new();
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -418,7 +460,10 @@ async fn rejects_when_store_not_registered() {
 
 #[tokio::test]
 async fn rejects_invalid_json_body() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -433,7 +478,10 @@ async fn rejects_invalid_json_body() {
 
 #[tokio::test]
 async fn rejects_non_string_previous_response_id() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -451,7 +499,10 @@ async fn rejects_when_store_fetch_fails() {
     let store = MockStore::failing();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -470,7 +521,10 @@ async fn rejects_when_conversation_store_fails() {
     let store = MockStore::failing();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -509,7 +563,10 @@ async fn extracts_mcp_tools_from_previous_response() {
     let store = MockStore::with_output_and_usage("resp_mcp", output, usage);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -557,7 +614,10 @@ async fn no_previous_tools_when_output_has_no_mcp_items() {
     let store = MockStore::with_output_and_usage("resp_no_mcp", output, usage);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -602,7 +662,10 @@ async fn extracts_mcp_tools_from_multiple_servers() {
     let store = MockStore::with_output_and_usage("resp_multi", output, Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -679,7 +742,10 @@ async fn deduplicates_mcp_tools_independent_of_tool_order() {
     };
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -740,7 +806,10 @@ async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
     };
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -799,7 +868,10 @@ async fn large_mcp_tool_listing_is_preserved_in_state() {
     let store = MockStore::with_output_and_usage("resp_big", output, Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -838,7 +910,10 @@ async fn extracts_usage_from_previous_response() {
     let store = MockStore::with_output_and_usage("resp_usage", output, usage.clone());
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -883,7 +958,10 @@ async fn no_usage_metadata_when_usage_missing() {
     let store = MockStore::with_output_and_usage("resp_no_usage", output, Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -925,7 +1003,10 @@ async fn extracts_partial_usage_fields() {
     let store = MockStore::with_output_and_usage("resp_partial", output, usage);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -991,7 +1072,10 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
     };
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1043,6 +1127,239 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
 }
 
 // -----------------------------------------------------------------------------
+// History Limits
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_stored_history_exceeding_byte_limit() {
+    let user_content = "A".repeat(500);
+    let assistant_content = "B".repeat(500);
+    let messages = json!([
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": assistant_content}
+    ]);
+    let store = MockStore::with_completed_response("resp_big", json!("Hello"), messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: 64,
+        max_history_items: None,
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_big"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 413, "should reject with 413 for oversized history");
+            let body_bytes = r.body.unwrap();
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.contains("byte limit"),
+                "rejection body should mention byte limit: {body_str}"
+            );
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejects_stored_history_exceeding_item_limit() {
+    let messages = json!([
+        {"role": "user", "content": "Turn 1"},
+        {"role": "assistant", "content": "Reply 1"},
+        {"role": "user", "content": "Turn 2"},
+        {"role": "assistant", "content": "Reply 2"},
+        {"role": "user", "content": "Turn 3"}
+    ]);
+    let store = MockStore::with_completed_response("resp_many", json!("Hello"), messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(3),
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_many"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 413, "should reject with 413 for too many items");
+            let body_bytes = r.body.unwrap();
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.contains("item limit"),
+                "rejection body should mention item limit: {body_str}"
+            );
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn allows_history_within_limits() {
+    let messages = json!([
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"}
+    ]);
+    let store = MockStore::with_completed_response("resp_ok", json!("Hello"), messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(10),
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Next","previous_response_id":"resp_ok"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release when history is within limits"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.messages.len(),
+        3,
+        "messages should contain 2 stored + 1 current input"
+    );
+}
+
+#[test]
+fn from_config_with_custom_limits() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_bytes: 1048576\nmax_history_items: 200").unwrap();
+    let filter = RehydrateFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "openai_responses_rehydrate");
+}
+
+#[test]
+fn from_config_rejects_zero_max_history_bytes() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_bytes: 0").unwrap();
+    let result = RehydrateFilter::from_config(&yaml);
+    assert!(result.is_err(), "max_history_bytes: 0 should be rejected");
+}
+
+#[test]
+fn from_config_rejects_zero_max_history_items() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_items: 0").unwrap();
+    let result = RehydrateFilter::from_config(&yaml);
+    assert!(result.is_err(), "max_history_items: 0 should be rejected");
+}
+
+#[tokio::test]
+async fn rejects_stored_history_exceeding_byte_limit_streaming() {
+    let user_content = "A".repeat(500);
+    let assistant_content = "B".repeat(500);
+    let messages = json!([
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": assistant_content}
+    ]);
+    let store = MockStore::with_completed_response("resp_big_stream", json!("Hello"), messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: 64,
+        max_history_items: None,
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    ctx.set_metadata("openai_responses_format.stream", "true");
+    let mut body = Some(Bytes::from(
+        r#"{"input":"Hi","previous_response_id":"resp_big_stream","stream":true}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 413, "should reject with 413 for oversized history");
+            let ct = r.headers.iter().find(|(k, _)| k == "content-type");
+            assert_eq!(
+                ct.map(|(_, v)| v.as_str()),
+                Some("text/event-stream"),
+                "streaming rejection should use SSE content type"
+            );
+            let body_bytes = r.body.unwrap();
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.starts_with("event: error\n"),
+                "streaming rejection should be an SSE error event: {body_str}"
+            );
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn allows_history_at_exact_byte_limit() {
+    let messages = json!([
+        {"role": "user", "content": "Hi"}
+    ]);
+    let serialized_size = serde_json::to_string(messages.as_array().unwrap()).unwrap().len();
+    let store = MockStore::with_completed_response("resp_exact", json!("Hi"), messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: serialized_size,
+        max_history_items: None,
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Next","previous_response_id":"resp_exact"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "history at exact byte limit should pass, not reject"
+    );
+}
+
+#[tokio::test]
+async fn allows_history_at_exact_item_limit() {
+    let messages = json!([
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"}
+    ]);
+    let store = MockStore::with_completed_response("resp_exact_items", json!("Hello"), messages);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: Some(2),
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"input":"Next","previous_response_id":"resp_exact_items"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "history at exact item limit should pass, not reject"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Conversation Rehydration
 // -----------------------------------------------------------------------------
 
@@ -1055,7 +1372,10 @@ async fn rehydrates_from_conversation_string_id() {
     let store = MockStore::with_conversation("conv_abc", messages);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1099,7 +1419,10 @@ async fn rehydrates_from_conversation_object_form() {
     let store = MockStore::with_conversation("conv_obj", messages);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1152,7 +1475,10 @@ async fn previous_response_id_takes_precedence_over_conversation() {
     );
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1187,7 +1513,10 @@ async fn rejects_when_conversation_not_found() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1208,7 +1537,10 @@ async fn tenant_mismatch_rejects_conversation() {
     let store = MockStore::with_conversation("conv_abc", json!([{"role": "user", "content": "hello"}]));
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1238,7 +1570,10 @@ async fn rejects_malformed_conversation_empty_object() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1257,7 +1592,10 @@ async fn rejects_malformed_conversation_numeric() {
     let store = MockStore::empty();
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1276,7 +1614,10 @@ async fn empty_conversation_produces_valid_state() {
     let store = MockStore::with_conversation("conv_empty", json!([]));
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
@@ -1305,7 +1646,10 @@ async fn empty_conversation_produces_valid_state() {
 
 #[tokio::test]
 async fn conversation_rehydration_requires_store_registry() {
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
@@ -1325,7 +1669,10 @@ async fn conversation_null_messages_treated_as_empty() {
     let store = MockStore::with_conversation("conv_null_msgs", Value::Null);
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter;
+    let filter = RehydrateFilter {
+        max_history_bytes: default_max_history_bytes(),
+        max_history_items: None,
+    };
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());

--- a/docs/filters/openai_responses_rehydrate.md
+++ b/docs/filters/openai_responses_rehydrate.md
@@ -9,6 +9,13 @@ Validates `previous_response_id` by fetching the stored response, confirming its
 
 The request body is **not** modified; downstream filters read from `ResponsesState.messages` instead.
 
+## Configuration
+
+| Field | Type | Required | Description |
+|-------|------|---------|-------------|
+| `max_history_bytes` | integer | no | Maximum serialized byte size of stored conversation history. |
+| `max_history_items` | integer | no | Optional cap on the number of stored history items. |
+
 ## Example
 
 ```yaml

--- a/docs/filters/openai_responses_rehydrate.md
+++ b/docs/filters/openai_responses_rehydrate.md
@@ -13,7 +13,7 @@ The request body is **not** modified; downstream filters read from `ResponsesSta
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `max_history_bytes` | integer | no | Maximum serialized byte size of stored conversation history. |
+| `max_history_bytes` | integer | no | Maximum serialized byte size of stored conversation history. Default: 2,097,152 (2 MiB). |
 | `max_history_items` | integer | no | Optional cap on the number of stored history items. |
 
 ## Example

--- a/examples/configs/openai/responses/rehydrate.yaml
+++ b/examples/configs/openai/responses/rehydrate.yaml
@@ -50,6 +50,8 @@ filter_chains:
         conversations_table: openai_conversations
 
       - filter: openai_responses_rehydrate
+        # max_history_bytes: 2097152  # 2 MiB (default)
+        # max_history_items: ~        # unlimited (default)
 
       - filter: router
         routes:


### PR DESCRIPTION
## Summary

Closes #66.

- Add `max_history_bytes` (default 2 MiB) and `max_history_items` (default unlimited) config fields to the `openai_responses_rehydrate` filter
- Enforce limits **before** stored history is spliced into `ResponsesState`, preventing unbounded proxy memory growth
- Reject oversized history with 413 and an actionable error message ("compact or shorten the conversation before continuing")
- Introduce a `RehydrationSource` trait so `build_state` is generic over `ResponseRecord` and `ConversationRecord` — limits are enforced uniformly on both the `previous_response_id` and `conversation` rehydration paths
- Restructure `rehydrate` into a clean dispatcher with two symmetric methods: `rehydrate_from_response` and `rehydrate_from_conversation`
- Fix fail-open bug: serialization failure in byte-size measurement now falls back to `usize::MAX` (reject) instead of `0` (allow)

## Config

```yaml
- filter: openai_responses_rehydrate
  max_history_bytes: 2097152  # 2 MiB (default)
  max_history_items: ~        # unlimited (default)
```

Both fields reject zero values at config load time.

## Test plan

- [x] 55 unit tests pass (`cargo test -p praxis-ai-apis -- rehydrate`)
- [x] Config validation: rejects zero `max_history_bytes`, zero `max_history_items`, unknown fields
- [x] Response path: rejects byte limit, item limit, exact boundary, streaming 413 format
- [x] Conversation path: rejects byte limit, item limit, within-limits passthrough
- [x] `make lint` clean (clippy + nightly fmt + filter docs)