### PR TITLE
fix(a2a): capture task route for non-SSE responses to streaming methods

### DIFF
--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -246,14 +246,12 @@ impl HttpFilter for A2aFilter {
             .and_then(|v| v.to_str().ok())
             .is_some_and(is_event_stream_content_type);
 
-        if is_sse_capable {
-            if is_sse {
-                let cluster = ctx.cluster_name().map(str::to_owned);
-                if let Some(cluster) = cluster {
-                    ctx.filter_metadata
-                        .insert("a2a.response.sse_capture_enabled".to_owned(), "true".to_owned());
-                    ctx.filter_metadata.insert("a2a.response.cluster".to_owned(), cluster);
-                }
+        if is_sse_capable && is_sse {
+            let cluster = ctx.cluster_name().map(str::to_owned);
+            if let Some(cluster) = cluster {
+                ctx.filter_metadata
+                    .insert("a2a.response.sse_capture_enabled".to_owned(), "true".to_owned());
+                ctx.filter_metadata.insert("a2a.response.cluster".to_owned(), cluster);
             }
             return Ok(FilterAction::Continue);
         }

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -2727,6 +2727,39 @@ async fn non_sse_response_does_not_enter_sse_capture_path() {
 }
 
 #[tokio::test]
+async fn non_sse_response_falls_through_to_non_streaming_capture() {
+    for method in ["SendStreamingMessage", "SubscribeToTask"] {
+        let filter = make_task_routing_filter();
+
+        let req = make_a2a_request(&[]);
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.cluster = Some(Arc::from("agent-a"));
+        ctx.filter_metadata.insert("a2a.method".to_owned(), method.to_owned());
+
+        let mut resp = praxis_filter::Response {
+            status: http::StatusCode::OK,
+            headers: HeaderMap::new(),
+        };
+        resp.headers.insert("content-type", "application/json".parse().unwrap());
+        ctx.response_header = Some(&mut resp);
+
+        drop(filter.on_response(&mut ctx).await.unwrap());
+        ctx.response_header = None;
+
+        assert_eq!(
+            ctx.get_metadata("a2a.response.capture_enabled"),
+            Some("true"),
+            "{method} with non-SSE success response should enable non-streaming capture"
+        );
+        assert_eq!(
+            ctx.get_metadata("a2a.response.cluster"),
+            Some("agent-a"),
+            "{method} with non-SSE success response should record cluster for capture"
+        );
+    }
+}
+
+#[tokio::test]
 async fn wrong_method_does_not_enter_sse_capture() {
     let filter = make_task_routing_filter();
 


### PR DESCRIPTION
## Summary
`on_response` in `filters/src/agentic/a2a/mod.rs` returned `FilterAction::Continue`
early whenever the A2A method was SSE-capable (`SendStreamingMessage` or
`SubscribeToTask`), **regardless of whether the response was actually SSE**.
Per the A2A spec, these methods *may* return a non-streaming JSON-RPC response
containing a full `Task` object (e.g. when the backend completes synchronously
instead of streaming). In that case, the early return skipped the
non-streaming task-route capture path entirely, so the task route was never
recorded. Subsequent `GetTask`/`CancelTask` calls for that task could then be
routed to the wrong backend.

## Fix
Only take the SSE capture branch when the response is **both** SSE-capable
**and** actually SSE (`is_sse_capable && is_sse`). Otherwise, execution now
falls through to the existing non-streaming capture logic, which records
`a2a.response.cluster` and `a2a.response.capture_enabled` so the task route
gets stored from the response body.
```rust
if is_sse_capable && is_sse {
    let cluster = ctx.cluster_name().map(str::to_owned);
    if let Some(cluster) = cluster {
        ctx.filter_metadata
            .insert("a2a.response.sse_capture_enabled".to_owned(), "true".to_owned());
        ctx.filter_metadata.insert("a2a.response.cluster".to_owned(), cluster);
    }
    return Ok(FilterAction::Continue);
}

Fixes #352