### PR TITLE
docs(store): clarify no-cascade delete for conversation items

### DIFF
--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -208,6 +208,11 @@ pub(super) async fn handle_update_conversation(
 }
 
 /// Handle `DELETE /v1/conversations/{id}` — delete a conversation.
+///
+/// This intentionally deletes only the conversation record. The OpenAI
+/// Conversations API specifies that deleting a conversation does not delete
+/// its items; item cleanup belongs to item deletion or a separate retention
+/// policy, not this endpoint.
 pub(super) async fn handle_delete_conversation(
     ctx: &HttpFilterContext<'_>,
     store: &dyn ConversationItemStore,

--- a/apis/src/store/schemas.rs
+++ b/apis/src/store/schemas.rs
@@ -134,6 +134,11 @@ fn conversations_ddl(c: &str) -> String {
 }
 
 /// Append DDL for the conversation items table and its index.
+///
+/// Items intentionally do not have a cascading foreign key to conversations.
+/// The OpenAI Conversations API preserves items when a conversation is
+/// deleted, so retention cleanup must be implemented separately from
+/// `DELETE /v1/conversations/{id}`.
 fn append_items_ddl(stmts: &mut Vec<String>, i: &str) {
     stmts.push(format!(
         "CREATE TABLE IF NOT EXISTS {i} (

--- a/apis/src/store/trait_def.rs
+++ b/apis/src/store/trait_def.rs
@@ -122,9 +122,10 @@ pub trait ConversationItemStore: Send + Sync {
     /// Delete a conversation by ID, scoped to a tenant.
     ///
     /// Returns `true` if a record was deleted, `false` if no
-    /// matching record existed for this tenant. This does not delete
-    /// conversation item rows; items are deleted only through
-    /// [`delete_conversation_item`].
+    /// matching record existed for this tenant. To match the OpenAI
+    /// Conversations API, this does not delete conversation item rows; items
+    /// are deleted only through [`delete_conversation_item`] or an explicit
+    /// retention cleanup path.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

Document that deleting a conversation intentionally does not cascade to its items, matching the OpenAI Conversations API specification. Adds doc comments to the handler, DDL schema, and trait definition explaining that item cleanup belongs to item deletion or a separate retention policy.

## Changes

- `handlers.rs`: doc comment on `handle_delete_conversation` explaining scope
- `schemas.rs`: doc comment on `append_items_ddl` explaining no cascading FK
- `trait_def.rs`: updated `delete_conversation` doc to reference API spec and retention cleanup