### PR TITLE
ci: add merge_group triggers to integration, vLLM, and unicode-safety

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,9 +7,31 @@ name: Tests (Integration)
 on:
   push:
     branches: [main]
+    paths:
+      - "apis/**"
+      - "filters/**"
+      - "server/**"
+      - "tests/**"
+      - "examples/configs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Makefile"
+      - ".github/workflows/integration.yaml"
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    paths:
+      - "apis/**"
+      - "filters/**"
+      - "server/**"
+      - "tests/**"
+      - "examples/configs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Makefile"
+      - ".github/workflows/integration.yaml"
+  merge_group:
+    branches: [main]
   workflow_dispatch:
     inputs:
       debug:
@@ -29,10 +51,50 @@ env:
 
 jobs:
   # ----------------------------------------------------------------------------
+  # Path filter for merge_group (which does not support on.paths)
+  # ----------------------------------------------------------------------------
+
+  changes:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant path changes
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only "${{ github.event.merge_group.base_sha }}" \
+                                         "${{ github.event.merge_group.head_sha }}" -- \
+            'apis/' \
+            'filters/' \
+            'server/' \
+            'tests/' \
+            'examples/configs/' \
+            'Cargo.toml' \
+            'Cargo.lock' \
+            'Makefile' \
+            '.github/workflows/integration.yaml')
+          if [ -n "$CHANGED" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ----------------------------------------------------------------------------
   # Integration test suites (tests/ crates)
   # ----------------------------------------------------------------------------
 
   test:
+    needs: [changes]
+    if: |
+      always() &&
+      (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/unicode-safety.yaml
+++ b/.github/workflows/unicode-safety.yaml
@@ -14,6 +14,8 @@ name: Unicode Safety Check
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -30,6 +30,8 @@ on:
       - "Cargo.lock"
       - "Makefile"
       - ".github/workflows/vllm-integration.yaml"
+  merge_group:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -45,10 +47,50 @@ env:
 
 jobs:
   # ----------------------------------------------------------------------------
+  # Path filter for merge_group (which does not support on.paths)
+  # ----------------------------------------------------------------------------
+
+  changes:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant path changes
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only "${{ github.event.merge_group.base_sha }}" \
+                                         "${{ github.event.merge_group.head_sha }}" -- \
+            'apis/src/openai/responses/' \
+            'apis/src/openai/sse/' \
+            'server/' \
+            'tests/integration/sdk/openai/' \
+            'examples/configs/openai/responses/' \
+            'Cargo.toml' \
+            'Cargo.lock' \
+            'Makefile' \
+            '.github/workflows/vllm-integration.yaml')
+          if [ -n "$CHANGED" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ----------------------------------------------------------------------------
   # Responses API integration tests against a real vLLM CPU backend
   # ----------------------------------------------------------------------------
 
   vllm-responses:
+    needs: [changes]
+    if: |
+      always() &&
+      (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     permissions:


### PR DESCRIPTION
## Summary

Three CI workflows ran on `pull_request` but were missing `merge_group` triggers, leaving them absent from the merge queue:

- **`integration.yaml`** — schema and integration tests (`make test-schema`, `make test-integration`)
- **`vllm-integration.yaml`** — end-to-end vLLM Responses API tests
- **`unicode-safety.yaml`** — hidden Unicode / ASCII smuggling security scan

This PR adds `merge_group` triggers to all three. For `integration.yaml` and `vllm-integration.yaml`, it also adds path filtering so docs-only changes skip the expensive jobs while still producing a successful check for `ci-status`. Since `merge_group` does not support `on.paths`, a lightweight `changes` detection job gates the main job using `git diff` against the merge group's base/head SHAs.

## Test plan

- [ ] Verify `integration.yaml` triggers on merge queue for code changes
- [ ] Verify `integration.yaml` skips on merge queue for docs-only changes
- [ ] Verify `vllm-integration.yaml` triggers on merge queue for relevant path changes
- [ ] Verify `vllm-integration.yaml` skips on merge queue for unrelated changes
- [ ] Verify `unicode-safety.yaml` triggers on merge queue
- [ ] Verify `ci-status` aggregator picks up all new checks without changes