### PR TITLE
fix(conversations): pass ids to sync_conversation_messages instead of a partial ConversationRecord

### DIFF
--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -25,7 +25,7 @@ use super::{
 };
 use crate::{
     openai::responses::{DEFAULT_TENANT_ID, TENANT_METADATA_KEY, state::ResponsesState},
-    store::{ConversationItemStore, ConversationRecord, PostgresResponseStore, SqliteResponseStore, StoreError},
+    store::{ConversationItemStore, PostgresResponseStore, SqliteResponseStore, StoreError},
 };
 
 // -----------------------------------------------------------------------------
@@ -311,11 +311,7 @@ impl HttpFilter for OpenaiConversationsFilter {
         true
     }
 
-    #[expect(
-        clippy::large_stack_frames,
-        clippy::too_many_lines,
-        reason = "dispatcher with one arm per endpoint"
-    )]
+    #[expect(clippy::too_many_lines, reason = "dispatcher with one arm per endpoint")]
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
         let path = ctx.request.uri.path();
         let path = path.strip_suffix('/').filter(|p| !p.is_empty()).unwrap_or(path);
@@ -580,14 +576,7 @@ async fn persist_items(
 
 /// Refresh the denormalized conversation message cache after item mutation.
 async fn refresh_message_cache(store: &dyn ConversationItemStore, tenant_id: &str, conversation_id: &str) {
-    let record = ConversationRecord {
-        conversation_id: conversation_id.to_owned(),
-        tenant_id: tenant_id.to_owned(),
-        created_at: 0,
-        metadata: Value::Object(serde_json::Map::default()),
-        messages: Value::Null,
-    };
-    if let Err(e) = handlers::sync_conversation_messages(store, record).await {
+    if let Err(e) = handlers::sync_conversation_messages(store, tenant_id, conversation_id).await {
         warn!(error = %e, conversation_id, "conversation message sync failed after append-back");
     }
 }

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -299,7 +299,7 @@ pub(super) async fn handle_create_items(
     if let Err(e) = store.create_conversation_items(&item_records).await {
         return Ok(FilterAction::Reject(store_error_response(&e)?));
     }
-    if let Err(e) = sync_conversation_messages(store, existing).await {
+    if let Err(e) = sync_conversation_messages(store, &existing.tenant_id, &existing.conversation_id).await {
         return Ok(FilterAction::Reject(store_error_response(&e)?));
     }
     debug!(
@@ -411,7 +411,7 @@ pub(super) async fn handle_delete_item(
         .await
     {
         Ok(true) => {
-            if let Err(e) = sync_conversation_messages(store, existing).await {
+            if let Err(e) = sync_conversation_messages(store, &existing.tenant_id, &existing.conversation_id).await {
                 return Ok(FilterAction::Reject(store_error_response(&e)?));
             }
             debug!(conversation_id, item_id, tenant_id, "conversation item deleted");
@@ -741,19 +741,18 @@ fn store_error_response(error: &StoreError) -> Result<Rejection, FilterError> {
 /// number of items; incremental updates would risk drift.
 pub(super) async fn sync_conversation_messages(
     store: &dyn ConversationItemStore,
-    record: ConversationRecord,
+    tenant_id: &str,
+    conversation_id: &str,
 ) -> Result<(), StoreError> {
-    let messages =
-        Value::Array(collect_conversation_messages(store, &record.tenant_id, &record.conversation_id).await?);
+    let messages = Value::Array(collect_conversation_messages(store, tenant_id, conversation_id).await?);
     let updated = store
-        .update_conversation_messages(&record.tenant_id, &record.conversation_id, &messages)
+        .update_conversation_messages(tenant_id, conversation_id, &messages)
         .await?;
     if updated {
         Ok(())
     } else {
         Err(StoreError::Database(format!(
-            "conversation disappeared during message sync: {}",
-            record.conversation_id
+            "conversation disappeared during message sync: {conversation_id}"
         )))
     }
 }


### PR DESCRIPTION
Refactors `sync_conversation_messages` to accept `tenant_id` and `conversation_id` as `&str` instead of a full `ConversationRecord`. This eliminates the partial record constructed in `filter.rs` with `created_at: 0` and `messages: Value::Null`, which could silently corrupt conversation data if the callee ever accessed those fields.

Verification:
- `cargo fmt -p praxis-ai-apis` (nightly rustfmt) — clean
- `cargo clippy -p praxis-ai-apis --all-targets -- -D warnings` — clean
- `cargo test -p praxis-ai-apis` — all 1456 tests passed

Closes #358

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.
