### PR TITLE
fix(openai): accumulate Responses usage across rounds

### DIFF
--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -95,6 +95,9 @@ pub(super) fn accumulate_response_object(
         {
             object.insert("usage".to_owned(), state.usage.clone());
         }
+        if let Some(Value::Array(output)) = response.get("output") {
+            output.clone_into(&mut state.output_items);
+        }
         state.response_object = response;
         had_prior_usage
     };

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -96,7 +96,7 @@ pub(super) fn accumulate_response_object(
             object.insert("usage".to_owned(), state.usage.clone());
         }
         if let Some(Value::Array(output)) = response.get("output") {
-            *state.output_items_mut() = output.clone();
+            state.output_items_mut().clone_from(output);
         }
         state.response_object = response;
         had_prior_usage

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -58,21 +58,7 @@ pub(super) fn accumulate_event(
 
 /// Overwrite `ResponsesState` from a terminal event's authoritative payload.
 fn handle_terminal_event(ctx: &mut HttpFilterContext<'_>, payload: &Value, event: &ResponsesEvent) {
-    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
-
     let response = payload.get("response").unwrap_or(payload);
-
-    response.clone_into(&mut state.response_object);
-
-    if let Some(Value::Array(output)) = response.get("output") {
-        output.clone_into(&mut state.output_items);
-    }
-
-    if let Some(usage) = response.get("usage")
-        && !usage.is_null()
-    {
-        usage.clone_into(&mut state.usage);
-    }
 
     let status = match event {
         ResponsesEvent::ResponseCompleted(_) => "completed",
@@ -80,9 +66,66 @@ fn handle_terminal_event(ctx: &mut HttpFilterContext<'_>, payload: &Value, event
         ResponsesEvent::ResponseFailed(_) => "failed",
         _ => "unknown",
     };
-    ctx.set_metadata("responses.status", status.to_owned());
+    // SSE payloads are borrowed from the frame parser, so terminal accumulation
+    // is the one path that must clone a complete response object.
+    let _ = accumulate_response_object(ctx, response.clone(), Some(status));
+}
 
-    debug!(status, "terminal event received, ResponsesState updated");
+/// Overwrite response fields from an authoritative complete response object.
+///
+/// `status_override` is authoritative for SSE terminal events. Other callers
+/// use the response object's own `status` field.
+pub(super) fn accumulate_response_object(
+    ctx: &mut HttpFilterContext<'_>,
+    mut response: Value,
+    status_override: Option<&str>,
+) -> bool {
+    let status = status_override
+        .map(str::to_owned)
+        .or_else(|| response.get("status").and_then(Value::as_str).map(str::to_owned))
+        .unwrap_or_else(|| "unknown".to_owned());
+    let had_prior_usage = {
+        let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
+        let had_prior_usage = !state.usage.is_null();
+        if let Some(usage) = response.get("usage").filter(|usage| !usage.is_null()) {
+            merge_usage(&mut state.usage, usage);
+        }
+        if !state.usage.is_null()
+            && let Some(object) = response.as_object_mut()
+        {
+            object.insert("usage".to_owned(), state.usage.clone());
+        }
+        state.response_object = response;
+        had_prior_usage
+    };
+    ctx.set_metadata("responses.status", status.clone());
+
+    debug!(status, "complete response received, ResponsesState updated");
+    had_prior_usage
+}
+
+/// Saturating recursive sum for numeric token-usage fields.
+fn merge_usage(accumulated: &mut Value, current: &Value) {
+    match (accumulated, current) {
+        (Value::Object(accumulated), Value::Object(current)) => {
+            for (key, value) in current {
+                match accumulated.get_mut(key) {
+                    Some(existing) => merge_usage(existing, value),
+                    None => {
+                        accumulated.insert(key.clone(), value.clone());
+                    },
+                }
+            }
+        },
+        (Value::Number(accumulated), Value::Number(current)) => {
+            if let (Some(left), Some(right)) = (accumulated.as_u64(), current.as_u64()) {
+                *accumulated = serde_json::Number::from(left.saturating_add(right));
+            } else {
+                *accumulated = current.clone();
+            }
+        },
+        (accumulated, current) => current.clone_into(accumulated),
+    }
 }
 
 /// Push a new output item to the incremental accumulator.

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -22,6 +22,8 @@ use praxis_filter::{
 };
 use tracing::{debug, trace, warn};
 
+#[cfg(test)]
+use self::accumulator::accumulate_response_object;
 use self::{accumulator::accumulate_event, config::StreamEventsConfig};
 use crate::openai::sse::{SseFrameParser, SseParseError, SseParserConfig, responses::ResponsesEvent};
 

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use praxis_filter::{FilterAction, HttpFilter};
 use serde_json::json;
 
-use super::{CompletionState, OpenaiStreamEventsFilter, StreamEventsState};
+use super::{CompletionState, OpenaiStreamEventsFilter, StreamEventsState, accumulate_response_object};
 use crate::{
     openai::{responses::state::ResponsesState, sse::SseFrameParser},
     test_utils::{make_filter_context, make_request},
@@ -196,6 +196,48 @@ async fn terminal_event_writes_response_object() {
     assert_eq!(state.output_items.len(), 1);
     assert_eq!(state.usage["total_tokens"], 15);
     assert_eq!(ctx.get_metadata("responses.status"), Some("completed"),);
+}
+
+#[test]
+fn response_accumulation_sums_usage_across_iterations() {
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.extensions.insert(ResponsesState::default());
+    let first = json!({
+        "status":"completed",
+        "output":[],
+        "usage":{
+            "input_tokens":10,
+            "output_tokens":4,
+            "total_tokens":14,
+            "input_tokens_details":{"cached_tokens":3}
+        }
+    });
+    let second = json!({
+        "status":"completed",
+        "output":[],
+        "usage":{
+            "input_tokens":7,
+            "output_tokens":2,
+            "total_tokens":9,
+            "input_tokens_details":{"cached_tokens":1}
+        }
+    });
+
+    assert!(!accumulate_response_object(&mut ctx, first, None));
+    assert!(accumulate_response_object(&mut ctx, second, None));
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.usage["input_tokens"], 17);
+    assert_eq!(state.usage["output_tokens"], 6);
+    assert_eq!(state.usage["total_tokens"], 23);
+    assert_eq!(state.usage["input_tokens_details"]["cached_tokens"], 4);
+    assert_eq!(state.response_object["usage"], state.usage);
+
+    let final_without_usage = json!({"status":"completed","output":[]});
+    assert!(accumulate_response_object(&mut ctx, final_without_usage, None));
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.response_object["usage"], state.usage);
+    assert_eq!(state.usage["total_tokens"], 23);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

When the Responses API is used in multi-round agentic loops (tool calls), the `usage` field was overwritten by each terminal event instead of being accumulated. This meant the final usage reported only the last round's token counts.

This introduces `merge_usage()` for recursive saturating addition of numeric fields and refactors terminal event handling into `accumulate_response_object()` which merges usage before setting the authoritative response object.

Fixes #427