### PR TITLE
fix(conversations): avoid per-call String allocation in normalize_message_item

### DIFF
--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -528,7 +528,7 @@ pub(super) fn normalize_item(ctx: &HttpFilterContext<'_>, item: Value) -> Result
 
 /// Normalize easy SDK message inputs into conversation message response objects.
 fn normalize_message_item(map: &mut Map<String, Value>) -> Result<(), String> {
-    if map.get("type") != Some(&Value::String("message".to_owned())) {
+    if map.get("type").and_then(Value::as_str) != Some("message") {
         return Ok(());
     }
 


### PR DESCRIPTION
Replaces the per-call `String` allocation in `normalize_message_item` with a borrowed string comparison via `Value::as_str`. The old and new expressions behave identically for missing or non-string `type` values.

Verification gates run on `praxis-ai-apis`:
- `cargo +nightly fmt -p praxis-ai-apis` — passed
- `cargo clippy -p praxis-ai-apis --all-targets -- -D warnings` — passed
- `cargo test -p praxis-ai-apis` — passed

Closes #357

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.
