### PR TITLE
Remove redundant replay proxy drops

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,17 +51,16 @@ jobs:
         with:
           components: clippy
 
-      - name: Cache Cargo registry and build artifacts
+      - name: Cache Cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-            target
-          key: ${{ runner.os }}-rust-1.96.0-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-rust-1.96.0-lint-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-1.96.0-cargo-
+            ${{ runner.os }}-rust-1.96.0-lint-cargo-
           save-always: true
 
       - name: Install cargo-machete

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,9 +91,9 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-rust-1.96.0-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-rust-1.96.0-test-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-1.96.0-cargo-
+            ${{ runner.os }}-rust-1.96.0-test-cargo-
           save-always: true
 
       - name: Unit tests

--- a/tests/integration/tests/suite/examples/session_replay.rs
+++ b/tests/integration/tests/suite/examples/session_replay.rs
@@ -74,8 +74,6 @@ fn replay_claude_messages_image_session_through_protocol_example() {
         forwarded["messages"][0]["content"][1]["source"]["media_type"], "image/png",
         "forwarded request should preserve the image content block"
     );
-
-    drop(proxy);
 }
 
 #[test]
@@ -131,8 +129,6 @@ fn replay_claude_messages_tool_cycle_preserves_source_records() {
             "{} backend request should match the replay fixture request",
             turn.name
         );
-
-        drop(proxy);
     }
     assert_eq!(
         replay.turns[0].response["content"][0]["type"], "text",
@@ -221,8 +217,6 @@ fn replay_claude_messages_thinking_session_through_protocol_example() {
         source_records[1]["message"]["id"], source_records[2]["message"]["id"],
         "split thinking and text records should retain their shared Claude message id"
     );
-
-    drop(proxy);
 }
 
 #[test]
@@ -281,8 +275,6 @@ fn replay_claude_messages_image_session_through_chat_completions_translation_exa
         transformed["stop_reason"], "end_turn",
         "Chat Completions stop finish reason should translate to Anthropic end_turn"
     );
-
-    drop(proxy);
 }
 
 #[test]
@@ -345,8 +337,6 @@ fn replay_claude_messages_thinking_fixture_translates_visible_text_for_openai() 
         transformed["stop_reason"], "end_turn",
         "Chat Completions stop finish reason should translate to Anthropic end_turn"
     );
-
-    drop(proxy);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -393,6 +383,4 @@ async fn replay_codex_responses_session_through_full_flow_example() {
         stored, turn.response,
         "stored response should match the replayed Codex fixture response"
     );
-
-    drop(proxy);
 }


### PR DESCRIPTION
## Summary
- remove redundant end-of-scope `drop(proxy)` calls from session replay example tests
- rely on `ProxyGuard` RAII cleanup at scope/iteration end
- isolate Tests workflow cargo caches per job so CI no longer restores the stale shared cache before `make lint` or unit tests

## Tests
- cargo +nightly fmt --all -- --check
- cargo test -p praxis-tests-integration session_replay -- --nocapture
- make lint