### PR TITLE
fix(mcp): block Alibaba metadata endpoint

### DIFF
--- a/apis/src/mcp_client/mod.rs
+++ b/apis/src/mcp_client/mod.rs
@@ -20,7 +20,7 @@ mod tests;
 
 use std::{
     collections::HashMap,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
 
@@ -36,9 +36,6 @@ use rmcp::{
 
 /// Alibaba Cloud instance metadata service IPv4 endpoint.
 const ALIBABA_CLOUD_METADATA_V4: Ipv4Addr = Ipv4Addr::new(100, 100, 100, 200);
-
-/// AWS EC2 instance metadata service IPv6 endpoint.
-const AWS_IMDS_V6: Ipv6Addr = Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
 
 // -----------------------------------------------------------------------------
 // McpClientError
@@ -436,7 +433,8 @@ fn is_ssrf_sensitive(ip: &IpAddr) -> bool {
 }
 
 /// AWS EC2 IMDS IPv6 endpoint.
-fn is_cloud_metadata_v6(v6: &Ipv6Addr) -> bool {
+fn is_cloud_metadata_v6(v6: &std::net::Ipv6Addr) -> bool {
+    const AWS_IMDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
     *v6 == AWS_IMDS_V6
 }
 

--- a/apis/src/mcp_client/mod.rs
+++ b/apis/src/mcp_client/mod.rs
@@ -20,7 +20,7 @@ mod tests;
 
 use std::{
     collections::HashMap,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
@@ -29,6 +29,16 @@ use rmcp::{
     model::PaginatedRequestParams,
     transport::{StreamableHttpClientTransport, streamable_http_client::StreamableHttpClientTransportConfig},
 };
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Alibaba Cloud instance metadata service IPv4 endpoint.
+const ALIBABA_CLOUD_METADATA_V4: Ipv4Addr = Ipv4Addr::new(100, 100, 100, 200);
+
+/// AWS EC2 instance metadata service IPv6 endpoint.
+const AWS_IMDS_V6: Ipv6Addr = Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
 
 // -----------------------------------------------------------------------------
 // McpClientError
@@ -351,19 +361,19 @@ async fn resolve_hostname_ssrf(
         })?
         .map_err(|_dns_err| McpClientError::SsrfBlocked(url.to_owned()))?
         .collect();
-    for addr in &addrs {
-        let ip = praxis_core::connectivity::normalize_mapped_ipv4(addr.ip());
-        if allow_loopback && ip.is_loopback() {
-            continue;
-        }
-        if is_ssrf_sensitive(&ip) {
-            return Err(McpClientError::SsrfBlocked(url.to_owned()));
-        }
-    }
+    check_resolved_addrs(&addrs, url, allow_loopback)?;
     Ok(ResolvedMcpUrl {
         hostname: Some(host.to_owned()),
         addrs,
     })
+}
+
+/// Check DNS-resolved addresses against the SSRF block list.
+fn check_resolved_addrs(addrs: &[SocketAddr], url: &str, allow_loopback: bool) -> Result<(), McpClientError> {
+    for addr in addrs {
+        check_ip(addr.ip(), url, allow_loopback)?;
+    }
+    Ok(())
 }
 
 /// Build a reqwest client with resolved addresses pinned, so
@@ -415,7 +425,9 @@ fn is_blocked_hostname(host: &str) -> bool {
 /// metadata addresses are SSRF-sensitive.
 fn is_ssrf_sensitive(ip: &IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => v4.is_loopback() || v4.is_link_local() || v4.is_unspecified(),
+        IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_link_local() || v4.is_unspecified() || *v4 == ALIBABA_CLOUD_METADATA_V4
+        },
         IpAddr::V6(v6) => {
             let [a, b, ..] = v6.octets();
             v6.is_loopback() || v6.is_unspecified() || (a == 0xFE && (b & 0xC0) == 0x80) || is_cloud_metadata_v6(v6)
@@ -424,8 +436,7 @@ fn is_ssrf_sensitive(ip: &IpAddr) -> bool {
 }
 
 /// AWS EC2 IMDS IPv6 endpoint.
-fn is_cloud_metadata_v6(v6: &std::net::Ipv6Addr) -> bool {
-    const AWS_IMDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
+fn is_cloud_metadata_v6(v6: &Ipv6Addr) -> bool {
     *v6 == AWS_IMDS_V6
 }
 

--- a/apis/src/mcp_client/tests.rs
+++ b/apis/src/mcp_client/tests.rs
@@ -258,6 +258,15 @@ async fn ssrf_blocks_link_local() {
 }
 
 #[tokio::test]
+async fn ssrf_blocks_alibaba_cloud_metadata() {
+    assert!(
+        validate_url("http://100.100.100.200/latest/meta-data/instance-id")
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
 async fn ssrf_blocks_mapped_ipv4_loopback() {
     assert!(validate_url("http://[::ffff:127.0.0.1]/mcp").await.is_err());
 }
@@ -265,6 +274,24 @@ async fn ssrf_blocks_mapped_ipv4_loopback() {
 #[tokio::test]
 async fn ssrf_blocks_mapped_metadata() {
     assert!(validate_url("http://[::ffff:169.254.169.254]/mcp").await.is_err());
+}
+
+#[tokio::test]
+async fn ssrf_blocks_mapped_alibaba_cloud_metadata() {
+    assert!(
+        validate_url("http://[::ffff:100.100.100.200]/latest/meta-data/instance-id")
+            .await
+            .is_err()
+    );
+}
+
+#[test]
+fn ssrf_blocks_dns_resolved_alibaba_cloud_metadata() {
+    let addrs = ["100.100.100.200:80".parse::<SocketAddr>().unwrap()];
+    assert!(
+        check_resolved_addrs(&addrs, "http://metadata.example/mcp", false).is_err(),
+        "DNS-resolved Alibaba Cloud metadata address should be blocked"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Block the Alibaba Cloud instance metadata endpoint (`100.100.100.200`) in MCP SSRF validation.

- Add the Alibaba metadata IPv4 endpoint to the centralized sensitive-address check.
- Route DNS-resolved socket addresses through the same normalized `check_ip` path used for literal addresses.
- Add regression coverage for literal IPv4, IPv4-mapped IPv6, and DNS-resolved forms.

Fixes #406

## Why

The existing IPv4 checks reject loopback, link-local, and unspecified addresses, but Alibaba Cloud's metadata endpoint is outside those ranges. As a result, MCP URLs targeting that endpoint were accepted. Reusing `check_ip` for resolved addresses also keeps mapped-IPv4 normalization and the `allow_loopback` behavior consistent across literal and DNS paths.

## Testing

Run with Rust 1.96 in the official `rust:1.96-bookworm` container:

- `cargo test -p praxis-ai-apis -- alibaba_cloud_metadata --nocapture` (3 passed)
- `cargo test -p praxis-ai-apis -- mcp_client::tests --nocapture` (45 passed)
- `cargo test -p praxis-ai-apis` (1,494 passed, 25 ignored; 2 doc-tests passed)
- `cargo clippy -p praxis-ai-apis --all-targets -- -D warnings`
- `rustfmt +nightly --edition 2024 --check apis/src/mcp_client/mod.rs apis/src/mcp_client/tests.rs`
- `cargo xtask lint-separators`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p praxis-ai-apis --no-deps --document-private-items`

## Responsibility

AI assistance was used during implementation and testing. I reviewed every changed line, understand the behavior, and take responsibility for this submission in accordance with the project conventions.