### PR TITLE
fix(openai): replay only canonical OpenResponses input items

### DIFF
--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -417,6 +417,47 @@ fn promote_boolean_results(
     Ok(())
 }
 
+/// Return an item that can be sent back as canonical `OpenResponses` input.
+///
+/// Hosted-tool output items remain available in persisted history, but
+/// `OpenResponses` backends do not accept them in a subsequent request. Old
+/// stored rows without the defaulted `type` field are normalized.
+pub(crate) fn canonical_openresponses_replay_item(item: &serde_json::Value) -> Option<serde_json::Value> {
+    if matches!(
+        item.get("type").and_then(serde_json::Value::as_str),
+        Some("item_reference" | "reasoning" | "compaction" | "message" | "function_call" | "function_call_output")
+    ) {
+        return Some(item.clone());
+    }
+    let object = item.as_object()?;
+    let item_type = defaulted_openresponses_item_type(object)?;
+    let mut normalized = object.clone();
+    normalized.insert("type".to_owned(), serde_json::Value::String(item_type.to_owned()));
+    Some(serde_json::Value::Object(normalized))
+}
+
+/// Resolve a schema-defaulted input item type from its distinguishing fields.
+fn defaulted_openresponses_item_type(object: &serde_json::Map<String, serde_json::Value>) -> Option<&'static str> {
+    if object.get("type").is_some_and(|item_type| !item_type.is_null()) {
+        return None;
+    }
+    let legacy_message = matches!(
+        object.get("role").and_then(serde_json::Value::as_str),
+        Some("user" | "system" | "developer" | "assistant")
+    ) && matches!(
+        object.get("content"),
+        Some(serde_json::Value::String(_) | serde_json::Value::Array(_))
+    );
+    if legacy_message {
+        Some("message")
+    } else {
+        object
+            .get("id")
+            .is_some_and(serde_json::Value::is_string)
+            .then_some("item_reference")
+    }
+}
+
 pub(crate) mod rehydrate;
 pub(crate) mod validate;
 pub(crate) mod web_search;

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -24,7 +24,8 @@ use serde_json::Value;
 use tracing::{debug, trace, warn};
 
 use super::{
-    DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, error::responses_error_rejection, state::ResponsesState,
+    DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, canonical_openresponses_replay_item,
+    error::responses_error_rejection, state::ResponsesState,
 };
 use crate::store::{ConversationRecord, ResponseRecord, ResponseStoreRegistry};
 
@@ -461,16 +462,7 @@ fn append_stored_output_items(messages: &mut Vec<Value>, output: &Value) {
 
 /// Return stored items that should be replayed as backend request input.
 fn replay_messages_from_stored(stored: &[Value]) -> Vec<Value> {
-    stored
-        .iter()
-        .filter(|item| !is_output_only_metadata_item(item))
-        .cloned()
-        .collect()
-}
-
-/// Return whether a stored output item carries metadata rather than replay context.
-fn is_output_only_metadata_item(item: &Value) -> bool {
-    item.get("type").and_then(Value::as_str) == Some("mcp_list_tools")
+    stored.iter().filter_map(canonical_openresponses_replay_item).collect()
 }
 
 /// Build a Responses API user message item from string input.

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -964,7 +964,7 @@ async fn extracts_partial_usage_fields() {
 // -----------------------------------------------------------------------------
 
 #[tokio::test]
-async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs() {
+async fn fallback_reconstruction_replays_only_canonical_input_items() {
     let mut records = std::collections::HashMap::new();
     records.insert(
         "resp_mcp_fb".to_owned(),
@@ -1017,26 +1017,24 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
         .expect("ResponsesState should be populated");
     assert_eq!(
         state.messages.len(),
-        4,
-        "fallback should reconstruct previous replay items before current input"
+        3,
+        "fallback should reconstruct canonical replay items before current input"
     );
     assert_eq!(state.messages[0]["content"], "Hello", "previous input should be first");
     assert!(
-        state
-            .messages
-            .iter()
-            .all(|item| item.get("type").and_then(Value::as_str) != Some("mcp_list_tools")),
-        "fallback should not replay output-only MCP list items as request input"
+        state.messages.iter().all(|item| {
+            !matches!(
+                item.get("type").and_then(Value::as_str),
+                Some("mcp_list_tools" | "web_search_call")
+            )
+        }),
+        "fallback should not replay hosted output items as request input"
     );
     assert_eq!(
-        state.messages[1]["type"], "web_search_call",
-        "non-MCP previous output should be preserved"
-    );
-    assert_eq!(
-        state.messages[2]["type"], "message",
+        state.messages[1]["type"], "message",
         "previous message output should follow"
     );
-    assert_eq!(state.messages[3]["content"], "Next", "current input should be last");
+    assert_eq!(state.messages[2]["content"], "Next", "current input should be last");
     assert_eq!(
         state.persisted_messages.len(),
         5,
@@ -1047,6 +1045,26 @@ async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs()
         "fallback persistence history should preserve MCP list metadata"
     );
     assert_eq!(state.previous_tools.len(), 1, "fallback should populate previous tools");
+}
+
+#[test]
+fn replay_canonicalizes_defaulted_item_types_and_excludes_unknown_items() {
+    let stored = vec![
+        json!({"id":"item-1"}),
+        json!({"id":"item-2","type":null}),
+        json!({"id":"msg-1","role":"assistant","content":"answer"}),
+        json!({"id":"hosted-1","type":"web_search_call","status":"completed"}),
+        json!({"type":"unknown","content":"not replayable"}),
+    ];
+
+    assert_eq!(
+        replay_messages_from_stored(&stored),
+        vec![
+            json!({"id":"item-1","type":"item_reference"}),
+            json!({"id":"item-2","type":"item_reference"}),
+            json!({"id":"msg-1","type":"message","role":"assistant","content":"answer"}),
+        ]
+    );
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Hosted-tool output items (`web_search_call`, `mcp_list_tools`, etc.) live in persisted history but are rejected when sent back as request input.
- Replace the single-type blocklist with a canonical allowlist of input types (`message`, `function_call`, `function_call_output`, `reasoning`, `compaction`, `item_reference`).
- Normalize legacy stored rows that lack the schema-defaulted `type` field by inferring from distinguishing fields (`role`+`content` → `message`, bare `id` → `item_reference`).

## Test plan

- [x] `fallback_reconstruction_replays_only_canonical_input_items` — verifies hosted output items are excluded from replay
- [x] `replay_canonicalizes_defaulted_item_types_and_excludes_unknown_items` — verifies legacy rows get normalized types and unknown items are dropped
- [x] `make lint` clean

Signed-off-by: Sébastien Han <seb@redhat.com>