### PR TITLE
docs: document bot-generated issue review process

### DIFF
--- a/docs/developing/project-management.md
+++ b/docs/developing/project-management.md
@@ -24,6 +24,46 @@ reverts it to `triage/needs-triage`.
 | `triage/needs-triage` | Awaiting maintainer review |
 | `triage/accepted` | Assigned to a milestone; accepted for work |
 
+## Bot-Generated Issues
+
+A weekly bot opens issues on the repository to surface
+potential improvements, bugs, or maintenance tasks. These
+issues are labeled `NEED HUMAN REVIEW` and **must not be
+worked on until a maintainer has reviewed them**.
+
+### Rules
+
+- **Do not self-assign** a bot-generated issue before it
+  has been reviewed.
+- **Do not submit a PR** for a bot-generated issue before
+  it has been validated by a maintainer.
+
+### Review Process
+
+A maintainer reviews the issue and leaves a comment with
+one of the following verdicts:
+
+**Approved:**
+
+```
+Reviewed by: @<maintainer>
+Verdict: Approved
+Reason: <optional explanation>
+```
+
+**Rejected:**
+
+```
+Reviewed by: @<maintainer>
+Verdict: Rejected
+Reason: <mandatory explanation>
+```
+
+Once an issue is approved, it follows the normal triage
+workflow (milestone assignment, priority, sizing). Rejected
+issues are closed with the reason stated in the review
+comment.
+
 ## Milestones
 
 Milestones represent a body of work toward a shared

--- a/docs/developing/project-management.md
+++ b/docs/developing/project-management.md
@@ -40,29 +40,24 @@ worked on until a maintainer has reviewed them**.
 
 ### Review Process
 
-A maintainer reviews the issue and leaves a comment with
-one of the following verdicts:
+A maintainer reviews the issue and applies one of the
+following labels:
 
-**Approved:**
+| Label | Meaning |
+| --- | --- |
+| `NEED HUMAN REVIEW` | Awaiting maintainer review (applied automatically by the bot) |
+| `HUMAN REVIEWED` | A maintainer has validated the issue |
 
-```
-Reviewed by: @<maintainer>
-Verdict: Approved
-Reason: <optional explanation>
-```
+To **approve** an issue, replace the `NEED HUMAN REVIEW`
+label with `HUMAN REVIEWED`. The label history records
+who approved and when.
 
-**Rejected:**
-
-```
-Reviewed by: @<maintainer>
-Verdict: Rejected
-Reason: <mandatory explanation>
-```
+To **reject** an issue, remove the `NEED HUMAN REVIEW`
+label, leave a comment explaining why, and close the
+issue.
 
 Once an issue is approved, it follows the normal triage
-workflow (milestone assignment, priority, sizing). Rejected
-issues are closed with the reason stated in the review
-comment.
+workflow (milestone assignment, priority, sizing).
 
 ## Milestones
 


### PR DESCRIPTION
Add a section to the project management guide documenting
the weekly bot that opens issues labeled `NEED HUMAN REVIEW`.
Covers the no-self-assign / no-PR-before-validation rules
and the review comment format for approving or rejecting
bot-generated issues.

Signed-off-by: Sébastien Han <seb@redhat.com>