### PR TITLE
refactor(openai): keep Responses output in response object

### DIFF
--- a/apis/src/openai/responses/state.rs
+++ b/apis/src/openai/responses/state.rs
@@ -79,9 +79,6 @@ pub(crate) struct ResponsesState {
     /// items must be omitted from this field.
     pub messages: Vec<serde_json::Value>,
 
-    /// Output items accumulated across the current response.
-    pub output_items: Vec<serde_json::Value>,
-
     /// Whether tool calls may execute concurrently within an
     /// iteration. Defaults to `true` per the API spec.
     pub parallel_tool_calls: bool,
@@ -144,7 +141,6 @@ impl Default for ResponsesState {
             max_tool_calls: None,
             mcp_tool_map: HashMap::new(),
             messages: Vec::new(),
-            output_items: Vec::new(),
             parallel_tool_calls: true,
             persisted_messages: Vec::new(),
             previous_response_id: None,
@@ -187,6 +183,36 @@ impl ResponsesState {
             tools,
             ..Default::default()
         }
+    }
+
+    /// Borrow the public output owned by [`Self::response_object`].
+    #[cfg(test)]
+    pub(crate) fn output_items(&self) -> &[serde_json::Value] {
+        self.response_object
+            .get("output")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Mutably borrow public output, creating a valid array when absent.
+    pub(crate) fn output_items_mut(&mut self) -> &mut Vec<serde_json::Value> {
+        if !self.response_object.is_object() {
+            self.response_object = serde_json::Value::Object(serde_json::Map::new());
+        }
+        let serde_json::Value::Object(response) = &mut self.response_object else {
+            unreachable!("response_object was normalized to an object")
+        };
+        let output = response
+            .entry("output".to_owned())
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        if !output.is_array() {
+            *output = serde_json::Value::Array(Vec::new());
+        }
+        let serde_json::Value::Array(items) = output else {
+            unreachable!("output was normalized to an array")
+        };
+        items
     }
 }
 
@@ -479,7 +505,7 @@ mod tests {
         assert!(state.max_tool_calls.is_none());
         assert!(state.mcp_tool_map.is_empty());
         assert!(state.messages.is_empty());
-        assert!(state.output_items.is_empty());
+        assert!(state.output_items().is_empty());
         assert!(state.parallel_tool_calls);
         assert!(state.persisted_messages.is_empty());
         assert!(state.previous_response_id.is_none());
@@ -498,6 +524,35 @@ mod tests {
         let body = json!({"model": "gpt-4o", "input": "test", "parallel_tool_calls": false});
         let state = ResponsesState::from_request_body(body);
         assert!(!state.parallel_tool_calls);
+    }
+
+    #[test]
+    fn response_object_is_the_single_output_owner() {
+        let first = json!({"type": "message", "id": "msg_1"});
+        let second = json!({"type": "reasoning", "id": "rs_1"});
+        let mut state = ResponsesState {
+            response_object: json!({"id": "resp_1", "output": [first.clone()]}),
+            ..Default::default()
+        };
+
+        state.output_items_mut().push(second.clone());
+        assert_eq!(state.output_items(), &[first.clone(), second.clone()]);
+        assert_eq!(state.response_object["output"], json!([first, second]));
+        assert_eq!(state.response_object["id"], "resp_1");
+    }
+
+    #[test]
+    fn mutable_output_normalizes_missing_or_malformed_response_output() {
+        let mut state = ResponsesState {
+            response_object: json!({"id": "resp_1", "output": "invalid"}),
+            ..Default::default()
+        };
+
+        state.output_items_mut().push(json!({"type": "message"}));
+
+        assert_eq!(state.output_items().len(), 1);
+        assert!(state.response_object["output"].is_array());
+        assert_eq!(state.response_object["id"], "resp_1");
     }
 
     #[test]

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -64,10 +64,6 @@ fn handle_terminal_event(ctx: &mut HttpFilterContext<'_>, payload: &Value, event
 
     response.clone_into(&mut state.response_object);
 
-    if let Some(Value::Array(output)) = response.get("output") {
-        output.clone_into(&mut state.output_items);
-    }
-
     if let Some(usage) = response.get("usage")
         && !usage.is_null()
     {
@@ -90,7 +86,7 @@ fn handle_output_item_added(ctx: &mut HttpFilterContext<'_>, payload: &Value) {
     let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
 
     if let Some(item) = payload.get("item") {
-        state.output_items.push(item.clone());
+        state.output_items_mut().push(item.clone());
     }
 }
 
@@ -106,7 +102,7 @@ fn handle_output_item_done(ctx: &mut HttpFilterContext<'_>, payload: &Value) {
         .get("output_index")
         .and_then(Value::as_u64)
         .and_then(|v| usize::try_from(v).ok())
-        && let Some(slot) = state.output_items.get_mut(idx)
+        && let Some(slot) = state.output_items_mut().get_mut(idx)
     {
         item.clone_into(slot);
         return;
@@ -114,7 +110,7 @@ fn handle_output_item_done(ctx: &mut HttpFilterContext<'_>, payload: &Value) {
 
     if let Some(id) = item.get("id").and_then(Value::as_str)
         && let Some(existing) = state
-            .output_items
+            .output_items_mut()
             .iter_mut()
             .find(|i| i.get("id").and_then(Value::as_str) == Some(id))
     {
@@ -122,7 +118,7 @@ fn handle_output_item_done(ctx: &mut HttpFilterContext<'_>, payload: &Value) {
         return;
     }
 
-    state.output_items.push(item.clone());
+    state.output_items_mut().push(item.clone());
 }
 
 /// Append a function-call argument delta to the running buffer.
@@ -163,20 +159,23 @@ fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut
         .or(accumulated)
         .unwrap_or_default();
 
-    let Some(item) = find_output_item_mut(&mut state.output_items, payload) else {
-        warn!(
-            key,
-            "dropping function-call arguments.done without matching output item"
-        );
-        return;
-    };
+    let tool_call = {
+        let Some(item) = find_output_item_mut(state.output_items_mut(), payload) else {
+            warn!(
+                key,
+                "dropping function-call arguments.done without matching output item"
+            );
+            return;
+        };
 
-    let Some(tool_call) = complete_function_call_item(item, &arguments) else {
-        warn!(
-            key,
-            "dropping function-call arguments.done for non-function output item"
-        );
-        return;
+        let Some(tool_call) = complete_function_call_item(item, &arguments) else {
+            warn!(
+                key,
+                "dropping function-call arguments.done for non-function output item"
+            );
+            return;
+        };
+        tool_call
     };
 
     upsert_tool_call(&mut state.tool_calls, tool_call);

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -193,7 +193,7 @@ async fn terminal_event_writes_response_object() {
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
     assert_eq!(state.response_object["id"], "resp_123");
-    assert_eq!(state.output_items.len(), 1);
+    assert_eq!(state.output_items().len(), 1);
     assert_eq!(state.usage["total_tokens"], 15);
     assert_eq!(ctx.get_metadata("responses.status"), Some("completed"),);
 }
@@ -210,8 +210,8 @@ async fn output_item_added_accumulates_incrementally() {
     filter.on_response_body(&mut ctx, &mut body, false).unwrap();
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
-    assert_eq!(state.output_items.len(), 1);
-    assert_eq!(state.output_items[0]["id"], "item_1");
+    assert_eq!(state.output_items().len(), 1);
+    assert_eq!(state.output_items()[0]["id"], "item_1");
 }
 
 #[tokio::test]
@@ -222,7 +222,7 @@ async fn terminal_event_overwrites_incremental_output() {
     let item = json!({"item": {"type": "message", "id": "item_1"}});
     let mut body1 = Some(make_sse_chunk("response.output_item.added", &item));
     filter.on_response_body(&mut ctx, &mut body1, false).unwrap();
-    assert_eq!(ctx.extensions.get::<ResponsesState>().unwrap().output_items.len(), 1);
+    assert_eq!(ctx.extensions.get::<ResponsesState>().unwrap().output_items().len(), 1);
 
     let completed = json!({
         "id": "resp_123",
@@ -240,11 +240,11 @@ async fn terminal_event_overwrites_incremental_output() {
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
     assert_eq!(
-        state.output_items.len(),
+        state.output_items().len(),
         2,
         "terminal event should overwrite incremental output"
     );
-    assert_eq!(state.output_items[0]["id"], "item_final_1");
+    assert_eq!(state.output_items()[0]["id"], "item_final_1");
 }
 
 #[tokio::test]
@@ -289,7 +289,7 @@ async fn function_call_accumulation() {
     assert_eq!(state.tool_calls[0]["name"], "get_weather");
     assert_eq!(state.tool_calls[0]["arguments"], "{\"city\":\"NYC\"}");
     assert_eq!(state.tool_calls[0]["status"], "completed");
-    assert_eq!(state.output_items[0]["arguments"], "{\"city\":\"NYC\"}");
+    assert_eq!(state.output_items()[0]["arguments"], "{\"city\":\"NYC\"}");
 }
 
 #[tokio::test]
@@ -427,9 +427,9 @@ async fn output_item_done_replaces_by_index() {
     filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
-    assert_eq!(state.output_items.len(), 1, "should replace, not append");
+    assert_eq!(state.output_items().len(), 1, "should replace, not append");
     assert!(
-        state.output_items[0]["content"][0]["text"] == "final",
+        state.output_items()[0]["content"][0]["text"] == "final",
         "should have updated content"
     );
 }
@@ -453,7 +453,7 @@ async fn terminal_incomplete_sets_status() {
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
     assert_eq!(state.response_object["id"], "resp_inc");
-    assert_eq!(state.output_items.len(), 1);
+    assert_eq!(state.output_items().len(), 1);
     assert_eq!(ctx.get_metadata("responses.status"), Some("incomplete"));
 }
 
@@ -476,7 +476,7 @@ async fn terminal_failed_sets_status() {
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
     assert_eq!(state.response_object["id"], "resp_fail");
-    assert_eq!(state.output_items.len(), 0);
+    assert_eq!(state.output_items().len(), 0);
     assert_eq!(ctx.get_metadata("responses.status"), Some("failed"));
 }
 
@@ -496,8 +496,8 @@ async fn output_item_done_replaces_by_id() {
     filter.on_response_body(&mut ctx, &mut b2, false).unwrap();
 
     let state = ctx.extensions.get::<ResponsesState>().unwrap();
-    assert_eq!(state.output_items.len(), 1, "should replace by id, not append");
-    assert_eq!(state.output_items[0]["content"][0]["text"], "replaced");
+    assert_eq!(state.output_items().len(), 1, "should replace by id, not append");
+    assert_eq!(state.output_items()[0]["content"][0]["text"], "replaced");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Remove the duplicate `output_items` ledger from `ResponsesState` and have streaming accumulation mutate `response_object.output` directly. This eliminates a class of bugs where the two public output representations could diverge—`output_items` reflecting incrementally accumulated deltas while `response_object.output` reflects the terminal truth.

Two accessor methods (`output_items()` for reads, `output_items_mut()` for writes) now reach into `response_object["output"]` as the single source of truth.

Fixes: #277