### PR TITLE
feat(mcp): route stateless tools/call through static broker catalog

### DIFF
--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -74,11 +74,14 @@ pub(crate) mod test_utils {
             request_headers_to_remove: Vec::new(),
             request_headers_to_set: Vec::new(),
             filter_metadata: std::collections::HashMap::new(),
+            pre_read_mutations: Vec::new(),
+            structured_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             filter_state: std::collections::HashMap::new(),
             health_registry: None,
             id_generator: &TEST_ID_GENERATOR,
             kv_stores: None,
+            peer_identity: None,
             request: req,
             request_body_bytes: 0,
             request_body_mode: praxis_filter::BodyMode::Stream,
@@ -91,9 +94,6 @@ pub(crate) mod test_utils {
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,
             upstream: None,
-            peer_identity: None,
-            pre_read_mutations: Vec::new(),
-            structured_metadata: std::collections::HashMap::new(),
         }
     }
 

--- a/docs/architecture/agentic-protocols.md
+++ b/docs/architecture/agentic-protocols.md
@@ -92,8 +92,9 @@ Client --> MCP Broker Filter
              +-- tools/list:  aggregated catalog
              |                from all servers
              +-- ping:        local response
-             +-- tools/call:  not yet supported
-             |                (returns -32601)
+             +-- tools/call:  stateless routes by
+             |                configured catalog tool
+             |                current profile returns -32601
              +-- DELETE:      session termination
 ```
 

--- a/docs/filters/mcp.md
+++ b/docs/filters/mcp.md
@@ -5,7 +5,7 @@
 
 Extracts MCP protocol metadata from JSON-RPC request bodies and promotes method, tool/resource/prompt name, JSON-RPC kind, protocol version, and session presence to request headers/filter results; stores session ID in durable metadata.
 
-MCP static catalog filter that aggregates tool catalogs from multiple backend MCP servers and handles `initialize`, `tools/list`, `tools/call`, `ping`, and `notifications/initialized` directly as a static broker.
+MCP static catalog filter that aggregates tool catalogs from multiple backend MCP servers and handles `initialize`, `tools/list`, `tools/call`, `ping`, and `notifications/initialized` as a static broker.
 
 ## Configuration Notes
 
@@ -15,7 +15,9 @@ Methods requiring a name selector (`tools/call`, `resources/read`, `prompts/get`
 
 Writes `mcp.*` and `json_rpc.*` entries to the filter result set for branch chain conditions.
 
-The broker serves configured catalog operations locally while backend tool routing is not implemented. It deliberately returns `-32601` for `tools/call` rather than forwarding a request whose target is unresolved.
+In the stateless profile, `tools/call` routes to the configured backend cluster by exposed tool name, stripping the public prefix from `params.name` and repairing the forwarded `Mcp-Name` header before forwarding.
+
+In the current profile, `tools/call` returns `-32601` because current-profile routing requires session infrastructure not implemented here.
 
 Supports two protocol profiles: `current` (session-based, default) and `stateless` (MCP 2026-07-28, configurable). Version and cache fields are derived from the selected profile when omitted.
 

--- a/examples/configs/mcp-stateless-broker.yaml
+++ b/examples/configs/mcp-stateless-broker.yaml
@@ -7,8 +7,10 @@
 # MCP-Protocol-Version, Mcp-Method, and Mcp-Name
 # headers on every request.
 #
-# Backend tools/call routing is not yet implemented;
-# tools/call returns a controlled unsupported response.
+# The broker serves server/discover and tools/list from
+# the configured static catalog. tools/call routes to the
+# backend cluster by exposed tool name, stripping the tool
+# prefix before forwarding.
 #
 #   cargo run -p praxis-ai-proxy -- -c examples/configs/mcp-stateless-broker.yaml
 

--- a/filters/src/agentic/mcp/broker/config.rs
+++ b/filters/src/agentic/mcp/broker/config.rs
@@ -170,8 +170,7 @@ pub(super) struct ValidatedBrokerConfig {
 
 /// Entry in the pre-built tool catalog.
 #[derive(Debug, Clone)]
-#[cfg_attr(not(test), expect(dead_code, reason = "fields used by follow-up tools/call routing"))]
-pub(super) struct CatalogTool {
+pub(crate) struct CatalogTool {
     /// Optional tool annotations.
     pub annotations: Option<serde_json::Value>,
     /// Backend MCP endpoint path.

--- a/filters/src/agentic/mcp/broker/mod.rs
+++ b/filters/src/agentic/mcp/broker/mod.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! MCP static catalog filter: static tool catalog, prefix management, and broker
-//! behavior for `initialize`, `tools/list`, `ping`, and `notifications`.
+//! MCP static catalog filter: static tool catalog, prefix management, broker
+//! behavior for `initialize`, `tools/list`, `ping`, `notifications`, and
+//! stateless-profile `tools/call` routing.
 
 pub(crate) mod config;
 
@@ -20,7 +21,10 @@ pub(crate) mod config;
 )]
 mod tests;
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use base64::Engine as _;
 use bytes::Bytes;
 use praxis_filter::{
     BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, Rejection,
@@ -54,6 +58,9 @@ const ERR_HEADER_MISMATCH: i32 = -32020;
 /// JSON-RPC error code for unsupported protocol version.
 const ERR_UNSUPPORTED_VERSION: i32 = -32022;
 
+/// JSON-RPC error code for invalid params.
+const ERR_INVALID_PARAMS: i32 = -32602;
+
 /// MCP `=?base64?` sentinel prefix.
 const BASE64_SENTINEL_PREFIX: &str = "=?base64?";
 
@@ -66,11 +73,14 @@ const BASE64_SENTINEL_SUFFIX: &str = "?=";
 
 /// MCP static catalog filter that aggregates tool catalogs from multiple backend
 /// MCP servers and handles `initialize`, `tools/list`, `tools/call`, `ping`,
-/// and `notifications/initialized` directly as a static broker.
+/// and `notifications/initialized` as a static broker.
 ///
-/// The broker serves configured catalog operations locally while backend tool
-/// routing is not implemented. It deliberately returns `-32601` for
-/// `tools/call` rather than forwarding a request whose target is unresolved.
+/// In the stateless profile, `tools/call` routes to the configured backend
+/// cluster by exposed tool name, stripping the public prefix from `params.name`
+/// and repairing the forwarded `Mcp-Name` header before forwarding.
+///
+/// In the current profile, `tools/call` returns `-32601` because current-profile
+/// routing requires session infrastructure not implemented here.
 ///
 /// # YAML
 ///
@@ -151,16 +161,18 @@ impl McpBrokerFilter {
     // -------------------------------------------------------------------------
 
     /// Maps a JSON-RPC method to the MCP handler that owns it.
+    #[expect(clippy::too_many_arguments, reason = "body reference needed for tools/call mutation")]
     fn dispatch_method(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         value: &serde_json::Value,
         envelope: &JsonRpcEnvelope,
         method_str: &str,
+        body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         match self.protocol_profile {
             ProtocolProfile::Current => self.dispatch_current(ctx, value, envelope, method_str),
-            ProtocolProfile::Stateless => Ok(self.dispatch_stateless(ctx, value, envelope, method_str)),
+            ProtocolProfile::Stateless => Ok(self.dispatch_stateless(ctx, value, envelope, method_str, body)),
         }
     }
 
@@ -195,16 +207,15 @@ impl McpBrokerFilter {
     }
 
     /// Stateless-profile dispatch: validates stateless headers, then dispatches.
-    #[expect(
-        clippy::needless_pass_by_ref_mut,
-        reason = "signature matches dispatch_current for consistent dispatch_method call"
-    )]
+    #[expect(clippy::too_many_arguments, reason = "body reference needed for tools/call mutation")]
+    #[expect(clippy::too_many_lines, reason = "linear dispatch with early returns")]
     fn dispatch_stateless(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         value: &serde_json::Value,
         envelope: &JsonRpcEnvelope,
         method_str: &str,
+        body: &mut Option<Bytes>,
     ) -> FilterAction {
         let is_notification = method_str.starts_with("notifications/");
         if is_notification {
@@ -219,6 +230,12 @@ impl McpBrokerFilter {
             return invalid_request_action(envelope);
         }
 
+        if method_str == "tools/call"
+            && let Err(detail) = extract_tool_name(value)
+        {
+            return invalid_params_action(envelope, detail);
+        }
+
         if let Some(action) = self.validate_stateless_headers(value, &ctx.request.headers, envelope, method_str) {
             return action;
         }
@@ -226,7 +243,7 @@ impl McpBrokerFilter {
         match method_str {
             "server/discover" => self.handle_server_discover(envelope),
             "tools/list" => self.handle_stateless_tools_list(envelope),
-            "tools/call" => json_rpc_error_action_with_status(envelope, 404, -32601, "method not yet supported"),
+            "tools/call" => self.handle_stateless_tools_call(ctx, value, envelope, body),
             "ping" => handle_ping(envelope),
             "initialize" => json_rpc_error_action_with_status(
                 envelope,
@@ -357,6 +374,48 @@ impl McpBrokerFilter {
         )
     }
 
+    /// Route a stateless `tools/call` to the configured backend cluster.
+    fn handle_stateless_tools_call(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        value: &serde_json::Value,
+        envelope: &JsonRpcEnvelope,
+        body: &mut Option<Bytes>,
+    ) -> FilterAction {
+        let tool_name = match extract_tool_name(value) {
+            Ok(name) => name,
+            Err(detail) => return invalid_params_action(envelope, detail),
+        };
+
+        let Some(tool) = self.catalog.iter().find(|t| t.exposed_name == tool_name) else {
+            return invalid_params_action(envelope, "unknown tool");
+        };
+
+        ctx.cluster = Some(Arc::from(tool.cluster.as_str()));
+        ctx.rewritten_path = Some(tool.backend_path.clone());
+
+        let mut mutated = value.clone();
+        if let Some(p) = mutated.get_mut("params").and_then(|p| p.as_object_mut()) {
+            p.insert("name".to_owned(), serde_json::Value::String(tool.original_name.clone()));
+        }
+        *body = Some(Bytes::from(mutated.to_string()));
+
+        ctx.request_headers_to_set.push((
+            http::header::HeaderName::from_static("mcp-name"),
+            encode_mcp_name(&tool.original_name),
+        ));
+
+        trace!(
+            exposed = tool_name,
+            original = tool.original_name,
+            cluster = tool.cluster,
+            server = tool.server_name,
+            "routing stateless tools/call"
+        );
+
+        FilterAction::Release
+    }
+
     /// `tools/list` response for the stateless profile with cache metadata.
     fn handle_stateless_tools_list(&self, envelope: &JsonRpcEnvelope) -> FilterAction {
         let tools: Vec<serde_json::Value> = self.catalog.iter().map(catalog_tool_to_json).collect();
@@ -449,13 +508,46 @@ impl HttpFilter for McpBrokerFilter {
             ctx.set_metadata("mcp.method", method_str.clone());
         }
 
-        self.dispatch_method(ctx, &value, &envelope, method_str)
+        self.dispatch_method(ctx, &value, &envelope, method_str, body)
     }
 }
 
 // -----------------------------------------------------------------------------
 // Stateless Helpers
 // -----------------------------------------------------------------------------
+
+/// Extracts and validates the tool name from `params.name`.
+fn extract_tool_name(value: &serde_json::Value) -> Result<&str, &'static str> {
+    let Some(params) = value.get("params") else {
+        return Err("missing params");
+    };
+    if params.is_null() {
+        return Err("params is null");
+    }
+    let Some(params_obj) = params.as_object() else {
+        return Err("params must be an object");
+    };
+    let Some(name) = params_obj.get("name") else {
+        return Err("missing params.name");
+    };
+    name.as_str().ok_or("params.name must be a string")
+}
+
+/// Encode a tool name as an HTTP header value, using the MCP `=?base64?`
+/// sentinel for values that contain non-visible-ASCII bytes.
+#[expect(clippy::expect_used, reason = "base64 sentinel is always valid ASCII")]
+fn encode_mcp_name(name: &str) -> http::header::HeaderValue {
+    if name.is_ascii()
+        && !name.bytes().any(|b| b < 0x20 || b == 0x7F)
+        && let Ok(hv) = http::header::HeaderValue::from_str(name)
+    {
+        return hv;
+    }
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(name);
+    let sentinel = format!("{BASE64_SENTINEL_PREFIX}{encoded}{BASE64_SENTINEL_SUFFIX}");
+    http::header::HeaderValue::from_str(&sentinel).expect("base64 sentinel is valid ASCII")
+}
 
 /// Validates the `Mcp-Name` header for stateless requests.
 #[expect(clippy::too_many_lines, reason = "linear validation with early returns")]
@@ -602,8 +694,6 @@ enum McpNameDecodeError {
 /// Returns `Ok(Some(decoded))` for valid sentinels, `Ok(None)` for
 /// non-sentinel values, and `Err` for malformed sentinels.
 fn decode_mcp_name(value: &str) -> Result<Option<String>, McpNameDecodeError> {
-    use base64::Engine as _;
-
     let Some(inner) = value
         .strip_prefix(BASE64_SENTINEL_PREFIX)
         .and_then(|rest| rest.strip_suffix(BASE64_SENTINEL_SUFFIX))
@@ -628,6 +718,21 @@ fn header_str<'a>(headers: &'a http::HeaderMap, name: &str) -> Option<&'a str> {
 // -----------------------------------------------------------------------------
 // Error Response Builders
 // -----------------------------------------------------------------------------
+
+/// Builds an invalid-params error response (HTTP 400, JSON-RPC -32602).
+fn invalid_params_action(envelope: &JsonRpcEnvelope, detail: &str) -> FilterAction {
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "error": { "code": ERR_INVALID_PARAMS, "message": detail },
+        "id": id_value(envelope),
+    });
+
+    FilterAction::Reject(
+        Rejection::status(400)
+            .with_header("content-type", "application/json")
+            .with_body(Bytes::from(response.to_string())),
+    )
+}
 
 /// Builds a header-mismatch error response (HTTP 400, JSON-RPC -32020).
 fn header_mismatch_action(envelope: &JsonRpcEnvelope, message: &str) -> FilterAction {

--- a/filters/src/agentic/mcp/broker/tests.rs
+++ b/filters/src/agentic/mcp/broker/tests.rs
@@ -3,6 +3,7 @@
 
 //! Unit tests for MCP static catalog filter.
 
+use base64::Engine as _;
 use bytes::Bytes;
 
 use super::{
@@ -930,7 +931,7 @@ async fn tools_list_returns_prefixed_catalog() {
 }
 
 #[tokio::test]
-async fn tools_call_returns_unsupported() {
+async fn current_profile_tools_call_returns_unsupported() {
     let filter = make_broker_filter();
     let body_str =
         r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"weather_get_weather","arguments":{}}}"#;
@@ -942,17 +943,14 @@ async fn tools_call_returns_unsupported() {
 
     match &action {
         FilterAction::Reject(rejection) => {
-            assert_eq!(
-                rejection.status, 200,
-                "tools/call should return a JSON-RPC error response before backend routing is added"
-            );
+            assert_eq!(rejection.status, 200, "current-profile tools/call must return -32601");
             let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
             assert!(
                 body_str.contains("-32601"),
-                "tools/call should return -32601 before backend routing is added: {body_str}"
+                "current-profile tools/call must return -32601: {body_str}"
             );
         },
-        FilterAction::Release => panic!("tools/call must not return Release before backend routing is added"),
+        FilterAction::Release => panic!("current-profile tools/call must not return Release"),
         _ => panic!("expected Reject with JSON-RPC error"),
     }
 }
@@ -2154,8 +2152,6 @@ async fn stateless_tools_call_mcp_name_mismatch_rejected() {
 
 #[tokio::test]
 async fn stateless_tools_call_base64_mcp_name_matches_body() {
-    use base64::Engine as _;
-
     let filter = make_stateless_broker_filter();
     let tool_name = "weather_get_weather";
     let encoded = base64::engine::general_purpose::STANDARD.encode(tool_name);
@@ -2168,20 +2164,15 @@ async fn stateless_tools_call_base64_mcp_name_matches_body() {
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
-    match &action {
-        FilterAction::Reject(rejection) => {
-            assert_eq!(
-                rejection.status, 404,
-                "base64-encoded Mcp-Name matching body should pass validation but tools/call returns 404"
-            );
-            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
-            assert!(
-                body_str.contains("-32601"),
-                "tools/call should still return unsupported: {body_str}"
-            );
-        },
-        _ => panic!("expected Reject with JSON-RPC error (tools/call unsupported)"),
-    }
+    assert!(
+        matches!(action, FilterAction::Release),
+        "base64-encoded Mcp-Name matching body should pass validation and route to backend"
+    );
+    assert_eq!(
+        ctx.cluster.as_deref(),
+        Some("weather-mcp"),
+        "should select weather-mcp cluster"
+    );
 }
 
 #[tokio::test]
@@ -2448,6 +2439,322 @@ async fn stateless_array_client_capabilities_rejected() {
             let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
             let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
             assert_eq!(parsed["error"]["code"], ERR_HEADER_MISMATCH);
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Stateless Tools/Call Routing Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stateless_tools_call_known_tool_releases_with_cluster() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Release),
+        "known stateless tool should return Release for forwarding"
+    );
+    assert_eq!(
+        ctx.cluster.as_deref(),
+        Some("weather-mcp"),
+        "should select weather-mcp cluster"
+    );
+}
+
+#[tokio::test]
+async fn stateless_tools_call_sets_rewritten_path() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert_eq!(
+        ctx.rewritten_path.as_deref(),
+        Some("/mcp"),
+        "should rewrite path to backend MCP path"
+    );
+}
+
+#[tokio::test]
+async fn stateless_tools_call_strips_prefix_in_body() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let mutated: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert_eq!(
+        mutated["params"]["name"], "get_weather",
+        "body params.name should be stripped to original tool name"
+    );
+}
+
+#[tokio::test]
+async fn stateless_tools_call_rewrites_forwarded_mcp_name() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let mcp_name_header = ctx
+        .request_headers_to_set
+        .iter()
+        .find(|(k, _)| k.as_str() == "mcp-name")
+        .map(|(_, v)| v.to_str().unwrap().to_owned());
+    assert_eq!(
+        mcp_name_header.as_deref(),
+        Some("get_weather"),
+        "forwarded Mcp-Name should match stripped backend tool name"
+    );
+}
+
+#[tokio::test]
+async fn stateless_tools_call_preserves_arguments() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params(
+        "tools/call",
+        1,
+        r#""name":"weather_get_weather","arguments":{"city":"NYC"}"#,
+    );
+    let mut body = Some(Bytes::from(body_str));
+
+    let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let mutated: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert_eq!(
+        mutated["params"]["arguments"]["city"], "NYC",
+        "arguments should be preserved after body mutation"
+    );
+    assert_eq!(mutated["id"], 1, "JSON-RPC id should be preserved after body mutation");
+    assert_eq!(
+        mutated["method"], "tools/call",
+        "method should be preserved after body mutation"
+    );
+}
+
+#[test]
+fn encode_mcp_name_ascii_returns_plain_value() {
+    let hv = encode_mcp_name("get_weather");
+    assert_eq!(hv.to_str().unwrap(), "get_weather", "ASCII name should pass through");
+}
+
+#[test]
+fn encode_mcp_name_non_ascii_uses_base64_sentinel() {
+    let hv = encode_mcp_name("wëäthér_tøøl");
+    let sentinel = std::str::from_utf8(hv.as_bytes()).expect("sentinel should be valid UTF-8");
+    assert!(
+        sentinel.starts_with("=?base64?"),
+        "non-ASCII name should use base64 sentinel prefix: {sentinel}"
+    );
+    assert!(
+        sentinel.ends_with("?="),
+        "non-ASCII name should use base64 sentinel suffix: {sentinel}"
+    );
+
+    let inner = sentinel
+        .strip_prefix("=?base64?")
+        .and_then(|s| s.strip_suffix("?="))
+        .unwrap();
+    let decoded = base64::engine::general_purpose::STANDARD.decode(inner).unwrap();
+    let decoded_str = String::from_utf8(decoded).unwrap();
+    assert_eq!(
+        decoded_str, "wëäthér_tøøl",
+        "decoded sentinel should match original name"
+    );
+}
+
+#[tokio::test]
+async fn stateless_tools_call_routes_second_server() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("cal_create_event"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"cal_create_event","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Release),
+        "cal_create_event should return Release"
+    );
+    assert_eq!(
+        ctx.cluster.as_deref(),
+        Some("calendar-mcp"),
+        "should select calendar-mcp cluster"
+    );
+
+    let mutated: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert_eq!(
+        mutated["params"]["name"], "create_event",
+        "body params.name should be stripped to original tool name"
+    );
+}
+
+#[tokio::test]
+async fn stateless_tools_call_unknown_tool_rejects_invalid_params() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("nonexistent_tool"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"nonexistent_tool","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "unknown tool should return HTTP 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32602, "should return -32602 InvalidParams");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_missing_params_rejects() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call"}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing params should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32602, "should return -32602");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_null_params_rejects() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":null}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "null params should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32602, "should return -32602");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_array_params_rejects() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":[1,2]}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "array params should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32602, "should return -32602");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_missing_name_rejects() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "missing name should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32602, "should return -32602");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_non_string_name_rejects() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("tools/call", Some("weather_get_weather"));
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":42,"arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "non-string name should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32602, "should return -32602");
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_header_body_mismatch_still_returns_32020() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("tools/call", Some("wrong_name"));
+    req.headers.insert("mcp-method", "tools/call".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""name":"weather_get_weather","arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "header/body mismatch should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["error"]["code"], ERR_HEADER_MISMATCH,
+                "header/body mismatch must return -32020, not -32602"
+            );
         },
         _ => panic!("expected Reject with 400"),
     }

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -69,11 +69,14 @@ pub(crate) mod test_utils {
             request_headers_to_remove: Vec::new(),
             request_headers_to_set: Vec::new(),
             filter_metadata: std::collections::HashMap::new(),
+            pre_read_mutations: Vec::new(),
+            structured_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             filter_state: std::collections::HashMap::new(),
             health_registry: None,
             id_generator: &TEST_ID_GENERATOR,
             kv_stores: None,
+            peer_identity: None,
             request: req,
             request_body_bytes: 0,
             request_body_mode: praxis_filter::BodyMode::Stream,
@@ -86,9 +89,6 @@ pub(crate) mod test_utils {
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,
             upstream: None,
-            peer_identity: None,
-            pre_read_mutations: Vec::new(),
-            structured_metadata: std::collections::HashMap::new(),
         }
     }
 

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -86,7 +86,7 @@ fn configure_pipeline(
 // -----------------------------------------------------------------------------
 
 /// Run pipeline ordering validation; either fail or warn depending
-/// on the `skip` flag.
+/// on insecure option flags.
 #[expect(clippy::cognitive_complexity, reason = "pre-existing complexity above threshold")]
 fn validate_pipeline(
     pipeline: &FilterPipeline,

--- a/tests/integration/tests/suite/examples/mcp_broker.rs
+++ b/tests/integration/tests/suite/examples/mcp_broker.rs
@@ -6,7 +6,8 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    free_port, http_send, load_example_config, parse_body, parse_status, start_backend_with_shutdown, start_proxy,
+    free_port, http_send, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
+    start_echo_backend, start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -136,6 +137,43 @@ fn mcp_stateless_broker_example_serves_tools_list() {
     assert!(!raw.contains("mcp-session-id:"), "should not include session header");
 }
 
+#[test]
+fn mcp_stateless_broker_example_routes_tools_call() {
+    let weather_guard = start_echo_backend();
+    let calendar_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "mcp-stateless-broker.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", weather_guard.port()),
+            ("127.0.0.1:3002", calendar_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_rpc_body_with_params(
+        3,
+        "tools/call",
+        r#""name":"weather_get_weather","arguments":{"city":"NYC"}"#,
+    );
+    let request = stateless_post("/mcp", &body_str, "tools/call", Some("weather_get_weather"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "routed tools/call should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed["params"]["name"], "get_weather",
+        "backend should receive stripped params.name"
+    );
+    assert_eq!(
+        parsed["params"]["arguments"]["city"], "NYC",
+        "arguments should be preserved"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
@@ -143,6 +181,12 @@ fn mcp_stateless_broker_example_serves_tools_list() {
 fn stateless_rpc_body(id: u64, method: &str) -> String {
     format!(
         r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{"_meta":{{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{{"name":"test","version":"1.0"}},"io.modelcontextprotocol/clientCapabilities":{{}}}}}}}}"#,
+    )
+}
+
+fn stateless_rpc_body_with_params(id: u64, method: &str, extra_params: &str) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{{"_meta":{{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{{"name":"test","version":"1.0"}},"io.modelcontextprotocol/clientCapabilities":{{}}}},{extra_params}}}}}"#,
     )
 }
 

--- a/tests/integration/tests/suite/mcp_broker.rs
+++ b/tests/integration/tests/suite/mcp_broker.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_send, load_example_config, parse_body, parse_status, start_backend_with_shutdown, start_proxy,
+    free_port, http_send, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
+    start_echo_backend, start_header_echo_backend, start_proxy, start_uri_echo_backend,
 };
 
 // -----------------------------------------------------------------------------
@@ -260,7 +261,7 @@ fn mcp_broker_unsupported_method_returns_method_not_found() {
 }
 
 #[test]
-fn mcp_broker_tools_call_not_forwarded_before_routing() {
+fn mcp_current_tools_call_returns_unsupported() {
     let backend_guard = start_backend_with_shutdown("not-reachable-backend");
     let proxy_port = free_port();
 
@@ -276,17 +277,14 @@ fn mcp_broker_tools_call_not_forwarded_before_routing() {
     let status = parse_status(&raw);
     let response_body = parse_body(&raw);
 
-    assert_eq!(
-        status, 200,
-        "tools/call should return a JSON-RPC error response before backend routing is added"
-    );
+    assert_eq!(status, 200, "current-profile tools/call must return -32601");
     assert!(
         response_body.contains("-32601"),
-        "tools/call should return -32601 before backend routing is added: {response_body}"
+        "current-profile tools/call must return -32601: {response_body}"
     );
     assert!(
         !response_body.contains("not-reachable-backend"),
-        "tools/call must not reach the backend before routing is added"
+        "current-profile tools/call must not reach the backend"
     );
 }
 
@@ -431,7 +429,107 @@ fn mcp_stateless_tools_list_returns_catalog_with_cache_metadata() {
 }
 
 #[test]
-fn mcp_stateless_tools_call_returns_unsupported_after_header_validation() {
+fn mcp_stateless_tools_call_routes_to_weather_backend() {
+    let weather_guard = start_echo_backend();
+    let calendar_guard = start_backend_with_shutdown("calendar-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_two_backend_yaml(proxy_port, weather_guard.port(), calendar_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(
+        3,
+        "tools/call",
+        Some(r#""name":"weather_get_weather","arguments":{"city":"NYC"}"#),
+    );
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("weather_get_weather"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "routed tools/call should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed["params"]["name"], "get_weather",
+        "backend should receive stripped params.name"
+    );
+    assert!(
+        !body.contains("calendar-backend"),
+        "weather tool must not reach calendar backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_routes_to_calendar_backend() {
+    let weather_guard = start_backend_with_shutdown("weather-backend");
+    let calendar_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let yaml = stateless_two_backend_yaml(proxy_port, weather_guard.port(), calendar_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(4, "tools/call", Some(r#""name":"cal_create_event","arguments":{}"#));
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("cal_create_event"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "routed tools/call should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed["params"]["name"], "create_event",
+        "backend should receive stripped params.name"
+    );
+    assert!(
+        !body.contains("weather-backend"),
+        "calendar tool must not reach weather backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_backend_receives_rewritten_path() {
+    let backend_guard = start_uri_echo_backend();
+    let proxy_port = free_port();
+
+    let yaml = stateless_custom_path_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(5, "tools/call", Some(r#""name":"weather_get_weather","arguments":{}"#));
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("weather_get_weather"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "routed tools/call should return 200");
+    let body = parse_body(&raw);
+    assert_eq!(
+        body, "/backend/v1/mcp",
+        "backend should receive configured backend path"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_backend_sees_rewritten_mcp_name() {
+    let backend_guard = start_header_echo_backend();
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = &stateless_rpc_body(6, "tools/call", Some(r#""name":"weather_get_weather","arguments":{}"#));
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("weather_get_weather"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "routed tools/call should return 200");
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("mcp-name: get_weather"),
+        "backend should see rewritten mcp-name header: {body}"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_unknown_tool_returns_400() {
     let backend_guard = start_backend_with_shutdown("not-reachable-backend");
     let proxy_port = free_port();
 
@@ -439,24 +537,98 @@ fn mcp_stateless_tools_call_returns_unsupported_after_header_validation() {
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
-    let body_str = &stateless_rpc_body(3, "tools/call", Some(r#""name":"weather_get_weather","arguments":{}"#));
+    let body_str = &stateless_rpc_body(7, "tools/call", Some(r#""name":"nonexistent_tool","arguments":{}"#));
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("nonexistent_tool"));
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 400, "unknown tool should return 400");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["error"]["code"], -32602, "should return -32602 InvalidParams");
+    assert!(
+        !body.contains("not-reachable-backend"),
+        "unknown tool must not reach backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_malformed_params_returns_400() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = r#"{"jsonrpc":"2.0","id":8,"method":"tools/call"}"#;
     let request = stateless_post("/mcp", body_str, "tools/call", Some("weather_get_weather"));
     let raw = http_send(proxy.addr(), &request);
 
-    assert_eq!(
-        parse_status(&raw),
-        404,
-        "stateless tools/call should return 404 per draft Streamable HTTP"
-    );
+    assert_eq!(parse_status(&raw), 400, "missing params should return 400");
     let body = parse_body(&raw);
     let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-    assert_eq!(
-        parsed["error"]["code"], -32601,
-        "should return method not yet supported"
-    );
+    assert_eq!(parsed["error"]["code"], -32602, "should return -32602 InvalidParams");
     assert!(
         !body.contains("not-reachable-backend"),
-        "tools/call must not hit backend"
+        "malformed params must not reach backend"
+    );
+}
+
+#[test]
+fn mcp_stateless_tools_call_backend_sees_repaired_content_length() {
+    let body_str = &stateless_rpc_body(
+        9,
+        "tools/call",
+        Some(r#""name":"weather_get_weather","arguments":{"city":"NYC"}"#),
+    );
+    let request = stateless_post("/mcp", body_str, "tools/call", Some("weather_get_weather"));
+
+    let echo_guard = start_echo_backend();
+    let echo_proxy_port = free_port();
+    let echo_config = Config::from_yaml(&stateless_single_backend_yaml(echo_proxy_port, echo_guard.port())).unwrap();
+    let echo_proxy = start_proxy(&echo_config);
+
+    let echo_raw = http_send(echo_proxy.addr(), &request);
+    assert_eq!(parse_status(&echo_raw), 200, "echo route should return 200");
+    let mutated_body = parse_body(&echo_raw);
+    assert!(
+        mutated_body.contains("\"get_weather\""),
+        "mutated body should contain stripped tool name: {mutated_body}"
+    );
+    assert!(
+        !mutated_body.contains("weather_get_weather"),
+        "mutated body must not contain prefixed tool name: {mutated_body}"
+    );
+    let expected_len = mutated_body.len();
+
+    let header_guard = start_header_echo_backend();
+    let header_proxy_port = free_port();
+    let header_config =
+        Config::from_yaml(&stateless_single_backend_yaml(header_proxy_port, header_guard.port())).unwrap();
+    let header_proxy = start_proxy(&header_config);
+
+    let header_raw = http_send(header_proxy.addr(), &request);
+    assert_eq!(parse_status(&header_raw), 200, "header route should return 200");
+    let headers_body = parse_body(&header_raw);
+
+    let cl_values: Vec<&str> = headers_body
+        .lines()
+        .filter(|line| line.to_lowercase().starts_with("content-length:"))
+        .collect();
+    assert_eq!(
+        cl_values.len(),
+        1,
+        "backend should receive exactly one content-length header: {headers_body}"
+    );
+    let cl: usize = cl_values[0]
+        .split_once(':')
+        .map(|(_, v)| v.trim())
+        .unwrap()
+        .parse()
+        .expect("content-length should be numeric");
+    assert_eq!(
+        cl, expected_len,
+        "content-length ({cl}) must equal mutated body length ({expected_len})"
     );
 }
 
@@ -695,6 +867,10 @@ filter_chains:
 }
 
 fn stateless_broker_yaml(proxy_port: u16, backend_port: u16) -> String {
+    stateless_two_backend_yaml(proxy_port, backend_port, backend_port)
+}
+
+fn stateless_two_backend_yaml(proxy_port: u16, weather_port: u16, calendar_port: u16) -> String {
     format!(
         r#"
 listeners:
@@ -727,8 +903,70 @@ filter_chains:
         clusters:
           - name: weather-mcp
             endpoints:
-              - "127.0.0.1:{backend_port}"
+              - "127.0.0.1:{weather_port}"
           - name: calendar-mcp
+            endpoints:
+              - "127.0.0.1:{calendar_port}"
+"#,
+    )
+}
+
+fn stateless_single_backend_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        path: /mcp
+        max_body_bytes: 65536
+        protocol_profile: stateless
+        servers:
+          - name: weather
+            cluster: weather-mcp
+            path: /mcp
+            tool_prefix: "weather_"
+            tools:
+              - name: get_weather
+                description: Get current weather
+      - filter: load_balancer
+        clusters:
+          - name: weather-mcp
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn stateless_custom_path_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        path: /mcp
+        max_body_bytes: 65536
+        protocol_profile: stateless
+        servers:
+          - name: weather
+            cluster: weather-mcp
+            path: /backend/v1/mcp
+            tool_prefix: "weather_"
+            tools:
+              - name: get_weather
+                description: Get current weather
+      - filter: load_balancer
+        clusters:
+          - name: weather-mcp
             endpoints:
               - "127.0.0.1:{backend_port}"
 "#,


### PR DESCRIPTION
## Summary

  Adds backend forwarding for stateless MCP `tools/call` requests using the static broker catalog.

  The stateless broker can now receive a `tools/call`, validate the stateless MCP headers/body, look up the exposed tool name, select the configured backend cluster, rewrite the backend path, and forward the call with the backend tool name. This turns the static catalog from discovery-only into a working broker path for configured tools.

  With this PR, the catalog becomes the routing table for stateless `tools/call`:

  1. The client calls an exposed tool name, for example `weather_get_forecast`.
  2. Praxis looks up that exposed name in the configured static catalog.
  3. The matched catalog entry tells Praxis which backend server/cluster owns the tool.
  4. Praxis selects that cluster, rewrites the upstream path, and rewrites `params.name` from the exposed name to the backend tool name, for
  example `get_forecast`.
  5. Praxis also updates the forwarded `Mcp-Name` header so the backend sees a consistent MCP request.
  6. The normal load-balancer path then forwards the request to the selected backend.

  The temporary Praxis dependency pin is needed because this forwarding happens after the request body has been inspected and rewritten. The MCP filter sets the rewritten `Mcp-Name` header during the body-processing phase, and `praxis-proxy/praxis#760` is the core fix that preserves those body-phase header mutations before the request is sent upstream.
  
## Changes

  - Routes stateless `tools/call` by static catalog entry.
  - Rewrites `params.name` from exposed name to backend/original tool name.
  - Preserves `params.arguments` unchanged.
  - Sets the upstream `Mcp-Name` header to the backend tool name.
  - Encodes non-visible-ASCII MCP names with the existing `=?base64?...?=` sentinel format.
  - Rewrites the upstream request path to the selected server path.
  - Repairs `Content-Length` after request body mutation.
  - Returns `-32602 Invalid Params` for malformed `tools/call` params before header mismatch validation.
  - Keeps the `current` (`2025-03-26`) compatibility-profile `tools/call` behavior unchanged.
  - Updates docs and the stateless broker example to reflect working forwarding behavior.

  ## Dependency Note

  This draft temporarily pins `praxis-proxy-*` crates to `praxis-proxy/praxis` commit `2bbce4386e84f6c8a8a0e64c7cc47b52f6d34cf9` because the latest crates.io release, `0.4.0`, predates `praxis-proxy/praxis#760`.

  `#760` is required for body-phase header mutations from StreamBuffer filters to reach upstream backends, which allows routed MCP `tools/call` requests to forward the rewritten `Mcp-Name` header.

  This pin should be replaced with the next published `praxis-proxy-*` crate version once available.

  ## Protocol Boundary

  This PR completes base stateless `tools/call` routing.

  The following are intentionally left to separate focused PRs:

  - Locked-RC method-set cleanup, including stateless `ping` removal
  - `logging/setLevel` and legacy notification conformance cleanup
  - Schema-driven `x-mcp-header` / `Mcp-Param-*` support
  - `subscriptions/listen`
  - MRTR / `input_required`
  - Dynamic catalog discovery
  - Legacy MCP sessions
  - Redis/Valkey state

  ## Validation

  - `cargo test -p praxis-ai-filters mcp` — 265 passed
  - `cargo test -p praxis-tests-integration --test suite mcp_broker` — 30 passed
  - `cargo test -p praxis-tests-schema` — 90 passed
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo +nightly fmt --all --check`
  - `cargo xtask lint-filter-docs`
  - `cargo xtask lint-example-tests`
  - `cargo xtask sync-example-readme`
  - `git diff --check`

  Refs praxis-proxy/ai#148