### PR TITLE
feat: orchestrate OpenAI web search through vLLM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -301,6 +290,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1169,11 +1168,23 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime 0.1.4",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
 dependencies = [
- "deadpool-runtime",
+ "deadpool-runtime 0.3.1",
  "num_cpus",
  "tokio",
 ]
@@ -1184,9 +1195,15 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafa30c49dafe086d10116074e422ad7fc1c3cf554697e744a3ab112599ebd09"
 dependencies = [
- "deadpool",
+ "deadpool 0.13.0",
  "redis",
 ]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deadpool-runtime"
@@ -1450,7 +1467,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1685,9 +1702,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1832,9 +1846,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2800,11 +2816,13 @@ dependencies = [
  "bytes",
  "chrono",
  "dashmap 6.2.1",
+ "futures",
  "http",
  "percent-encoding",
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "regex",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -2813,6 +2831,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "wiremock",
  "yaml_serde",
  "zeroize",
 ]
@@ -3161,7 +3180,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a820a1a3e59644b38bc03606b638b41f1c5a474215efcec37f94b15871a7e1c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "blake2",
  "bstr",
@@ -3196,7 +3215,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d6d9e04414ba6819c51ec210eddf17865c505431a492c86c6356338c2b4f60"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "brotli",
  "bstr",
@@ -3284,7 +3303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec55d3bcbd56e52b3424bc62739a237d43c14df8ed04aaf294ae187b60da348a"
 dependencies = [
  "arrayvec 0.7.8",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -4459,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5369,6 +5388,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool 0.12.3",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ quote = "1.0.46"
 rand = "0.10.1"
 rcgen = "0.14.8"
 regex = "1.12.4"
-reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.23.41"
 rustls-pemfile = "2.2.0"
 secrecy = { version = "0.10.3", features = ["serde"] }

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -24,9 +24,11 @@ bytes = { workspace = true }
 dashmap = { workspace = true, optional = true }
 http = { workspace = true }
 percent-encoding = { workspace = true }
+futures = { workspace = true }
 praxis-core = { workspace = true }
 praxis-filter = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -41,3 +43,4 @@ zeroize = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+wiremock = { workspace = true }

--- a/apis/src/openai/mod.rs
+++ b/apis/src/openai/mod.rs
@@ -16,5 +16,5 @@ pub(crate) mod translation;
 pub use conversations::OpenaiConversationsFilter;
 pub use responses::{
     ModelRewriteFilter, OpenaiResponsesValidateFilter, RehydrateFilter, ResponseStoreFilter, ResponsesFormatFilter,
-    ToolParseFilter, proxy::ResponsesProxyFilter, stream_events::OpenaiStreamEventsFilter,
+    ToolParseFilter, WebSearchOrchestratorFilter, proxy::ResponsesProxyFilter, stream_events::OpenaiStreamEventsFilter,
 };

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -415,6 +415,8 @@ fn promote_boolean_results(
 
 pub(crate) mod rehydrate;
 pub(crate) mod validate;
+pub(crate) mod web_search;
 
 pub use rehydrate::RehydrateFilter;
 pub use validate::OpenaiResponsesValidateFilter;
+pub use web_search::WebSearchOrchestratorFilter;

--- a/apis/src/openai/responses/web_search.rs
+++ b/apis/src/openai/responses/web_search.rs
@@ -1,0 +1,694 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Praxis-owned web-search orchestration for direct vLLM Responses backends.
+
+#![allow(
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items,
+    clippy::multiple_inherent_impl,
+    clippy::too_many_lines,
+    reason = "the first blocking demo keeps the orchestration contract in one focused module"
+)]
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use praxis_filter::{
+    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, parse_filter_config,
+};
+use secrecy::{ExposeSecret as _, SecretString};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::debug;
+
+const WEB_SEARCH_TYPES: &[&str] = &[
+    "web_search",
+    "web_search_preview",
+    "web_search_preview_2025_03_11",
+    "web_search_2025_08_26",
+];
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+const MAX_ERROR_BODY_CHARS: usize = 4_096;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WebSearchConfig {
+    vllm_base_url: String,
+    #[serde(default = "default_you_base_url")]
+    you_api_base_url: String,
+    #[serde(default = "default_max_rounds")]
+    max_tool_rounds: u32,
+    #[serde(default = "default_timeout_secs")]
+    timeout_secs: u64,
+}
+
+fn default_you_base_url() -> String {
+    "https://api.you.com".to_owned()
+}
+fn default_max_rounds() -> u32 {
+    5
+}
+fn default_timeout_secs() -> u64 {
+    30
+}
+
+/// A blocking direct-vLLM demo filter. It owns the vLLM/You.com loop and
+/// returns the completed Responses payload as an immediate response.
+pub struct WebSearchOrchestratorFilter {
+    config: WebSearchConfig,
+    client: reqwest::Client,
+    api_key: SecretString,
+}
+
+impl WebSearchOrchestratorFilter {
+    /// Build the direct-vLLM orchestrator from YAML configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when configuration parsing, validation, or HTTP client
+    /// construction fails.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: WebSearchConfig = parse_filter_config("openai_web_search", config)?;
+        if cfg.vllm_base_url.trim().is_empty() || cfg.max_tool_rounds < 2 || cfg.timeout_secs == 0 {
+            return Err(
+                "openai_web_search requires a non-empty vllm_base_url, max_tool_rounds >= 2, and timeout_secs > 0"
+                    .into(),
+            );
+        }
+        let api_key = std::env::var("YOU_API_KEY")
+            .map(|value| value.trim().to_owned())
+            .ok()
+            .filter(|value| !value.is_empty())
+            .map(SecretString::from)
+            .ok_or_else(|| FilterError::from("openai_web_search requires YOU_API_KEY at startup"))?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(cfg.timeout_secs))
+            .build()
+            .map_err(|e| format!("openai_web_search client: {e}"))?;
+        Ok(Box::new(Self {
+            config: cfg,
+            client,
+            api_key,
+        }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for WebSearchOrchestratorFilter {
+    fn name(&self) -> &'static str {
+        "openai_web_search"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadWrite
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(MAX_BODY_BYTES),
+        }
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream || ctx.request.uri.path() != "/v1/responses" {
+            return Ok(FilterAction::Continue);
+        }
+        let Some(bytes) = body.as_ref() else {
+            return Ok(FilterAction::Continue);
+        };
+        let request: Value =
+            serde_json::from_slice(bytes).map_err(|e| format!("openai_web_search request JSON: {e}"))?;
+        if !has_web_search(&request) {
+            return Ok(FilterAction::Continue);
+        }
+        if request.get("stream").and_then(Value::as_bool) == Some(true) {
+            let body = serde_json::to_vec(&json!({
+                "error": {
+                    "message": "streaming web_search orchestration is not supported by this blocking filter"
+                }
+            }))
+            .map_err(|e| format!("openai_web_search error JSON: {e}"))?;
+            return Ok(FilterAction::Reject(
+                praxis_filter::Rejection::status(501)
+                    .with_header("content-type", "application/json")
+                    .with_body(body),
+            ));
+        }
+
+        let response = self
+            .orchestrate(request, self.api_key.expose_secret())
+            .await
+            .map_err(FilterError::from)?;
+        let serialized = serde_json::to_vec(&response).map_err(|e| format!("openai_web_search response JSON: {e}"))?;
+        let rejection = praxis_filter::Rejection::status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serialized);
+        Ok(FilterAction::Reject(rejection))
+    }
+}
+
+impl WebSearchOrchestratorFilter {
+    async fn orchestrate(&self, request: Value, api_key: &str) -> Result<Value, String> {
+        tokio::time::timeout(
+            Duration::from_secs(self.config.timeout_secs),
+            self.orchestrate_inner(request, api_key),
+        )
+        .await
+        .map_err(|error| format!("web_search orchestration timed out: {error}"))?
+    }
+
+    async fn orchestrate_inner(&self, mut request: Value, api_key: &str) -> Result<Value, String> {
+        normalize_web_search_tools_in_place(&mut request);
+        request["stream"] = Value::Bool(false);
+        let mut input_items = input_items(&request);
+
+        for round in 0..self.config.max_tool_rounds {
+            request["input"] = Value::Array(input_items.clone());
+            let response = self
+                .client
+                .post(format!(
+                    "{}/v1/responses",
+                    self.config.vllm_base_url.trim_end_matches('/')
+                ))
+                .json(&request)
+                .send()
+                .await
+                .map_err(|e| format!("vLLM request failed: {e}"))?;
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .map_err(|e| format!("vLLM response body could not be read: {e}"))?;
+            if !status.is_success() {
+                return Err(format!("vLLM returned HTTP {status}: {}", bounded_error_body(&body)));
+            }
+            let response: Value =
+                serde_json::from_str(&body).map_err(|e| format!("vLLM returned invalid JSON: {e}"))?;
+            let calls = search_calls(&response)?;
+            if calls.is_empty() {
+                return Ok(response);
+            }
+            debug!(round, calls = calls.len(), "executing vLLM web_search calls in Praxis");
+            if round + 1 == self.config.max_tool_rounds {
+                return Err("web_search tool loop exceeded max_tool_rounds".to_owned());
+            }
+            if let Some(output) = response.get("output").and_then(Value::as_array) {
+                input_items.extend(output.iter().cloned());
+            }
+            let outputs = futures::future::try_join_all(calls.iter().map(|call| async {
+                let call_id = call
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .ok_or("web_search call missing call_id")?
+                    .to_owned();
+                let args = call.get("arguments").ok_or("web_search call missing arguments")?;
+                let output = self.you_search(args, api_key).await?;
+                Ok::<_, String>((call_id, output))
+            }))
+            .await?;
+            input_items.extend(
+                outputs.into_iter().map(
+                    |(call_id, output)| json!({"type":"function_call_output", "call_id":call_id, "output":output}),
+                ),
+            );
+        }
+        unreachable!("max_tool_rounds is validated during filter construction");
+    }
+
+    async fn you_search(&self, args: &Value, api_key: &str) -> Result<String, String> {
+        let query = args
+            .get("query")
+            .and_then(Value::as_str)
+            .filter(|q| !q.trim().is_empty())
+            .ok_or("web_search query is required")?;
+        debug!(query, "sending direct-vLLM web_search request to You.com");
+        let search_request = you_search_request(args, query);
+        let response = self
+            .client
+            .post(format!(
+                "{}/v1/search",
+                self.config.you_api_base_url.trim_end_matches('/')
+            ))
+            .header("X-API-Key", api_key)
+            .json(&search_request)
+            .send()
+            .await
+            .map_err(|e| format!("You.com request failed: {e}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("You.com response body could not be read: {e}"))?;
+        if !status.is_success() {
+            return Err(format!("You.com returned HTTP {status}: {}", bounded_error_body(&body)));
+        }
+        let value: Value = serde_json::from_str(&body).map_err(|e| format!("You.com returned invalid JSON: {e}"))?;
+        serde_json::to_string(&json!({"query":query, "results":value.get("results").cloned().unwrap_or(json!({"web":[],"news":[]})), "metadata":value.get("metadata").cloned().unwrap_or(Value::Null)})).map_err(|e| format!("You.com result serialization failed: {e}"))
+    }
+}
+
+fn bounded_error_body(body: &str) -> String {
+    let mut bounded = body.chars().take(MAX_ERROR_BODY_CHARS).collect::<String>();
+    if body.chars().nth(MAX_ERROR_BODY_CHARS).is_some() {
+        bounded.push_str("...");
+    }
+    bounded
+}
+
+fn you_search_request(args: &Value, query: &str) -> Value {
+    let mut request = json!({"query": query});
+    for field in [
+        "count",
+        "freshness",
+        "country",
+        "language",
+        "safesearch",
+        "livecrawl",
+        "livecrawl_formats",
+        "crawl_timeout",
+        "include_domains",
+        "exclude_domains",
+        "boost_domains",
+    ] {
+        if let Some(value) = args.get(field) {
+            request[field] = value.clone();
+        }
+    }
+    request
+}
+
+fn has_web_search(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| tools.iter().any(is_web_search_tool))
+}
+
+fn is_web_search_tool(tool: &Value) -> bool {
+    tool.get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| WEB_SEARCH_TYPES.contains(&kind))
+}
+
+fn normalize_web_search_tools_in_place(body: &mut Value) {
+    let Some(tools) = body.get("tools").and_then(Value::as_array) else {
+        return;
+    };
+    let normalized = normalize_tools(tools);
+    body["tools"] = Value::Array(normalized);
+}
+
+fn normalize_tools(tools: &[Value]) -> Vec<Value> {
+    let mut normalized = Vec::with_capacity(tools.len());
+    let mut added = false;
+    for tool in tools {
+        if is_web_search_tool(tool) {
+            if !added {
+                normalized.push(web_search_function_tool());
+                added = true;
+            }
+        } else {
+            normalized.push(tool.clone());
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+fn normalize_web_search_tools(body: &Value) -> Vec<Value> {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .map_or_else(Vec::new, |tools| normalize_tools(tools))
+}
+
+fn web_search_function_tool() -> Value {
+    json!({"type":"function", "name":"web_search", "description":"Search the public web for current information and return structured results.", "parameters":{"type":"object","properties":{"query":{"type":"string"},"count":{"type":"integer"},"freshness":{"type":"string"},"country":{"type":"string"},"language":{"type":"string"},"include_domains":{"type":"array","items":{"type":"string"}},"exclude_domains":{"type":"array","items":{"type":"string"}}},"required":["query"]},"strict":false})
+}
+
+fn search_calls(response: &Value) -> Result<Vec<Value>, String> {
+    response.get("output").and_then(Value::as_array).map_or_else(
+        || Ok(Vec::new()),
+        |output| {
+            output
+                .iter()
+                .filter(|item| {
+                    item.get("type").and_then(Value::as_str) == Some("function_call")
+                        && item.get("name").and_then(Value::as_str) == Some("web_search")
+                        && item.get("status").and_then(Value::as_str) == Some("completed")
+                })
+                .map(|item| {
+                    let args = item
+                        .get("arguments")
+                        .and_then(Value::as_str)
+                        .ok_or("web_search arguments missing")?;
+                    let arguments: Value =
+                        serde_json::from_str(args).map_err(|e| format!("web_search arguments invalid JSON: {e}"))?;
+                    let mut call = item.clone();
+                    call["arguments"] = arguments;
+                    Ok(call)
+                })
+                .collect()
+        },
+    )
+}
+
+fn input_items(body: &Value) -> Vec<Value> {
+    match body.get("input") {
+        Some(Value::Array(items)) => items.clone(),
+        Some(Value::String(text)) => vec![json!({"type":"message", "role":"user", "content":text})],
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+fn append_function_call_outputs(body: &mut Value, outputs: &[Value]) {
+    let items = input_items(body);
+    body["input_items"] = Value::Array(outputs.to_vec());
+    body["input"] = Value::Array(items.into_iter().chain(outputs.iter().cloned()).collect());
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test assertions use expect for readable failure context"
+)]
+mod tests {
+    use bytes::Bytes;
+    use http::Method;
+    use praxis_filter::HttpFilter as _;
+    use serde_json::{Value, json};
+    use wiremock::{
+        Match, Mock, MockServer, Request, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    #[derive(Debug)]
+    struct InputContainsReasoning;
+
+    impl Match for InputContainsReasoning {
+        fn matches(&self, request: &Request) -> bool {
+            serde_json::from_slice::<Value>(&request.body)
+                .ok()
+                .and_then(|body| body.get("input").cloned())
+                .and_then(|input| input.as_array().cloned())
+                .is_some_and(|items| {
+                    items
+                        .iter()
+                        .any(|item| item.get("type").and_then(Value::as_str) == Some("reasoning"))
+                })
+        }
+    }
+
+    use super::{
+        WebSearchConfig, WebSearchOrchestratorFilter, append_function_call_outputs, normalize_web_search_tools,
+        search_calls,
+    };
+
+    #[test]
+    fn normalizes_all_seb_supported_web_search_variants() {
+        let body = json!({
+            "tools": [
+                {"type": "web_search"},
+                {"type": "web_search_preview"},
+                {"type": "web_search_preview_2025_03_11"},
+                {"type": "web_search_2025_08_26"}
+            ]
+        });
+
+        let normalized = normalize_web_search_tools(&body);
+        assert_eq!(normalized[0]["type"], "function");
+        assert_eq!(normalized[0]["name"], "web_search");
+        assert_eq!(normalized.len(), 1);
+    }
+
+    #[test]
+    fn extracts_completed_web_search_calls() {
+        let response = json!({
+            "output": [
+                {"type": "reasoning"},
+                {"type": "function_call", "id": "fc_1", "call_id": "call_1", "name": "web_search", "arguments": "{\"query\":\"latest Rust release\"}", "status": "completed"}
+            ]
+        });
+
+        let calls = search_calls(&response).expect("valid call");
+        assert_eq!(calls[0]["call_id"], "call_1");
+        assert_eq!(calls[0]["arguments"]["query"], "latest Rust release");
+    }
+
+    #[test]
+    fn bounds_provider_error_bodies() {
+        let body = "x".repeat(5_000);
+        let bounded = super::bounded_error_body(&body);
+        assert_eq!(bounded.chars().count(), 4_099);
+        assert!(bounded.ends_with("..."));
+    }
+
+    #[test]
+    fn appends_function_call_outputs_without_replacing_original_input() {
+        let mut body = json!({"input": "Search this", "tools": []});
+        append_function_call_outputs(
+            &mut body,
+            &[json!({"type":"function_call_output", "call_id":"call_1", "output":"{\"query\":\"Search this\"}"})],
+        );
+
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][1]["type"], "function_call_output");
+        assert_eq!(body["input"][1]["call_id"], "call_1");
+    }
+
+    #[tokio::test]
+    async fn orchestrates_vllm_tool_call_through_you_and_back_to_vllm() {
+        let vllm = MockServer::start().await;
+        let you = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": {"web": [{"url":"https://www.rust-lang.org","title":"Rust"}], "news": []},
+                "metadata": {"search_uuid":"search_1"}
+            })))
+            .expect(1)
+            .mount(&you)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output": [{"type":"function_call","id":"fc_1","call_id":"call_1","name":"web_search","arguments":"{\"query\":\"latest Rust release\"}","status":"completed"}]
+            })))
+            .up_to_n_times(1)
+            .mount(&vllm)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id":"resp_final","object":"response","status":"completed",
+                "output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Rust is current."}]}]
+            })))
+            .mount(&vllm)
+            .await;
+
+        let filter = WebSearchOrchestratorFilter {
+            config: WebSearchConfig {
+                vllm_base_url: vllm.uri(),
+                you_api_base_url: you.uri(),
+                max_tool_rounds: 3,
+                timeout_secs: 5,
+            },
+            client: reqwest::Client::new(),
+            api_key: secrecy::SecretString::from("test-you-key"),
+        };
+        let response = filter
+            .orchestrate(
+                json!({"model":"openai/gpt-oss-20b","input":"Find the latest Rust release.","tools":[{"type":"web_search_preview"}]}),
+                "test-you-key",
+            )
+            .await
+            .expect("orchestration should complete");
+
+        assert_eq!(response["id"], "resp_final");
+    }
+
+    #[tokio::test]
+    async fn bypasses_requests_without_web_search_tools() {
+        let request = crate::test_utils::make_request(Method::POST, "/v1/responses");
+        let mut ctx = crate::test_utils::make_filter_context(&request);
+        let filter = WebSearchOrchestratorFilter {
+            config: WebSearchConfig {
+                vllm_base_url: "http://unused".to_owned(),
+                you_api_base_url: "http://unused".to_owned(),
+                max_tool_rounds: 1,
+                timeout_secs: 5,
+            },
+            client: reqwest::Client::new(),
+            api_key: secrecy::SecretString::from("test-you-key"),
+        };
+        let mut body = Some(Bytes::from(
+            json!({"tools": [{"type": "function", "name": "lookup"}]}).to_string(),
+        ));
+        let action = filter
+            .on_request_body(&mut ctx, &mut body, true)
+            .await
+            .expect("filter should continue");
+        assert!(matches!(action, praxis_filter::FilterAction::Continue));
+
+        let request = crate::test_utils::make_request(Method::POST, "/v1/responses");
+        let mut ctx = crate::test_utils::make_filter_context(&request);
+        let mut body = Some(Bytes::from(
+            json!({"stream": true, "tools": [{"type": "web_search_preview"}]}).to_string(),
+        ));
+        let action = filter
+            .on_request_body(&mut ctx, &mut body, true)
+            .await
+            .expect("filter should reject streaming input");
+        assert!(matches!(
+            action,
+            praxis_filter::FilterAction::Reject(rejection) if rejection.status == 501
+        ));
+    }
+
+    #[tokio::test]
+    async fn preserves_all_vllm_output_items_between_rounds() {
+        let vllm = MockServer::start().await;
+        let you = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"results": {"web": []}})))
+            .mount(&you)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output": [
+                    {"type":"reasoning","summary":[]},
+                    {"type":"function_call","call_id":"call_1","name":"web_search","arguments":"{\"query\":\"Rust\"}","status":"completed"}
+                ]
+            })))
+            .up_to_n_times(1)
+            .mount(&vllm)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .and(InputContainsReasoning)
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id":"final","output":[]})))
+            .expect(1)
+            .mount(&vllm)
+            .await;
+
+        let filter = WebSearchOrchestratorFilter {
+            config: WebSearchConfig {
+                vllm_base_url: vllm.uri(),
+                you_api_base_url: you.uri(),
+                max_tool_rounds: 3,
+                timeout_secs: 5,
+            },
+            client: reqwest::Client::new(),
+            api_key: secrecy::SecretString::from("test-you-key"),
+        };
+        let response = filter
+            .orchestrate(
+                json!({"input":"Search","tools":[{"type":"web_search_preview"}]}),
+                "test-you-key",
+            )
+            .await
+            .expect("orchestration should complete");
+        assert_eq!(response["id"], "final");
+    }
+
+    #[tokio::test]
+    async fn returns_vllm_error_details() {
+        let vllm = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(422).set_body_string("invalid model"))
+            .mount(&vllm)
+            .await;
+        let filter = WebSearchOrchestratorFilter {
+            config: WebSearchConfig {
+                vllm_base_url: vllm.uri(),
+                you_api_base_url: "http://unused".to_owned(),
+                max_tool_rounds: 1,
+                timeout_secs: 5,
+            },
+            client: reqwest::Client::new(),
+            api_key: secrecy::SecretString::from("test-you-key"),
+        };
+        let error = filter
+            .orchestrate(json!({"tools":[{"type":"web_search_preview"}]}), "test-you-key")
+            .await
+            .expect_err("vLLM error should propagate");
+        assert!(error.contains("422") && error.contains("invalid model"));
+    }
+
+    #[tokio::test]
+    async fn returns_you_error_details() {
+        let vllm = MockServer::start().await;
+        let you = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output": [{"type":"function_call","call_id":"call_1","name":"web_search","arguments":"{\"query\":\"Rust\"}","status":"completed"}]
+            })))
+            .mount(&vllm)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+            .mount(&you)
+            .await;
+        let filter = WebSearchOrchestratorFilter {
+            config: WebSearchConfig {
+                vllm_base_url: vllm.uri(),
+                you_api_base_url: you.uri(),
+                max_tool_rounds: 2,
+                timeout_secs: 5,
+            },
+            client: reqwest::Client::new(),
+            api_key: secrecy::SecretString::from("test-you-key"),
+        };
+        let error = filter
+            .orchestrate(json!({"tools":[{"type":"web_search_preview"}]}), "test-you-key")
+            .await
+            .expect_err("You.com error should propagate");
+        assert!(error.contains("429") && error.contains("rate limited"));
+    }
+
+    #[tokio::test]
+    async fn enforces_max_tool_rounds() {
+        let vllm = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output": [{"type":"function_call","call_id":"call_1","name":"web_search","arguments":"{\"query\":\"Rust\"}","status":"completed"}]
+            })))
+            .mount(&vllm)
+            .await;
+        let filter = WebSearchOrchestratorFilter {
+            config: WebSearchConfig {
+                vllm_base_url: vllm.uri(),
+                you_api_base_url: "http://unused".to_owned(),
+                max_tool_rounds: 1,
+                timeout_secs: 5,
+            },
+            client: reqwest::Client::new(),
+            api_key: secrecy::SecretString::from("test-you-key"),
+        };
+        let error = filter
+            .orchestrate(json!({"tools":[{"type":"web_search_preview"}]}), "test-you-key")
+            .await
+            .expect_err("tool loop should stop at max_tool_rounds");
+        assert!(error.contains("max_tool_rounds"));
+    }
+}

--- a/apis/src/openai/sse/responses/event.rs
+++ b/apis/src/openai/sse/responses/event.rs
@@ -71,6 +71,14 @@ pub(crate) enum ResponsesEvent {
     /// `response.reasoning_summary_part.done` — reasoning summary part completed.
     ReasoningSummaryPartDone(Value),
 
+    // Web search
+    /// `response.web_search_call.in_progress` — web search call initiated.
+    WebSearchCallInProgress(Value),
+    /// `response.web_search_call.searching` — web search call executing.
+    WebSearchCallSearching(Value),
+    /// `response.web_search_call.completed` — web search call completed.
+    WebSearchCallCompleted(Value),
+
     // Error
     /// `error` — error event.
     Error(Value),
@@ -114,6 +122,10 @@ impl ResponsesEvent {
     }
 
     /// Match event type string to enum variant.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the Responses event discriminator keeps canonical wire names together"
+    )]
     fn from_event_type(event_type: &str, data: Value) -> Self {
         match event_type {
             "response.created" => Self::ResponseCreated(data),
@@ -141,6 +153,9 @@ impl ResponsesEvent {
             "response.reasoning_summary_text.done" => Self::ReasoningSummaryTextDone(data),
             "response.reasoning_summary_part.added" => Self::ReasoningSummaryPartAdded(data),
             "response.reasoning_summary_part.done" => Self::ReasoningSummaryPartDone(data),
+            "response.web_search_call.in_progress" => Self::WebSearchCallInProgress(data),
+            "response.web_search_call.searching" => Self::WebSearchCallSearching(data),
+            "response.web_search_call.completed" => Self::WebSearchCallCompleted(data),
             "error" => Self::Error(data),
             other => Self::Unknown {
                 event_type: other.to_owned(),
@@ -183,6 +198,9 @@ impl ResponsesEvent {
             Self::ReasoningSummaryTextDone(_) => "response.reasoning_summary_text.done",
             Self::ReasoningSummaryPartAdded(_) => "response.reasoning_summary_part.added",
             Self::ReasoningSummaryPartDone(_) => "response.reasoning_summary_part.done",
+            Self::WebSearchCallInProgress(_) => "response.web_search_call.in_progress",
+            Self::WebSearchCallSearching(_) => "response.web_search_call.searching",
+            Self::WebSearchCallCompleted(_) => "response.web_search_call.completed",
             Self::Error(_) => "error",
             Self::Unknown { event_type, .. } => event_type,
         }
@@ -463,6 +481,9 @@ mod tests {
             "response.reasoning_summary_text.done",
             "response.reasoning_summary_part.added",
             "response.reasoning_summary_part.done",
+            "response.web_search_call.in_progress",
+            "response.web_search_call.searching",
+            "response.web_search_call.completed",
         ] {
             let f = typed_frame(event_type, json!({}));
             let event = ResponsesEvent::from_frame(&f).unwrap();

--- a/examples/configs/openai/responses/web-search-vllm.yaml
+++ b/examples/configs/openai/responses/web-search-vllm.yaml
@@ -1,0 +1,31 @@
+# Direct vLLM web-search demo.
+#
+# Requests declaring an OpenAI Responses web_search tool are handled by
+# openai_web_search. Praxis calls vLLM Core, executes You.com with YOU_API_KEY,
+# appends function_call_output, and repeats until vLLM returns the final answer.
+# Requests without web_search pass through to the same vLLM endpoint.
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [direct-vllm-web-search]
+
+filter_chains:
+  - name: direct-vllm-web-search
+    filters:
+      - filter: openai_web_search
+        vllm_base_url: "http://10.0.0.99:8000"
+        you_api_base_url: "https://api.you.com"
+        max_tool_rounds: 5
+        timeout_secs: 90
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "10.0.0.99:8000"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -146,4 +146,8 @@ fn register_openai_response_filters(registry: &mut praxis_filter::FilterRegistry
         @register registry,
         http "tool_parse" => praxis_ai_apis::openai::ToolParseFilter::from_config
     );
+    praxis_filter::register_filters!(
+        @register registry,
+        http "openai_web_search" => praxis_ai_apis::openai::WebSearchOrchestratorFilter::from_config
+    );
 }

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -20,6 +20,7 @@ mod openai_responses_format;
 mod openai_responses_model_rewrite;
 mod openai_responses_validate;
 mod openai_stream_events;
+mod openai_web_search;
 mod prompt_enrichment;
 mod rehydrate;
 mod responses_proxy;

--- a/tests/integration/tests/suite/examples/openai_web_search.rs
+++ b/tests/integration/tests/suite/examples/openai_web_search.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration coverage for the direct-vLLM web-search example configuration.
+
+use praxis_test_utils::example_config_path;
+
+#[test]
+fn web_search_example_config_parses_and_registers_filter() {
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/web-search-vllm.yaml"))
+        .expect("web-search example config should exist");
+    let config = praxis_core::config::Config::from_yaml(&yaml).expect("web-search example config should parse");
+    let filters = config
+        .filter_chains
+        .iter()
+        .flat_map(|chain| chain.filters.iter())
+        .collect::<Vec<_>>();
+    assert!(
+        filters.iter().any(|filter| filter.filter_type == "openai_web_search"),
+        "example config should register openai_web_search"
+    );
+}


### PR DESCRIPTION
## What changed

- Add a Praxis-owned blocking web-search orchestrator for direct vLLM Core Responses requests.
- Normalize OpenAI web-search tool declarations into a function tool, call vLLM, execute You.com searches, and continue the tool loop until vLLM returns the final response.
- Add OpenAI Responses web-search SSE event variants and a runnable example configuration.
- Add unit and integration coverage for the orchestration loop, error paths, streaming rejection, round limits, and example config registration.

## Why

This demonstrates the Praxis + vLLM Core deployment where Praxis owns the You.com call and credential boundary. Requests without web search continue through the normal vLLM route. Streaming web-search orchestration is explicitly rejected for this first blocking demo.

## Validation

- `cargo test -p praxis-ai-apis openai::responses::web_search --lib`
- `cargo test -p praxis-ai-apis openai::sse::responses::event --lib`
- `cargo test -p praxis-tests-integration openai_web_search --no-default-features`
- `cargo clippy -p praxis-ai-apis -p praxis-ai-proxy --all-targets -- -D warnings`
- `git diff --check`

## Follow-up

The vLLM Agentic API path remains separate: when that service owns web-search hydration, Praxis should bypass this direct orchestrator and proxy to Agentic API.
