### PR TITLE
docs: add vLLM Agentic API passthrough example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,7 @@ before sending requests.
 | [stream-events.yaml](configs/openai/responses/stream-events.yaml) | Demonstrates the `openai_stream_events` filter, which observes SSE chunks from the backend without modification, accumulates state (response object, output items, tool calls, usage), and writes it to ResponsesState metadata |
 | [tool-routing.yaml](configs/openai/responses/tool-routing.yaml) | Demonstrates using `openai_tool_parse` to route Responses API requests by their tool composition |
 | [web-search.yaml](configs/openai/responses/web-search.yaml) | Demonstrates the `openai_web_search` filter configuration for model-driven web search dispatch |
+| [vllm-agentic-api.yaml](configs/openai/responses/vllm-agentic-api.yaml) | Routes Responses API traffic to vLLM Agentic API without Praxis hydration, response persistence, or tool dispatch |
 
 ### Payload Processing
 

--- a/examples/configs/openai/responses/vllm-agentic-api.yaml
+++ b/examples/configs/openai/responses/vllm-agentic-api.yaml
@@ -1,0 +1,31 @@
+# vLLM Agentic API Responses passthrough
+#
+# Agentic API owns previous_response_id hydration, response persistence,
+# web-search credentials, tool execution, and the model loop. Praxis only
+# classifies and routes this traffic, preserving the original request body.
+#
+# This pipeline intentionally does not include openai_response_store,
+# openai_responses_rehydrate, responses_proxy, openai_web_search,
+# openai_tool_parse, or openai_stream_events.
+
+listeners:
+  - name: agentic-api-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [agentic-api-passthrough]
+
+filter_chains:
+  - name: agentic-api-passthrough
+    filters:
+      - filter: openai_responses_format
+        on_invalid: continue
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            cluster: "vllm-agentic-api"
+
+      - filter: load_balancer
+        clusters:
+          - name: "vllm-agentic-api"
+            endpoints:
+              - "127.0.0.1:3001"

--- a/examples/configs/openai/responses/vllm-agentic-api.yaml
+++ b/examples/configs/openai/responses/vllm-agentic-api.yaml
@@ -1,5 +1,7 @@
 # vLLM Agentic API Responses passthrough
 #
+# vLLM Agentic API: https://github.com/vllm-project/agentic-api
+#
 # Agentic API owns previous_response_id hydration, response persistence,
 # web-search credentials, tool execution, and the model loop. Praxis only
 # classifies and routes this traffic, preserving the original request body.

--- a/tests/integration/fixtures/agentic_api/web_search_nonstreaming.json
+++ b/tests/integration/fixtures/agentic_api/web_search_nonstreaming.json
@@ -1,0 +1,85 @@
+{
+  "source": "Sanitized from agentic-api's recorded gpt_oss_web_search_nonstreaming cassette (vLLM plus You.com); reasoning content omitted.",
+  "request": {
+    "input": "Use web search to look up potato, then summarize in one sentence.",
+    "max_output_tokens": 1024,
+    "model": "openai/gpt-oss-20b",
+    "store": true,
+    "stream": false,
+    "tool_choice": "auto",
+    "tools": [
+      {
+        "type": "web_search_preview"
+      }
+    ]
+  },
+  "response": {
+    "conversation_id": null,
+    "created_at": 1783307879,
+    "error": null,
+    "id": "resp_019f356e-aacf-7ea3-87c6-075c2fcc1eb2",
+    "incomplete_details": null,
+    "instructions": null,
+    "model": "openai/gpt-oss-20b",
+    "object": "response",
+    "output": [
+      {
+        "action": {
+          "query": "potato",
+          "sources": [
+            {
+              "title": "Potato - Wikipedia",
+              "url": "https://en.wikipedia.org/wiki/Potato"
+            },
+            {
+              "title": "Potatoes | Potato Nutrition | Types of Potatoes | Recipes",
+              "url": "https://potatogoodness.com/"
+            },
+            {
+              "title": "Potato Facts",
+              "url": "https://www.idahopotatomuseum.com/potato-facts/"
+            },
+            {
+              "title": "Idaho Potato Commission",
+              "url": "https://idahopotato.com/"
+            },
+            {
+              "title": "Home of U.S. Potato Farmers | Potatoes USA",
+              "url": "https://potatoesusa.com/"
+            }
+          ],
+          "type": "search"
+        },
+        "id": "ws_b67561c650733812",
+        "status": "completed",
+        "type": "web_search_call"
+      },
+      {
+        "content": [
+          {
+            "annotations": [],
+            "text": "Potato (Solanum tuberosum) is a starchy, underground tuber native to the Americas that has been domesticated for thousands of years and is today a staple food in many cultures worldwide.",
+            "type": "output_text"
+          }
+        ],
+        "id": "msg_a8af96caf08bdc00",
+        "role": "assistant",
+        "status": "completed",
+        "type": "message"
+      }
+    ],
+    "previous_response_id": null,
+    "status": "completed",
+    "usage": {
+      "input_tokens": 2285,
+      "input_tokens_details": {
+        "cached_tokens": 352
+      },
+      "output_tokens": 204,
+      "output_tokens_details": {
+        "reasoning_tokens": 135
+      },
+      "total_tokens": 2489
+    }
+  }
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -30,4 +30,5 @@ mod session_replay;
 mod token_count;
 mod token_counting;
 mod token_usage_headers;
+mod vllm_agentic_api;
 mod web_search;

--- a/tests/integration/tests/suite/examples/vllm_agentic_api.rs
+++ b/tests/integration/tests/suite/examples/vllm_agentic_api.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional test for the vLLM Agentic API passthrough example.
+
+use std::collections::HashMap;
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    Recording, free_port, http_send, json_post, parse_body, parse_status, patch_yaml, start_capturing_backend,
+    start_proxy,
+};
+
+fn load_agentic_api_config(proxy_port: u16, port_map: &HashMap<&str, u16>) -> Config {
+    let path = praxis_test_utils::example_config_path("openai/responses/vllm-agentic-api.yaml");
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let patched = patch_yaml(&yaml, proxy_port, port_map);
+    Config::from_yaml(&patched).unwrap_or_else(|e| panic!("parse vllm-agentic-api.yaml: {e}"))
+}
+
+#[test]
+fn vllm_agentic_api_example_preserves_previous_response_id() {
+    let backend =
+        start_capturing_backend(r#"{"id":"resp_agentic_456","object":"response","status":"completed","output":[]}"#);
+    let proxy_port = free_port();
+    let config = load_agentic_api_config(proxy_port, &HashMap::from([("127.0.0.1:3001", backend.port())]));
+    let proxy = start_proxy(&config);
+    let body = r#"{
+        "model":"open-model",
+        "input":"Continue the previous answer",
+        "previous_response_id":"resp_agentic_123",
+        "tools":[{"type":"web_search"}]
+    }"#;
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "Agentic API upstream should receive the request"
+    );
+    let forwarded: serde_json::Value =
+        serde_json::from_str(&backend.body()).expect("captured request body should be valid JSON");
+    assert_eq!(forwarded["previous_response_id"], "resp_agentic_123");
+    assert_eq!(forwarded["tools"], serde_json::json!([{"type":"web_search"}]));
+    assert_eq!(forwarded["input"], "Continue the previous answer");
+}
+
+#[test]
+fn vllm_agentic_api_example_replays_web_search_recording() {
+    let recording = Recording::load("agentic_api/web_search_nonstreaming.json");
+    let response_body = recording.response_body();
+    let request_body = recording.request_body();
+    let backend = start_capturing_backend(&response_body);
+    let proxy_port = free_port();
+    let config = load_agentic_api_config(proxy_port, &HashMap::from([("127.0.0.1:3001", backend.port())]));
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &request_body));
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "recorded Agentic API response should reach the client"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&parse_body(&raw)).expect("response body should be JSON"),
+        recording.response.expect("recording should contain a JSON response"),
+        "Praxis must relay Agentic API web-search output unchanged"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&backend.body()).expect("captured request body should be valid JSON"),
+        recording.request,
+        "Praxis must forward the recorded web-search request unchanged"
+    );
+}


### PR DESCRIPTION
## Summary

- add a dedicated vLLM Agentic API Responses passthrough configuration
- intentionally omit Praxis hydration, response persistence, and tool dispatch so Agentic API retains ownership of state and tool execution
- add a recorded web-search request replay to prove Praxis forwards Agentic-owned tool traffic and `previous_response_id` unchanged

## Why a separate example

`web-search.yaml` demonstrates Praxis-managed `openai_web_search` dispatch for direct vLLM Core. This example demonstrates the distinct Agentic API topology, where Praxis must not run that filter or hydrate continuation state.

## Validation

- `cargo test -p praxis-tests-integration vllm_agentic_api --no-default-features`
- `make lint`