### PR TITLE
refactor(openai): extract shared API client for callout filters

### DIFF
--- a/apis/src/openai/api_client/error.rs
+++ b/apis/src/openai/api_client/error.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Error types for OpenAI-compatible API client operations.
+
+/// Errors from OpenAI-compatible API client HTTP operations.
+///
+/// Covers transport failures, bounded-read overflows, JSON decode
+/// errors, and URL construction problems. Consumers map these to
+/// domain-specific error types (e.g. `ResolveError` for the file
+/// resolver).
+#[derive(Debug, Clone)]
+pub(crate) enum ApiClientError {
+    /// The HTTP callout failed (transport error, timeout, circuit
+    /// open, or non-2xx status).
+    CalloutFailed {
+        /// Human-readable error description.
+        detail: String,
+    },
+
+    /// A resource ID cannot be safely encoded as a URL path segment.
+    InvalidResourceId {
+        /// The resource ID that was rejected.
+        resource_id: String,
+        /// Human-readable error description.
+        detail: String,
+    },
+
+    /// The response body exceeded the configured size limit during
+    /// a bounded read.
+    ResponseTooLarge {
+        /// Maximum allowed response size in bytes.
+        limit: usize,
+    },
+
+    /// The response body could not be decoded as JSON.
+    DecodeFailed {
+        /// Human-readable error description.
+        detail: String,
+    },
+}
+
+impl std::fmt::Display for ApiClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CalloutFailed { detail } => {
+                write!(f, "API callout failed: {detail}")
+            },
+            Self::InvalidResourceId { resource_id, detail } => {
+                write!(f, "invalid resource id '{resource_id}': {detail}")
+            },
+            Self::ResponseTooLarge { limit } => {
+                write!(f, "response exceeds size limit ({limit} bytes)")
+            },
+            Self::DecodeFailed { detail } => {
+                write!(f, "response decode failed: {detail}")
+            },
+        }
+    }
+}

--- a/apis/src/openai/api_client/mod.rs
+++ b/apis/src/openai/api_client/mod.rs
@@ -5,8 +5,9 @@
 //!
 //! Provides URL construction, SSRF-safe base-URL validation,
 //! resource-ID path-segment encoding, header forwarding, bounded
-//! JSON and byte reads, and normalized error mapping. Used by
-//! [`FilesApiClient`] and (in the future) vector-store search.
+//! byte reads, JSON metadata fetches, and normalized error
+//! mapping. Used by [`FilesApiClient`] and (in the future)
+//! vector-store search.
 //!
 //! JSON requests route through `praxis_core::callout::CalloutClient`
 //! for circuit breaking, callout-depth protection, and timeout.
@@ -51,9 +52,9 @@ pub(crate) struct ApiClientConfig {
 
 /// Shared HTTP client for OpenAI-compatible API callouts.
 ///
-/// JSON requests (`get_json`, `post_json`) route through
-/// [`CalloutClient`] for circuit breaking and callout-depth
-/// protection. Content downloads (`get_bytes`) use a direct
+/// JSON requests (`get_json`) route through [`CalloutClient`]
+/// for circuit breaking and callout-depth protection. Content
+/// downloads (`get_bytes`) use a direct
 /// `reqwest::Client` with chunk-by-chunk bounded reads so
 /// oversized responses are rejected during collection without
 /// unbounded memory consumption. Unifying both paths behind
@@ -140,7 +141,7 @@ impl ApiClient {
     /// response body as JSON.
     pub(crate) async fn get_json(
         &self,
-        url: &str,
+        url: String,
         request_headers: &http::HeaderMap,
     ) -> Result<serde_json::Value, ApiClientError> {
         let headers = self.forward_headers(request_headers);
@@ -149,41 +150,7 @@ impl ApiClient {
             depth: 0,
             headers,
             method: http::Method::GET,
-            url: url.to_owned(),
-        };
-
-        let response = execute_callout(&self.client, request).await?;
-
-        serde_json::from_slice(&response.body).map_err(|e| ApiClientError::DecodeFailed {
-            detail: format!("JSON decode failed: {e}"),
-        })
-    }
-
-    /// Send a POST request with a JSON body via the callout client
-    /// and parse the response body as JSON.
-    pub(crate) async fn post_json(
-        &self,
-        url: &str,
-        body: &serde_json::Value,
-        request_headers: &http::HeaderMap,
-    ) -> Result<serde_json::Value, ApiClientError> {
-        let mut headers = self.forward_headers(request_headers);
-        headers.retain(|(name, _)| name != http::header::CONTENT_TYPE);
-        headers.push((
-            http::header::CONTENT_TYPE,
-            http::HeaderValue::from_static("application/json"),
-        ));
-
-        let serialized = serde_json::to_vec(body).map_err(|e| ApiClientError::DecodeFailed {
-            detail: format!("request body serialization failed: {e}"),
-        })?;
-
-        let request = CalloutRequest {
-            body: Some(serialized),
-            depth: 0,
-            headers,
-            method: http::Method::POST,
-            url: url.to_owned(),
+            url,
         };
 
         let response = execute_callout(&self.client, request).await?;
@@ -490,7 +457,7 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let json = client
-            .get_json(&format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
+            .get_json(format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
             .await
             .unwrap();
 
@@ -513,82 +480,13 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let err = client
-            .get_json(&format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
+            .get_json(format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
             .await
             .unwrap_err();
 
         assert!(
             matches!(err, ApiClientError::DecodeFailed { .. }),
             "invalid JSON should return a decode error"
-        );
-    }
-
-    #[tokio::test]
-    async fn post_json_sends_body_and_parses_response() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0_u8; 4096];
-            let n = stream.read(&mut request).unwrap();
-            let request_str = String::from_utf8_lossy(&request[..n]);
-            assert!(request_str.starts_with("POST"), "should be a POST request");
-            assert!(
-                request_str.contains("content-type: application/json"),
-                "should have JSON content-type: {request_str}"
-            );
-            let body = r#"{"results":[]}"#;
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                body.len()
-            );
-            stream.write_all(response.as_bytes()).unwrap();
-        });
-        let client = test_client(&format!("http://{address}"));
-
-        let request_body = serde_json::json!({"query": "test"});
-        let json = client
-            .post_json(
-                &format!("http://{address}/v1/vector_stores/vs-123/search"),
-                &request_body,
-                &http::HeaderMap::new(),
-            )
-            .await
-            .unwrap();
-
-        assert!(json["results"].as_array().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn post_json_strips_forwarded_content_type() {
-        let (listener, address) = bind_test_server();
-        let captured = capture_request(listener, r#"{"ok":true}"#);
-
-        let client = ApiClient::new(ApiClientConfig {
-            api_base_url: format!("http://{address}"),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                timeout_ms: 1_000,
-                ..CalloutConfig::default()
-            },
-            forward_header_names: vec![http::header::CONTENT_TYPE],
-        })
-        .unwrap();
-
-        let mut headers = http::HeaderMap::new();
-        headers.insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
-
-        client
-            .post_json(&format!("http://{address}/v1/search"), &serde_json::json!({}), &headers)
-            .await
-            .unwrap();
-
-        let req = captured.join().unwrap();
-        let ct_count = req.matches("content-type:").count();
-        assert_eq!(ct_count, 1, "exactly one content-type header, got {ct_count}");
-        assert!(
-            req.contains("content-type: application/json"),
-            "should be application/json"
         );
     }
 
@@ -610,7 +508,7 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let err = client
-            .get_json(&format!("http://{address}/v1/files/missing"), &http::HeaderMap::new())
+            .get_json(format!("http://{address}/v1/files/missing"), &http::HeaderMap::new())
             .await
             .unwrap_err();
 
@@ -706,5 +604,50 @@ mod tests {
             .unwrap();
 
         assert_eq!(bytes.len(), payload_size, "should receive full >1 MiB payload");
+    }
+
+    fn slow_body_server(listener: TcpListener) {
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let _n = stream.read(&mut buf).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\na")
+                .unwrap();
+            stream.flush().unwrap();
+            std::thread::park_timeout(Duration::from_millis(250));
+            let _result = stream.write_all(b"bcde");
+        });
+    }
+
+    #[tokio::test]
+    async fn get_bytes_timeout_covers_response_body() {
+        let (listener, addr) = bind_test_server();
+        slow_body_server(listener);
+
+        let client = ApiClient::new(ApiClientConfig {
+            api_base_url: format!("http://{addr}"),
+            callout_config: CalloutConfig {
+                failure_mode: FailureMode::Closed,
+                timeout_ms: 50,
+                ..CalloutConfig::default()
+            },
+            forward_header_names: Vec::new(),
+        })
+        .unwrap();
+
+        let err = client
+            .get_bytes(
+                &format!("http://{addr}/v1/files/slow/content"),
+                &http::HeaderMap::new(),
+                1024,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(&err, ApiClientError::CalloutFailed { .. }),
+            "slow body should fail before completing: {err}"
+        );
     }
 }

--- a/apis/src/openai/api_client/mod.rs
+++ b/apis/src/openai/api_client/mod.rs
@@ -1,0 +1,710 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Shared HTTP client for OpenAI-compatible API callouts.
+//!
+//! Provides URL construction, SSRF-safe base-URL validation,
+//! resource-ID path-segment encoding, header forwarding, bounded
+//! JSON and byte reads, and normalized error mapping. Used by
+//! [`FilesApiClient`] and (in the future) vector-store search.
+//!
+//! JSON requests route through `praxis_core::callout::CalloutClient`
+//! for circuit breaking, callout-depth protection, and timeout.
+//! Content downloads use a direct `reqwest::Client` with
+//! chunk-by-chunk bounded reads so oversized responses are rejected
+//! during collection. Unifying both paths behind `CalloutClient`
+//! is tracked in [#454].
+//!
+//! Each consuming filter retains its own [`ApiClient`] instance so
+//! circuit-breaker state is isolated per filter.
+//!
+//! [#454]: https://github.com/praxis-proxy/ai/issues/454
+//!
+//! [`FilesApiClient`]: super::responses::file_resolve
+
+pub(crate) mod error;
+pub(crate) mod url;
+
+use std::time::Duration;
+
+use praxis_core::callout::{CalloutClient, CalloutConfig, CalloutRequest, CalloutResult};
+use reqwest::redirect;
+
+pub(crate) use self::{
+    error::ApiClientError,
+    url::{resource_url, validate_base_url, validate_forward_headers},
+};
+
+/// Configuration for constructing an [`ApiClient`].
+///
+/// Assembled programmatically by each consuming filter from its
+/// own validated YAML config — no shared YAML schema.
+pub(crate) struct ApiClientConfig {
+    /// Base URL of the API endpoint (trailing slash stripped).
+    pub api_base_url: String,
+    /// Transport configuration for the underlying
+    /// [`CalloutClient`].
+    pub callout_config: CalloutConfig,
+    /// Header names to forward from the original request.
+    pub forward_header_names: Vec<http::HeaderName>,
+}
+
+/// Shared HTTP client for OpenAI-compatible API callouts.
+///
+/// JSON requests (`get_json`, `post_json`) route through
+/// [`CalloutClient`] for circuit breaking and callout-depth
+/// protection. Content downloads (`get_bytes`) use a direct
+/// `reqwest::Client` with chunk-by-chunk bounded reads so
+/// oversized responses are rejected during collection without
+/// unbounded memory consumption. Unifying both paths behind
+/// `CalloutClient` is tracked in [#454] and requires
+/// `CalloutConfig::max_response_bytes` (praxis-core post-0.4.0).
+///
+/// [#454]: https://github.com/praxis-proxy/ai/issues/454
+pub(crate) struct ApiClient {
+    /// Base URL of the API endpoint (trailing slash stripped).
+    api_base_url: String,
+    /// Callout client for JSON metadata requests.
+    client: CalloutClient,
+    /// Direct HTTP client for bounded content downloads.
+    content_client: reqwest::Client,
+    /// Header names to forward from the original downstream
+    /// request.
+    forward_header_names: Vec<http::HeaderName>,
+    /// Per-request timeout (from the callout config).
+    timeout: Duration,
+}
+
+impl ApiClient {
+    /// Build a new client from validated configuration.
+    ///
+    /// The base URL should already be validated with
+    /// [`validate_base_url`]. This constructor strips trailing
+    /// slashes and builds the transport client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the callout client cannot be
+    /// constructed.
+    pub(crate) fn new(config: ApiClientConfig) -> Result<Self, String> {
+        let ApiClientConfig {
+            api_base_url,
+            callout_config,
+            forward_header_names,
+        } = config;
+
+        let timeout = Duration::from_millis(callout_config.timeout_ms);
+
+        let client = CalloutClient::new(callout_config).map_err(|e| format!("failed to build callout client: {e}"))?;
+
+        let content_client = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(redirect::Policy::none())
+            .timeout(timeout)
+            .build()
+            .map_err(|e| format!("failed to build content client: {e}"))?;
+
+        Ok(Self {
+            api_base_url: api_base_url.trim_end_matches('/').to_owned(),
+            client,
+            content_client,
+            forward_header_names,
+            timeout,
+        })
+    }
+
+    /// Return the validated base URL.
+    pub(crate) fn api_base_url(&self) -> &str {
+        &self.api_base_url
+    }
+
+    /// Return the configured per-request timeout.
+    pub(crate) fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Build a resource URL from the configured base, a path
+    /// prefix, a resource ID, and an optional suffix.
+    ///
+    /// See [`resource_url`] for encoding and validation behavior.
+    pub(crate) fn resource_url(
+        &self,
+        path_prefix: &str,
+        resource_id: &str,
+        suffix: Option<&str>,
+    ) -> Result<String, ApiClientError> {
+        resource_url(&self.api_base_url, path_prefix, resource_id, suffix)
+    }
+
+    /// Send a GET request via the callout client and parse the
+    /// response body as JSON.
+    pub(crate) async fn get_json(
+        &self,
+        url: &str,
+        request_headers: &http::HeaderMap,
+    ) -> Result<serde_json::Value, ApiClientError> {
+        let headers = self.forward_headers(request_headers);
+        let request = CalloutRequest {
+            body: None,
+            depth: 0,
+            headers,
+            method: http::Method::GET,
+            url: url.to_owned(),
+        };
+
+        let response = execute_callout(&self.client, request).await?;
+
+        serde_json::from_slice(&response.body).map_err(|e| ApiClientError::DecodeFailed {
+            detail: format!("JSON decode failed: {e}"),
+        })
+    }
+
+    /// Send a POST request with a JSON body via the callout client
+    /// and parse the response body as JSON.
+    pub(crate) async fn post_json(
+        &self,
+        url: &str,
+        body: &serde_json::Value,
+        request_headers: &http::HeaderMap,
+    ) -> Result<serde_json::Value, ApiClientError> {
+        let mut headers = self.forward_headers(request_headers);
+        headers.retain(|(name, _)| name != http::header::CONTENT_TYPE);
+        headers.push((
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        ));
+
+        let serialized = serde_json::to_vec(body).map_err(|e| ApiClientError::DecodeFailed {
+            detail: format!("request body serialization failed: {e}"),
+        })?;
+
+        let request = CalloutRequest {
+            body: Some(serialized),
+            depth: 0,
+            headers,
+            method: http::Method::POST,
+            url: url.to_owned(),
+        };
+
+        let response = execute_callout(&self.client, request).await?;
+
+        serde_json::from_slice(&response.body).map_err(|e| ApiClientError::DecodeFailed {
+            detail: format!("JSON decode failed: {e}"),
+        })
+    }
+
+    /// Send a GET request and return the response body with
+    /// chunk-by-chunk bounded reads.
+    ///
+    /// Uses a direct `reqwest::Client` so the `max_bytes` limit
+    /// is enforced during collection — oversized responses are
+    /// rejected without unbounded memory consumption. Redirects
+    /// are rejected, and the configured timeout spans the full
+    /// request including body transfer.
+    ///
+    /// This path does not share the [`CalloutClient`]'s circuit
+    /// breaker or callout-depth accounting. Unifying both behind
+    /// `CalloutClient` is tracked in [#454].
+    ///
+    /// [#454]: https://github.com/praxis-proxy/ai/issues/454
+    pub(crate) async fn get_bytes(
+        &self,
+        url: &str,
+        request_headers: &http::HeaderMap,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, ApiClientError> {
+        let mut builder = self.content_client.get(url);
+        for (name, value) in self.forward_headers(request_headers) {
+            builder = builder.header(name, value);
+        }
+
+        let response = builder.send().await.map_err(|e| ApiClientError::CalloutFailed {
+            detail: format!("content download failed: {e}"),
+        })?;
+
+        if !response.status().is_success() {
+            return Err(ApiClientError::CalloutFailed {
+                detail: format!("content download failed: {}", response.status()),
+            });
+        }
+
+        read_bounded_body(response, max_bytes).await
+    }
+
+    /// Copy configured headers from the original downstream
+    /// request for forwarding to the external API.
+    pub(crate) fn forward_headers(
+        &self,
+        request_headers: &http::HeaderMap,
+    ) -> Vec<(http::HeaderName, http::HeaderValue)> {
+        let mut headers = Vec::new();
+        for name in &self.forward_header_names {
+            if let Some(value) = request_headers.get(name) {
+                headers.push((name.clone(), value.clone()));
+            }
+        }
+        headers
+    }
+}
+
+/// Read a response body chunk-by-chunk, rejecting it as soon as
+/// accumulated bytes exceed `max_bytes`.
+async fn read_bounded_body(mut response: reqwest::Response, max_bytes: usize) -> Result<Vec<u8>, ApiClientError> {
+    if let Some(len) = response.content_length()
+        && len > max_bytes as u64
+    {
+        return Err(ApiClientError::ResponseTooLarge { limit: max_bytes });
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| ApiClientError::CalloutFailed {
+        detail: format!("content download failed: {e}"),
+    })? {
+        if body.len() + chunk.len() > max_bytes {
+            return Err(ApiClientError::ResponseTooLarge { limit: max_bytes });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// Execute a callout and map non-success outcomes to
+/// [`ApiClientError`].
+async fn execute_callout(
+    client: &CalloutClient,
+    request: CalloutRequest,
+) -> Result<praxis_core::callout::CalloutResponse, ApiClientError> {
+    match client.execute(request).await {
+        CalloutResult::Success(r) => Ok(r),
+        CalloutResult::Failed => Err(ApiClientError::CalloutFailed {
+            detail: "callout failed (fail-open)".to_owned(),
+        }),
+        CalloutResult::Rejected(rejection) => Err(ApiClientError::CalloutFailed {
+            detail: format!("callout rejected with status {}", rejection.status),
+        }),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use std::{
+        io::{Read as _, Write as _},
+        net::{SocketAddr, TcpListener},
+        thread::JoinHandle,
+    };
+
+    use praxis_core::callout::{CalloutConfig, FailureMode};
+
+    use super::*;
+
+    fn bind_test_server() -> (TcpListener, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        (listener, addr)
+    }
+
+    fn capture_request(listener: TcpListener, response_body: &str) -> JoinHandle<String> {
+        let body = response_body.to_owned();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let n = stream.read(&mut buf).unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            String::from_utf8_lossy(&buf[..n]).into_owned()
+        })
+    }
+
+    fn test_client(base_url: &str) -> ApiClient {
+        ApiClient::new(ApiClientConfig {
+            api_base_url: base_url.to_owned(),
+            callout_config: CalloutConfig {
+                failure_mode: FailureMode::Closed,
+                timeout_ms: 1_000,
+                ..CalloutConfig::default()
+            },
+            forward_header_names: Vec::new(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn new_strips_trailing_slash() {
+        let client = test_client("http://ogx:8321/");
+        assert_eq!(client.api_base_url(), "http://ogx:8321");
+    }
+
+    #[test]
+    fn forward_headers_copies_configured_headers() {
+        let client = ApiClient::new(ApiClientConfig {
+            api_base_url: "http://ogx:8321".to_owned(),
+            callout_config: CalloutConfig {
+                failure_mode: FailureMode::Closed,
+                ..CalloutConfig::default()
+            },
+            forward_header_names: vec![
+                http::header::AUTHORIZATION,
+                http::HeaderName::from_static("x-tenant-id"),
+            ],
+        })
+        .unwrap();
+
+        let mut request_headers = http::HeaderMap::new();
+        request_headers.insert(http::header::AUTHORIZATION, "Bearer token".parse().unwrap());
+        request_headers.insert("x-tenant-id", "tenant-1".parse().unwrap());
+        request_headers.insert("x-unrelated", "ignored".parse().unwrap());
+
+        let forwarded = client.forward_headers(&request_headers);
+
+        assert_eq!(forwarded.len(), 2, "only configured headers should be forwarded");
+        assert!(
+            forwarded
+                .iter()
+                .any(|(n, v)| n == "authorization" && v == "Bearer token"),
+            "authorization header should be forwarded"
+        );
+        assert!(
+            forwarded.iter().any(|(n, v)| n == "x-tenant-id" && v == "tenant-1"),
+            "x-tenant-id header should be forwarded"
+        );
+    }
+
+    #[test]
+    fn resource_url_delegates_to_url_module() {
+        let client = test_client("http://ogx:8321");
+        let url = client.resource_url("v1/files", "file-abc", Some("content")).unwrap();
+        assert_eq!(url, "http://ogx:8321/v1/files/file-abc/content");
+    }
+
+    #[tokio::test]
+    async fn get_bytes_does_not_follow_redirects() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/secret\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_bytes(
+                &format!("http://{address}/v1/files/test/content"),
+                &http::HeaderMap::new(),
+                1024,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::CalloutFailed { .. }),
+            "redirect response should be rejected without contacting its target"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_bytes_transport_failure_returns_callout_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            drop(stream);
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_bytes(
+                &format!("http://{address}/v1/files/test/content"),
+                &http::HeaderMap::new(),
+                1024,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::CalloutFailed { .. }),
+            "transport errors should be mapped to CalloutFailed"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_bytes_rejects_response_exceeding_per_request_limit() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n0123456789abcdef")
+                .unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_bytes(
+                &format!("http://{address}/v1/files/test/content"),
+                &http::HeaderMap::new(),
+                8,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::ResponseTooLarge { .. }),
+            "responses exceeding per-request max_bytes should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_json_parses_valid_json() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            let body = r#"{"id":"file-abc","content_type":"text/plain"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let json = client
+            .get_json(&format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
+            .await
+            .unwrap();
+
+        assert_eq!(json["id"].as_str().unwrap(), "file-abc");
+        assert_eq!(json["content_type"].as_str().unwrap(), "text/plain");
+    }
+
+    #[tokio::test]
+    async fn get_json_returns_decode_error_on_invalid_json() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n\r\nnot-json!!!")
+                .unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_json(&format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::DecodeFailed { .. }),
+            "invalid JSON should return a decode error"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_json_sends_body_and_parses_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let n = stream.read(&mut request).unwrap();
+            let request_str = String::from_utf8_lossy(&request[..n]);
+            assert!(request_str.starts_with("POST"), "should be a POST request");
+            assert!(
+                request_str.contains("content-type: application/json"),
+                "should have JSON content-type: {request_str}"
+            );
+            let body = r#"{"results":[]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let request_body = serde_json::json!({"query": "test"});
+        let json = client
+            .post_json(
+                &format!("http://{address}/v1/vector_stores/vs-123/search"),
+                &request_body,
+                &http::HeaderMap::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(json["results"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn post_json_strips_forwarded_content_type() {
+        let (listener, address) = bind_test_server();
+        let captured = capture_request(listener, r#"{"ok":true}"#);
+
+        let client = ApiClient::new(ApiClientConfig {
+            api_base_url: format!("http://{address}"),
+            callout_config: CalloutConfig {
+                failure_mode: FailureMode::Closed,
+                timeout_ms: 1_000,
+                ..CalloutConfig::default()
+            },
+            forward_header_names: vec![http::header::CONTENT_TYPE],
+        })
+        .unwrap();
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+
+        client
+            .post_json(&format!("http://{address}/v1/search"), &serde_json::json!({}), &headers)
+            .await
+            .unwrap();
+
+        let req = captured.join().unwrap();
+        let ct_count = req.matches("content-type:").count();
+        assert_eq!(ct_count, 1, "exactly one content-type header, got {ct_count}");
+        assert!(
+            req.contains("content-type: application/json"),
+            "should be application/json"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_json_non_2xx_returns_callout_failed() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            let body = r#"{"error":"not found"}"#;
+            let response = format!(
+                "HTTP/1.1 404 Not Found\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_json(&format!("http://{address}/v1/files/missing"), &http::HeaderMap::new())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::CalloutFailed { .. }),
+            "non-2xx JSON response should map to CalloutFailed"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_bytes_non_2xx_returns_callout_failed() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_bytes(
+                &format!("http://{address}/v1/files/test/content"),
+                &http::HeaderMap::new(),
+                1024,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::CalloutFailed { .. }),
+            "non-2xx byte download should map to CalloutFailed via callout client"
+        );
+    }
+
+    #[test]
+    fn display_callout_failed() {
+        let err = ApiClientError::CalloutFailed {
+            detail: "connection refused".to_owned(),
+        };
+        assert_eq!(err.to_string(), "API callout failed: connection refused");
+    }
+
+    #[test]
+    fn display_invalid_resource_id() {
+        let err = ApiClientError::InvalidResourceId {
+            resource_id: "../etc/passwd".to_owned(),
+            detail: "path traversal".to_owned(),
+        };
+        assert_eq!(err.to_string(), "invalid resource id '../etc/passwd': path traversal");
+    }
+
+    #[test]
+    fn display_response_too_large() {
+        let err = ApiClientError::ResponseTooLarge { limit: 1024 };
+        assert_eq!(err.to_string(), "response exceeds size limit (1024 bytes)");
+    }
+
+    #[test]
+    fn display_decode_failed() {
+        let err = ApiClientError::DecodeFailed {
+            detail: "expected value at line 1".to_owned(),
+        };
+        assert_eq!(err.to_string(), "response decode failed: expected value at line 1");
+    }
+
+    #[tokio::test]
+    async fn get_bytes_above_one_mib_succeeds() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let payload_size: usize = 1_200_000;
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            let body = vec![0x42_u8; payload_size];
+            let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {payload_size}\r\nConnection: close\r\n\r\n");
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.write_all(&body).unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let bytes = client
+            .get_bytes(
+                &format!("http://{address}/v1/files/big/content"),
+                &http::HeaderMap::new(),
+                2_000_000,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(bytes.len(), payload_size, "should receive full >1 MiB payload");
+    }
+}

--- a/apis/src/openai/api_client/url.rs
+++ b/apis/src/openai/api_client/url.rs
@@ -1,0 +1,568 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! URL construction, resource-ID encoding, SSRF validation, and
+//! forward-header validation for OpenAI-compatible API clients.
+//!
+//! These functions are shared by every filter that makes callouts
+//! to an OpenAI-compatible API (Files API, vector-store search).
+//! Each filter calls the validation helpers during its own config
+//! validation phase, passing its filter name for error messages.
+
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr},
+};
+
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use praxis_core::connectivity::normalize_mapped_ipv4;
+use praxis_filter::FilterError;
+
+use super::error::ApiClientError;
+
+/// Characters that could let a client-supplied resource ID escape
+/// its single URL path segment.
+///
+/// Encoding path separators, query/fragment delimiters, `%`, and
+/// URL parser special characters keeps the ID opaque when it is
+/// appended to a path prefix like `/v1/files/` or
+/// `/v1/vector_stores/`. Dots are encoded as an additional defense
+/// against path normalization; exact `.` and `..` IDs are rejected
+/// by [`resource_url`].
+pub(crate) const RESOURCE_ID_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'.')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}');
+
+/// Build a resource URL with the ID encoded as a single path
+/// segment.
+///
+/// Produces `{api_base_url}/{path_prefix}/{encoded_id}` when
+/// `suffix` is `None`, or
+/// `{api_base_url}/{path_prefix}/{encoded_id}/{suffix}` when
+/// provided.
+///
+/// Rejects exact `.` and `..` resource IDs before encoding to
+/// prevent path normalization attacks regardless of server
+/// behavior.
+pub(crate) fn resource_url(
+    api_base_url: &str,
+    path_prefix: &str,
+    resource_id: &str,
+    suffix: Option<&str>,
+) -> Result<String, ApiClientError> {
+    if matches!(resource_id, "." | "..") {
+        return Err(ApiClientError::InvalidResourceId {
+            resource_id: resource_id.to_owned(),
+            detail: "dot path segments are not valid resource IDs".to_owned(),
+        });
+    }
+
+    let encoded_id = utf8_percent_encode(resource_id, RESOURCE_ID_ENCODE_SET);
+    match suffix {
+        Some(s) => Ok(format!("{api_base_url}/{path_prefix}/{encoded_id}/{s}")),
+        None => Ok(format!("{api_base_url}/{path_prefix}/{encoded_id}")),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Base URL validation (SSRF)
+// -----------------------------------------------------------------------------
+
+/// Validate a base URL against SSRF-sensitive targets.
+///
+/// Checks scheme, embedded credentials, query strings, fragments,
+/// and host address. When `allow_private` is `false`, private,
+/// loopback, link-local, CGNAT, and DNS-name hosts are rejected.
+///
+/// `filter_name` is used as a prefix in error messages so each
+/// consuming filter reports its own name.
+pub(crate) fn validate_base_url(filter_name: &str, url: &str, allow_private: bool) -> Result<(), FilterError> {
+    if url.contains('#') {
+        return Err(format!("{filter_name}: base URL must not contain a fragment").into());
+    }
+
+    let uri: http::Uri = url.parse().map_err(|e: http::uri::InvalidUri| -> FilterError {
+        format!("{filter_name}: base URL is not valid: {e}").into()
+    })?;
+
+    match uri.scheme_str() {
+        Some("http" | "https") => {},
+        _ => {
+            return Err(format!("{filter_name}: base URL must use http or https scheme").into());
+        },
+    }
+
+    if uri
+        .authority()
+        .is_some_and(|authority| authority.as_str().contains('@'))
+    {
+        return Err(format!("{filter_name}: base URL must not contain embedded credentials").into());
+    }
+
+    if uri.query().is_some() {
+        return Err(format!("{filter_name}: base URL must not contain a query string").into());
+    }
+
+    let host = uri
+        .host()
+        .ok_or_else(|| -> FilterError { format!("{filter_name}: base URL must include a host").into() })?;
+
+    validate_host(filter_name, host, allow_private)
+}
+
+/// Validate a host value against SSRF-sensitive targets.
+fn validate_host(filter_name: &str, host: &str, allow_private: bool) -> Result<(), FilterError> {
+    if !allow_private && is_localhost_name(host) {
+        return Err(format!(
+            "{filter_name}: base URL targets localhost; \
+             set the allow-private option to true to allow"
+        )
+        .into());
+    }
+
+    let ip_host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    if let Ok(ip) = ip_host.parse::<IpAddr>() {
+        validate_ip(filter_name, ip, allow_private)?;
+    } else if let Some(ip) = parse_legacy_ipv4_host(host) {
+        validate_ip(filter_name, IpAddr::V4(ip), allow_private)?;
+    } else {
+        validate_dns(filter_name, host, allow_private)?;
+    }
+
+    Ok(())
+}
+
+/// Validate an IP target against SSRF-sensitive ranges.
+fn validate_ip(filter_name: &str, ip: IpAddr, allow_private: bool) -> Result<(), FilterError> {
+    let ip = normalize_mapped_ipv4(ip);
+    if !allow_private && is_ssrf_sensitive_ip(&ip) {
+        return Err(format!(
+            "{filter_name}: base URL targets a local-sensitive address; \
+             set the allow-private option to true to allow"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Reject DNS hostnames unless private targets are opted in.
+fn validate_dns(filter_name: &str, host: &str, allow_private: bool) -> Result<(), FilterError> {
+    if allow_private {
+        return Ok(());
+    }
+    Err(format!(
+        "{filter_name}: base URL host '{host}' is a DNS name; \
+         use a literal IP address or set the allow-private option to true to allow DNS targets"
+    )
+    .into())
+}
+
+/// Return whether an IP address is SSRF-sensitive (loopback,
+/// private, link-local, CGNAT/shared, current-network, or
+/// unspecified).
+fn is_ssrf_sensitive_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.octets()[0] == 0
+                || is_cgnat(*v4)
+        },
+        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local() || v6.is_unicast_link_local() || v6.is_unspecified(),
+    }
+}
+
+/// Return whether an IPv4 address is in the shared CGNAT range
+/// (`100.64.0.0/10`, RFC 6598).
+fn is_cgnat(ip: Ipv4Addr) -> bool {
+    u32::from(ip) & 0xFFC0_0000 == 0x6440_0000
+}
+
+/// Return whether a host name is a localhost alias.
+fn is_localhost_name(host: &str) -> bool {
+    host.trim_end_matches('.').eq_ignore_ascii_case("localhost")
+}
+
+/// Parse legacy IPv4 literals accepted by common libc resolvers.
+fn parse_legacy_ipv4_host(host: &str) -> Option<Ipv4Addr> {
+    let host = host.trim_end_matches('.');
+    let parts: Vec<_> = host.split('.').collect();
+    if parts.is_empty() || parts.len() > 4 || parts.iter().any(|part| part.is_empty()) {
+        return None;
+    }
+
+    let mut numbers = Vec::with_capacity(parts.len());
+    for part in parts {
+        numbers.push(parse_legacy_ipv4_number(part)?);
+    }
+
+    let addr = match numbers.as_slice() {
+        [a] => *a,
+        [a, b] if *a <= 0xFF && *b <= 0x00FF_FFFF => (*a << 24) | *b,
+        [a, b, c] if *a <= 0xFF && *b <= 0xFF && *c <= 0xFFFF => (*a << 24) | (*b << 16) | *c,
+        [a, b, c, d] if numbers.iter().all(|part| *part <= 0xFF) => (*a << 24) | (*b << 16) | (*c << 8) | *d,
+        _ => return None,
+    };
+
+    Some(Ipv4Addr::from(addr))
+}
+
+/// Parse a decimal, octal, or hexadecimal legacy IPv4 component.
+fn parse_legacy_ipv4_number(part: &str) -> Option<u32> {
+    let (digits, radix) = part.strip_prefix("0x").or_else(|| part.strip_prefix("0X")).map_or_else(
+        || {
+            if part.len() > 1 && part.starts_with('0') {
+                (part.get(1..).unwrap_or_default(), 8)
+            } else {
+                (part, 10)
+            }
+        },
+        |digits| (digits, 16),
+    );
+
+    if digits.is_empty() || !digits.chars().all(|c| c.is_digit(radix)) {
+        return None;
+    }
+
+    u32::from_str_radix(digits, radix).ok()
+}
+
+// -----------------------------------------------------------------------------
+// Forward-header validation
+// -----------------------------------------------------------------------------
+
+/// Validate and normalize headers forwarded across an external API
+/// security boundary.
+///
+/// Normalizes header names to lowercase, rejects transport and
+/// internal headers, and rejects duplicates.
+pub(crate) fn validate_forward_headers(filter_name: &str, headers: &mut [String]) -> Result<(), FilterError> {
+    let mut seen = HashSet::with_capacity(headers.len());
+
+    for configured in headers {
+        let name = http::HeaderName::from_bytes(configured.as_bytes()).map_err(|e| -> FilterError {
+            format!("{filter_name}: invalid 'forward_headers' entry '{configured}': {e}").into()
+        })?;
+        let normalized = name.as_str();
+
+        if is_blocked_forward_header(normalized) {
+            return Err(format!(
+                "{filter_name}: 'forward_headers' must not include transport or internal header '{normalized}'"
+            )
+            .into());
+        }
+
+        if !seen.insert(normalized.to_owned()) {
+            return Err(format!("{filter_name}: duplicate 'forward_headers' entry '{normalized}'").into());
+        }
+
+        normalized.clone_into(configured);
+    }
+
+    Ok(())
+}
+
+/// Return whether a header is unsafe to copy from the client
+/// request to a newly constructed external API request.
+fn is_blocked_forward_header(name: &str) -> bool {
+    name.starts_with("x-praxis-")
+        || name.starts_with("x-ext-protocol-")
+        || name.starts_with("x-ext-agent-")
+        || name.starts_with("x-mcp-")
+        || name.starts_with("x-a2a-")
+        || matches!(
+            name,
+            "connection"
+                | "content-length"
+                | "host"
+                | "keep-alive"
+                | "proxy-authenticate"
+                | "proxy-authorization"
+                | "proxy-connection"
+                | "te"
+                | "trailer"
+                | "transfer-encoding"
+                | "upgrade"
+        )
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    // -- resource_url --------------------------------------------------------
+
+    #[test]
+    fn resource_url_encodes_id_as_single_path_segment() {
+        let url = resource_url("http://ogx:8321", "v1/files", "../admin?x#y", None).unwrap();
+
+        assert!(
+            url.starts_with("http://ogx:8321/v1/files/"),
+            "URL should use the resource path prefix: {url}"
+        );
+        assert!(
+            !url.contains("../admin"),
+            "raw path traversal should not appear in URL: {url}"
+        );
+        assert!(!url.contains("?x"), "query delimiter should be encoded: {url}");
+        assert!(!url.contains("#y"), "fragment delimiter should be encoded: {url}");
+        assert!(url.contains("%2F"), "slash should be encoded: {url}");
+        assert!(url.contains("%3F"), "question mark should be encoded: {url}");
+        assert!(url.contains("%23"), "fragment marker should be encoded: {url}");
+    }
+
+    #[test]
+    fn resource_url_rejects_exact_dot_dot_segment() {
+        let err = resource_url("http://ogx:8321", "v1/files", "..", None).unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::InvalidResourceId { .. }),
+            "exact dot-dot resource id should be rejected before URL construction"
+        );
+    }
+
+    #[test]
+    fn resource_url_rejects_exact_dot_segment() {
+        let err = resource_url("http://ogx:8321", "v1/files", ".", None).unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::InvalidResourceId { .. }),
+            "exact dot resource id should be rejected"
+        );
+    }
+
+    #[test]
+    fn resource_url_preserves_base_path_and_adds_suffix() {
+        let url = resource_url("http://ogx:8321/files-api", "v1/files", "file-abc", Some("content")).unwrap();
+
+        assert_eq!(
+            url, "http://ogx:8321/files-api/v1/files/file-abc/content",
+            "URL should preserve configured base path and append suffix"
+        );
+    }
+
+    #[test]
+    fn resource_url_without_suffix() {
+        let url = resource_url("http://ogx:8321", "v1/files", "file-abc", None).unwrap();
+
+        assert_eq!(url, "http://ogx:8321/v1/files/file-abc");
+    }
+
+    // -- SSRF validation -----------------------------------------------------
+
+    #[test]
+    fn ssrf_rejects_loopback_ipv4() {
+        assert!(
+            validate_base_url("test", "http://127.0.0.1:8321", false).is_err(),
+            "loopback IPv4 should be rejected without allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_loopback_ipv6() {
+        assert!(
+            validate_base_url("test", "http://[::1]:8321", false).is_err(),
+            "loopback IPv6 should be rejected without allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_private_ipv4() {
+        assert!(
+            validate_base_url("test", "http://10.0.0.1:8321", false).is_err(),
+            "private IPv4 should be rejected without allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_link_local_ipv4() {
+        assert!(
+            validate_base_url("test", "http://169.254.169.254", false).is_err(),
+            "link-local IPv4 (metadata endpoint) should be rejected"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_cgnat_ipv4() {
+        assert!(
+            validate_base_url("test", "http://100.64.0.1:8321", false).is_err(),
+            "CGNAT IPv4 should be rejected without allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_localhost_name() {
+        assert!(
+            validate_base_url("test", "http://localhost:8321", false).is_err(),
+            "localhost name should be rejected without allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_dns_name() {
+        assert!(
+            validate_base_url("test", "http://ogx:8321", false).is_err(),
+            "DNS name should be rejected without allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_legacy_octal_loopback() {
+        assert!(
+            validate_base_url("test", "http://0177.0.0.1:8321", false).is_err(),
+            "octal-encoded loopback should be rejected"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv4_mapped_ipv6_loopback() {
+        assert!(
+            validate_base_url("test", "http://[::ffff:127.0.0.1]:8321", false).is_err(),
+            "IPv4-mapped IPv6 loopback should be rejected"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_public_ipv4() {
+        assert!(
+            validate_base_url("test", "http://203.0.113.1:8321", false).is_ok(),
+            "public IPv4 should be allowed"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_public_ipv6() {
+        assert!(
+            validate_base_url("test", "https://[2606:4700:4700::1111]:8321", false).is_ok(),
+            "bracketed public IPv6 should be recognized as an IP literal"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_private_with_override() {
+        assert!(
+            validate_base_url("test", "http://127.0.0.1:8321", true).is_ok(),
+            "loopback should be allowed with allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_dns_with_override() {
+        assert!(
+            validate_base_url("test", "http://ogx:8321", true).is_ok(),
+            "DNS name should be allowed with allow_private"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_non_http_scheme() {
+        assert!(
+            validate_base_url("test", "ftp://ogx:8321", false).is_err(),
+            "non-http scheme should be rejected"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_embedded_credentials() {
+        assert!(
+            validate_base_url("test", "http://user:password@ogx:8321", true).is_err(),
+            "embedded URL credentials should be rejected"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_query_string() {
+        assert!(
+            validate_base_url("test", "http://ogx:8321/base?tenant=abc", true).is_err(),
+            "query strings should be rejected"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_fragment() {
+        assert!(
+            validate_base_url("test", "http://ogx:8321/base#v2", true).is_err(),
+            "fragments should be rejected"
+        );
+    }
+
+    // -- forward-header validation -------------------------------------------
+
+    #[test]
+    fn forward_headers_are_normalized() {
+        let mut headers = vec!["Authorization".to_owned(), "X-Tenant-ID".to_owned()];
+        validate_forward_headers("test", &mut headers).unwrap();
+
+        assert_eq!(
+            headers,
+            vec!["authorization", "x-tenant-id"],
+            "forwarded header names should be normalized"
+        );
+    }
+
+    #[test]
+    fn invalid_forward_header_rejected() {
+        let mut headers = vec!["bad header".to_owned()];
+        assert!(
+            validate_forward_headers("test", &mut headers).is_err(),
+            "syntactically invalid forwarded header names should be rejected"
+        );
+    }
+
+    #[test]
+    fn unsafe_forward_headers_rejected() {
+        for name in [
+            "host",
+            "content-length",
+            "transfer-encoding",
+            "proxy-authorization",
+            "x-praxis-route",
+        ] {
+            let mut headers = vec![name.to_owned()];
+            assert!(
+                validate_forward_headers("test", &mut headers).is_err(),
+                "unsafe forwarded header '{name}' should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_forward_headers_rejected_case_insensitively() {
+        let mut headers = vec!["Authorization".to_owned(), "authorization".to_owned()];
+        assert!(
+            validate_forward_headers("test", &mut headers).is_err(),
+            "duplicate forwarded header names should be rejected after normalization"
+        );
+    }
+}

--- a/apis/src/openai/mod.rs
+++ b/apis/src/openai/mod.rs
@@ -6,7 +6,7 @@
 #[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on module")]
 #[allow(
     dead_code,
-    reason = "api_base_url and post_json are wired in by the vector-store search client (#312)"
+    reason = "api_base_url and timeout are wired in by the vector-store search client (#312)"
 )]
 pub(crate) mod api_client;
 pub(crate) mod conversations;

--- a/apis/src/openai/mod.rs
+++ b/apis/src/openai/mod.rs
@@ -3,6 +3,12 @@
 
 //! `OpenAI` API filters: Responses API pipeline.
 
+#[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on module")]
+#[allow(
+    dead_code,
+    reason = "api_base_url and post_json are wired in by the vector-store search client (#312)"
+)]
+pub(crate) mod api_client;
 pub(crate) mod conversations;
 pub(crate) mod responses;
 pub(crate) mod sse;

--- a/apis/src/openai/responses/file_resolve/config.rs
+++ b/apis/src/openai/responses/file_resolve/config.rs
@@ -3,14 +3,10 @@
 
 //! Configuration types for the `openai_file_resolve` filter.
 
-use std::{
-    collections::HashSet,
-    net::{IpAddr, Ipv4Addr},
-};
-
-use praxis_core::connectivity::normalize_mapped_ipv4;
 use praxis_filter::{FilterError, body::MAX_JSON_BODY_BYTES};
 use serde::Deserialize;
+
+use crate::openai::api_client;
 
 /// Default HTTP timeout for Files API callout requests (30 000 ms).
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
@@ -59,7 +55,7 @@ pub(crate) struct FileResolveConfig {
     #[serde(default)]
     pub allow_pre_security_callout: bool,
 
-    /// Base URL of the Files API (OGX) endpoint.
+    /// Base URL of the Files API endpoint.
     ///
     /// Example: `http://ogx:8321`
     pub files_api_url: String,
@@ -113,8 +109,12 @@ pub(crate) fn validate_config(mut cfg: FileResolveConfig) -> Result<FileResolveC
         return Err("openai_file_resolve: 'files_api_url' must not end with '/'".into());
     }
 
-    validate_files_api_url(&cfg.files_api_url, cfg.allow_private_files_api_url)?;
-    validate_forward_headers(&mut cfg.forward_headers)?;
+    api_client::validate_base_url(
+        "openai_file_resolve",
+        &cfg.files_api_url,
+        cfg.allow_private_files_api_url,
+    )?;
+    api_client::validate_forward_headers("openai_file_resolve", &mut cfg.forward_headers)?;
     validate_limits(&cfg)?;
     validate_pre_security_callout(&cfg)?;
 
@@ -176,212 +176,6 @@ fn validate_resolution_limits(cfg: &FileResolveConfig) -> Result<(), FilterError
     }
 
     Ok(())
-}
-
-/// Validate `files_api_url` against SSRF-sensitive targets.
-fn validate_files_api_url(url: &str, allow_private: bool) -> Result<(), FilterError> {
-    if url.contains('#') {
-        return Err("openai_file_resolve: 'files_api_url' must not contain a fragment".into());
-    }
-
-    let uri: http::Uri = url.parse().map_err(|e: http::uri::InvalidUri| -> FilterError {
-        format!("openai_file_resolve: 'files_api_url' is not a valid URL: {e}").into()
-    })?;
-
-    match uri.scheme_str() {
-        Some("http" | "https") => {},
-        _ => {
-            return Err("openai_file_resolve: 'files_api_url' must use http or https scheme".into());
-        },
-    }
-
-    if uri
-        .authority()
-        .is_some_and(|authority| authority.as_str().contains('@'))
-    {
-        return Err("openai_file_resolve: 'files_api_url' must not contain embedded credentials".into());
-    }
-
-    if uri.query().is_some() {
-        return Err("openai_file_resolve: 'files_api_url' must not contain a query string".into());
-    }
-
-    let host = uri
-        .host()
-        .ok_or_else(|| -> FilterError { "openai_file_resolve: 'files_api_url' must include a host".into() })?;
-
-    validate_files_api_host(host, allow_private)
-}
-
-/// Validate and normalize headers forwarded across the Files API
-/// security boundary.
-fn validate_forward_headers(headers: &mut [String]) -> Result<(), FilterError> {
-    let mut seen = HashSet::with_capacity(headers.len());
-
-    for configured in headers {
-        let name = http::HeaderName::from_bytes(configured.as_bytes()).map_err(|e| -> FilterError {
-            format!("openai_file_resolve: invalid 'forward_headers' entry '{configured}': {e}").into()
-        })?;
-        let normalized = name.as_str();
-
-        if is_blocked_forward_header(normalized) {
-            return Err(format!(
-                "openai_file_resolve: 'forward_headers' must not include transport or internal header '{normalized}'"
-            )
-            .into());
-        }
-
-        if !seen.insert(normalized.to_owned()) {
-            return Err(format!("openai_file_resolve: duplicate 'forward_headers' entry '{normalized}'").into());
-        }
-
-        normalized.clone_into(configured);
-    }
-
-    Ok(())
-}
-
-/// Return whether a header is unsafe to copy from the client request
-/// to a newly constructed Files API request.
-fn is_blocked_forward_header(name: &str) -> bool {
-    name.starts_with("x-praxis-")
-        || name.starts_with("x-ext-protocol-")
-        || name.starts_with("x-ext-agent-")
-        || name.starts_with("x-mcp-")
-        || name.starts_with("x-a2a-")
-        || matches!(
-            name,
-            "connection"
-                | "content-length"
-                | "host"
-                | "keep-alive"
-                | "proxy-authenticate"
-                | "proxy-authorization"
-                | "proxy-connection"
-                | "te"
-                | "trailer"
-                | "transfer-encoding"
-                | "upgrade"
-        )
-}
-
-/// Validate a `files_api_url` host value against SSRF-sensitive targets.
-fn validate_files_api_host(host: &str, allow_private: bool) -> Result<(), FilterError> {
-    if !allow_private && is_localhost_name(host) {
-        return Err("openai_file_resolve: 'files_api_url' targets localhost; \
-             set allow_private_files_api_url: true to allow"
-            .into());
-    }
-
-    let ip_host = host
-        .strip_prefix('[')
-        .and_then(|value| value.strip_suffix(']'))
-        .unwrap_or(host);
-    if let Ok(ip) = ip_host.parse::<IpAddr>() {
-        validate_files_api_ip(ip, allow_private)?;
-    } else if let Some(ip) = parse_legacy_ipv4_host(host) {
-        validate_files_api_ip(IpAddr::V4(ip), allow_private)?;
-    } else {
-        validate_files_api_dns(host, allow_private)?;
-    }
-
-    Ok(())
-}
-
-/// Validate an IP target against SSRF-sensitive ranges.
-fn validate_files_api_ip(ip: IpAddr, allow_private: bool) -> Result<(), FilterError> {
-    let ip = normalize_mapped_ipv4(ip);
-    if !allow_private && is_ssrf_sensitive_ip(&ip) {
-        return Err(
-            "openai_file_resolve: 'files_api_url' targets a local-sensitive address; \
-             set allow_private_files_api_url: true to allow"
-                .into(),
-        );
-    }
-    Ok(())
-}
-
-/// Reject DNS hostnames unless private targets are opted in.
-fn validate_files_api_dns(host: &str, allow_private: bool) -> Result<(), FilterError> {
-    if allow_private {
-        return Ok(());
-    }
-    Err(format!(
-        "openai_file_resolve: 'files_api_url' host '{host}' is a DNS name; \
-         use a literal IP address or set allow_private_files_api_url: true to allow DNS targets"
-    )
-    .into())
-}
-
-/// Return whether an IP address is SSRF-sensitive (loopback, private,
-/// link-local, CGNAT/shared, current-network, or unspecified).
-fn is_ssrf_sensitive_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_unspecified()
-                || v4.octets()[0] == 0
-                || is_cgnat(*v4)
-        },
-        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local() || v6.is_unicast_link_local() || v6.is_unspecified(),
-    }
-}
-
-/// Return whether an IPv4 address is in the shared CGNAT range
-/// (`100.64.0.0/10`, RFC 6598).
-fn is_cgnat(ip: Ipv4Addr) -> bool {
-    u32::from(ip) & 0xFFC0_0000 == 0x6440_0000
-}
-
-/// Return whether a host name is a localhost alias.
-fn is_localhost_name(host: &str) -> bool {
-    host.trim_end_matches('.').eq_ignore_ascii_case("localhost")
-}
-
-/// Parse legacy IPv4 literals accepted by common libc resolvers.
-fn parse_legacy_ipv4_host(host: &str) -> Option<Ipv4Addr> {
-    let host = host.trim_end_matches('.');
-    let parts: Vec<_> = host.split('.').collect();
-    if parts.is_empty() || parts.len() > 4 || parts.iter().any(|part| part.is_empty()) {
-        return None;
-    }
-
-    let mut numbers = Vec::with_capacity(parts.len());
-    for part in parts {
-        numbers.push(parse_legacy_ipv4_number(part)?);
-    }
-
-    let addr = match numbers.as_slice() {
-        [a] => *a,
-        [a, b] if *a <= 0xFF && *b <= 0x00FF_FFFF => (*a << 24) | *b,
-        [a, b, c] if *a <= 0xFF && *b <= 0xFF && *c <= 0xFFFF => (*a << 24) | (*b << 16) | *c,
-        [a, b, c, d] if numbers.iter().all(|part| *part <= 0xFF) => (*a << 24) | (*b << 16) | (*c << 8) | *d,
-        _ => return None,
-    };
-
-    Some(Ipv4Addr::from(addr))
-}
-
-/// Parse a decimal, octal, or hexadecimal legacy IPv4 component.
-fn parse_legacy_ipv4_number(part: &str) -> Option<u32> {
-    let (digits, radix) = part.strip_prefix("0x").or_else(|| part.strip_prefix("0X")).map_or_else(
-        || {
-            if part.len() > 1 && part.starts_with('0') {
-                (part.get(1..).unwrap_or_default(), 8)
-            } else {
-                (part, 10)
-            }
-        },
-        |digits| (digits, 16),
-    );
-
-    if digits.is_empty() || !digits.chars().all(|c| c.is_digit(radix)) {
-        return None;
-    }
-
-    u32::from_str_radix(digits, radix).ok()
 }
 
 #[cfg(test)]
@@ -637,92 +431,17 @@ allow_private_files_api_url: true
         );
     }
 
-    // -------------------------------------------------------------------------
-    // SSRF validation
-    // -------------------------------------------------------------------------
+    // SSRF validation is tested thoroughly in api_client::url::tests.
+    // These tests verify the delegation path through validate_config.
 
     #[test]
     fn ssrf_rejects_loopback_ipv4() {
         let yaml = r#"files_api_url: "http://127.0.0.1:8321""#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
         assert!(
-            result.is_err(),
+            validate_config(cfg).is_err(),
             "loopback IPv4 should be rejected without allow_private"
         );
-    }
-
-    #[test]
-    fn ssrf_rejects_loopback_ipv6() {
-        let yaml = r#"files_api_url: "http://[::1]:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(
-            result.is_err(),
-            "loopback IPv6 should be rejected without allow_private"
-        );
-    }
-
-    #[test]
-    fn ssrf_rejects_private_ipv4() {
-        let yaml = r#"files_api_url: "http://10.0.0.1:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(result.is_err(), "private IPv4 should be rejected without allow_private");
-    }
-
-    #[test]
-    fn ssrf_rejects_link_local_ipv4() {
-        let yaml = r#"files_api_url: "http://169.254.169.254""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(
-            result.is_err(),
-            "link-local IPv4 (metadata endpoint) should be rejected"
-        );
-    }
-
-    #[test]
-    fn ssrf_rejects_cgnat_ipv4() {
-        let yaml = r#"files_api_url: "http://100.64.0.1:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(result.is_err(), "CGNAT IPv4 should be rejected without allow_private");
-    }
-
-    #[test]
-    fn ssrf_rejects_localhost_name() {
-        let yaml = r#"files_api_url: "http://localhost:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(
-            result.is_err(),
-            "localhost name should be rejected without allow_private"
-        );
-    }
-
-    #[test]
-    fn ssrf_rejects_dns_name() {
-        let yaml = r#"files_api_url: "http://ogx:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(result.is_err(), "DNS name should be rejected without allow_private");
-    }
-
-    #[test]
-    fn ssrf_rejects_legacy_octal_loopback() {
-        let yaml = r#"files_api_url: "http://0177.0.0.1:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(result.is_err(), "octal-encoded loopback should be rejected");
-    }
-
-    #[test]
-    fn ssrf_rejects_ipv4_mapped_ipv6_loopback() {
-        let yaml = r#"files_api_url: "http://[::ffff:127.0.0.1]:8321""#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(result.is_err(), "IPv4-mapped IPv6 loopback should be rejected");
     }
 
     #[test]
@@ -731,18 +450,6 @@ allow_private_files_api_url: true
 allow_pre_security_callout: true"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(validate_config(cfg).is_ok(), "public IPv4 should be allowed");
-    }
-
-    #[test]
-    fn ssrf_allows_public_ipv6() {
-        let yaml = r#"files_api_url: "https://[2606:4700:4700::1111]:8321"
-allow_pre_security_callout: true"#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-
-        assert!(
-            validate_config(cfg).is_ok(),
-            "bracketed public IPv6 should be recognized as an IP literal"
-        );
     }
 
     #[test]
@@ -760,25 +467,10 @@ allow_pre_security_callout: true
     }
 
     #[test]
-    fn ssrf_allows_dns_with_override() {
-        let yaml = r#"
-files_api_url: "http://ogx:8321"
-allow_private_files_api_url: true
-allow_pre_security_callout: true
-"#;
-        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(
-            validate_config(cfg).is_ok(),
-            "DNS name should be allowed with allow_private_files_api_url"
-        );
-    }
-
-    #[test]
     fn ssrf_rejects_non_http_scheme() {
         let yaml = r#"files_api_url: "ftp://ogx:8321""#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-        let result = validate_config(cfg);
-        assert!(result.is_err(), "non-http scheme should be rejected");
+        assert!(validate_config(cfg).is_err(), "non-http scheme should be rejected");
     }
 
     #[test]
@@ -788,7 +480,6 @@ files_api_url: "http://user:password@ogx:8321"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-
         assert!(
             validate_config(cfg).is_err(),
             "embedded URL credentials should be rejected"
@@ -802,7 +493,6 @@ files_api_url: "http://ogx:8321/base?tenant=abc"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-
         assert!(
             validate_config(cfg).is_err(),
             "query strings would make appended Files API paths ambiguous"
@@ -816,7 +506,6 @@ files_api_url: "http://ogx:8321/base#v2"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
-
         assert!(
             validate_config(cfg).is_err(),
             "fragments would hide appended Files API paths from the HTTP request"

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -5,8 +5,8 @@
 //!
 //! Walks `message` content arrays and `function_call_output` output
 //! arrays, finds content parts that reference files by ID, fetches
-//! file metadata and content from an external Files API (e.g. OGX)
-//! via [`CalloutClient`], and inlines the content: raw base64 in
+//! file metadata and content from an external Files API
+//! via [`ApiClient`], and inlines the content: raw base64 in
 //! `file_data` for `input_file`, or a `data:` URL in `image_url`
 //! for `input_image`. Forwards configurable headers
 //! (`Authorization`, `X-Tenant-ID`) to the Files API for tenant
@@ -40,7 +40,7 @@
 //! `OpenAI` extension and converts it to portable inline content.
 //!
 //! [#397]: https://github.com/praxis-proxy/ai/issues/397
-//! [`CalloutClient`]: praxis_core::callout::CalloutClient
+//! [`ApiClient`]: crate::openai::api_client::ApiClient
 //! [`ResponsesState`]: super::state::ResponsesState
 
 mod config;
@@ -62,7 +62,7 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use praxis_core::callout::{CalloutClient, CalloutConfig, FailureMode};
+use praxis_core::callout::{CalloutConfig, FailureMode};
 use praxis_filter::{
     BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, Rejection, parse_filter_config,
 };
@@ -75,10 +75,13 @@ use self::{
     },
 };
 use super::{openai_responses_proxy::serialized_outbound_body_len, state::ResponsesState};
-use crate::classifier::is_responses_create;
+use crate::{
+    classifier::is_responses_create,
+    openai::api_client::{ApiClient, ApiClientConfig},
+};
 
 /// Resolves `file_id` references in Responses API input by fetching
-/// content from a Files API via [`CalloutClient`] and inlining the
+/// content from a Files API via `ApiClient` and inlining the
 /// base64-encoded content in the provider-native field.
 ///
 /// The inference backend must support the resulting inline content
@@ -109,10 +112,8 @@ use crate::classifier::is_responses_create;
 /// max_body_bytes: 67108864
 /// max_file_references: 32
 /// ```
-///
-/// [`CalloutClient`]: praxis_core::callout::CalloutClient
 pub struct FileResolveFilter {
-    /// Files API HTTP client backed by callout.
+    /// Files API HTTP client backed by shared API callout.
     client: FilesApiClient,
     /// Parsed and validated configuration.
     config: FileResolveConfig,
@@ -130,28 +131,25 @@ impl FileResolveFilter {
         let validated = validate_config(cfg)?;
         let forward_header_names = prepare_forward_header_names(&validated.forward_headers)?;
 
-        let callout_config = CalloutConfig {
-            failure_mode: FailureMode::Closed,
-            timeout_ms: validated.timeout_ms,
-            status_on_error: 502,
-            ..CalloutConfig::default()
-        };
-
-        let callout_client = CalloutClient::new(callout_config).map_err(|e| -> FilterError {
-            format!("openai_file_resolve: failed to build callout client: {e}").into()
-        })?;
+        let api_client = ApiClient::new(ApiClientConfig {
+            api_base_url: validated.files_api_url.clone(),
+            callout_config: CalloutConfig {
+                failure_mode: FailureMode::Closed,
+                timeout_ms: validated.timeout_ms,
+                status_on_error: 502,
+                ..CalloutConfig::default()
+            },
+            forward_header_names,
+        })
+        .map_err(|e| -> FilterError { format!("openai_file_resolve: {e}").into() })?;
 
         let client = FilesApiClient::new(
-            &validated.files_api_url,
-            forward_header_names,
-            callout_client,
+            api_client,
             FilesApiClientOptions {
                 max_file_references: validated.max_file_references,
                 max_resolved_bytes: validated.max_body_bytes,
-                timeout_ms: validated.timeout_ms,
             },
-        )
-        .map_err(|e| -> FilterError { format!("openai_file_resolve: failed to build content client: {e}").into() })?;
+        );
 
         Ok(Box::new(Self {
             client,

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -300,7 +300,7 @@ impl FilesApiClient {
 
         let body = self
             .client
-            .get_json(&url, request_headers)
+            .get_json(url, request_headers)
             .await
             .map_err(|e| map_api_error(e, file_id))?;
 

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -6,7 +6,7 @@
 //! Walks the parsed JSON body, finds `file_id` references in
 //! `message` content arrays and `function_call_output` output
 //! arrays, fetches file metadata and content from the Files API
-//! via [`CalloutClient`], and replaces the reference with inline
+//! via [`ApiClient`], and replaces the reference with inline
 //! content: raw base64 in `file_data` for `input_file`, or a
 //! `data:` URL in `image_url` for `input_image`.
 //!
@@ -15,41 +15,18 @@
 //! extension and emits the baseline inline `file_data` / `image_url`
 //! fields before proxying the request.
 //!
-//! [`CalloutClient`]: praxis_core::callout::CalloutClient
+//! [`ApiClient`]: crate::openai::api_client::ApiClient
 
 use std::collections::HashMap;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
-use praxis_core::callout::{CalloutClient, CalloutRequest, CalloutResult};
 use tracing::{debug, warn};
 
 use super::config::OnMissing;
+use crate::openai::api_client::{ApiClient, ApiClientError};
 
-/// Characters that could let a client-supplied file ID escape its
-/// single URL path segment.
-///
-/// Encoding path separators, query/fragment delimiters, `%`, and URL
-/// parser special characters keeps the ID opaque when it is appended to
-/// `/v1/files/`. Dots are encoded as an additional defense against path
-/// normalization; exact `.` and `..` IDs are rejected by [`file_url`].
-const FILE_ID_PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
-    .add(b' ')
-    .add(b'"')
-    .add(b'#')
-    .add(b'%')
-    .add(b'.')
-    .add(b'/')
-    .add(b'<')
-    .add(b'>')
-    .add(b'?')
-    .add(b'[')
-    .add(b'\\')
-    .add(b']')
-    .add(b'^')
-    .add(b'`')
-    .add(b'{')
-    .add(b'}');
+/// Files API path prefix used in resource URL construction.
+const FILES_PATH_PREFIX: &str = "v1/files";
 
 /// Errors that can occur during file resolution.
 #[derive(Debug, Clone)]
@@ -104,23 +81,35 @@ impl std::fmt::Display for ResolveError {
     }
 }
 
+/// Map an [`ApiClientError`] to a [`ResolveError`], adding the
+/// file ID context that the shared client does not carry.
+fn map_api_error(err: ApiClientError, file_id: &str) -> ResolveError {
+    match err {
+        ApiClientError::CalloutFailed { detail } => ResolveError::CalloutFailed {
+            file_id: file_id.to_owned(),
+            detail,
+        },
+        ApiClientError::InvalidResourceId { resource_id, detail } => ResolveError::InvalidFileId {
+            file_id: resource_id,
+            detail,
+        },
+        ApiClientError::ResponseTooLarge { limit } => ResolveError::TooLarge {
+            file_id: file_id.to_owned(),
+            limit,
+        },
+        ApiClientError::DecodeFailed { detail } => ResolveError::CalloutFailed {
+            file_id: file_id.to_owned(),
+            detail: format!("metadata response invalid: {detail}"),
+        },
+    }
+}
+
 /// HTTP client wrapper for fetching files from an OpenAI-compatible
-/// Files API, backed by [`CalloutClient`] for metadata and
-/// bounded `reqwest` reads for content.
+/// Files API, backed by [`ApiClient`] for metadata and bounded
+/// byte reads for content.
 pub(crate) struct FilesApiClient {
-    /// Base URL of the Files API.
-    api_base_url: String,
-
-    /// The underlying callout client for metadata requests
-    /// (small responses; provides circuit breaking).
-    client: CalloutClient,
-
-    /// Direct HTTP client for content downloads with bounded
-    /// reads (prevents unbounded memory allocation).
-    content_client: reqwest::Client,
-
-    /// Header names to forward from the original request.
-    forward_header_names: Vec<http::HeaderName>,
+    /// Shared API client providing HTTP operations.
+    client: ApiClient,
 
     /// Maximum number of file references processed per request.
     max_file_references: usize,
@@ -165,8 +154,6 @@ pub(crate) struct FilesApiClientOptions {
     pub max_file_references: usize,
     /// Maximum bytes added by resolved inline content.
     pub max_resolved_bytes: usize,
-    /// Per-call and overall resolution timeout in milliseconds.
-    pub timeout_ms: u64,
 }
 
 /// Inputs needed to resolve and cache one file reference.
@@ -225,8 +212,6 @@ impl ResolutionBudget {
         } = request;
         let key = (part_type.to_owned(), file_id.to_owned());
         if let Some(cached) = self.cache.get(&key) {
-            // Each rewritten JSON part needs its own owned strings;
-            // the cache retains one copy to avoid repeated callouts.
             return cached.clone();
         }
 
@@ -238,8 +223,6 @@ impl ResolutionBudget {
         )
         .await
         .unwrap_or_else(|_elapsed| overall_timeout_error(file_id));
-        // Retain one owned outcome for repeated references while
-        // returning an independently owned value to the JSON part.
         self.cache.insert(key, resolution.clone());
         resolution
     }
@@ -277,37 +260,19 @@ fn overall_timeout_error(file_id: &str) -> Result<ResolvedFile, ResolveError> {
 }
 
 impl FilesApiClient {
-    /// Build a new client from base URL, forward headers, and a
-    /// pre-built [`CalloutClient`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the bounded content client cannot be built.
-    pub(crate) fn new(
-        api_base_url: &str,
-        forward_header_names: Vec<http::HeaderName>,
-        client: CalloutClient,
-        options: FilesApiClientOptions,
-    ) -> Result<Self, reqwest::Error> {
+    /// Build a new client from a pre-built [`ApiClient`] and
+    /// domain-specific options.
+    pub(crate) fn new(client: ApiClient, options: FilesApiClientOptions) -> Self {
         let FilesApiClientOptions {
             max_file_references,
             max_resolved_bytes,
-            timeout_ms,
         } = options;
-        let content_client = reqwest::Client::builder()
-            .no_proxy()
-            .redirect(reqwest::redirect::Policy::none())
-            .timeout(std::time::Duration::from_millis(timeout_ms))
-            .build()?;
-        Ok(Self {
-            api_base_url: api_base_url.trim_end_matches('/').to_owned(),
+        Self {
+            resolution_timeout: client.timeout(),
             client,
-            content_client,
-            forward_header_names,
             max_file_references,
             max_resolved_bytes,
-            resolution_timeout: std::time::Duration::from_millis(timeout_ms),
-        })
+        }
     }
 
     /// Create request-scoped resolution limits and cache state.
@@ -328,31 +293,22 @@ impl FilesApiClient {
         file_id: &str,
         request_headers: &http::HeaderMap,
     ) -> Result<FileMetadata, ResolveError> {
-        let url = file_url(&self.api_base_url, file_id, false)?;
-        let headers = forward_headers(request_headers, &self.forward_header_names);
-        let request = build_get_request(url, headers);
+        let url = self
+            .client
+            .resource_url(FILES_PATH_PREFIX, file_id, None)
+            .map_err(|e| map_api_error(e, file_id))?;
 
-        let response = execute_callout(&self.client, request, file_id).await?;
-
-        let body: serde_json::Value =
-            serde_json::from_slice(&response.body).map_err(|e| ResolveError::CalloutFailed {
-                file_id: file_id.to_owned(),
-                detail: format!("metadata response invalid: {e}"),
-            })?;
+        let body = self
+            .client
+            .get_json(&url, request_headers)
+            .await
+            .map_err(|e| map_api_error(e, file_id))?;
 
         Ok(parse_file_metadata(&body))
     }
 
     /// Fetch file content from `GET /v1/files/{file_id}/content`
     /// using bounded reads.
-    ///
-    /// Uses `reqwest` directly (bypassing [`CalloutClient`]) to
-    /// enforce `max_content_bytes` during download: the
-    /// `Content-Length` header is checked before reading, and the
-    /// body is consumed in chunks that are rejected as soon as
-    /// the accumulated size exceeds the limit.
-    ///
-    /// [`CalloutClient`]: praxis_core::callout::CalloutClient
     async fn fetch_content(
         &self,
         file_id: &str,
@@ -360,53 +316,21 @@ impl FilesApiClient {
         max_content_bytes: usize,
         max_resolved_bytes: usize,
     ) -> Result<Vec<u8>, ResolveError> {
-        let url = file_url(&self.api_base_url, file_id, true)?;
-        let response = self.send_content_request(&url, request_headers, file_id).await?;
+        let url = self
+            .client
+            .resource_url(FILES_PATH_PREFIX, file_id, Some("content"))
+            .map_err(|e| map_api_error(e, file_id))?;
 
-        if !response.status().is_success() {
-            return Err(ResolveError::CalloutFailed {
-                file_id: file_id.to_owned(),
-                detail: format!("content download returned {}", response.status()),
-            });
-        }
-
-        if response
-            .content_length()
-            .is_some_and(|cl| usize::try_from(cl).unwrap_or(usize::MAX) > max_content_bytes)
-        {
-            return Err(ResolveError::TooLarge {
-                file_id: file_id.to_owned(),
-                limit: max_resolved_bytes,
-            });
-        }
-
-        read_bounded_body(response, file_id, max_content_bytes, max_resolved_bytes).await
-    }
-
-    /// Send a GET request for file content with forwarded headers
-    /// and timeout.
-    async fn send_content_request(
-        &self,
-        url: &str,
-        request_headers: &http::HeaderMap,
-        file_id: &str,
-    ) -> Result<reqwest::Response, ResolveError> {
-        let headers = forward_headers(request_headers, &self.forward_header_names);
-        let mut req = self.content_client.get(url);
-        for (name, value) in headers {
-            req = req.header(name, value);
-        }
-        req.send().await.map_err(|e| {
-            warn!(file_id, error = %e, "content download request failed");
-            ResolveError::CalloutFailed {
-                file_id: file_id.to_owned(),
-                detail: if e.is_timeout() {
-                    "content download timed out".to_owned()
-                } else {
-                    "content download failed".to_owned()
+        self.client
+            .get_bytes(&url, request_headers, max_content_bytes)
+            .await
+            .map_err(|e| match e {
+                ApiClientError::ResponseTooLarge { .. } => ResolveError::TooLarge {
+                    file_id: file_id.to_owned(),
+                    limit: max_resolved_bytes,
                 },
-            }
-        })
+                other => map_api_error(other, file_id),
+            })
     }
 
     /// Fetch metadata and content, returning the base64 content
@@ -447,64 +371,6 @@ impl FilesApiClient {
             content_type: metadata.content_type,
             filename: metadata.filename,
         })
-    }
-}
-
-/// Read a response body in chunks, enforcing a size limit.
-async fn read_bounded_body(
-    mut response: reqwest::Response,
-    file_id: &str,
-    max_content_bytes: usize,
-    limit: usize,
-) -> Result<Vec<u8>, ResolveError> {
-    let mut body = Vec::new();
-    while let Some(chunk) = response.chunk().await.map_err(|e| ResolveError::CalloutFailed {
-        file_id: file_id.to_owned(),
-        detail: if e.is_timeout() {
-            "content download timed out".to_owned()
-        } else {
-            format!("content download read error: {e}")
-        },
-    })? {
-        if body.len() + chunk.len() > max_content_bytes {
-            return Err(ResolveError::TooLarge {
-                file_id: file_id.to_owned(),
-                limit,
-            });
-        }
-        body.extend_from_slice(&chunk);
-    }
-    Ok(body)
-}
-
-/// Build a GET [`CalloutRequest`] with the given URL and headers.
-fn build_get_request(url: String, headers: Vec<(http::HeaderName, http::HeaderValue)>) -> CalloutRequest {
-    CalloutRequest {
-        body: None,
-        depth: 0,
-        headers,
-        method: http::Method::GET,
-        url,
-    }
-}
-
-/// Execute a callout and map non-success outcomes to
-/// [`ResolveError`].
-async fn execute_callout(
-    client: &CalloutClient,
-    request: CalloutRequest,
-    file_id: &str,
-) -> Result<praxis_core::callout::CalloutResponse, ResolveError> {
-    match client.execute(request).await {
-        CalloutResult::Success(r) => Ok(r),
-        CalloutResult::Failed => Err(ResolveError::CalloutFailed {
-            file_id: file_id.to_owned(),
-            detail: "Files API callout failed (fail-open)".to_owned(),
-        }),
-        CalloutResult::Rejected(rejection) => Err(ResolveError::CalloutFailed {
-            file_id: file_id.to_owned(),
-            detail: format!("Files API callout rejected with status {}", rejection.status),
-        }),
     }
 }
 
@@ -549,20 +415,6 @@ pub(crate) struct ResolvedFile {
     content_type: String,
     /// Original filename from the Files API metadata.
     filename: Option<String>,
-}
-
-/// Build a Files API URL with `file_id` encoded as one path segment.
-fn file_url(api_base_url: &str, file_id: &str, content: bool) -> Result<String, ResolveError> {
-    if matches!(file_id, "." | "..") {
-        return Err(ResolveError::InvalidFileId {
-            file_id: file_id.to_owned(),
-            detail: "dot path segments are not valid file IDs".to_owned(),
-        });
-    }
-
-    let encoded_file_id = utf8_percent_encode(file_id, FILE_ID_PATH_SEGMENT_ENCODE_SET);
-    let content_suffix = if content { "/content" } else { "" };
-    Ok(format!("{api_base_url}/v1/files/{encoded_file_id}{content_suffix}"))
 }
 
 /// Walk the Responses API `input` array and resolve all `file_id`
@@ -667,9 +519,6 @@ async fn resolve_content_part(
     let (file_id, part_type) = (file_id.to_owned(), part_type.to_owned());
     debug!(file_id = %file_id, part_type = %part_type, "resolving file reference");
 
-    // Bound proxy resource use with the configured request budget, but leave
-    // provider-specific field-size validation to the upstream (for example,
-    // vLLM). This filter validates only fields needed for safe proxying.
     let max_resolved_bytes = resolver.budget.remaining_resolved_bytes;
     let Some(resolved) = resolve_reference(&file_id, &part_type, max_resolved_bytes, resolver).await? else {
         return Ok(None);
@@ -746,10 +595,6 @@ fn output_len_for_part(part_type: &str, resolved: &ResolvedFile) -> usize {
 }
 
 /// Replace `file_id` with the resolved content in a content part.
-///
-/// For `input_file`, writes raw base64 to `file_data` and
-/// populates `filename` from metadata when not already present.
-/// For `input_image`, writes a `data:` URL to `image_url`.
 fn rewrite_part(part: &mut serde_json::Value, part_type: &str, resolved: ResolvedFile) {
     let Some(obj) = part.as_object_mut() else {
         return;
@@ -776,21 +621,6 @@ fn rewrite_part(part: &mut serde_json::Value, part_type: &str, resolved: Resolve
         },
         _ => {},
     }
-}
-
-/// Forward configured headers from the original request to a
-/// callout request.
-fn forward_headers(
-    request_headers: &http::HeaderMap,
-    header_names: &[http::HeaderName],
-) -> Vec<(http::HeaderName, http::HeaderValue)> {
-    let mut headers = Vec::new();
-    for name in header_names {
-        if let Some(value) = request_headers.get(name) {
-            headers.push((name.clone(), value.clone()));
-        }
-    }
-    headers
 }
 
 /// Maximum raw file bytes whose base64 encoding fits in
@@ -845,12 +675,12 @@ mod tests {
     use std::{
         io::{Read as _, Write as _},
         net::TcpListener,
-        time::Duration,
     };
 
     use praxis_core::callout::{CalloutConfig, FailureMode};
 
     use super::*;
+    use crate::openai::api_client::{ApiClient, ApiClientConfig};
 
     #[test]
     fn infer_mime_pdf() {
@@ -931,45 +761,6 @@ mod tests {
     }
 
     #[test]
-    fn file_url_encodes_file_id_as_single_path_segment() {
-        let url = file_url("http://ogx:8321", "../admin?x#y", false).unwrap();
-
-        assert!(
-            url.starts_with("http://ogx:8321/v1/files/"),
-            "metadata URL should use the files endpoint: {url}"
-        );
-        assert!(
-            !url.contains("../admin"),
-            "raw path traversal should not appear in URL: {url}"
-        );
-        assert!(!url.contains("?x"), "query delimiter should be encoded: {url}");
-        assert!(!url.contains("#y"), "fragment delimiter should be encoded: {url}");
-        assert!(url.contains("%2F"), "slash should be encoded: {url}");
-        assert!(url.contains("%3F"), "question mark should be encoded: {url}");
-        assert!(url.contains("%23"), "fragment marker should be encoded: {url}");
-    }
-
-    #[test]
-    fn file_url_rejects_exact_dot_dot_segment() {
-        let err = file_url("http://ogx:8321", "..", false).unwrap_err();
-
-        assert!(
-            matches!(err, ResolveError::InvalidFileId { .. }),
-            "exact dot-dot file id should be rejected before URL construction"
-        );
-    }
-
-    #[test]
-    fn file_url_preserves_base_path_and_adds_content_suffix() {
-        let url = file_url("http://ogx:8321/files-api", "file-abc", true).unwrap();
-
-        assert_eq!(
-            url, "http://ogx:8321/files-api/v1/files/file-abc/content",
-            "content URL should preserve configured base path"
-        );
-    }
-
-    #[test]
     fn max_content_bytes_accounts_for_base64_expansion() {
         let prefix_len = "data:text/plain;base64,".len();
 
@@ -1019,28 +810,32 @@ mod tests {
         assert_eq!(meta.bytes, None, "bytes should be None when absent from metadata");
     }
 
+    fn test_api_client(api_base_url: &str, timeout_ms: u64) -> ApiClient {
+        ApiClient::new(ApiClientConfig {
+            api_base_url: api_base_url.to_owned(),
+            callout_config: CalloutConfig {
+                failure_mode: FailureMode::Closed,
+                timeout_ms,
+                ..CalloutConfig::default()
+            },
+            forward_header_names: Vec::new(),
+        })
+        .unwrap()
+    }
+
     fn test_client(api_base_url: &str) -> FilesApiClient {
         test_client_with_limits(api_base_url, 1024, 1_000)
     }
 
     fn test_client_with_limits(api_base_url: &str, max_resolved_bytes: usize, timeout_ms: u64) -> FilesApiClient {
-        let callout = CalloutClient::new(CalloutConfig {
-            failure_mode: FailureMode::Closed,
-            timeout_ms,
-            ..CalloutConfig::default()
-        })
-        .unwrap();
+        let api = test_api_client(api_base_url, timeout_ms);
         FilesApiClient::new(
-            api_base_url,
-            Vec::new(),
-            callout,
+            api,
             FilesApiClientOptions {
                 max_file_references: 32,
                 max_resolved_bytes,
-                timeout_ms,
             },
         )
-        .unwrap()
     }
 
     #[tokio::test]
@@ -1065,11 +860,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            matches!(
-                err,
-                ResolveError::CalloutFailed { detail, .. } if detail.contains("302 Found")
-            ),
-            "redirect response should be rejected without contacting its target"
+            matches!(err, ResolveError::CalloutFailed { .. }),
+            "redirect response should be rejected without contacting its target: {err}"
         );
     }
 
@@ -1089,42 +881,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            matches!(
-                err,
-                ResolveError::CalloutFailed { detail, .. } if detail == "content download failed"
-            ),
-            "transport errors should retain a generic detail after the internal error is logged"
-        );
-    }
-
-    #[tokio::test]
-    async fn content_download_timeout_covers_response_body() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0_u8; 4096];
-            let _read = stream.read(&mut request).unwrap();
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\na")
-                .unwrap();
-            stream.flush().unwrap();
-            std::thread::park_timeout(Duration::from_millis(250));
-            let _result = stream.write_all(b"bcde");
-        });
-        let client = test_client_with_limits(&format!("http://{address}"), 1024, 50);
-
-        let err = client
-            .fetch_content("file-slow", &http::HeaderMap::new(), 1024, 1024)
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                &err,
-                ResolveError::CalloutFailed { detail, .. } if detail.contains("timed out")
-            ),
-            "timeout should remain active while the response body is being downloaded: {err}"
+            matches!(err, ResolveError::CalloutFailed { .. }),
+            "transport errors should map to CalloutFailed: {err}"
         );
     }
 
@@ -1218,7 +976,14 @@ mod tests {
 
     #[tokio::test]
     async fn distinct_reference_limit_is_enforced_in_continue_mode() {
-        let mut client = test_client("http://ogx:8321");
+        let api = test_api_client("http://ogx:8321", 1_000);
+        let mut client = FilesApiClient::new(
+            api,
+            FilesApiClientOptions {
+                max_file_references: 2,
+                max_resolved_bytes: 1024,
+            },
+        );
         client.max_file_references = 2;
         let mut body = serde_json::json!({
             "input": [{
@@ -1244,8 +1009,14 @@ mod tests {
 
     #[tokio::test]
     async fn repeated_reference_reuses_cached_failure() {
-        let mut client = test_client("http://ogx:8321");
-        client.max_file_references = 1;
+        let api = test_api_client("http://ogx:8321", 1_000);
+        let client = FilesApiClient::new(
+            api,
+            FilesApiClientOptions {
+                max_file_references: 1,
+                max_resolved_bytes: 1024,
+            },
+        );
         let mut body = serde_json::json!({
             "input": [{
                 "type": "message",

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -12,7 +12,10 @@ use bytes::Bytes;
 use serde_json::json;
 
 use super::*;
-use crate::openai::responses::state::ResponsesState;
+use crate::openai::{
+    api_client::{ApiClient, ApiClientConfig},
+    responses::state::ResponsesState,
+};
 
 // -----------------------------------------------------------------------------
 // Config Parsing
@@ -654,19 +657,19 @@ fn make_client() -> FilesApiClient {
 }
 
 fn make_client_for_url_with_max(files_api_url: &str, max_resolved_bytes: usize) -> FilesApiClient {
-    let callout_config = CalloutConfig::default();
-    let callout = CalloutClient::new(callout_config).unwrap();
+    let api = ApiClient::new(ApiClientConfig {
+        api_base_url: files_api_url.to_owned(),
+        callout_config: CalloutConfig::default(),
+        forward_header_names: vec![],
+    })
+    .unwrap();
     FilesApiClient::new(
-        files_api_url,
-        vec![],
-        callout,
+        api,
         FilesApiClientOptions {
             max_file_references: 32,
             max_resolved_bytes,
-            timeout_ms: 30_000,
         },
     )
-    .unwrap()
 }
 
 fn start_files_api_stub() -> String {

--- a/docs/filters/openai_file_resolve.md
+++ b/docs/filters/openai_file_resolve.md
@@ -3,7 +3,7 @@
 
 # `openai_file_resolve`
 
-Resolves `file_id` references in Responses API input by fetching content from a Files API via [`CalloutClient`] and inlining the base64-encoded content in the provider-native field.
+Resolves `file_id` references in Responses API input by fetching content from a Files API via `ApiClient` and inlining the base64-encoded content in the provider-native field.
 
 ## Configuration Notes
 
@@ -15,7 +15,7 @@ The inference backend must support the resulting inline content part. This filte
 |-------|------|---------|-------------|
 | `allow_private_files_api_url` | bool | no | Allow `files_api_url` to target private, loopback, link-local, or DNS-name hosts.  Default `false` rejects SSRF-sensitive targets; set to `true` in development or when the Files API is an internal service on a private network. |
 | `allow_pre_security_callout` | bool | no | Allow Files API callouts from the `StreamBuffer` pre-read phase, before header-phase security filters execute. This must be explicitly enabled only when an outer trust boundary authenticates and authorizes requests before they reach this listener. Forwarded headers are the original downstream values, not mutations from request filters. |
-| `files_api_url` | string | yes | Base URL of the Files API (OGX) endpoint. Example: `http://ogx:8321` |
+| `files_api_url` | string | yes | Base URL of the Files API endpoint. Example: `http://ogx:8321` |
 | `forward_headers` | string[] | no | Headers to forward from the original request to the Files API for authentication and tenant isolation. No downstream headers are forwarded by default. |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `max_file_references` | integer | no | Maximum number of distinct content-part / `file_id` pairs to resolve in one request, including rehydrated history. |

--- a/docs/filters/reference.md
+++ b/docs/filters/reference.md
@@ -27,7 +27,7 @@ see the [Praxis core filter reference][core-ref].
 |--------|-------------|
 | [`openai_conversations`](openai_conversations.md) | Handles all `/v1/conversations` endpoints locally. |
 | [`openai_doc_extract`](openai_doc_extract.md) | Converts `input_file` content parts to `input_text` for backends that do not support `input_file` natively (e.g. vLLM, llm-d). |
-| [`openai_file_resolve`](openai_file_resolve.md) | Resolves `file_id` references in Responses API input by fetching content from a Files API via [`CalloutClient`] and inlining the base64-encoded content in the provider-native field. |
+| [`openai_file_resolve`](openai_file_resolve.md) | Resolves `file_id` references in Responses API input by fetching content from a Files API via `ApiClient` and inlining the base64-encoded content in the provider-native field. |
 | [`openai_mcp_dispatch`](openai_mcp_dispatch.md) | Executes MCP tool calls against upstream MCP servers within the Responses API agentic loop. |
 | [`openai_mcp_tool_resolve`](openai_mcp_tool_resolve.md) | Resolves MCP tool entries from the Responses API `tools` array into concrete tool definitions by calling `tools/list` on each upstream MCP server. |
 | [`openai_response_store`](openai_response_store.md) | Persists Responses API responses to the configured response store backend. |


### PR DESCRIPTION
## Summary

Extracts common HTTP client functionality from `FilesApiClient` into a shared `api_client` module (`apis/src/openai/api_client/`) so both the Files API client and the future vector-store search client (#312) can reuse a single implementation.

- **Dual-transport design**: `CalloutClient` for JSON requests (`get_json`/`post_json`) with circuit breaking and depth protection; direct `reqwest::Client` for bounded byte downloads (`get_bytes`) with chunk-by-chunk size enforcement via `read_bounded_body`.
- **Extracted shared utilities**: SSRF validation, resource-ID path-segment encoding, and forward-header validation moved to `api_client::url`.
- **`FilesApiClient` simplified**: now wraps `ApiClient` instead of owning transport clients directly, reducing ~500 lines from `file_resolve/`.
- Once praxis-core publishes `max_response_bytes` on `CalloutConfig`, both paths can be unified behind `CalloutClient` (tracked in #454).

Closes #405

## Test plan

- [x] All existing `file_resolve` tests pass unchanged (behavioral preservation)
- [x] New `api_client` unit tests cover: JSON parsing, bounded reads, redirect rejection, transport failures, >1 MiB downloads, forward-header copying, SSRF validation, resource-ID encoding
- [x] `make build` / `make lint` / `make test` / `make doc` all pass