### PR TITLE
docs(conventions): document praxis-bot PR review process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,9 @@ pipeline, registry; `praxis-core` for config types;
 Follows the same conventions as
 [praxis core](https://github.com/praxis-proxy/praxis).
 See `docs/developing/conventions.md` for the full
-coding style guide.
+coding style guide, including the
+[PR review process](docs/developing/conventions.md#pr-review-process)
+for handling `praxis-bot` automated review comments.
 
 ## Test Requirements
 

--- a/docs/developing/conventions.md
+++ b/docs/developing/conventions.md
@@ -297,3 +297,33 @@ Before submitting or merging PRs, ensure that you have:
 
 > **Note**: `Draft` pull requests are not exempt from these guidelines.
 > They are still expected to be reviewed before submission.
+
+## PR Review Process
+
+The `praxis-bot` GitHub App runs automated code review
+on every pull request. Its comments are treated with the
+same weight as human reviewer comments — **every finding
+must be addressed** before the PR can be merged. This
+ensures maintainers can quickly verify that all feedback
+has been handled and keeps the review process moving
+smoothly.
+
+### Responding to praxis-bot comments
+
+Each comment must be resolved in one of two ways:
+
+1. **Acknowledge and fix**: apply the suggested change
+   (or an equivalent fix), reply to the comment with
+   a reference to the commit that addresses it
+   (e.g. `Fixed in <commit-sha>`), then resolve the
+   conversation.
+
+2. **Reject with justification**: if the finding does
+   not apply or the current code is intentionally
+   correct, reply with a comment explaining why the
+   suggestion is being declined, then resolve the
+   conversation.
+
+Leaving praxis-bot comments unresolved blocks merge.
+Do not dismiss or ignore findings without an explicit
+response.


### PR DESCRIPTION
Document the praxis-bot automated review workflow in the development
conventions. Every praxis-bot comment must be explicitly addressed
before merge — either acknowledged with a commit reference or rejected
with a justification — so maintainers can quickly verify all feedback
has been handled.

Signed-off-by: Sébastien Han <seb@redhat.com>