### PR TITLE
feat(store): add conversation message compare-and-swap

### DIFF
--- a/apis/src/store/postgres.rs
+++ b/apis/src/store/postgres.rs
@@ -342,6 +342,31 @@ impl ConversationItemStore for PostgresResponseStore {
         Ok(result.rows_affected() > 0)
     }
 
+    async fn compare_and_swap_conversation_messages(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+        expected_messages: &serde_json::Value,
+        messages: &serde_json::Value,
+    ) -> Result<bool, StoreError> {
+        let expected =
+            serde_json::to_string(expected_messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let messages = serde_json::to_string(messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let sql = format!(
+            "UPDATE {} SET messages = $1 WHERE conversation_id = $2 AND tenant_id = $3 AND messages = $4",
+            self.tables.conversations
+        );
+        let result = sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(&messages)
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .bind(&expected)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
+
     async fn get_conversation(
         &self,
         tenant_id: &str,

--- a/apis/src/store/sqlite.rs
+++ b/apis/src/store/sqlite.rs
@@ -282,6 +282,31 @@ impl ConversationItemStore for SqliteResponseStore {
         Ok(result.rows_affected() > 0)
     }
 
+    async fn compare_and_swap_conversation_messages(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+        expected_messages: &serde_json::Value,
+        messages: &serde_json::Value,
+    ) -> Result<bool, StoreError> {
+        let expected =
+            serde_json::to_string(expected_messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let messages = serde_json::to_string(messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let sql = format!(
+            "UPDATE {} SET messages = ? WHERE conversation_id = ? AND tenant_id = ? AND messages = ?",
+            self.tables.conversations
+        );
+        let result = sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(&messages)
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .bind(&expected)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
+
     async fn get_conversation(
         &self,
         tenant_id: &str,

--- a/apis/src/store/tests.rs
+++ b/apis/src/store/tests.rs
@@ -544,6 +544,39 @@ async fn update_conversation_messages_preserves_metadata() {
 }
 
 #[tokio::test]
+async fn compare_and_swap_conversation_messages_rejects_stale_snapshot() {
+    let store = make_store().await;
+    let initial = json!([{"role":"user","content":"initial"}]);
+    let record = ConversationRecord {
+        conversation_id: "conv_cas".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        created_at: 1000,
+        metadata: json!({}),
+        messages: initial.clone(),
+    };
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let first = json!([{"role":"assistant","content":"first"}]);
+    assert!(
+        store
+            .compare_and_swap_conversation_messages("tenant_a", "conv_cas", &initial, &first)
+            .await
+            .expect("first compare-and-swap should succeed")
+    );
+    assert!(
+        !store
+            .compare_and_swap_conversation_messages("tenant_a", "conv_cas", &initial, &json!([]))
+            .await
+            .expect("stale compare-and-swap should be conflict-free")
+    );
+    let fetched = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_cas")
+        .await
+        .expect("get should succeed")
+        .expect("conversation should exist");
+    assert_eq!(fetched.messages, first);
+}
+
+#[tokio::test]
 async fn get_missing_conversation_returns_none() {
     let store = make_store().await;
 

--- a/apis/src/store/trait_def.rs
+++ b/apis/src/store/trait_def.rs
@@ -105,6 +105,23 @@ pub trait ConversationItemStore: Send + Sync {
         messages: &serde_json::Value,
     ) -> Result<bool, StoreError>;
 
+    /// Replace the denormalized message cache only when it still equals
+    /// `expected_messages`.
+    ///
+    /// Returns `true` when the compare-and-swap succeeds and `false` after a
+    /// concurrent cache update or when the conversation does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if serialization or the database operation fails.
+    async fn compare_and_swap_conversation_messages(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+        expected_messages: &serde_json::Value,
+        messages: &serde_json::Value,
+    ) -> Result<bool, StoreError>;
+
     /// Retrieve conversation messages by conversation ID and tenant.
     ///
     /// Returns `None` if the conversation does not exist or belongs


### PR DESCRIPTION
## Summary

- Add `compare_and_swap_conversation_messages` to the `ConversationItemStore` trait, with implementations for both SQLite and PostgreSQL
- The method atomically updates the denormalized message cache only when it still equals the expected snapshot, preventing concurrent refreshes from silently overwriting each other
- This is the store-layer primitive needed for #410 (appending response items back to conversations after completion)

Ref: #410

## Test plan

- [x] Unit test verifies CAS accepts a fresh snapshot and rejects a stale one
- [x] Clippy and nightly rustfmt pass
- [ ] Integration test with concurrent writers (follow-up with full append-back implementation)