### PR TITLE
fix(openai): arm SSE accumulation only for POST /v1/responses

### DIFF
--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -24,6 +24,7 @@ use tracing::{debug, trace, warn};
 
 use self::{accumulator::accumulate_event, config::StreamEventsConfig};
 use crate::{
+    classifier::is_responses_create,
     is_event_stream_content_type,
     openai::sse::{SseFrameParser, SseParseError, SseParserConfig, responses::ResponsesEvent},
 };
@@ -124,7 +125,8 @@ impl HttpFilter for OpenaiStreamEventsFilter {
     }
 
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
-        let is_responses = ctx.get_metadata("openai_responses_format.format") == Some("openai_responses");
+        let is_responses = is_responses_create(&ctx.request.method, ctx.request.uri.path())
+            && ctx.get_metadata("openai_responses_format.format") == Some("openai_responses");
         let is_streaming = ctx.get_metadata("openai_responses_format.stream") == Some("true");
 
         if is_responses && is_streaming {

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -144,6 +144,29 @@ async fn does_not_arm_for_non_responses_format() {
     );
 }
 
+#[tokio::test]
+async fn does_not_arm_for_other_responses_routes() {
+    for (method, path) in [
+        (http::Method::GET, "/v1/responses"),
+        (http::Method::POST, "/v1/responses/input_tokens"),
+    ] {
+        let filter = make_filter();
+        let req = make_request(method, path);
+        let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+        ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+        ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+        ctx.current_filter_id = Some(0);
+
+        let action = filter.on_request(&mut ctx).await.unwrap();
+
+        assert!(matches!(action, FilterAction::Continue));
+        assert!(
+            ctx.get_filter_state::<StreamEventsState>().is_none(),
+            "filter should not arm for {path}"
+        );
+    }
+}
+
 #[test]
 fn unarmed_filter_passes_through_body() {
     let filter = make_filter();


### PR DESCRIPTION
## Summary

- The `stream_events` filter was arming on any request tagged with `openai_responses` format metadata, including `GET /v1/responses` and `POST /v1/responses/input_tokens`.
- Gate on `is_responses_create()` so accumulation only activates for the create route.

## Test plan

- [x] New test `does_not_arm_for_other_responses_routes` covers GET and non-create POST paths
- [x] Existing stream_events tests pass (77/77)
- [x] `make lint` clean

Signed-off-by: Sébastien Han <seb@redhat.com>