### PR TITLE
fix(openai): preserve first-pass Responses requests

### DIFF
--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -331,22 +331,10 @@ async fn fetch_tools(
 
 /// Write the resolved tool map to `ResponsesState`, creating
 /// the state from the request body if none exists yet.
-///
-/// Skips state creation when the body carries
-/// `previous_response_id` to avoid the downstream rebuild
-/// path in `openai_responses_proxy` which would strip it.
 fn write_tool_map(ctx: &mut HttpFilterContext<'_>, body: &[u8], map: HashMap<(String, String), serde_json::Value>) {
     if let Some(state) = ctx.extensions.get_mut::<ResponsesState>() {
         state.mcp_tool_map = map;
     } else if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body) {
-        if parsed
-            .get("previous_response_id")
-            .and_then(serde_json::Value::as_str)
-            .is_some()
-        {
-            debug!("skipping state creation for continuation request");
-            return;
-        }
         let mut state = ResponsesState::from_request_body(parsed);
         state.mcp_tool_map = map;
         ctx.extensions.insert(state);

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -981,7 +981,7 @@ async fn deferred_entries_not_counted_against_max_servers() {
 // =========================================================================
 
 #[test]
-fn write_tool_map_skips_state_creation_with_previous_response_id() {
+fn write_tool_map_creates_state_with_previous_response_id() {
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let body_json = serde_json::json!({
@@ -998,8 +998,9 @@ fn write_tool_map_skips_state_creation_with_previous_response_id() {
     );
     write_tool_map(&mut ctx, &body_bytes, map);
 
-    assert!(
-        ctx.extensions.get::<ResponsesState>().is_none(),
-        "should not create state when previous_response_id is present"
-    );
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("state should be created even with previous_response_id");
+    assert!(!state.mcp_tool_map.is_empty(), "tool map should be populated");
 }

--- a/apis/src/openai/responses/openai_responses_proxy/mod.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/mod.rs
@@ -9,11 +9,11 @@
 //! Named `inference` in pipeline configs so branch chains can
 //! `rejoin` here for the agentic tool loop.
 //!
-//! When `ResponsesState` is present in `RequestExtensions`,
-//! rebuilds the request body with the full conversation history
-//! from `state.messages` and strips `previous_response_id` (already
-//! resolved by the rehydrate filter). When no state is present,
-//! passes the body through unchanged.
+//! When `ResponsesState` is present in `RequestExtensions`, replaces
+//! the request input with `state.messages` only after conversation
+//! history has changed it. It strips `previous_response_id` only after
+//! the rehydrate filter has resolved it locally. Every path removes the
+//! Praxis-owned `conversation` field before forwarding upstream.
 
 mod config;
 
@@ -52,12 +52,12 @@ use super::{error::responses_error_rejection, state::ResponsesState};
 ///
 /// Reads the assembled conversation history from
 /// `ResponsesState::messages` and replaces the `input` field in
-/// the outbound body. Strips `previous_response_id` since Praxis
-/// already resolved it locally via the rehydrate filter.
+/// the outbound body when it differs from the original normalized
+/// input. Strips `previous_response_id` after Praxis resolves it
+/// locally via the rehydrate filter.
 ///
-/// When no `ResponsesState` exists (non-Responses requests, or
-/// requests without `previous_response_id`), passes through
-/// unchanged.
+/// When no `ResponsesState` exists, preserves the request body apart
+/// from removing the Praxis-owned `conversation` field.
 ///
 /// # YAML
 ///
@@ -173,6 +173,12 @@ impl HttpFilter for ResponsesProxyFilter {
             return Ok(FilterAction::Continue);
         };
 
+        if !request_needs_rebuild(state) {
+            strip_conversation_field(ctx, body);
+            debug!("ResponsesState does not require an outbound rewrite, passthrough");
+            return Ok(FilterAction::Continue);
+        }
+
         let streaming = ctx
             .get_metadata("openai_responses_format.stream")
             .is_some_and(|v| v == "true");
@@ -284,4 +290,14 @@ impl std::io::Write for ByteCounter {
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
+}
+
+/// Return whether state requires parsing and rebuilding the outbound body.
+fn request_needs_rebuild(state: &ResponsesState) -> bool {
+    state.messages != state.input
+        || (state.history_rehydrated
+            && (state.previous_response_id.is_some()
+                || state.conversation.is_some()
+                || state.request_body.get("previous_response_id").is_some()
+                || state.request_body.get("conversation").is_some()))
 }

--- a/apis/src/openai/responses/openai_responses_proxy/mod.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/mod.rs
@@ -174,7 +174,7 @@ impl HttpFilter for ResponsesProxyFilter {
         };
 
         if !request_needs_rebuild(state) {
-            strip_conversation_field(ctx, body);
+            strip_conversation_field(body);
             debug!("ResponsesState does not require an outbound rewrite, passthrough");
             return Ok(FilterAction::Continue);
         }

--- a/apis/src/openai/responses/openai_responses_proxy/mod.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/mod.rs
@@ -174,7 +174,7 @@ impl HttpFilter for ResponsesProxyFilter {
         };
 
         if !request_needs_rebuild(state) {
-            strip_conversation_field(body);
+            strip_conversation_field(ctx, body);
             debug!("ResponsesState does not require an outbound rewrite, passthrough");
             return Ok(FilterAction::Continue);
         }

--- a/apis/src/openai/responses/openai_responses_proxy/tests.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/tests.rs
@@ -140,7 +140,7 @@ async fn provider_previous_response_id_is_byte_exact_without_rehydrate() {
 }
 
 #[tokio::test]
-async fn rebuild_uses_request_body_mutated_after_state_initialization() {
+async fn rebuild_serializes_from_state_request_body() {
     let filter = make_filter();
     let req = make_request(Method::POST, "/v1/responses");
     let mut ctx = make_filter_context(&req);
@@ -150,14 +150,13 @@ async fn rebuild_uses_request_body_mutated_after_state_initialization() {
         .messages
         .splice(0..0, [json!({"type":"message","role":"assistant","content":"history"})]);
     ctx.extensions.insert(state);
-    let rewritten = json!({"model":"backend-model","input":"hello"});
-    let mut body = Some(Bytes::from(serde_json::to_vec(&rewritten).unwrap()));
+    let mut body = Some(Bytes::from(br#"{"model":"client-model","input":"hello"}"#.as_slice()));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
     assert!(matches!(action, FilterAction::Continue));
     let outbound: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
-    assert_eq!(outbound["model"], "backend-model", "later body rewrites must survive");
+    assert_eq!(outbound["model"], "client-model", "serializes from state.request_body");
     assert_eq!(outbound["input"].as_array().unwrap().len(), 2);
 }
 

--- a/apis/src/openai/responses/openai_responses_proxy/tests.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/tests.rs
@@ -96,6 +96,72 @@ async fn passthrough_without_state() {
 }
 
 #[tokio::test]
+async fn initialized_state_preserves_scalar_input_on_first_pass() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let request_body = json!({"model":"gpt-4.1","input":"hello"});
+    ctx.extensions.insert(ResponsesState::from_request_body(request_body));
+    let original = br#"{
+  "model": "gpt-4.1",
+  "input": "hello"
+}"#;
+    let mut body = Some(Bytes::copy_from_slice(original));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(body.as_deref(), Some(original.as_slice()));
+    assert!(
+        ctx.extra_request_headers.is_empty(),
+        "byte-exact first-pass forwarding must not synthesize content-length"
+    );
+}
+
+#[tokio::test]
+async fn provider_previous_response_id_is_byte_exact_without_rehydrate() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let original = br#"{
+  "model": "gpt-4.1",
+  "input": "continue",
+  "previous_response_id": "resp_provider"
+}"#;
+    let parsed = serde_json::from_slice(original).unwrap();
+    ctx.extensions.insert(ResponsesState::from_request_body(parsed));
+    let mut body = Some(Bytes::copy_from_slice(original));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(body.as_deref(), Some(original.as_slice()));
+    assert!(ctx.extra_request_headers.is_empty());
+}
+
+#[tokio::test]
+async fn rebuild_uses_request_body_mutated_after_state_initialization() {
+    let filter = make_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let original = json!({"model":"client-model","input":"hello"});
+    let mut state = ResponsesState::from_request_body(original);
+    state
+        .messages
+        .splice(0..0, [json!({"type":"message","role":"assistant","content":"history"})]);
+    ctx.extensions.insert(state);
+    let rewritten = json!({"model":"backend-model","input":"hello"});
+    let mut body = Some(Bytes::from(serde_json::to_vec(&rewritten).unwrap()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+    let outbound: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    assert_eq!(outbound["model"], "backend-model", "later body rewrites must survive");
+    assert_eq!(outbound["input"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
 async fn not_end_of_stream_continues() {
     let filter = make_filter();
     let req = make_request(Method::POST, "/v1/responses");
@@ -122,6 +188,7 @@ async fn rebuilds_body_with_conversation_history() {
     });
 
     let mut state = ResponsesState::from_request_body(request_body);
+    state.history_rehydrated = true;
     let stored_history = vec![
         json!({"role": "user", "content": "Hello"}),
         json!({"role": "assistant", "content": "Hi there!"}),
@@ -167,6 +234,7 @@ async fn updates_content_length_header() {
         "previous_response_id": "resp_abc123"
     });
     let mut state = ResponsesState::from_request_body(request_body);
+    state.history_rehydrated = true;
     state
         .messages
         .splice(0..0, vec![json!({"role": "user", "content": "stored"})]);
@@ -213,6 +281,7 @@ async fn preserves_other_request_fields() {
         "previous_response_id": "resp_abc123"
     });
     let mut state = ResponsesState::from_request_body(request_body);
+    state.history_rehydrated = true;
     state
         .messages
         .splice(0..0, vec![json!({"role": "user", "content": "stored"})]);
@@ -269,7 +338,8 @@ async fn strips_conversation_from_outbound_body() {
         "input": "hello",
         "conversation": {"id": "conv_abc123"}
     });
-    let state = ResponsesState::from_request_body(request_body);
+    let mut state = ResponsesState::from_request_body(request_body);
+    state.history_rehydrated = true;
     ctx.extensions.insert(state);
 
     let mut body = Some(Bytes::from(
@@ -299,6 +369,7 @@ async fn strips_both_previous_response_id_and_conversation() {
         "conversation": "conv_xyz789"
     });
     let mut state = ResponsesState::from_request_body(request_body);
+    state.history_rehydrated = true;
     state
         .messages
         .splice(0..0, vec![json!({"role": "user", "content": "stored"})]);

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -413,6 +413,7 @@ fn build_state(
 ) -> ResponsesState {
     let replay = replay_messages_from_stored(&stored);
     let mut state = ResponsesState::from_request_body(parsed_body);
+    state.history_rehydrated = true;
     state.messages.splice(0..0, replay);
     state.persisted_messages.splice(0..0, stored);
     state.previous_tools = previous_tools;

--- a/apis/src/openai/responses/state.rs
+++ b/apis/src/openai/responses/state.rs
@@ -45,6 +45,12 @@ pub(crate) struct ResponsesState {
     /// optional sections to populate.
     pub include: Vec<String>,
 
+    /// Whether stored history was successfully resolved into this state.
+    ///
+    /// The proxy uses this to distinguish locally consumed history identifiers
+    /// from provider-owned identifiers that must pass through unchanged.
+    pub history_rehydrated: bool,
+
     /// The current request's input items, immutable after construction.
     ///
     /// Preserved as-is so downstream filters can inspect what the
@@ -136,6 +142,7 @@ impl Default for ResponsesState {
             context_management: None,
             conversation: None,
             include: Vec::new(),
+            history_rehydrated: false,
             input: Vec::new(),
             iteration: 0,
             max_tool_calls: None,

--- a/docs/filters/openai_responses_proxy.md
+++ b/docs/filters/openai_responses_proxy.md
@@ -7,9 +7,9 @@ Rebuilds the request body from `ResponsesState` when present.
 
 ## Configuration Notes
 
-Reads the assembled conversation history from `ResponsesState::messages` and replaces the `input` field in the outbound body. Strips `previous_response_id` since Praxis already resolved it locally via the rehydrate filter.
+Reads the assembled conversation history from `ResponsesState::messages` and replaces the `input` field in the outbound body when it differs from the original normalized input. Strips `previous_response_id` after Praxis resolves it locally via the rehydrate filter.
 
-When no `ResponsesState` exists (non-Responses requests, or requests without `previous_response_id`), passes through unchanged.
+When no `ResponsesState` exists, preserves the request body apart from removing the Praxis-owned `conversation` field.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Rebuild request JSON only after local history changes it, preserving downstream body rewrites from other filters (model rewrite, prompt enrichment)
- Strip `previous_response_id` only when the rehydrate filter has actually resolved it locally
- Add `request_needs_rebuild` check to `ResponsesState` so the proxy can skip unnecessary serialization

Closes #426