### PR TITLE
docs: add git workflow conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,9 @@ coding style guide.
 
 ## Git Workflow
 
-- **Never amend commits** (`git commit --amend`).
-- When addressing PR review feedback, add new
-  fixup commits on top of the branch.
+- **Never amend commits** — when addressing PR
+  review feedback, add new fixup commits on top
+  of the branch.
 - PRs are merged with **squash and merge**, so the
   final commit on the target branch is always clean
   regardless of intermediate fixup commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,15 @@ Follows the same conventions as
 See `docs/developing/conventions.md` for the full
 coding style guide.
 
+## Git Workflow
+
+- **Never amend commits** (`git commit --amend`).
+- When addressing PR review feedback, add new
+  fixup commits on top of the branch.
+- PRs are merged with **squash and merge**, so the
+  final commit on the target branch is always clean
+  regardless of intermediate fixup commits.
+
 ## Test Requirements
 
 New capabilities require:


### PR DESCRIPTION
Add a Git Workflow section to AGENTS.md documenting the project's commit conventions: never amend commits, use fixup commits for PR review feedback, and rely on squash-and-merge to keep the target branch clean.

Signed-off-by: Sébastien Han <seb@redhat.com>