### PR TITLE
ci: add live vLLM CPU integration tests for Responses API

### DIFF
--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -1,0 +1,116 @@
+name: vLLM Integration
+
+# ------------------------------------------------------------------------------
+# Workflow Settings
+# ------------------------------------------------------------------------------
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apis/src/openai/responses/**"
+      - "apis/src/openai/sse/**"
+      - "server/**"
+      - "tests/integration/sdk/openai/**"
+      - "examples/configs/openai/responses/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Makefile"
+      - ".github/workflows/vllm-integration.yaml"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "apis/src/openai/responses/**"
+      - "apis/src/openai/sse/**"
+      - "server/**"
+      - "tests/integration/sdk/openai/**"
+      - "examples/configs/openai/responses/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Makefile"
+      - ".github/workflows/vllm-integration.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+  VLLM_IMAGE: "quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english@sha256:0212dc82981178033cb71c7477ba8ad1998fb6c0b1ee40646119fb9724ac951b"
+  VLLM_MODEL: "Qwen/Qwen3-0.6B"
+
+jobs:
+  # ----------------------------------------------------------------------------
+  # Responses API integration tests against a real vLLM CPU backend
+  # ----------------------------------------------------------------------------
+
+  vllm-responses:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@6190aa5fb88a88ee71c12769924bbe63a9ab152e # 1.96.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Cache Cargo artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-rust-1.96.0-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-1.96.0-cargo-
+          save-always: true
+
+      - name: Pull vLLM CPU image
+        run: docker pull "$VLLM_IMAGE"
+
+      - name: Start vLLM
+        run: |
+          docker run -d --name vllm \
+            -p 8000:8000 \
+            --privileged=true \
+            "$VLLM_IMAGE" \
+            --model /root/.cache/Qwen/Qwen3-0.6B \
+            --max-model-len 4096 \
+            --served-model-name "$VLLM_MODEL" \
+            --enable-auto-tool-choice \
+            --tool-call-parser hermes \
+            --reasoning-parser deepseek_r1
+
+      - name: Build Praxis
+        run: cargo build -p praxis-ai-proxy
+
+      - name: Wait for vLLM readiness
+        run: |
+          echo "Waiting for vLLM health and model endpoints..."
+          timeout 900 bash -c 'until curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
+                                     curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
+            sleep 5
+          done'
+          echo "vLLM is ready"
+
+      - name: Run vLLM integration tests
+        run: |
+          uv run pytest tests/integration/sdk/openai/test_openai_responses_vllm.py -v -s
+
+      - name: vLLM container logs
+        if: failure()
+        run: docker logs vllm
+
+      - name: Stop vLLM
+        if: always()
+        run: docker rm -f vllm || true

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -54,6 +54,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          docker system prune -af
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install stable Rust

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -94,7 +94,8 @@ jobs:
             --served-model-name "$VLLM_MODEL" \
             --enable-auto-tool-choice \
             --tool-call-parser hermes \
-            --reasoning-parser deepseek_r1
+            --reasoning-parser deepseek_r1 \
+            --gpu-memory-utilization 0.7
 
       - name: Build Praxis
         run: cargo build -p praxis-ai-proxy

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run vLLM integration tests
         run: |
-          uv run pytest tests/integration/sdk/openai/test_openai_responses_vllm.py -v -s
+          uv run tests/integration/sdk/openai/test_openai_responses_vllm.py -s
 
       - name: vLLM container logs
         if: failure()

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -15,7 +15,7 @@ using the official OpenAI Python SDK.
 
 Usage:
     cargo build -p praxis-ai-proxy
-    uv run pytest tests/integration/sdk/openai/test_openai_responses_vllm.py -v
+    uv run tests/integration/sdk/openai/test_openai_responses_vllm.py -s
 """
 
 import os
@@ -38,19 +38,6 @@ VLLM_BASE_URL = os.environ.get("VLLM_BASE_URL", "http://127.0.0.1:8000")
 VLLM_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-0.6B")
 PRAXIS_AI_BIN = os.environ.get("PRAXIS_AI_BIN")
 CONFIG_PATH = "examples/configs/openai/responses/full-flow.yaml"
-
-# ---------------------------------------------------------------------------
-# Failure tracking for log output
-# ---------------------------------------------------------------------------
-
-_any_test_failed = False
-
-
-def pytest_runtest_makereport(item, call):
-    global _any_test_failed
-    if call.when == "call" and call.excinfo is not None:
-        _any_test_failed = True
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -119,7 +106,7 @@ def _wait_for_proxy(port: int, timeout: float = 30.0) -> None:
 
 
 @pytest.fixture(scope="session")
-def praxis_proxy(tmp_path_factory):
+def praxis_proxy(tmp_path_factory, request):
     """Start a Praxis proxy backed by vLLM for the test session."""
     port = _free_port()
     db_dir = tmp_path_factory.mktemp("responses")
@@ -148,7 +135,7 @@ def praxis_proxy(tmp_path_factory):
             proc.kill()
             proc.wait()
         log_file.close()
-        if not started or _any_test_failed:
+        if not started or request.session.testsfailed > 0:
             with open(log_path) as f:
                 print(
                     f"\n=== Praxis logs ===\n{f.read()}",

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "openai>=2.0",
+#     "pytest>=8.0",
+# ]
+# ///
+"""
+OpenAI Responses API integration tests against a real vLLM CPU backend.
+
+Starts a Praxis proxy with the full responses pipeline backed by vLLM,
+then exercises stateless requests, persistence, rehydration, and streaming
+using the official OpenAI Python SDK.
+
+Usage:
+    cargo build -p praxis-ai-proxy
+    uv run pytest tests/integration/sdk/openai/test_openai_responses_vllm.py -v
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from urllib.parse import urlparse
+
+import pytest
+from openai import OpenAI
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+VLLM_BASE_URL = os.environ.get("VLLM_BASE_URL", "http://127.0.0.1:8000")
+VLLM_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-0.6B")
+PRAXIS_AI_BIN = os.environ.get("PRAXIS_AI_BIN")
+CONFIG_PATH = "examples/configs/openai/responses/full-flow.yaml"
+
+# ---------------------------------------------------------------------------
+# Failure tracking for log output
+# ---------------------------------------------------------------------------
+
+_any_test_failed = False
+
+
+def pytest_runtest_makereport(item, call):
+    global _any_test_failed
+    if call.when == "call" and call.excinfo is not None:
+        _any_test_failed = True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _find_binary() -> str:
+    if PRAXIS_AI_BIN:
+        if os.path.isfile(PRAXIS_AI_BIN):
+            return PRAXIS_AI_BIN
+        raise FileNotFoundError(
+            f"PRAXIS_AI_BIN={PRAXIS_AI_BIN!r} not found"
+        )
+    for candidate in ["target/debug/praxis-ai", "target/release/praxis-ai"]:
+        if os.path.isfile(candidate):
+            return candidate
+    raise FileNotFoundError(
+        "praxis-ai binary not found — run `cargo build -p praxis-ai-proxy` first"
+    )
+
+
+def _vllm_endpoint() -> str:
+    parsed = urlparse(VLLM_BASE_URL)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8000
+    return f"{host}:{port}"
+
+
+def _write_config(praxis_port: int, db_path: str) -> str:
+    with open(CONFIG_PATH) as f:
+        config = f.read()
+
+    config = config.replace("127.0.0.1:8080", f"127.0.0.1:{praxis_port}")
+    config = config.replace("127.0.0.1:3001", _vllm_endpoint())
+    config = config.replace(
+        "sqlite://responses.db?mode=rwc",
+        f"sqlite://{db_path}?mode=rwc",
+    )
+
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    with os.fdopen(fd, "w") as f:
+        f.write(config)
+    return path
+
+
+def _wait_for_proxy(port: int, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.2)
+    raise TimeoutError(f"Praxis did not start within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def praxis_proxy(tmp_path_factory):
+    """Start a Praxis proxy backed by vLLM for the test session."""
+    port = _free_port()
+    db_dir = tmp_path_factory.mktemp("responses")
+    db_path = str(db_dir / "responses.db")
+    config_path = _write_config(port, db_path)
+    binary = _find_binary()
+
+    log_path = str(db_dir / "praxis.log")
+    log_file = open(log_path, "w")
+    started = False
+
+    proc = subprocess.Popen(
+        [binary, "-c", config_path],
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        _wait_for_proxy(port)
+        started = True
+        yield port
+    finally:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        log_file.close()
+        if not started or _any_test_failed:
+            with open(log_path) as f:
+                print(
+                    f"\n=== Praxis logs ===\n{f.read()}",
+                    file=sys.stderr,
+                )
+        os.unlink(config_path)
+
+
+@pytest.fixture(scope="session")
+def openai_client(praxis_proxy):
+    """Return an OpenAI client pointed at the local Praxis proxy."""
+    return OpenAI(
+        base_url=f"http://127.0.0.1:{praxis_proxy}/v1",
+        api_key="test",
+        max_retries=0,
+        timeout=180,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIResponsesVLLM:
+    """Integration tests for the Responses API against a vLLM backend."""
+
+    def test_stateless_request(self, openai_client):
+        response = openai_client.responses.create(
+            model=VLLM_MODEL,
+            input="Say exactly: HELLO-PRAXIS /no_think",
+            store=False,
+            max_output_tokens=128,
+        )
+
+        assert response.status == "completed"
+        assert "HELLO-PRAXIS" in response.output_text
+
+    def test_store_and_retrieve(self, openai_client):
+        response = openai_client.responses.create(
+            model=VLLM_MODEL,
+            input="Say exactly: STORED-OK /no_think",
+            store=True,
+            max_output_tokens=128,
+        )
+
+        assert response.status == "completed"
+        assert response.id
+
+        retrieved = openai_client.responses.retrieve(response.id)
+
+        assert retrieved.id == response.id
+        assert retrieved.status == "completed"
+
+    def test_rehydrated_second_turn(self, openai_client):
+        first = openai_client.responses.create(
+            model=VLLM_MODEL,
+            input=(
+                "Remember this nonce: VIOLET-7319. "
+                "Acknowledge it. /no_think"
+            ),
+            store=True,
+            max_output_tokens=128,
+        )
+
+        assert first.status == "completed"
+
+        second = openai_client.responses.create(
+            model=VLLM_MODEL,
+            input=(
+                "What nonce did I just tell you? "
+                "Repeat it exactly. /no_think"
+            ),
+            previous_response_id=first.id,
+            store=True,
+            max_output_tokens=128,
+        )
+
+        assert second.status == "completed"
+        assert "VIOLET-7319" in second.output_text
+
+    def test_streaming(self, openai_client):
+        stream = openai_client.responses.create(
+            model=VLLM_MODEL,
+            input="Say exactly: STREAM-OK /no_think",
+            store=False,
+            stream=True,
+            max_output_tokens=128,
+        )
+
+        event_types = []
+        text_parts = []
+        final_status = None
+
+        for event in stream:
+            event_types.append(event.type)
+            if event.type == "response.output_text.delta":
+                text_parts.append(event.delta)
+            if event.type == "response.completed":
+                final_status = event.response.status
+
+        assert event_types[0] == "response.created"
+        assert event_types[-1] == "response.completed"
+        assert final_status == "completed"
+        assert "STREAM-OK" in "".join(text_parts)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"] + sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Adds a Python SDK integration test (`test_openai_responses_vllm.py`) that validates Responses API stateless requests, store/retrieve, multi-turn rehydration via `previous_response_id`, and streaming against a real CPU-only vLLM backend (Qwen/Qwen3-0.6B).
- Adds a GitHub Actions workflow (`vllm-integration.yaml`) that pulls a pre-baked Quay.io vLLM CPU image, starts the model, builds Praxis, and runs the test suite — no API keys or GPU runner required.

## Test plan

- [ ] Workflow triggers on relevant path changes and `workflow_dispatch`
- [ ] vLLM container starts and becomes healthy within the job timeout
- [ ] All four SDK test scenarios pass: stateless, store+retrieve, rehydrated second turn, streaming
- [ ] vLLM and Praxis logs are printed on failure
- [ ] Existing Rust tests remain green