### PR TITLE
fix(openai): update Content-Length after stripping conversation field

### DIFF
--- a/apis/src/openai/responses/openai_responses_proxy/mod.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/mod.rs
@@ -168,7 +168,7 @@ impl HttpFilter for ResponsesProxyFilter {
         }
 
         let Some(state) = ctx.extensions.get::<ResponsesState>() else {
-            strip_conversation_field(body);
+            strip_conversation_field(ctx, body);
             debug!("no ResponsesState in extensions, passthrough");
             return Ok(FilterAction::Continue);
         };
@@ -197,7 +197,7 @@ impl HttpFilter for ResponsesProxyFilter {
 
 /// Defensively strip `conversation` from a passthrough body so it never
 /// leaks to the backend even when no [`ResponsesState`] was produced.
-fn strip_conversation_field(body: &mut Option<Bytes>) {
+fn strip_conversation_field(ctx: &mut HttpFilterContext<'_>, body: &mut Option<Bytes>) {
     let Some(bytes) = body.as_ref() else {
         return;
     };
@@ -210,7 +210,10 @@ fn strip_conversation_field(body: &mut Option<Bytes>) {
     {
         debug!("stripped conversation from passthrough body");
         if let Ok(serialized) = serde_json::to_vec(&parsed) {
+            let len = serialized.len();
             *body = Some(Bytes::from(serialized));
+            ctx.extra_request_headers
+                .push((Cow::Borrowed("content-length"), len.to_string()));
         }
     }
 }

--- a/apis/src/openai/responses/openai_responses_proxy/tests.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/tests.rs
@@ -334,6 +334,13 @@ async fn passthrough_strips_conversation_from_body() {
         "conversation should be stripped even without ResponsesState"
     );
     assert_eq!(parsed["model"], "gpt-4.1", "other fields should be preserved");
+    assert_eq!(
+        ctx.extra_request_headers
+            .iter()
+            .find(|(name, _value)| name.as_ref() == "content-length")
+            .map(|(_name, value)| value.parse::<usize>().unwrap()),
+        body.as_ref().map(Bytes::len)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- When the proxy strips the internal `conversation` field from a passthrough Responses body, the serialized payload shrinks but `Content-Length` was left unchanged.
- Push the corrected length into `extra_request_headers` so the backend receives a consistent frame.

## Test plan

- [x] Existing test `passthrough_strips_conversation_from_body` extended to assert `Content-Length` header matches body length
- [x] `make lint` clean
- [x] `make build` clean

Signed-off-by: Sébastien Han <seb@redhat.com>