### PR TITLE
fix(token_count): flush SSE at EOF and fix streaming finalization (#119)

### DIFF
--- a/filters/src/agentic/a2a/sse.rs
+++ b/filters/src/agentic/a2a/sse.rs
@@ -117,6 +117,25 @@ pub(crate) fn scan_sse_chunk(state: &mut SseScanState, chunk: &[u8], max_scratch
     }
 }
 
+/// Flush any incomplete line or pending `data:` event at stream end.
+///
+/// Providers such as Google Gemini may omit a trailing blank line before
+/// closing the connection, so the scanner must dispatch buffered state on
+/// `end_of_stream` rather than waiting for another `\n\n` boundary.
+pub(crate) fn flush_sse_state(state: &mut SseScanState, payloads: &mut Vec<Vec<u8>>) {
+    if !state.line_buf.is_empty() {
+        process_line(&state.line_buf, &mut state.data_buf, &mut state.has_data, payloads);
+        state.line_buf.clear();
+    }
+
+    if state.has_data {
+        payloads.push(std::mem::take(&mut state.data_buf));
+        state.has_data = false;
+    }
+
+    state.scratch_bytes = 0;
+}
+
 // -----------------------------------------------------------------------------
 // Private Utilities
 // -----------------------------------------------------------------------------
@@ -181,6 +200,23 @@ mod tests {
     // -------------------------------------------------------------------------
     // Single Complete Frame
     // -------------------------------------------------------------------------
+
+    #[test]
+    fn flush_pending_event_without_trailing_blank_line() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+        assert!(payloads.is_empty(), "no blank line yet");
+
+        let mut flushed = Vec::new();
+        flush_sse_state(&mut state, &mut flushed);
+        assert_eq!(flushed.len(), 1, "EOF flush should dispatch pending event");
+        assert_eq!(
+            flushed[0],
+            b"{\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}"
+        );
+    }
 
     #[test]
     fn single_data_frame_yields_payload() {

--- a/filters/src/token_count/mod.rs
+++ b/filters/src/token_count/mod.rs
@@ -381,6 +381,13 @@ fn handle_sse_body(
     }
 
     if end_of_stream {
+        let mut state = load_sse_scan_state(ctx);
+        let mut pending = Vec::new();
+        sse::flush_sse_state(&mut state, &mut pending);
+        for payload in &pending {
+            process_sse_payload(ctx, payload, provider);
+        }
+
         finalize_streaming_counts(ctx);
         clear_all_metadata(ctx);
     }
@@ -443,6 +450,11 @@ fn merge_accumulated_count(ctx: &mut HttpFilterContext<'_>, key: &str, value: u6
 
 /// Write accumulated streaming counts to the well-known metadata keys.
 fn finalize_streaming_counts(ctx: &mut HttpFilterContext<'_>) {
+    let has_accumulated = ctx.filter_metadata.contains_key(META_INPUT) || ctx.filter_metadata.contains_key(META_OUTPUT);
+    if !has_accumulated {
+        return;
+    }
+
     let input: u64 = ctx
         .filter_metadata
         .get(META_INPUT)
@@ -454,10 +466,8 @@ fn finalize_streaming_counts(ctx: &mut HttpFilterContext<'_>) {
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
-    if input > 0 || output > 0 {
-        set_token_usage(ctx, input, output, None);
-        debug!(input, output, "finalized streaming token counts");
-    }
+    set_token_usage(ctx, input, output, None);
+    debug!(input, output, "finalized streaming token counts");
 }
 
 // -----------------------------------------------------------------------------

--- a/filters/src/token_count/tests.rs
+++ b/filters/src/token_count/tests.rs
@@ -463,6 +463,29 @@ async fn sse_bedrock_metadata_event() {
     assert_eq!(total.as_deref(), Some("48"), "Bedrock SSE total tokens (computed)");
 }
 
+#[tokio::test]
+async fn sse_zero_token_counts_are_written() {
+    let events = b"data: {\"usage\":{\"prompt_tokens\":0,\"completion_tokens\":0,\"total_tokens\":0}}\n\n";
+
+    let (input, output, total) = run_sse_extraction(TokenUsageProvider::OpenAi, events).await;
+
+    assert_eq!(input.as_deref(), Some("0"), "zero input tokens should be written");
+    assert_eq!(output.as_deref(), Some("0"), "zero output tokens should be written");
+    assert_eq!(total.as_deref(), Some("0"), "zero total tokens should be written");
+}
+
+#[tokio::test]
+async fn sse_final_event_without_trailing_blank_line() {
+    let events =
+        b"data: {\"usageMetadata\":{\"promptTokenCount\":12,\"candidatesTokenCount\":34,\"totalTokenCount\":46}}";
+
+    let (input, output, total) = run_sse_extraction(TokenUsageProvider::Google, events).await;
+
+    assert_eq!(input.as_deref(), Some("12"), "Google EOF usage should be extracted");
+    assert_eq!(output.as_deref(), Some("34"), "Google EOF usage should be extracted");
+    assert_eq!(total.as_deref(), Some("46"), "Google EOF total should be extracted");
+}
+
 // -----------------------------------------------------------------------------
 // SSE: Scratch Overflow
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix two streaming token accumulation bugs in `token_count` (#119):

- **SSE EOF flush** — flush pending scanner state on `end_of_stream` so streams
  without a trailing blank line (e.g. Google Gemini) still extract usage metadata.
- **Zero token finalization** — write `0` counts when usage keys are present
  instead of skipping `set_token_usage` when both counts are zero.

Adds `flush_sse_state` to the shared SSE scanner and regression unit tests.
Response bodies continue to pass through unchanged.

The broader streaming accumulation design (provider parsers, filter wiring,
integration passthrough) is already on main via #262, #261, #243. SSE e2e
token count assertion remains follow-up per proposal.

## Test plan

- [x] `make lint`
- [x] `cargo test -p praxis-ai-filters token_count::` (49 passed)
- [x] `cargo test -p praxis-tests-integration token_count` (2 passed)
- [x] `cargo test -p praxis-tests-integration token_counting` (12 passed)