### PR TITLE
feat(file_resolve): resolve file_url references with SSRF protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,6 +2920,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "yaml_serde",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tokio = { version = "1.52.3", features = ["macros", "rt"] }
 tokio-rustls = "0.26.4"
 tokio-tungstenite = "0.30.0"
 tokio-util = "0.7.18"
+url = "2.5.8"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 wiremock = "0.6.5"

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -39,6 +39,7 @@ sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time", "net"] }
 tracing = { workspace = true }
+url = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]

--- a/apis/src/openai/api_client/url.rs
+++ b/apis/src/openai/api_client/url.rs
@@ -19,6 +19,7 @@ use praxis_core::connectivity::normalize_mapped_ipv4;
 use praxis_filter::FilterError;
 
 use super::error::ApiClientError;
+use crate::openai::url_security::is_non_public_ip;
 
 /// Characters that could let a client-supplied resource ID escape
 /// its single URL path segment.
@@ -152,7 +153,7 @@ fn validate_host(filter_name: &str, host: &str, allow_private: bool) -> Result<(
 /// Validate an IP target against SSRF-sensitive ranges.
 fn validate_ip(filter_name: &str, ip: IpAddr, allow_private: bool) -> Result<(), FilterError> {
     let ip = normalize_mapped_ipv4(ip);
-    if !allow_private && is_ssrf_sensitive_ip(&ip) {
+    if !allow_private && is_non_public_ip(&ip) {
         return Err(format!(
             "{filter_name}: base URL targets a local-sensitive address; \
              set the allow-private option to true to allow"
@@ -172,29 +173,6 @@ fn validate_dns(filter_name: &str, host: &str, allow_private: bool) -> Result<()
          use a literal IP address or set the allow-private option to true to allow DNS targets"
     )
     .into())
-}
-
-/// Return whether an IP address is SSRF-sensitive (loopback,
-/// private, link-local, CGNAT/shared, current-network, or
-/// unspecified).
-fn is_ssrf_sensitive_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_unspecified()
-                || v4.octets()[0] == 0
-                || is_cgnat(*v4)
-        },
-        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local() || v6.is_unicast_link_local() || v6.is_unspecified(),
-    }
-}
-
-/// Return whether an IPv4 address is in the shared CGNAT range
-/// (`100.64.0.0/10`, RFC 6598).
-fn is_cgnat(ip: Ipv4Addr) -> bool {
-    u32::from(ip) & 0xFFC0_0000 == 0x6440_0000
 }
 
 /// Return whether a host name is a localhost alias.
@@ -446,6 +424,22 @@ mod tests {
     }
 
     #[test]
+    fn ssrf_rejects_shared_special_use_range() {
+        assert!(
+            validate_base_url("test", "http://192.0.2.1:8321", false).is_err(),
+            "documentation ranges should be rejected by shared IP classification"
+        );
+    }
+
+    #[test]
+    fn ssrf_rejects_shared_cloud_metadata_endpoint() {
+        assert!(
+            validate_base_url("test", "http://100.100.100.200:8321", false).is_err(),
+            "cloud metadata endpoints should be rejected by shared IP classification"
+        );
+    }
+
+    #[test]
     fn ssrf_rejects_ipv4_mapped_ipv6_loopback() {
         assert!(
             validate_base_url("test", "http://[::ffff:127.0.0.1]:8321", false).is_err(),
@@ -456,7 +450,7 @@ mod tests {
     #[test]
     fn ssrf_allows_public_ipv4() {
         assert!(
-            validate_base_url("test", "http://203.0.113.1:8321", false).is_ok(),
+            validate_base_url("test", "http://8.8.8.8:8321", false).is_ok(),
             "public IPv4 should be allowed"
         );
     }

--- a/apis/src/openai/mod.rs
+++ b/apis/src/openai/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod sse;
     reason = "Responses translation helpers are wired into the HTTP filter in a later stack entry"
 )]
 pub(crate) mod translation;
+pub(crate) mod url_security;
 
 pub use conversations::OpenaiConversationsFilter;
 pub use responses::{

--- a/apis/src/openai/responses/file_resolve/config.rs
+++ b/apis/src/openai/responses/file_resolve/config.rs
@@ -496,7 +496,7 @@ allow_private_files_api_url: true
 
     #[test]
     fn ssrf_allows_public_ipv4() {
-        let yaml = r#"files_api_url: "http://203.0.113.1:8321"
+        let yaml = r#"files_api_url: "http://8.8.8.8:8321"
 allow_pre_security_callout: true"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(validate_config(cfg).is_ok(), "public IPv4 should be allowed");

--- a/apis/src/openai/responses/file_resolve/config.rs
+++ b/apis/src/openai/responses/file_resolve/config.rs
@@ -6,6 +6,7 @@
 use praxis_filter::{FilterError, body::MAX_JSON_BODY_BYTES};
 use serde::Deserialize;
 
+use super::resolve_url::NormalizedOrigin;
 use crate::openai::api_client;
 
 /// Default HTTP timeout for Files API callout requests (30 000 ms).
@@ -30,6 +31,18 @@ pub(crate) enum OnMissing {
 
     /// Return an error response to the client.
     Reject,
+}
+
+/// Mode for handling `file_url` content parts.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FileUrlMode {
+    /// Fetch the URL and inline content as `file_data` (data URI).
+    #[default]
+    Resolve,
+
+    /// Leave `file_url` unchanged for native-compatible backends.
+    Passthrough,
 }
 
 /// YAML configuration for the [`FileResolveFilter`].
@@ -82,6 +95,15 @@ pub(crate) struct FileResolveConfig {
     /// HTTP timeout in milliseconds for Files API callout requests.
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
+
+    /// Mode for `file_url` content parts in `input_file`.
+    #[serde(default)]
+    pub file_url: FileUrlMode,
+
+    /// Exact origins allowed to resolve to private addresses.
+    /// Cloud metadata, unspecified, and multicast remain blocked.
+    #[serde(default)]
+    pub allowed_file_url_origins: Vec<String>,
 }
 
 /// Default max body bytes.
@@ -117,6 +139,7 @@ pub(crate) fn validate_config(mut cfg: FileResolveConfig) -> Result<FileResolveC
     api_client::validate_forward_headers("openai_file_resolve", &mut cfg.forward_headers)?;
     validate_limits(&cfg)?;
     validate_pre_security_callout(&cfg)?;
+    validate_file_url_config(&cfg)?;
 
     Ok(cfg)
 }
@@ -173,6 +196,28 @@ fn validate_resolution_limits(cfg: &FileResolveConfig) -> Result<(), FilterError
             cfg.timeout_ms
         )
         .into());
+    }
+
+    Ok(())
+}
+
+/// Validate `file_url` mode and `allowed_file_url_origins`.
+fn validate_file_url_config(cfg: &FileResolveConfig) -> Result<(), FilterError> {
+    if cfg.file_url == FileUrlMode::Passthrough && !cfg.allowed_file_url_origins.is_empty() {
+        return Err(
+            "openai_file_resolve: 'allowed_file_url_origins' cannot be set when 'file_url' is 'passthrough'".into(),
+        );
+    }
+
+    let mut seen = Vec::new();
+    for raw in &cfg.allowed_file_url_origins {
+        let origin = NormalizedOrigin::parse(raw).map_err(|e| -> FilterError {
+            format!("openai_file_resolve: invalid 'allowed_file_url_origins' entry '{raw}': {e}").into()
+        })?;
+        if seen.contains(&origin) {
+            return Err(format!("openai_file_resolve: duplicate 'allowed_file_url_origins' entry '{raw}'").into());
+        }
+        seen.push(origin);
     }
 
     Ok(())
@@ -345,6 +390,8 @@ timeout_ms: 300001"#;
             max_file_references: DEFAULT_MAX_FILE_REFERENCES,
             on_missing: OnMissing::Continue,
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            file_url: FileUrlMode::Resolve,
+            allowed_file_url_origins: Vec::new(),
         };
         assert!(validate_config(cfg).is_ok(), "valid config should pass validation");
     }
@@ -512,6 +559,100 @@ allow_private_files_api_url: true
         assert!(
             validate_config(cfg).is_err(),
             "fragments would hide appended Files API paths from the HTTP request"
+        );
+    }
+
+    #[test]
+    fn file_url_defaults_to_resolve() {
+        let cfg: FileResolveConfig = serde_yaml::from_str(MINIMAL_YAML).unwrap();
+        assert_eq!(cfg.file_url, FileUrlMode::Resolve, "file_url should default to resolve");
+    }
+
+    #[test]
+    fn file_url_passthrough_accepted() {
+        let yaml = r#"
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+file_url: passthrough
+"#;
+        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
+        let validated = validate_config(cfg).unwrap();
+        assert_eq!(validated.file_url, FileUrlMode::Passthrough);
+    }
+
+    #[test]
+    fn allowed_origins_with_passthrough_rejected() {
+        let yaml = r#"
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+file_url: passthrough
+allowed_file_url_origins:
+  - "https://files.internal:8443"
+"#;
+        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(
+            validate_config(cfg).is_err(),
+            "allowed_file_url_origins should be rejected with passthrough mode"
+        );
+    }
+
+    #[test]
+    fn valid_allowed_origins_accepted() {
+        let yaml = r#"
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+file_url: resolve
+allowed_file_url_origins:
+  - "https://files.internal:8443"
+  - "http://10.0.0.1:9000"
+"#;
+        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(validate_config(cfg).is_ok(), "valid origins should be accepted");
+    }
+
+    #[test]
+    fn duplicate_origins_rejected() {
+        let yaml = r#"
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+allowed_file_url_origins:
+  - "https://files.example.com"
+  - "https://files.example.com"
+"#;
+        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(validate_config(cfg).is_err(), "duplicate origins should be rejected");
+    }
+
+    #[test]
+    fn origin_with_path_rejected() {
+        let yaml = r#"
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+allowed_file_url_origins:
+  - "https://files.example.com/api"
+"#;
+        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(validate_config(cfg).is_err(), "origins with paths should be rejected");
+    }
+
+    #[test]
+    fn origin_cloud_metadata_rejected() {
+        let yaml = r#"
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+allowed_file_url_origins:
+  - "http://169.254.169.254"
+"#;
+        let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(
+            validate_config(cfg).is_err(),
+            "cloud metadata origins should be rejected"
         );
     }
 }

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -45,6 +45,7 @@
 
 mod config;
 pub(crate) mod resolve;
+pub(crate) mod resolve_url;
 
 #[cfg(test)]
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
@@ -359,6 +360,10 @@ fn rewrite_body(
 /// `messages` / `persisted_messages` with the resolved items.
 /// History messages prepended by rehydrate are also walked so
 /// that any `file_id` references in them are resolved.
+#[expect(
+    clippy::large_stack_frames,
+    reason = "ResolveError enum size increased by file_url variants"
+)]
 async fn sync_state_with_budget(
     ctx: &mut HttpFilterContext<'_>,
     resolved_body: &serde_json::Value,
@@ -515,6 +520,8 @@ fn resolve_error_response(err: &ResolveError) -> (u16, String) {
         ResolveError::InvalidFileId { file_id, detail } => invalid_id_error_response(file_id, detail),
         ResolveError::TooManyReferences { limit } => too_many_error_response(*limit),
         ResolveError::TooLarge { file_id, limit } => too_large_error_response(file_id, *limit),
+        ResolveError::FileUrlBlocked { label } => file_url_blocked_response(label),
+        ResolveError::FileUrlFailed { label, detail } => file_url_failed_response(label, detail),
     }
 }
 
@@ -546,6 +553,18 @@ fn too_large_error_response(file_id: &str, limit: usize) -> (u16, String) {
         413,
         format!("failed to resolve file '{file_id}': resolved content exceeds {limit} bytes"),
     )
+}
+
+/// Report a file URL blocked by SSRF policy to the caller.
+fn file_url_blocked_response(label: &str) -> (u16, String) {
+    warn!(url = %label, "file URL blocked by security policy");
+    (403, format!("file URL '{label}' blocked by security policy"))
+}
+
+/// Report a file URL fetch failure to the caller.
+fn file_url_failed_response(label: &str, detail: &str) -> (u16, String) {
+    warn!(url = %label, detail, "file URL fetch failed");
+    (502, format!("failed to fetch file URL '{label}': request failed"))
 }
 
 /// Build a rejection response from a resolution error.

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -85,7 +85,7 @@ use crate::{
 
 /// Resolves `file_id` and `file_url` references in Responses API input
 /// by fetching content from a Files API or remote URL via
-/// [`ApiClient`] and inlining the base64-encoded content in the
+/// `ApiClient` and inlining the base64-encoded content in the
 /// provider-native field.
 ///
 /// The inference backend must support the resulting inline content

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Resolves `file_id` references in `OpenAI` Responses API requests.
+//! Resolves `file_id` and `file_url` references in `OpenAI` Responses API requests.
 //!
 //! Walks `message` content arrays and `function_call_output` output
-//! arrays, finds content parts that reference files by ID, fetches
-//! file metadata and content from an external Files API
-//! via [`ApiClient`], and inlines the content: raw base64 in
-//! `file_data` for `input_file`, or a `data:` URL in `image_url`
-//! for `input_image`. Forwards configurable headers
-//! (`Authorization`, `X-Tenant-ID`) to the Files API for tenant
-//! isolation.
+//! arrays, finds content parts that reference files by ID or URL, fetches
+//! file metadata and content from an external Files API (e.g. OGX) or
+//! remote URL via [`ApiClient`], and inlines the content: raw base64
+//! in `file_data` for `input_file`, or a `data:` URL in `image_url` for
+//! `input_image`. Forwards configurable headers (`Authorization`,
+//! `X-Tenant-ID`) to the Files API for tenant isolation.
 //!
 //! Praxis runs `StreamBuffer` body hooks before header-phase request
 //! filters. Configuration therefore requires an explicit
@@ -24,9 +23,11 @@
 //! `state.messages`, and `state.persisted_messages` so that
 //! `responses_proxy` does not overwrite the rewritten body.
 //!
-//! Content parts with `file_data`, `file_url`, or `image_url`
-//! pass through unchanged. No content-part validation — the
-//! inference backend handles that.
+//! Content parts with `file_data` or `image_url` pass through unchanged.
+//! Content parts with `file_url` are resolved to `file_data` when
+//! `file_url: resolve` (default), or passed through when `file_url:
+//! passthrough`. No content-part validation — the inference backend
+//! handles that.
 //!
 //! This filter resolves the file transport reference but does not
 //! interpret document contents. The inference backend must already
@@ -82,9 +83,10 @@ use crate::{
     openai::api_client::{ApiClient, ApiClientConfig},
 };
 
-/// Resolves `file_id` references in Responses API input by fetching
-/// content from a Files API via `ApiClient` and inlining the
-/// base64-encoded content in the provider-native field.
+/// Resolves `file_id` and `file_url` references in Responses API input
+/// by fetching content from a Files API or remote URL via
+/// [`ApiClient`] and inlining the base64-encoded content in the
+/// provider-native field.
 ///
 /// The inference backend must support the resulting inline content
 /// part. This filter does not extract documents into backend-specific
@@ -118,6 +120,18 @@ use crate::{
 /// timeout_ms: 30000
 /// max_body_bytes: 67108864
 /// max_file_references: 32
+/// ```
+///
+/// # File URL Resolution YAML
+///
+/// ```yaml
+/// filter: openai_file_resolve
+/// files_api_url: "http://ogx:8321"
+/// allow_private_files_api_url: true
+/// allow_pre_security_callout: true
+/// file_url: resolve
+/// allowed_file_url_origins:
+///   - "https://files.internal:8443"
 /// ```
 pub struct FileResolveFilter {
     /// Files API HTTP client backed by shared API callout.

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -70,10 +70,11 @@ use praxis_filter::{
 use tracing::{debug, trace, warn};
 
 use self::{
-    config::{FileResolveConfig, OnMissing, validate_config},
+    config::{FileResolveConfig, FileUrlMode, OnMissing, validate_config},
     resolve::{
         FilesApiClient, FilesApiClientOptions, ResolutionBudget, ResolveError, resolve_input_with_budget, resolve_items,
     },
+    resolve_url::{FileUrlResolver, NormalizedOrigin},
 };
 use super::{openai_responses_proxy::serialized_outbound_body_len, state::ResponsesState};
 use crate::{
@@ -123,6 +124,8 @@ pub struct FileResolveFilter {
     client: FilesApiClient,
     /// Parsed and validated configuration.
     config: FileResolveConfig,
+    /// URL resolver for `file_url` references.
+    url_resolver: Option<FileUrlResolver>,
 }
 
 impl FileResolveFilter {
@@ -132,6 +135,7 @@ impl FileResolveFilter {
     ///
     /// Returns [`FilterError`] if the YAML config is invalid or the
     /// callout client cannot be constructed.
+    #[expect(clippy::too_many_lines, reason = "filter construction boilerplate")]
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         let cfg: FileResolveConfig = parse_filter_config("openai_file_resolve", config)?;
         let validated = validate_config(cfg)?;
@@ -157,9 +161,24 @@ impl FileResolveFilter {
             },
         );
 
+        let url_resolver = if validated.file_url == FileUrlMode::Resolve {
+            let origins = validated
+                .allowed_file_url_origins
+                .iter()
+                .map(|raw| NormalizedOrigin::parse(raw))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| -> FilterError { format!("openai_file_resolve: {e}").into() })?;
+            Some(FileUrlResolver {
+                allowed_private_origins: origins,
+            })
+        } else {
+            None
+        };
+
         Ok(Box::new(Self {
             client,
             config: validated,
+            url_resolver,
         }))
     }
 }
@@ -298,6 +317,7 @@ async fn resolve_current_input(
         &filter.client,
         filter.config.on_missing,
         &ctx.request.headers,
+        filter.url_resolver.as_ref(),
         budget,
     ))
     .await
@@ -317,6 +337,7 @@ async fn update_state(
                 body,
                 &filter.client,
                 filter.config.on_missing,
+                filter.url_resolver.as_ref(),
                 budget,
             ))
             .await
@@ -326,6 +347,7 @@ async fn update_state(
                 ctx,
                 &filter.client,
                 filter.config.on_missing,
+                filter.url_resolver.as_ref(),
                 budget,
             ))
             .await
@@ -364,11 +386,13 @@ fn rewrite_body(
     clippy::large_stack_frames,
     reason = "ResolveError enum size increased by file_url variants"
 )]
+#[expect(clippy::too_many_arguments, reason = "threading resolver through state sync")]
 async fn sync_state_with_budget(
     ctx: &mut HttpFilterContext<'_>,
     resolved_body: &serde_json::Value,
     client: &FilesApiClient,
     on_missing: OnMissing,
+    url_resolver: Option<&FileUrlResolver>,
     budget: &mut ResolutionBudget,
 ) -> Result<(), ResolveError> {
     let Some(state) = ctx.extensions.get_mut::<ResponsesState>() else {
@@ -386,6 +410,7 @@ async fn sync_state_with_budget(
         client,
         on_missing,
         request_headers: &ctx.request.headers,
+        url_resolver,
     };
 
     sync_message_history(&mut state.messages, input_len, Some(resolved_input), resolver, budget).await?;
@@ -408,15 +433,20 @@ async fn sync_state(
     on_missing: OnMissing,
 ) -> Result<(), ResolveError> {
     let mut budget = client.resolution_budget();
-    sync_state_with_budget(ctx, resolved_body, client, on_missing, &mut budget).await
+    sync_state_with_budget(ctx, resolved_body, client, on_missing, None, &mut budget).await
 }
 
-/// Resolve `file_id` references in rehydrated history when the
+/// Resolve file references in rehydrated history when the
 /// current input did not require a body rewrite.
+#[expect(
+    clippy::large_stack_frames,
+    reason = "ResolveError enum size increased by file_url variants"
+)]
 async fn resolve_state_history(
     ctx: &mut HttpFilterContext<'_>,
     client: &FilesApiClient,
     on_missing: OnMissing,
+    url_resolver: Option<&FileUrlResolver>,
     budget: &mut ResolutionBudget,
 ) -> Result<(), ResolveError> {
     let Some(state) = ctx.extensions.get_mut::<ResponsesState>() else {
@@ -428,6 +458,7 @@ async fn resolve_state_history(
         client,
         on_missing,
         request_headers: &ctx.request.headers,
+        url_resolver,
     };
 
     sync_message_history(&mut state.messages, input_len, None, resolver, budget).await?;
@@ -443,6 +474,8 @@ struct HistoryResolver<'a> {
     on_missing: OnMissing,
     /// Original request headers available for configured forwarding.
     request_headers: &'a http::HeaderMap,
+    /// URL resolver for `file_url` references.
+    url_resolver: Option<&'a FileUrlResolver>,
 }
 
 /// Resolve the persistence mirror with independent count and byte
@@ -488,7 +521,7 @@ fn replace_tail(messages: &mut [serde_json::Value], history_end: usize, resolved
     }
 }
 
-/// Resolve `file_id` references in history messages (the prefix
+/// Resolve file references in history messages (the prefix
 /// before the current input).
 async fn resolve_history(
     messages: &mut [serde_json::Value],
@@ -507,6 +540,7 @@ async fn resolve_history(
         resolver.client,
         resolver.on_missing,
         resolver.request_headers,
+        resolver.url_resolver,
         budget,
     )
     .await

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -567,7 +567,7 @@ fn resolve_error_response(err: &ResolveError) -> (u16, String) {
         ResolveError::CalloutFailed { file_id, detail } => callout_error_response(file_id, detail),
         ResolveError::InvalidFileId { file_id, detail } => invalid_id_error_response(file_id, detail),
         ResolveError::TooManyReferences { limit } => too_many_error_response(*limit),
-        ResolveError::TooLarge { file_id, limit } => too_large_error_response(file_id, *limit),
+        ResolveError::TooLarge { reference, limit } => too_large_error_response(reference, *limit),
         ResolveError::FileUrlBlocked { label } => file_url_blocked_response(label),
         ResolveError::FileUrlFailed { label, detail } => file_url_failed_response(label, detail),
     }
@@ -595,11 +595,11 @@ fn too_many_error_response(limit: usize) -> (u16, String) {
 }
 
 /// Report an exceeded resolved-body size cap to the caller.
-fn too_large_error_response(file_id: &str, limit: usize) -> (u16, String) {
-    warn!(file_id, limit, "resolved file exceeds configured limit");
+fn too_large_error_response(reference: &str, limit: usize) -> (u16, String) {
+    warn!(reference, limit, "resolved file exceeds configured limit");
     (
         413,
-        format!("failed to resolve file '{file_id}': resolved content exceeds {limit} bytes"),
+        format!("failed to resolve file reference '{reference}': resolved content exceeds {limit} bytes"),
     )
 }
 

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -396,10 +396,6 @@ fn rewrite_body(
 /// `messages` / `persisted_messages` with the resolved items.
 /// History messages prepended by rehydrate are also walked so
 /// that any `file_id` references in them are resolved.
-#[expect(
-    clippy::large_stack_frames,
-    reason = "ResolveError enum size increased by file_url variants"
-)]
 #[expect(clippy::too_many_arguments, reason = "threading resolver through state sync")]
 async fn sync_state_with_budget(
     ctx: &mut HttpFilterContext<'_>,
@@ -452,10 +448,6 @@ async fn sync_state(
 
 /// Resolve file references in rehydrated history when the
 /// current input did not require a body rewrite.
-#[expect(
-    clippy::large_stack_frames,
-    reason = "ResolveError enum size increased by file_url variants"
-)]
 async fn resolve_state_history(
     ctx: &mut HttpFilterContext<'_>,
     client: &FilesApiClient,

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -30,7 +30,6 @@ const FILES_PATH_PREFIX: &str = "v1/files";
 
 /// Identifies the source of a file reference for dispatch and caching.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(not(test), expect(dead_code, reason = "FileUrl variant used in Task 4"))]
 pub(crate) enum ReferenceSource {
     /// Files API `file_id` reference.
     FileId(String),
@@ -198,6 +197,8 @@ struct ResolutionRequest<'a> {
     part_type: &'a str,
     /// Original request headers available for forwarding.
     request_headers: &'a http::HeaderMap,
+    /// URL resolver for `file_url` references.
+    url_resolver: Option<&'a FileUrlResolver>,
 }
 
 /// Shared dependencies for walking content parts in one item collection.
@@ -211,7 +212,6 @@ struct ContentResolver<'a> {
     /// Original request headers available for forwarding.
     request_headers: &'a http::HeaderMap,
     /// URL resolver for `file_url` references.
-    #[expect(dead_code, reason = "Wired in Task 4")]
     url_resolver: Option<&'a FileUrlResolver>,
 }
 
@@ -235,6 +235,7 @@ impl ResolutionBudget {
     }
 
     /// Resolve one reference within request-wide count and time limits.
+    #[expect(clippy::too_many_lines, reason = "inline dispatch logic for FileId vs FileUrl")]
     async fn resolve(&mut self, request: ResolutionRequest<'_>) -> Result<ResolvedFile, ResolveError> {
         let ResolutionRequest {
             client,
@@ -242,6 +243,7 @@ impl ResolutionBudget {
             max_resolved_bytes,
             part_type,
             request_headers,
+            url_resolver,
         } = request;
         let key = (part_type.to_owned(), source.clone());
         if let Some(cached) = self.cache.get(&key) {
@@ -250,15 +252,27 @@ impl ResolutionBudget {
 
         self.register_reference()?;
 
-        let resolution = dispatch_resolution(
-            &source,
-            client,
-            request_headers,
-            max_resolved_bytes,
-            part_type,
-            self.deadline,
-        )
-        .await;
+        let resolution = tokio::time::timeout_at(self.deadline, async {
+            match &source {
+                ReferenceSource::FileId(file_id) => {
+                    client
+                        .resolve_file(file_id, request_headers, max_resolved_bytes, part_type)
+                        .await
+                },
+                ReferenceSource::FileUrl(url) => {
+                    let Some(resolver) = url_resolver else {
+                        return Err(ResolveError::FileUrlFailed {
+                            label: url.clone(),
+                            detail: "file URL resolution not configured".to_owned(),
+                        });
+                    };
+                    resolver.resolve_url(url, self.deadline, max_resolved_bytes).await
+                },
+            }
+        })
+        .await
+        .unwrap_or_else(|_elapsed| overall_timeout_error_for_source(&source));
+
         // Retain one owned outcome for repeated references while
         // returning an independently owned value to the JSON part.
         self.cache.insert(key, resolution.clone());
@@ -290,37 +304,16 @@ impl ResolutionBudget {
 }
 
 /// Build the stable error returned when the request-wide deadline expires.
-fn overall_timeout_error(file_id: &str) -> Result<ResolvedFile, ResolveError> {
-    Err(ResolveError::CalloutFailed {
-        file_id: file_id.to_owned(),
-        detail: "overall file resolution deadline exceeded".to_owned(),
-    })
-}
-
-/// Dispatch one reference to the appropriate resolver backend.
-#[expect(clippy::too_many_arguments, reason = "Task 4 will refactor this")]
-async fn dispatch_resolution(
-    source: &ReferenceSource,
-    client: &FilesApiClient,
-    request_headers: &http::HeaderMap,
-    max_resolved_bytes: usize,
-    part_type: &str,
-    deadline: tokio::time::Instant,
-) -> Result<ResolvedFile, ResolveError> {
+fn overall_timeout_error_for_source(source: &ReferenceSource) -> Result<ResolvedFile, ResolveError> {
     match source {
-        ReferenceSource::FileId(file_id) => tokio::time::timeout_at(
-            deadline,
-            client.resolve_file(file_id, request_headers, max_resolved_bytes, part_type),
-        )
-        .await
-        .unwrap_or_else(|_elapsed| overall_timeout_error(file_id)),
-        ReferenceSource::FileUrl(_url) => {
-            // Placeholder until Task 3 wires the real FileUrlResolver.
-            Err(ResolveError::CalloutFailed {
-                file_id: "<file_url>".to_owned(),
-                detail: "file_url resolution not yet implemented".to_owned(),
-            })
-        },
+        ReferenceSource::FileId(file_id) => Err(ResolveError::CalloutFailed {
+            file_id: file_id.clone(),
+            detail: "overall file resolution deadline exceeded".to_owned(),
+        }),
+        ReferenceSource::FileUrl(url) => Err(ResolveError::FileUrlFailed {
+            label: url.clone(),
+            detail: "overall file resolution deadline exceeded".to_owned(),
+        }),
     }
 }
 
@@ -508,8 +501,7 @@ pub(crate) struct ResolvedFile {
     pub(super) filename: Option<String>,
 }
 
-/// Walk the Responses API `input` array and resolve all `file_id`
-/// references in place.
+/// Walk the Responses API `input` array and resolve all references in place.
 ///
 /// Returns the number of references resolved.
 #[cfg(test)]
@@ -518,36 +510,41 @@ pub(crate) async fn resolve_input(
     client: &FilesApiClient,
     on_missing: OnMissing,
     request_headers: &http::HeaderMap,
+    url_resolver: Option<&FileUrlResolver>,
 ) -> Result<usize, ResolveError> {
     let mut budget = client.resolution_budget();
-    resolve_input_with_budget(body, client, on_missing, request_headers, &mut budget).await
+    resolve_input_with_budget(body, client, on_missing, request_headers, url_resolver, &mut budget).await
 }
 
 /// Resolve request input using limits shared with other request state.
+#[expect(clippy::too_many_arguments, reason = "threading url_resolver through resolution")]
 pub(crate) async fn resolve_input_with_budget(
     body: &mut serde_json::Value,
     client: &FilesApiClient,
     on_missing: OnMissing,
     request_headers: &http::HeaderMap,
+    url_resolver: Option<&FileUrlResolver>,
     budget: &mut ResolutionBudget,
 ) -> Result<usize, ResolveError> {
     let Some(serde_json::Value::Array(input)) = body.get_mut("input") else {
         return Ok(0);
     };
 
-    resolve_items(input, client, on_missing, request_headers, budget).await
+    resolve_items(input, client, on_missing, request_headers, url_resolver, budget).await
 }
 
-/// Walk a slice of input/message items and resolve all `file_id`
-/// references in their content arrays.
+/// Walk a slice of input/message items and resolve all file references
+/// in their content arrays.
 ///
 /// Handles `message` items (with `content`), `function_call_output`
 /// items (with `output`), and the shorthand message form.
+#[expect(clippy::too_many_arguments, reason = "threading url_resolver through resolution")]
 pub(crate) async fn resolve_items(
     items: &mut [serde_json::Value],
     client: &FilesApiClient,
     on_missing: OnMissing,
     request_headers: &http::HeaderMap,
+    url_resolver: Option<&FileUrlResolver>,
     budget: &mut ResolutionBudget,
 ) -> Result<usize, ResolveError> {
     let mut resolved_count = 0_usize;
@@ -556,7 +553,7 @@ pub(crate) async fn resolve_items(
         client,
         on_missing,
         request_headers,
-        url_resolver: None,
+        url_resolver,
     };
 
     for item in items.iter_mut() {
@@ -600,35 +597,41 @@ pub(crate) fn content_parts_mut(item: &mut serde_json::Value) -> Option<&mut Vec
     }
 }
 
-/// Resolve a single content part if it contains a `file_id`.
+/// Resolve a single content part if it contains a resolvable reference.
 async fn resolve_content_part(
     part: &mut serde_json::Value,
     resolver: &mut ContentResolver<'_>,
 ) -> Result<Option<usize>, ResolveError> {
-    let Some((part_type, file_id)) = resolvable_reference(part) else {
+    let Some((part_type, source)) = resolvable_reference(part) else {
         return Ok(None);
     };
-    let (file_id, part_type) = (file_id.to_owned(), part_type.to_owned());
-    debug!(file_id = %file_id, part_type = %part_type, "resolving file reference");
+
+    // Skip file_url references when url_resolver is not configured.
+    if matches!(source, ReferenceSource::FileUrl(_)) && resolver.url_resolver.is_none() {
+        return Ok(None);
+    }
+
+    let (source, part_type) = (source, part_type.to_owned());
+    debug!(source = ?source, part_type = %part_type, "resolving file reference");
 
     let max_resolved_bytes = resolver.budget.remaining_resolved_bytes;
-    let Some(resolved) = resolve_reference(&file_id, &part_type, max_resolved_bytes, resolver).await? else {
+    let Some(resolved) = resolve_reference(&source, &part_type, max_resolved_bytes, resolver).await? else {
         return Ok(None);
     };
-    let len = output_len_for_part(&part_type, &resolved);
+    let len = output_len_for_part(&part_type, &source, &resolved);
     if len > max_resolved_bytes {
         return Err(ResolveError::TooLarge {
-            file_id,
+            file_id: format!("{source:?}"),
             limit: resolver.client.max_resolved_bytes,
         });
     }
-    rewrite_part(part, &part_type, resolved);
+    rewrite_part(part, &part_type, &source, resolved);
     Ok(Some(len))
 }
 
 /// Resolve one reference and apply the configured missing-file policy.
 async fn resolve_reference(
-    file_id: &str,
+    source: &ReferenceSource,
     part_type: &str,
     remaining_resolved_bytes: usize,
     resolver: &mut ContentResolver<'_>,
@@ -637,57 +640,112 @@ async fn resolve_reference(
         .budget
         .resolve(ResolutionRequest {
             client: resolver.client,
-            source: ReferenceSource::FileId(file_id.to_owned()),
+            source: source.clone(),
             max_resolved_bytes: remaining_resolved_bytes,
             part_type,
             request_headers: resolver.request_headers,
+            url_resolver: resolver.url_resolver,
         })
         .await
     {
         Ok(resolved) => Ok(Some(resolved)),
         Err(e @ ResolveError::TooManyReferences { .. }) => Err(e),
         Err(e) if resolver.on_missing == OnMissing::Continue => {
-            warn!(file_id = %file_id, error = %e, "file resolution failed, passing through");
+            warn!(source = ?source, error = %e, "file resolution failed, passing through");
             Ok(None)
         },
         Err(e) => Err(e),
     }
 }
 
-/// Return the type and file ID for a reference that needs resolution.
-fn resolvable_reference(part: &serde_json::Value) -> Option<(&str, &str)> {
-    let part_type @ ("input_file" | "input_image") = part.get("type")?.as_str()? else {
+/// Return the type and reference source for a part that needs resolution.
+///
+/// Classifies `input_file` parts by their single valid source field:
+/// `file_id` or `file_url`. Parts with multiple sources, no sources, or
+/// malformed (present, non-null, non-string) fields are skipped. Null
+/// values are treated as absent per the Responses schema.
+///
+/// `input_image` parts continue to resolve only via `file_id`.
+#[expect(clippy::too_many_lines, reason = "explicit field validation logic")]
+fn resolvable_reference(part: &serde_json::Value) -> Option<(&str, ReferenceSource)> {
+    let part_type @ "input_file" = part.get("type")?.as_str()? else {
+        // input_image file_id resolution is unchanged — keep the
+        // existing has_inline_content/file_id path for it.
+        if part.get("type")?.as_str()? == "input_image" {
+            return resolvable_image_reference(part);
+        }
         return None;
     };
-    if has_inline_content(part, part_type) {
+
+    // Count valid string sources and detect malformed (present, non-null,
+    // non-string) fields. Null is valid per the Responses schema and
+    // treated as absent.
+    let mut valid_sources = 0_u8;
+    let mut has_malformed = false;
+    let mut file_id: Option<&str> = None;
+    let mut file_url_str: Option<&str> = None;
+
+    for field in ["file_data", "file_id", "file_url"] {
+        if let Some(val) = part.get(field) {
+            if val.is_null() {
+                continue;
+            }
+            if let Some(s) = val.as_str() {
+                valid_sources += 1;
+                match field {
+                    "file_id" => file_id = Some(s),
+                    "file_url" => file_url_str = Some(s),
+                    _ => {},
+                }
+            } else {
+                has_malformed = true;
+            }
+        }
+    }
+
+    if has_malformed || valid_sources != 1 {
         return None;
     }
-    Some((part_type, part.get("file_id")?.as_str()?))
+
+    if let Some(url) = file_url_str {
+        return Some((part_type, ReferenceSource::FileUrl(url.to_owned())));
+    }
+    if let Some(id) = file_id {
+        return Some((part_type, ReferenceSource::FileId(id.to_owned())));
+    }
+    None
 }
 
-/// Return whether a content part already has a usable inline source.
-fn has_inline_content(part: &serde_json::Value, part_type: &str) -> bool {
-    match part_type {
-        "input_file" => ["file_data", "file_url"]
-            .into_iter()
-            .any(|field| part.get(field).and_then(serde_json::Value::as_str).is_some()),
-        "input_image" => part.get("image_url").and_then(serde_json::Value::as_str).is_some(),
-        _ => false,
+/// Existing `input_image` `file_id` resolution (unchanged behavior).
+fn resolvable_image_reference(part: &serde_json::Value) -> Option<(&'static str, ReferenceSource)> {
+    if part.get("image_url").and_then(serde_json::Value::as_str).is_some() {
+        return None;
     }
+    let file_id = part.get("file_id")?.as_str()?;
+    Some(("input_image", ReferenceSource::FileId(file_id.to_owned())))
 }
 
 /// Compute the JSON string length of the resolved value for a
-/// given content part type.
-fn output_len_for_part(part_type: &str, resolved: &ResolvedFile) -> usize {
-    match part_type {
-        "input_file" => resolved.base64.len(),
-        "input_image" => "data:".len() + resolved.content_type.len() + ";base64,".len() + resolved.base64.len(),
+/// given content part type and source.
+fn output_len_for_part(part_type: &str, source: &ReferenceSource, resolved: &ResolvedFile) -> usize {
+    match (part_type, source) {
+        ("input_file", ReferenceSource::FileId(_)) => resolved.base64.len(),
+        ("input_file", ReferenceSource::FileUrl(_)) => {
+            "data:".len() + resolved.content_type.len() + ";base64,".len() + resolved.base64.len()
+        },
+        ("input_image", _) => "data:".len() + resolved.content_type.len() + ";base64,".len() + resolved.base64.len(),
         _ => 0,
     }
 }
 
-/// Replace `file_id` with the resolved content in a content part.
-fn rewrite_part(part: &mut serde_json::Value, part_type: &str, resolved: ResolvedFile) {
+/// Replace the reference field with the resolved content in a content part.
+///
+/// For `input_file` with `FileId`, writes raw base64 to `file_data`.
+/// For `input_file` with `FileUrl`, writes a data URI to `file_data`.
+/// For `input_image`, writes a `data:` URL to `image_url`.
+/// Populates `filename` from metadata when not already user-provided.
+#[expect(clippy::too_many_lines, reason = "explicit branching per part type and source")]
+fn rewrite_part(part: &mut serde_json::Value, part_type: &str, source: &ReferenceSource, resolved: ResolvedFile) {
     let Some(obj) = part.as_object_mut() else {
         return;
     };
@@ -696,17 +754,31 @@ fn rewrite_part(part: &mut serde_json::Value, part_type: &str, resolved: Resolve
         content_type,
         filename,
     } = resolved;
-    obj.remove("file_id");
-    match part_type {
-        "input_file" => {
+
+    match source {
+        ReferenceSource::FileId(_) => {
+            obj.remove("file_id");
+        },
+        ReferenceSource::FileUrl(_) => {
+            obj.remove("file_url");
+        },
+    }
+
+    match (part_type, source) {
+        ("input_file", ReferenceSource::FileId(_)) => {
             obj.insert("file_data".to_owned(), serde_json::Value::String(base64));
-            if !obj.contains_key("filename")
-                && let Some(filename) = filename
-            {
+            if !obj.contains_key("filename") && let Some(filename) = filename {
                 obj.insert("filename".to_owned(), serde_json::Value::String(filename));
             }
         },
-        "input_image" => {
+        ("input_file", ReferenceSource::FileUrl(_)) => {
+            let data_uri = format!("data:{content_type};base64,{base64}");
+            obj.insert("file_data".to_owned(), serde_json::Value::String(data_uri));
+            if !obj.contains_key("filename") && let Some(filename) = filename {
+                obj.insert("filename".to_owned(), serde_json::Value::String(filename));
+            }
+        },
+        ("input_image", _) => {
             let prefix = format!("data:{content_type};base64,");
             base64.insert_str(0, &prefix);
             obj.insert("image_url".to_owned(), serde_json::Value::String(base64));
@@ -1012,7 +1084,7 @@ mod tests {
                 "content": [{"type": "input_file", "file_id": ".."}]
             }]
         });
-        let err = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+        let err = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
             .await
             .unwrap_err();
 
@@ -1033,7 +1105,7 @@ mod tests {
             }]
         });
 
-        let err = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+        let err = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
             .await
             .unwrap_err();
 
@@ -1055,7 +1127,7 @@ mod tests {
         });
         let original = body.clone();
 
-        let resolved = resolve_input(&mut body, &client, OnMissing::Continue, &http::HeaderMap::new())
+        let resolved = resolve_input(&mut body, &client, OnMissing::Continue, &http::HeaderMap::new(), None)
             .await
             .unwrap();
 
@@ -1089,7 +1161,7 @@ mod tests {
             }]
         });
 
-        let err = resolve_input(&mut body, &client, OnMissing::Continue, &http::HeaderMap::new())
+        let err = resolve_input(&mut body, &client, OnMissing::Continue, &http::HeaderMap::new(), None)
             .await
             .unwrap_err();
 
@@ -1120,7 +1192,7 @@ mod tests {
             }]
         });
 
-        let count = resolve_input(&mut body, &client, OnMissing::Continue, &http::HeaderMap::new())
+        let count = resolve_input(&mut body, &client, OnMissing::Continue, &http::HeaderMap::new(), None)
             .await
             .unwrap();
 
@@ -1163,7 +1235,15 @@ mod tests {
         budget: &mut ResolutionBudget,
     ) -> Result<usize, ResolveError> {
         let mut items = cached_file_items();
-        resolve_items(&mut items, client, OnMissing::Reject, &http::HeaderMap::new(), budget).await
+        resolve_items(
+            &mut items,
+            client,
+            OnMissing::Reject,
+            &http::HeaderMap::new(),
+            None,
+            budget,
+        )
+        .await
     }
 
     fn cached_file_items() -> Vec<serde_json::Value> {
@@ -1194,7 +1274,7 @@ mod tests {
             });
             let original = body.clone();
 
-            let resolved = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+            let resolved = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
                 .await
                 .unwrap();
 
@@ -1214,7 +1294,7 @@ mod tests {
                 "content": [{"type": "input_file", "file_id": ".."}]
             }]
         });
-        let resolved = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+        let resolved = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
             .await
             .unwrap();
 
@@ -1239,7 +1319,7 @@ mod tests {
             }]
         });
         let original = body.clone();
-        let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+        let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
             .await
             .unwrap();
 
@@ -1262,7 +1342,7 @@ mod tests {
             }]
         });
         let original = body.clone();
-        let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+        let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
             .await
             .unwrap();
 
@@ -1285,7 +1365,7 @@ mod tests {
             }]
         });
         let original = body.clone();
-        let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new())
+        let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
             .await
             .unwrap();
 
@@ -1305,7 +1385,12 @@ mod tests {
             content_type: "image/png".to_owned(),
             filename: None,
         };
-        rewrite_part(&mut part, "input_image", resolved);
+        rewrite_part(
+            &mut part,
+            "input_image",
+            &ReferenceSource::FileId("img-456".to_owned()),
+            resolved,
+        );
 
         assert!(part.get("file_id").is_none(), "file_id should be removed");
         assert_eq!(part["detail"].as_str().unwrap(), "high", "detail should be preserved");
@@ -1330,7 +1415,12 @@ mod tests {
             content_type: "application/pdf".to_owned(),
             filename: Some("api-filename.pdf".to_owned()),
         };
-        rewrite_part(&mut part, "input_file", resolved);
+        rewrite_part(
+            &mut part,
+            "input_file",
+            &ReferenceSource::FileId("file-abc".to_owned()),
+            resolved,
+        );
 
         assert_eq!(
             part["filename"].as_str().unwrap(),
@@ -1350,7 +1440,12 @@ mod tests {
             content_type: "text/plain".to_owned(),
             filename: Some("test.txt".to_owned()),
         };
-        rewrite_part(&mut part, "input_file", resolved);
+        rewrite_part(
+            &mut part,
+            "input_file",
+            &ReferenceSource::FileId("file-abc".to_owned()),
+            resolved,
+        );
 
         assert_eq!(
             part["filename"].as_str().unwrap(),
@@ -1375,5 +1470,75 @@ mod tests {
             "FileUrl key should be distinct from FileId"
         );
         assert_eq!(cache.len(), 2, "two distinct keys should produce two entries");
+    }
+
+    // -------------------------------------------------------------------------
+    // Source classification tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn resolvable_reference_file_url_only() {
+        let part = serde_json::json!({"type": "input_file", "file_url": "https://example.com/file.pdf"});
+        let result = resolvable_reference(&part);
+        assert!(
+            matches!(result, Some(("input_file", ReferenceSource::FileUrl(url))) if url == "https://example.com/file.pdf"),
+            "file_url-only part should be classified as FileUrl"
+        );
+    }
+
+    #[test]
+    fn resolvable_reference_file_id_only() {
+        let part = serde_json::json!({"type": "input_file", "file_id": "file-abc"});
+        let result = resolvable_reference(&part);
+        assert!(
+            matches!(result, Some(("input_file", ReferenceSource::FileId(id))) if id == "file-abc"),
+            "file_id-only part should be classified as FileId"
+        );
+    }
+
+    #[test]
+    fn resolvable_reference_multi_source_skipped() {
+        let part = serde_json::json!({"type": "input_file", "file_id": "abc", "file_url": "https://example.com/f"});
+        assert!(
+            resolvable_reference(&part).is_none(),
+            "multi-source parts should be skipped"
+        );
+    }
+
+    #[test]
+    fn resolvable_reference_file_data_skipped() {
+        let part = serde_json::json!({"type": "input_file", "file_data": "SGVsbG8="});
+        assert!(
+            resolvable_reference(&part).is_none(),
+            "file_data-only parts should be skipped"
+        );
+    }
+
+    #[test]
+    fn resolvable_reference_malformed_non_string_file_url_skipped() {
+        let part = serde_json::json!({"type": "input_file", "file_url": 123, "file_id": "valid-id"});
+        assert!(
+            resolvable_reference(&part).is_none(),
+            "non-string file_url should mark part malformed, skipping even valid file_id"
+        );
+    }
+
+    #[test]
+    fn resolvable_reference_null_file_url_treated_as_absent() {
+        let part = serde_json::json!({"type": "input_file", "file_url": null, "file_id": "valid-id"});
+        let result = resolvable_reference(&part);
+        assert!(
+            matches!(result, Some(("input_file", ReferenceSource::FileId(id))) if id == "valid-id"),
+            "null file_url should be treated as absent, resolving file_id normally"
+        );
+    }
+
+    #[test]
+    fn resolvable_reference_non_string_file_data_marks_malformed() {
+        let part = serde_json::json!({"type": "input_file", "file_data": 42});
+        assert!(
+            resolvable_reference(&part).is_none(),
+            "non-string file_data should mark part malformed"
+        );
     }
 }

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -441,6 +441,32 @@ impl FilesApiClient {
     }
 }
 
+/// Read a response body in chunks, enforcing a size limit.
+pub(super) async fn read_bounded_body(
+    mut response: reqwest::Response,
+    file_id: &str,
+    max_content_bytes: usize,
+    limit: usize,
+) -> Result<Vec<u8>, ResolveError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| ResolveError::CalloutFailed {
+        file_id: file_id.to_owned(),
+        detail: if e.is_timeout() {
+            "content download timed out".to_owned()
+        } else {
+            format!("content download read error: {e}")
+        },
+    })? {
+        if body.len() + chunk.len() > max_content_bytes {
+            return Err(ResolveError::TooLarge {
+                file_id: file_id.to_owned(),
+                limit,
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
 /// Extract content type and reported size from a Files API
 /// metadata response.
 fn parse_file_metadata(body: &serde_json::Value) -> FileMetadata {
@@ -477,11 +503,11 @@ struct FileMetadata {
 #[derive(Clone)]
 pub(crate) struct ResolvedFile {
     /// Base64-encoded file content (no `data:` prefix).
-    base64: String,
+    pub(super) base64: String,
     /// MIME content type (e.g. `text/plain`).
-    content_type: String,
+    pub(super) content_type: String,
     /// Original filename from the Files API metadata.
-    filename: Option<String>,
+    pub(super) filename: Option<String>,
 }
 
 /// Walk the Responses API `input` array and resolve all `file_id`
@@ -699,7 +725,7 @@ fn max_content_bytes_for_base64(max_output_bytes: usize) -> usize {
 
 /// Maximum raw file bytes that can fit in a data URL with base64
 /// expansion.
-fn max_content_bytes_for_data_url(max_data_url_bytes: usize, content_type: &str) -> Option<usize> {
+pub(super) fn max_content_bytes_for_data_url(max_data_url_bytes: usize, content_type: &str) -> Option<usize> {
     let prefix_len = "data:"
         .len()
         .checked_add(content_type.len())?

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -22,11 +22,21 @@ use std::collections::HashMap;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use tracing::{debug, warn};
 
-use super::config::OnMissing;
+use super::{config::OnMissing, resolve_url::FileUrlResolver};
 use crate::openai::api_client::{ApiClient, ApiClientError};
 
 /// Files API path prefix used in resource URL construction.
 const FILES_PATH_PREFIX: &str = "v1/files";
+
+/// Identifies the source of a file reference for dispatch and caching.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(not(test), expect(dead_code, reason = "FileUrl variant used in Task 4"))]
+pub(crate) enum ReferenceSource {
+    /// Files API `file_id` reference.
+    FileId(String),
+    /// Remote `file_url` reference.
+    FileUrl(String),
+}
 
 /// Errors that can occur during file resolution.
 #[derive(Debug, Clone)]
@@ -60,6 +70,22 @@ pub(crate) enum ResolveError {
         /// Maximum allowed resolved size in bytes.
         limit: usize,
     },
+
+    /// The file URL target is blocked by SSRF policy.
+    #[cfg_attr(not(test), expect(dead_code, reason = "Used in Task 3"))]
+    FileUrlBlocked {
+        /// Redacted URL label for client-facing messages.
+        label: String,
+    },
+
+    /// The file URL fetch failed (DNS, timeout, non-success status).
+    #[cfg_attr(not(test), expect(dead_code, reason = "Used in Task 3"))]
+    FileUrlFailed {
+        /// Redacted URL label for client-facing messages.
+        label: String,
+        /// Human-readable error description.
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for ResolveError {
@@ -76,6 +102,12 @@ impl std::fmt::Display for ResolveError {
             },
             Self::TooLarge { file_id, limit } => {
                 write!(f, "resolved file '{file_id}' exceeds configured limit ({limit} bytes)")
+            },
+            Self::FileUrlBlocked { label } => {
+                write!(f, "file URL '{label}' blocked by security policy")
+            },
+            Self::FileUrlFailed { label, detail } => {
+                write!(f, "file URL fetch failed for '{label}': {detail}")
             },
         }
     }
@@ -123,8 +155,8 @@ pub(crate) struct FilesApiClient {
 
 /// Request-scoped limits and cached resolution outcomes.
 pub(crate) struct ResolutionBudget {
-    /// Resolutions cached by content part type and file ID.
-    cache: HashMap<(String, String), Result<ResolvedFile, ResolveError>>,
+    /// Resolutions cached by content part type and reference source.
+    cache: HashMap<(String, ReferenceSource), Result<ResolvedFile, ResolveError>>,
     /// Deadline shared by every Files API callout in the request.
     deadline: tokio::time::Instant,
     /// Maximum file references allowed for this request.
@@ -160,8 +192,8 @@ pub(crate) struct FilesApiClientOptions {
 struct ResolutionRequest<'a> {
     /// Files API client.
     client: &'a FilesApiClient,
-    /// Referenced file ID.
-    file_id: &'a str,
+    /// Reference source (file ID or file URL).
+    source: ReferenceSource,
     /// Maximum resolved bytes remaining for this item collection.
     max_resolved_bytes: usize,
     /// Responses content part type.
@@ -180,6 +212,9 @@ struct ContentResolver<'a> {
     on_missing: OnMissing,
     /// Original request headers available for forwarding.
     request_headers: &'a http::HeaderMap,
+    /// URL resolver for `file_url` references.
+    #[expect(dead_code, reason = "Wired in Task 4")]
+    url_resolver: Option<&'a FileUrlResolver>,
 }
 
 impl ResolutionBudget {
@@ -205,24 +240,29 @@ impl ResolutionBudget {
     async fn resolve(&mut self, request: ResolutionRequest<'_>) -> Result<ResolvedFile, ResolveError> {
         let ResolutionRequest {
             client,
-            file_id,
+            source,
             max_resolved_bytes,
             part_type,
             request_headers,
         } = request;
-        let key = (part_type.to_owned(), file_id.to_owned());
+        let key = (part_type.to_owned(), source.clone());
         if let Some(cached) = self.cache.get(&key) {
             return cached.clone();
         }
 
         self.register_reference()?;
 
-        let resolution = tokio::time::timeout_at(
+        let resolution = dispatch_resolution(
+            &source,
+            client,
+            request_headers,
+            max_resolved_bytes,
+            part_type,
             self.deadline,
-            client.resolve_file(file_id, request_headers, max_resolved_bytes, part_type),
         )
-        .await
-        .unwrap_or_else(|_elapsed| overall_timeout_error(file_id));
+        .await;
+        // Retain one owned outcome for repeated references while
+        // returning an independently owned value to the JSON part.
         self.cache.insert(key, resolution.clone());
         resolution
     }
@@ -257,6 +297,33 @@ fn overall_timeout_error(file_id: &str) -> Result<ResolvedFile, ResolveError> {
         file_id: file_id.to_owned(),
         detail: "overall file resolution deadline exceeded".to_owned(),
     })
+}
+
+/// Dispatch one reference to the appropriate resolver backend.
+#[expect(clippy::too_many_arguments, reason = "Task 4 will refactor this")]
+async fn dispatch_resolution(
+    source: &ReferenceSource,
+    client: &FilesApiClient,
+    request_headers: &http::HeaderMap,
+    max_resolved_bytes: usize,
+    part_type: &str,
+    deadline: tokio::time::Instant,
+) -> Result<ResolvedFile, ResolveError> {
+    match source {
+        ReferenceSource::FileId(file_id) => tokio::time::timeout_at(
+            deadline,
+            client.resolve_file(file_id, request_headers, max_resolved_bytes, part_type),
+        )
+        .await
+        .unwrap_or_else(|_elapsed| overall_timeout_error(file_id)),
+        ReferenceSource::FileUrl(_url) => {
+            // Placeholder until Task 3 wires the real FileUrlResolver.
+            Err(ResolveError::CalloutFailed {
+                file_id: "<file_url>".to_owned(),
+                detail: "file_url resolution not yet implemented".to_owned(),
+            })
+        },
+    }
 }
 
 impl FilesApiClient {
@@ -465,6 +532,7 @@ pub(crate) async fn resolve_items(
         client,
         on_missing,
         request_headers,
+        url_resolver: None,
     };
 
     for item in items.iter_mut() {
@@ -545,7 +613,7 @@ async fn resolve_reference(
         .budget
         .resolve(ResolutionRequest {
             client: resolver.client,
-            file_id,
+            source: ReferenceSource::FileId(file_id.to_owned()),
             max_resolved_bytes: remaining_resolved_bytes,
             part_type,
             request_headers: resolver.request_headers,
@@ -1040,7 +1108,10 @@ mod tests {
         let client = test_client_with_limits("http://files-api:8321", 8, 1_000);
         let mut budget = client.resolution_budget();
         budget.cache.insert(
-            ("input_file".to_owned(), "file-cached".to_owned()),
+            (
+                "input_file".to_owned(),
+                ReferenceSource::FileId("file-cached".to_owned()),
+            ),
             Ok(ResolvedFile {
                 base64: "ZGF0".to_owned(),
                 content_type: "text/plain".to_owned(),
@@ -1262,5 +1333,23 @@ mod tests {
             "test.txt",
             "filename should be populated from metadata when not provided by user"
         );
+    }
+
+    #[test]
+    fn reference_source_file_id_and_file_url_are_distinct_cache_keys() {
+        use std::collections::HashMap;
+
+        let mut cache = HashMap::new();
+        let key_id = ("input_file".to_owned(), ReferenceSource::FileId("abc".to_owned()));
+        let key_url = ("input_file".to_owned(), ReferenceSource::FileUrl("abc".to_owned()));
+        cache.insert(key_id.clone(), "from_id");
+        cache.insert(key_url.clone(), "from_url");
+
+        assert_eq!(cache[&key_id], "from_id", "FileId key should be distinct from FileUrl");
+        assert_eq!(
+            cache[&key_url], "from_url",
+            "FileUrl key should be distinct from FileId"
+        );
+        assert_eq!(cache.len(), 2, "two distinct keys should produce two entries");
     }
 }

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -22,7 +22,10 @@ use std::collections::HashMap;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use tracing::{debug, warn};
 
-use super::{config::OnMissing, resolve_url::FileUrlResolver};
+use super::{
+    config::OnMissing,
+    resolve_url::{FileUrlResolver, redact_url},
+};
 use crate::openai::api_client::{ApiClient, ApiClientError};
 
 /// Files API path prefix used in resource URL construction.
@@ -41,7 +44,7 @@ impl std::fmt::Display for ReferenceSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::FileId(id) => write!(f, "{id}"),
-            Self::FileUrl(url) => write!(f, "{url}"),
+            Self::FileUrl(url) => write!(f, "{}", redact_url(url)),
         }
     }
 }
@@ -271,7 +274,7 @@ impl ResolutionBudget {
                 ReferenceSource::FileUrl(url) => {
                     let Some(resolver) = url_resolver else {
                         return Err(ResolveError::FileUrlFailed {
-                            label: url.clone(),
+                            label: redact_url(url),
                             detail: "file URL resolution not configured".to_owned(),
                         });
                     };
@@ -320,7 +323,7 @@ fn overall_timeout_error_for_source(source: &ReferenceSource) -> Result<Resolved
             detail: "overall file resolution deadline exceeded".to_owned(),
         }),
         ReferenceSource::FileUrl(url) => Err(ResolveError::FileUrlFailed {
-            label: url.clone(),
+            label: redact_url(url),
             detail: "overall file resolution deadline exceeded".to_owned(),
         }),
     }
@@ -658,7 +661,7 @@ async fn resolve_reference(
         .await
     {
         Ok(resolved) => Ok(Some(resolved)),
-        Err(e @ ResolveError::TooManyReferences { .. }) => Err(e),
+        Err(e @ (ResolveError::TooManyReferences { .. } | ResolveError::FileUrlBlocked { .. })) => Err(e),
         Err(e) if resolver.on_missing == OnMissing::Continue => {
             warn!(source = %source, error = %e, "file resolution failed, passing through");
             Ok(None)

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -37,6 +37,15 @@ pub(crate) enum ReferenceSource {
     FileUrl(String),
 }
 
+impl std::fmt::Display for ReferenceSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FileId(id) => write!(f, "{id}"),
+            Self::FileUrl(url) => write!(f, "{url}"),
+        }
+    }
+}
+
 /// Errors that can occur during file resolution.
 #[derive(Debug, Clone)]
 pub(crate) enum ResolveError {
@@ -612,7 +621,7 @@ async fn resolve_content_part(
     }
 
     let (source, part_type) = (source, part_type.to_owned());
-    debug!(source = ?source, part_type = %part_type, "resolving file reference");
+    debug!(source = %source, part_type = %part_type, "resolving file reference");
 
     let max_resolved_bytes = resolver.budget.remaining_resolved_bytes;
     let Some(resolved) = resolve_reference(&source, &part_type, max_resolved_bytes, resolver).await? else {
@@ -621,7 +630,7 @@ async fn resolve_content_part(
     let len = output_len_for_part(&part_type, &source, &resolved);
     if len > max_resolved_bytes {
         return Err(ResolveError::TooLarge {
-            file_id: format!("{source:?}"),
+            file_id: source.to_string(),
             limit: resolver.client.max_resolved_bytes,
         });
     }
@@ -651,7 +660,7 @@ async fn resolve_reference(
         Ok(resolved) => Ok(Some(resolved)),
         Err(e @ ResolveError::TooManyReferences { .. }) => Err(e),
         Err(e) if resolver.on_missing == OnMissing::Continue => {
-            warn!(source = ?source, error = %e, "file resolution failed, passing through");
+            warn!(source = %source, error = %e, "file resolution failed, passing through");
             Ok(None)
         },
         Err(e) => Err(e),
@@ -767,14 +776,18 @@ fn rewrite_part(part: &mut serde_json::Value, part_type: &str, source: &Referenc
     match (part_type, source) {
         ("input_file", ReferenceSource::FileId(_)) => {
             obj.insert("file_data".to_owned(), serde_json::Value::String(base64));
-            if !obj.contains_key("filename") && let Some(filename) = filename {
+            if !obj.contains_key("filename")
+                && let Some(filename) = filename
+            {
                 obj.insert("filename".to_owned(), serde_json::Value::String(filename));
             }
         },
         ("input_file", ReferenceSource::FileUrl(_)) => {
             let data_uri = format!("data:{content_type};base64,{base64}");
             obj.insert("file_data".to_owned(), serde_json::Value::String(data_uri));
-            if !obj.contains_key("filename") && let Some(filename) = filename {
+            if !obj.contains_key("filename")
+                && let Some(filename) = filename
+            {
                 obj.insert("filename".to_owned(), serde_json::Value::String(filename));
             }
         },

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -76,8 +76,8 @@ pub(crate) enum ResolveError {
 
     /// Resolved content would exceed the configured body limit.
     TooLarge {
-        /// The file ID that was requested.
-        file_id: String,
+        /// Redacted file reference label.
+        reference: String,
         /// Maximum allowed resolved size in bytes.
         limit: usize,
     },
@@ -109,8 +109,11 @@ impl std::fmt::Display for ResolveError {
             Self::TooManyReferences { limit } => {
                 write!(f, "request exceeds configured file reference limit ({limit})")
             },
-            Self::TooLarge { file_id, limit } => {
-                write!(f, "resolved file '{file_id}' exceeds configured limit ({limit} bytes)")
+            Self::TooLarge { reference, limit } => {
+                write!(
+                    f,
+                    "resolved file reference '{reference}' exceeds configured limit ({limit} bytes)"
+                )
             },
             Self::FileUrlBlocked { label } => {
                 write!(f, "file URL '{label}' blocked by security policy")
@@ -135,7 +138,7 @@ fn map_api_error(err: ApiClientError, file_id: &str) -> ResolveError {
             detail,
         },
         ApiClientError::ResponseTooLarge { limit } => ResolveError::TooLarge {
-            file_id: file_id.to_owned(),
+            reference: file_id.to_owned(),
             limit,
         },
         ApiClientError::DecodeFailed { detail } => ResolveError::CalloutFailed {
@@ -308,7 +311,7 @@ impl ResolutionBudget {
             self.remaining_resolved_bytes
                 .checked_sub(bytes)
                 .ok_or_else(|| ResolveError::TooLarge {
-                    file_id: "<aggregate>".to_owned(),
+                    reference: "<aggregate>".to_owned(),
                     limit,
                 })?;
         Ok(())
@@ -396,7 +399,7 @@ impl FilesApiClient {
             .await
             .map_err(|e| match e {
                 ApiClientError::ResponseTooLarge { .. } => ResolveError::TooLarge {
-                    file_id: file_id.to_owned(),
+                    reference: file_id.to_owned(),
                     limit: max_resolved_bytes,
                 },
                 other => map_api_error(other, file_id),
@@ -418,7 +421,7 @@ impl FilesApiClient {
             _ => Some(max_content_bytes_for_base64(max_resolved_bytes)),
         }
         .ok_or_else(|| ResolveError::TooLarge {
-            file_id: file_id.to_owned(),
+            reference: file_id.to_owned(),
             limit: max_resolved_bytes,
         })?;
         if metadata
@@ -426,7 +429,7 @@ impl FilesApiClient {
             .is_some_and(|b| usize::try_from(b).unwrap_or(usize::MAX) > max_content_bytes)
         {
             return Err(ResolveError::TooLarge {
-                file_id: file_id.to_owned(),
+                reference: file_id.to_owned(),
                 limit: max_resolved_bytes,
             });
         }
@@ -444,32 +447,6 @@ impl FilesApiClient {
     }
 }
 
-/// Read a response body in chunks, enforcing a size limit.
-pub(super) async fn read_bounded_body(
-    mut response: reqwest::Response,
-    file_id: &str,
-    max_content_bytes: usize,
-    limit: usize,
-) -> Result<Vec<u8>, ResolveError> {
-    let mut body = Vec::new();
-    while let Some(chunk) = response.chunk().await.map_err(|e| ResolveError::CalloutFailed {
-        file_id: file_id.to_owned(),
-        detail: if e.is_timeout() {
-            "content download timed out".to_owned()
-        } else {
-            format!("content download read error: {e}")
-        },
-    })? {
-        if body.len() + chunk.len() > max_content_bytes {
-            return Err(ResolveError::TooLarge {
-                file_id: file_id.to_owned(),
-                limit,
-            });
-        }
-        body.extend_from_slice(&chunk);
-    }
-    Ok(body)
-}
 /// Extract content type and reported size from a Files API
 /// metadata response.
 fn parse_file_metadata(body: &serde_json::Value) -> FileMetadata {
@@ -633,7 +610,7 @@ async fn resolve_content_part(
     let len = output_len_for_part(&part_type, &source, &resolved);
     if len > max_resolved_bytes {
         return Err(ResolveError::TooLarge {
-            file_id: source.to_string(),
+            reference: source.to_string(),
             limit: resolver.client.max_resolved_bytes,
         });
     }
@@ -919,12 +896,12 @@ mod tests {
     #[test]
     fn resolve_error_display_too_large() {
         let err = ResolveError::TooLarge {
-            file_id: "file-abc".to_owned(),
+            reference: "file-abc".to_owned(),
             limit: 1024,
         };
         assert_eq!(
             err.to_string(),
-            "resolved file 'file-abc' exceeds configured limit (1024 bytes)",
+            "resolved file reference 'file-abc' exceeds configured limit (1024 bytes)",
             "TooLarge display should format correctly"
         );
     }

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -72,14 +72,12 @@ pub(crate) enum ResolveError {
     },
 
     /// The file URL target is blocked by SSRF policy.
-    #[cfg_attr(not(test), expect(dead_code, reason = "Used in Task 3"))]
     FileUrlBlocked {
         /// Redacted URL label for client-facing messages.
         label: String,
     },
 
     /// The file URL fetch failed (DNS, timeout, non-success status).
-    #[cfg_attr(not(test), expect(dead_code, reason = "Used in Task 3"))]
     FileUrlFailed {
         /// Redacted URL label for client-facing messages.
         label: String,

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -239,11 +239,32 @@ fn is_valid_mime_type(s: &str) -> bool {
         && subtype.chars().all(is_data_uri_safe_token)
 }
 
+/// Extract the embedded IPv4 from a NAT64 Well-Known Prefix (`64:ff9b::/96`).
+fn nat64_embedded_ipv4(v6: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+    let s = v6.segments();
+    (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0).then(|| {
+        let [.., a, b, c, d] = v6.octets();
+        std::net::Ipv4Addr::new(a, b, c, d)
+    })
+}
+
 /// Check if an IP should be blocked for `file_url` fetches.
 pub(crate) fn is_file_url_ssrf_blocked(ip: &IpAddr, allow_private: bool) -> bool {
     let ip = &normalize_mapped_ipv4(*ip);
     if is_unconditionally_blocked(ip) {
         return true;
+    }
+    // RFC 6052: apply IPv4 policy to the embedded address in 64:ff9b::/96
+    if let IpAddr::V6(v6) = ip
+        && let Some(v4) = nat64_embedded_ipv4(v6)
+    {
+        let embedded = IpAddr::V4(v4);
+        if is_unconditionally_blocked(&embedded) {
+            return true;
+        }
+        if !allow_private && is_private_range(&embedded) {
+            return true;
+        }
     }
     if !allow_private && is_private_range(ip) {
         return true;
@@ -302,36 +323,97 @@ pub(crate) fn validate_file_url(raw: &str) -> Result<url::Url, ResolveError> {
     Ok(url)
 }
 
-/// Extract filename from a `Content-Disposition` header value.
+/// Extract filename from a `Content-Disposition` header value (RFC 6266).
 ///
-/// Handles both `filename*=UTF-8''encoded` (RFC 5987) and `filename="quoted"` forms.
+/// `filename*` (RFC 5987) always takes precedence over `filename` regardless
+/// of parameter order. Parameter names are matched case-insensitively.
+/// Quoted values may contain embedded semicolons.
 fn parse_content_disposition_filename(header: &str) -> Option<String> {
-    for part in header.split(';').skip(1) {
-        let part = part.trim();
-        // RFC 5987 extended notation: filename*=UTF-8''percent-encoded
-        if let Some(rest) = part.strip_prefix("filename*=") {
-            let rest = rest.trim();
-            if let Some(encoded) = rest.split_once("''").map(|(_, v)| v) {
-                let decoded = percent_decode_utf8(encoded);
-                if !decoded.is_empty() {
-                    return Some(decoded);
-                }
-            }
+    let params = split_header_params(header);
+    // First pass: prefer filename* (RFC 5987 extended notation)
+    for (name, value) in &params {
+        if name.eq_ignore_ascii_case("filename*")
+            && let Some(decoded) = decode_rfc5987(value)
+            && !decoded.is_empty()
+        {
+            return Some(decoded);
         }
-        // Standard: filename="value" or filename=value
-        if let Some(rest) = part.strip_prefix("filename=") {
-            let rest = rest.trim();
-            let value = if rest.starts_with('"') && rest.ends_with('"') && rest.len() >= 2 {
-                rest.strip_prefix('"').and_then(|s| s.strip_suffix('"')).unwrap_or(rest)
-            } else {
-                rest
-            };
-            if !value.is_empty() {
-                return Some(value.to_owned());
+    }
+    // Second pass: fall back to filename
+    for (name, value) in &params {
+        if name.eq_ignore_ascii_case("filename") {
+            let unquoted = unquote(value);
+            if !unquoted.is_empty() {
+                return Some(unquoted);
             }
         }
     }
     None
+}
+
+/// Split a header value into `(name, value)` parameter pairs, respecting
+/// quoted strings so that semicolons inside quotes do not split.
+fn split_header_params(header: &str) -> Vec<(String, String)> {
+    split_on_unquoted_semicolons(header)
+        .into_iter()
+        .skip(1)
+        .filter_map(|seg| {
+            let seg = seg.trim();
+            let (name, value) = seg.split_once('=')?;
+            let name = name.trim();
+            (!name.is_empty()).then(|| (name.to_owned(), value.trim().to_owned()))
+        })
+        .collect()
+}
+
+/// Split on `;` outside of double-quoted strings.
+fn split_on_unquoted_semicolons(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quote = false;
+    let mut prev_backslash = false;
+    for (i, c) in s.char_indices() {
+        if prev_backslash {
+            prev_backslash = false;
+            continue;
+        }
+        match c {
+            '\\' if in_quote => prev_backslash = true,
+            '"' => in_quote = !in_quote,
+            ';' if !in_quote => {
+                parts.push(s.get(start..i).unwrap_or_default());
+                start = i + 1;
+            },
+            _ => {},
+        }
+    }
+    parts.push(s.get(start..).unwrap_or_default());
+    parts
+}
+
+/// Decode an RFC 5987 `charset'language'percent-encoded` value.
+fn decode_rfc5987(raw: &str) -> Option<String> {
+    let (_, after_charset) = raw.split_once('\'')?;
+    let (_, encoded) = after_charset.split_once('\'')?;
+    Some(percent_decode_utf8(encoded))
+}
+
+/// Strip surrounding double-quotes and unescape backslash-escaped characters.
+fn unquote(s: &str) -> String {
+    let s = s.trim();
+    let inner = s.strip_prefix('"').and_then(|s| s.strip_suffix('"')).unwrap_or(s);
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(escaped) = chars.next() {
+                out.push(escaped);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Percent-decode a UTF-8 string, replacing invalid sequences with `_`.
@@ -1300,6 +1382,59 @@ mod tests {
         );
     }
 
+    // NAT64 Well-Known Prefix (64:ff9b::/96) — embedded IPv4 policy (RFC 6052)
+    #[test]
+    fn ssrf_blocks_nat64_embedded_metadata() {
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::a9fe:a9fe".parse().unwrap(), false),
+            "64:ff9b::169.254.169.254 embeds cloud metadata"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_nat64_embedded_loopback() {
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::7f00:1".parse().unwrap(), false),
+            "64:ff9b::127.0.0.1 embeds loopback"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_nat64_embedded_private() {
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::c0a8:1".parse().unwrap(), false),
+            "64:ff9b::192.168.0.1 embeds private range"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::a9fe:aa02".parse().unwrap(), false),
+            "64:ff9b::169.254.170.2 embeds ECS credential endpoint"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_nat64_embedded_public() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"64:ff9b::808:808".parse().unwrap(), false),
+            "64:ff9b::8.8.8.8 embeds public DNS, should be allowed"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_nat64_embedded_private_with_allowlist() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"64:ff9b::c0a8:1".parse().unwrap(), true),
+            "64:ff9b::192.168.0.1 should be allowed with allowlist override"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_nat64_embedded_metadata_even_with_allowlist() {
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::a9fe:a9fe".parse().unwrap(), true),
+            "cloud metadata via NAT64 is unconditionally blocked"
+        );
+    }
+
     // Allowlist override
     #[test]
     fn ssrf_allows_special_use_with_allowlist() {
@@ -1593,6 +1728,47 @@ mod tests {
             parse_content_disposition_filename("attachment; filename*=UTF-8''correct.pdf; filename=\"fallback.pdf\""),
             Some("correct.pdf".to_owned()),
             "filename* should take precedence over filename"
+        );
+    }
+
+    #[test]
+    fn content_disposition_plain_before_star() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"fallback.pdf\"; filename*=UTF-8''correct.pdf"),
+            Some("correct.pdf".to_owned()),
+            "filename* should win even when filename appears first"
+        );
+    }
+
+    #[test]
+    fn content_disposition_case_insensitive() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; FILENAME=\"report.pdf\""),
+            Some("report.pdf".to_owned()),
+            "parameter names should be case-insensitive"
+        );
+        assert_eq!(
+            parse_content_disposition_filename("attachment; FileName*=UTF-8''r%C3%A9sum%C3%A9.pdf"),
+            Some("résumé.pdf".to_owned()),
+            "filename* should be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn content_disposition_non_empty_language_tag() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename*=UTF-8'en'actual.pdf"),
+            Some("actual.pdf".to_owned()),
+            "non-empty language tag should be accepted"
+        );
+    }
+
+    #[test]
+    fn content_disposition_quoted_semicolon() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"file;name.pdf\""),
+            Some("file;name.pdf".to_owned()),
+            "semicolons inside quotes should not split the value"
         );
     }
 

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -164,8 +164,12 @@ fn is_site_local_v6(v6: &std::net::Ipv6Addr) -> bool {
 fn is_special_use_v4(ip: std::net::Ipv4Addr) -> bool {
     let o = ip.octets();
     let n = u32::from(ip);
-    // 192.0.0.0/24 (IETF Protocol Assignments) + 192.0.2.0/24 (TEST-NET-1)
-    (o[0] == 192 && o[1] == 0 && (o[2] == 0 || o[2] == 2))
+    // 192.0.0.0/24 (IETF Protocol Assignments) — 192.0.0.9, 192.0.0.10 are globally reachable
+    (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] != 9 && o[3] != 10)
+    // 192.0.2.0/24 — Documentation (TEST-NET-1)
+    || (o[0] == 192 && o[1] == 0 && o[2] == 2)
+    // 192.88.99.0/24 — Deprecated 6to4 relay anycast (RFC 7526)
+    || (o[0] == 192 && o[1] == 88 && o[2] == 99)
     // 198.18.0.0/15 — Benchmarking
     || (n & 0xFFFE_0000 == 0xC612_0000)
     // 198.51.100.0/24 — Documentation (TEST-NET-2)
@@ -183,16 +187,33 @@ fn is_special_use_v6(v6: std::net::Ipv6Addr) -> bool {
     (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0x0001)
     // 100::/64 — Discard-Only (RFC 6666)
     || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
-    // 100::1:0:0/96..100::ffff:ffff:ffff — extended discard prefix
-    || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] >= 1)
-    // 2001:2::/48 — Benchmarking (RFC 5180)
-    || (s[0] == 0x2001 && s[1] == 0x0002 && s[2] == 0)
-    // 2001:db8::/32 — Documentation (RFC 3849)
+    // 100:0:0:1::/64 — Discard-Only dummy prefix
+    || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 1)
+    // 2001::/23 — IETF Protocol Assignments (block non-global sub-ranges)
+    || is_2001_ietf_non_global(s)
+    // 2001:db8::/32 — Documentation (RFC 3849, standalone IANA entry outside /23)
     || (s[0] == 0x2001 && s[1] == 0x0DB8)
-    // 3fff::/20 — Documentation (RFC 9637)
-    || (s[0] & 0xFFF0 == 0x3FF0)
-    // 5f00::/16 — Segment Routing (SRv6) SID (RFC 9602)
+    // 2002::/16 — 6to4 (deprecated, RFC 7526)
+    || s[0] == 0x2002
+    // 3fff::/20 — Documentation (RFC 9637): s[0]==0x3FFF, top 4 bits of s[1]==0
+    || (s[0] == 0x3FFF && s[1] & 0xF000 == 0)
+    // 5f00::/16 — Segment Routing SRv6 SID (RFC 9602)
     || s[0] == 0x5F00
+}
+
+/// Non-globally-reachable sub-ranges within `2001::/23` (IETF Protocol Assignments).
+fn is_2001_ietf_non_global(s: [u16; 8]) -> bool {
+    if s[0] != 0x2001 || s[1] > 0x01FF {
+        return false;
+    }
+    // Globally reachable exceptions per IANA — these pass through:
+    match s[1] {
+        // 2001::/32 Teredo (RFC 4380), 2001:3::/32 AMT (RFC 7450)
+        0x0000 | 0x0003 => false,
+        0x0004 if s[2] == 0x0112 => false,  // 2001:4:112::/48 — AS112-v6 (RFC 7535)
+        v if v & 0xFFF0 == 0x0020 => false, // 2001:20::/28 — ORCHIDv2 (RFC 7343)
+        _ => true,
+    }
 }
 
 /// Validate that a string is a well-formed MIME type (`token/token`).
@@ -913,117 +934,191 @@ mod tests {
         );
     }
 
-    // Special-use range tests
+    // IPv4 special-use range tests
     #[test]
     fn ssrf_blocks_benchmarking_range() {
-        assert!(
-            is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), false),
-            "198.18.0.0/15 benchmarking should be blocked"
-        );
-        assert!(
-            is_file_url_ssrf_blocked(&"198.19.255.254".parse().unwrap(), false),
-            "198.19.x upper range should be blocked"
-        );
+        assert!(is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), false));
+        assert!(is_file_url_ssrf_blocked(&"198.19.255.254".parse().unwrap(), false));
     }
 
     #[test]
     fn ssrf_blocks_ietf_protocol_assignments() {
+        assert!(is_file_url_ssrf_blocked(&"192.0.0.1".parse().unwrap(), false));
+    }
+
+    #[test]
+    fn ssrf_allows_globally_reachable_in_192_0_0() {
         assert!(
-            is_file_url_ssrf_blocked(&"192.0.0.1".parse().unwrap(), false),
-            "192.0.0.0/24 IETF assignments should be blocked"
+            !is_file_url_ssrf_blocked(&"192.0.0.9".parse().unwrap(), false),
+            "192.0.0.9 is globally reachable per IANA"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"192.0.0.10".parse().unwrap(), false),
+            "192.0.0.10 is globally reachable per IANA"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_6to4_relay_anycast() {
+        assert!(
+            is_file_url_ssrf_blocked(&"192.88.99.1".parse().unwrap(), false),
+            "192.88.99.0/24 deprecated 6to4 relay should be blocked"
         );
     }
 
     #[test]
     fn ssrf_blocks_documentation_ranges() {
-        assert!(
-            is_file_url_ssrf_blocked(&"192.0.2.1".parse().unwrap(), false),
-            "TEST-NET-1 should be blocked"
-        );
-        assert!(
-            is_file_url_ssrf_blocked(&"198.51.100.1".parse().unwrap(), false),
-            "TEST-NET-2 should be blocked"
-        );
-        assert!(
-            is_file_url_ssrf_blocked(&"203.0.113.1".parse().unwrap(), false),
-            "TEST-NET-3 should be blocked"
-        );
+        assert!(is_file_url_ssrf_blocked(&"192.0.2.1".parse().unwrap(), false));
+        assert!(is_file_url_ssrf_blocked(&"198.51.100.1".parse().unwrap(), false));
+        assert!(is_file_url_ssrf_blocked(&"203.0.113.1".parse().unwrap(), false));
     }
 
     #[test]
     fn ssrf_blocks_reserved_v4() {
-        assert!(
-            is_file_url_ssrf_blocked(&"240.0.0.1".parse().unwrap(), false),
-            "240.0.0.0/4 reserved should be blocked"
-        );
-        assert!(
-            is_file_url_ssrf_blocked(&"255.255.255.254".parse().unwrap(), false),
-            "255.x reserved upper should be blocked"
-        );
+        assert!(is_file_url_ssrf_blocked(&"240.0.0.1".parse().unwrap(), false));
+        assert!(is_file_url_ssrf_blocked(&"255.255.255.254".parse().unwrap(), false));
     }
 
+    // IPv6 special-use range tests
     #[test]
     fn ssrf_blocks_discard_only_v6() {
+        assert!(is_file_url_ssrf_blocked(&"100::".parse().unwrap(), false));
         assert!(
-            is_file_url_ssrf_blocked(&"100::1".parse().unwrap(), false),
-            "100::/64 discard-only should be blocked"
+            is_file_url_ssrf_blocked(&"100:0:0:1::1".parse().unwrap(), false),
+            "100:0:0:1::/64 dummy prefix should be blocked"
         );
     }
 
     #[test]
-    fn ssrf_blocks_documentation_v6() {
+    fn ssrf_allows_outside_discard_prefix() {
         assert!(
-            is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), false),
-            "2001:db8::/32 documentation should be blocked"
+            !is_file_url_ssrf_blocked(&"100:0:0:2::1".parse().unwrap(), false),
+            "100:0:0:2:: is outside the registered discard prefixes"
         );
     }
 
     #[test]
     fn ssrf_blocks_nat64_local_use() {
+        assert!(is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), false));
+    }
+
+    #[test]
+    fn ssrf_blocks_6to4_v6() {
         assert!(
-            is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), false),
-            "64:ff9b:1::/48 local-use NAT64 should be blocked"
+            is_file_url_ssrf_blocked(&"2002:c0a8:1::1".parse().unwrap(), false),
+            "6to4 2002::/16 should be blocked (deprecated RFC 7526)"
+        );
+    }
+
+    // 2001::/23 IETF Protocol Assignments
+    #[test]
+    fn ssrf_blocks_2001_non_global() {
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:5::1".parse().unwrap(), false),
+            "2001:5:: is non-global within 2001::/23"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:1ff::1".parse().unwrap(), false),
+            "2001:1ff:: is at the edge of 2001::/23"
         );
     }
 
     #[test]
-    fn ssrf_blocks_benchmarking_v6() {
+    fn ssrf_blocks_2001_benchmarking() {
+        assert!(is_file_url_ssrf_blocked(&"2001:2:0::1".parse().unwrap(), false));
+    }
+
+    #[test]
+    fn ssrf_blocks_2001_documentation() {
+        assert!(is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), false));
+    }
+
+    #[test]
+    fn ssrf_allows_2001_teredo() {
         assert!(
-            is_file_url_ssrf_blocked(&"2001:2:0::1".parse().unwrap(), false),
-            "2001:2::/48 benchmarking should be blocked"
+            !is_file_url_ssrf_blocked(&"2001::1".parse().unwrap(), false),
+            "2001::/32 Teredo is globally reachable"
         );
     }
 
+    #[test]
+    fn ssrf_allows_2001_amt() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:3::1".parse().unwrap(), false),
+            "2001:3::/32 AMT is globally reachable"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_2001_as112() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:4:112::1".parse().unwrap(), false),
+            "2001:4:112::/48 AS112-v6 is globally reachable"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_2001_orchidv2() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:20::1".parse().unwrap(), false),
+            "2001:20::/28 ORCHIDv2 is globally reachable"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:2f::1".parse().unwrap(), false),
+            "2001:2f:: is at the edge of ORCHIDv2"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_outside_orchidv2_in_2001() {
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:30::1".parse().unwrap(), false),
+            "2001:30:: is outside ORCHIDv2, still in 2001::/23 non-global"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_outside_2001_23() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:200::1".parse().unwrap(), false),
+            "2001:200:: is outside 2001::/23"
+        );
+    }
+
+    // 3fff::/20 and 5f00::/16
     #[test]
     fn ssrf_blocks_documentation_rfc9637() {
+        assert!(is_file_url_ssrf_blocked(&"3fff::1".parse().unwrap(), false));
         assert!(
-            is_file_url_ssrf_blocked(&"3fff::1".parse().unwrap(), false),
-            "3fff::/20 documentation should be blocked"
+            is_file_url_ssrf_blocked(&"3fff:0fff::1".parse().unwrap(), false),
+            "3fff:0fff:: is inside 3fff::/20"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_outside_3fff_20() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"3fff:1000::1".parse().unwrap(), false),
+            "3fff:1000:: is outside 3fff::/20"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"3ffe::1".parse().unwrap(), false),
+            "3ffe:: is outside 3fff::/20"
         );
     }
 
     #[test]
     fn ssrf_blocks_srv6_sid() {
-        assert!(
-            is_file_url_ssrf_blocked(&"5f00::1".parse().unwrap(), false),
-            "5f00::/16 SRv6 SID should be blocked"
-        );
+        assert!(is_file_url_ssrf_blocked(&"5f00::1".parse().unwrap(), false));
     }
 
+    // Allowlist override
     #[test]
     fn ssrf_allows_special_use_with_allowlist() {
-        assert!(
-            !is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), true),
-            "benchmarking range should be allowed with allowlist"
-        );
-        assert!(
-            !is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), true),
-            "documentation v6 should be allowed with allowlist"
-        );
-        assert!(
-            !is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), true),
-            "NAT64 local-use should be allowed with allowlist"
-        );
+        assert!(!is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), true));
+        assert!(!is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), true));
+        assert!(!is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), true));
+        assert!(!is_file_url_ssrf_blocked(&"2002:c0a8:1::1".parse().unwrap(), true));
     }
 
     #[test]

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -3,8 +3,272 @@
 
 //! URL resolution and SSRF validation for `file_url` references.
 
+use std::net::IpAddr;
+
+use praxis_core::connectivity::normalize_mapped_ipv4;
+
+/// A validated, normalized origin (scheme + host + port) for allowlist matching.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct NormalizedOrigin {
+    /// URL scheme (`http` or `https`).
+    pub scheme: String,
+    /// Canonical host (lowercase, brackets stripped for IPv6).
+    pub host: String,
+    /// Effective port (443 for https, 80 for http if not explicit).
+    pub port: u16,
+}
+
+impl NormalizedOrigin {
+    /// Parse and validate an origin string.
+    ///
+    /// Accepts `scheme://host[:port]`. Rejects paths (other than `/`),
+    /// queries, fragments, and credentials. Normalizes default ports
+    /// and lowercases the host.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let url = url::Url::parse(raw).map_err(|e| format!("invalid origin URL: {e}"))?;
+        let scheme = url.scheme();
+        if scheme != "http" && scheme != "https" {
+            return Err(format!("origin must use http or https scheme, got '{scheme}'"));
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err("origin must not contain credentials".to_owned());
+        }
+        if url.path() != "/" {
+            return Err(format!("origin must not contain a path, got '{}'", url.path()));
+        }
+        if url.query().is_some() {
+            return Err("origin must not contain a query string".to_owned());
+        }
+        if url.fragment().is_some() {
+            return Err("origin must not contain a fragment".to_owned());
+        }
+        let host = url
+            .host_str()
+            .ok_or_else(|| "origin must include a host".to_owned())?
+            .to_ascii_lowercase();
+        let default_port = if scheme == "https" { 443 } else { 80 };
+        let port = url.port().unwrap_or(default_port);
+
+        let origin = Self {
+            scheme: scheme.to_owned(),
+            host,
+            port,
+        };
+        origin.reject_unconditionally_blocked_ips()?;
+        Ok(origin)
+    }
+
+    /// Check whether a request URL's origin matches this allowlist entry.
+    #[cfg_attr(not(test), expect(dead_code, reason = "used in Task 3"))]
+    pub fn matches_url(&self, url: &url::Url) -> bool {
+        let url_scheme = url.scheme();
+        let Some(url_host) = url.host_str() else {
+            return false;
+        };
+        let default_port = if url_scheme == "https" { 443 } else { 80 };
+        let url_port = url.port().unwrap_or(default_port);
+        self.scheme == url_scheme && self.host == url_host.to_ascii_lowercase() && self.port == url_port
+    }
+
+    /// Reject IPs that are never valid in an allowlist: unspecified,
+    /// multicast, and cloud metadata.
+    fn reject_unconditionally_blocked_ips(&self) -> Result<(), String> {
+        // Strip brackets for IPv6 addresses
+        let host_without_brackets = self
+            .host
+            .strip_prefix('[')
+            .and_then(|h| h.strip_suffix(']'))
+            .unwrap_or(&self.host);
+
+        let ip: IpAddr = match host_without_brackets.parse() {
+            Ok(ip) => normalize_mapped_ipv4(ip),
+            Err(_) => return Ok(()),
+        };
+        if ip.is_unspecified() {
+            return Err("origin must not target an unspecified address".to_owned());
+        }
+        if ip.is_multicast() {
+            return Err("origin must not target a multicast address".to_owned());
+        }
+        if is_cloud_metadata(&ip) {
+            return Err("origin must not target a cloud metadata endpoint".to_owned());
+        }
+        Ok(())
+    }
+}
+
+/// Cloud metadata endpoints that are never permitted.
+fn is_cloud_metadata(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            *v4 == std::net::Ipv4Addr::new(169, 254, 169, 254) || *v4 == std::net::Ipv4Addr::new(100, 100, 100, 200)
+        },
+        IpAddr::V6(v6) => {
+            const AWS_IMDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
+            *v6 == AWS_IMDS_V6
+        },
+    }
+}
+
 /// Resolves `file_url` references with DNS pinning and SSRF protection.
+#[expect(dead_code, reason = "used in Task 3")] // Used in Task 3
 pub(crate) struct FileUrlResolver {
-    /// Placeholder field; implementation in Task 3.
-    _placeholder: (),
+    /// Origins that permit resolution to private/loopback addresses.
+    pub(crate) allowed_private_origins: Vec<NormalizedOrigin>,
+    /// Overall timeout for URL resolution.
+    pub(crate) timeout: std::time::Duration,
+}
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_https_origin() {
+        let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
+        assert_eq!(origin.scheme, "https");
+        assert_eq!(origin.host, "files.example.com");
+        assert_eq!(origin.port, 443, "default https port should be 443");
+    }
+
+    #[test]
+    fn parse_valid_http_origin_with_port() {
+        let origin = NormalizedOrigin::parse("http://files.internal:8443").unwrap();
+        assert_eq!(origin.scheme, "http");
+        assert_eq!(origin.host, "files.internal");
+        assert_eq!(origin.port, 8443);
+    }
+
+    #[test]
+    fn parse_normalizes_host_case() {
+        let origin = NormalizedOrigin::parse("https://Files.EXAMPLE.Com").unwrap();
+        assert_eq!(origin.host, "files.example.com", "host should be lowercased");
+    }
+
+    #[test]
+    fn parse_normalizes_default_port() {
+        let with_port = NormalizedOrigin::parse("https://example.com:443").unwrap();
+        let without_port = NormalizedOrigin::parse("https://example.com").unwrap();
+        assert_eq!(with_port, without_port, "explicit default port should normalize");
+    }
+
+    #[test]
+    fn parse_rejects_non_http_scheme() {
+        assert!(NormalizedOrigin::parse("ftp://example.com").is_err());
+        assert!(NormalizedOrigin::parse("file:///tmp/x").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_credentials() {
+        assert!(NormalizedOrigin::parse("https://user@example.com").is_err());
+        assert!(NormalizedOrigin::parse("https://user:pass@example.com").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_path() {
+        assert!(NormalizedOrigin::parse("https://example.com/files").is_err());
+    }
+
+    #[test]
+    fn parse_accepts_root_path() {
+        assert!(NormalizedOrigin::parse("https://example.com/").is_ok());
+    }
+
+    #[test]
+    fn parse_rejects_query() {
+        assert!(NormalizedOrigin::parse("https://example.com?q=1").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_fragment() {
+        assert!(NormalizedOrigin::parse("https://example.com#frag").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_cloud_metadata_ipv4() {
+        assert!(NormalizedOrigin::parse("http://169.254.169.254").is_err());
+        assert!(NormalizedOrigin::parse("http://100.100.100.200").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_cloud_metadata_ipv6() {
+        assert!(NormalizedOrigin::parse("http://[fd00:ec2::254]").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unspecified() {
+        assert!(NormalizedOrigin::parse("http://0.0.0.0").is_err());
+        assert!(NormalizedOrigin::parse("http://[::]").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_multicast() {
+        assert!(NormalizedOrigin::parse("http://224.0.0.1").is_err());
+    }
+
+    #[test]
+    fn parse_allows_private_ip_in_allowlist() {
+        assert!(
+            NormalizedOrigin::parse("http://10.0.0.1:8080").is_ok(),
+            "private IPs should be allowed in the allowlist"
+        );
+    }
+
+    #[test]
+    fn parse_allows_loopback_in_allowlist() {
+        assert!(
+            NormalizedOrigin::parse("http://127.0.0.1:8080").is_ok(),
+            "loopback should be allowed in the allowlist"
+        );
+    }
+
+    #[test]
+    fn matches_url_exact() {
+        let origin = NormalizedOrigin::parse("https://files.example.com:8443").unwrap();
+        let url = url::Url::parse("https://files.example.com:8443/path/to/file.pdf?token=abc").unwrap();
+        assert!(origin.matches_url(&url), "exact origin should match");
+    }
+
+    #[test]
+    fn matches_url_default_port() {
+        let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
+        let url = url::Url::parse("https://files.example.com/file.pdf").unwrap();
+        assert!(origin.matches_url(&url), "default-port origin should match");
+    }
+
+    #[test]
+    fn matches_url_case_insensitive() {
+        let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
+        let url = url::Url::parse("https://Files.Example.Com/file.pdf").unwrap();
+        assert!(origin.matches_url(&url), "host matching should be case-insensitive");
+    }
+
+    #[test]
+    fn no_match_wrong_scheme() {
+        let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
+        let url = url::Url::parse("http://files.example.com/file.pdf").unwrap();
+        assert!(!origin.matches_url(&url), "scheme mismatch should not match");
+    }
+
+    #[test]
+    fn no_match_wrong_port() {
+        let origin = NormalizedOrigin::parse("https://files.example.com:8443").unwrap();
+        let url = url::Url::parse("https://files.example.com:9443/file.pdf").unwrap();
+        assert!(!origin.matches_url(&url), "port mismatch should not match");
+    }
+
+    #[test]
+    fn no_match_wrong_host() {
+        let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
+        let url = url::Url::parse("https://other.example.com/file.pdf").unwrap();
+        assert!(!origin.matches_url(&url), "host mismatch should not match");
+    }
 }

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! URL resolution and SSRF validation for `file_url` references.
+
+/// Resolves `file_url` references with DNS pinning and SSRF protection.
+pub(crate) struct FileUrlResolver {
+    /// Placeholder field; implementation in Task 3.
+    _placeholder: (),
+}

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -12,7 +12,7 @@ use praxis_core::connectivity::normalize_mapped_ipv4;
 pub(crate) struct NormalizedOrigin {
     /// URL scheme (`http` or `https`).
     pub scheme: String,
-    /// Canonical host (lowercase, brackets stripped for IPv6).
+    /// Canonical host (lowercase; brackets preserved for IPv6).
     pub host: String,
     /// Effective port (443 for https, 80 for http if not explicit).
     pub port: u16,

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -107,6 +107,8 @@ fn is_cloud_metadata(ip: &IpAddr) -> bool {
             *v4 == std::net::Ipv4Addr::new(169, 254, 169, 254)
                 || *v4 == std::net::Ipv4Addr::new(169, 254, 170, 2)
                 || *v4 == std::net::Ipv4Addr::new(169, 254, 170, 23)
+                || *v4 == std::net::Ipv4Addr::new(169, 254, 0, 23)
+                || *v4 == std::net::Ipv4Addr::new(169, 254, 10, 10)
                 || *v4 == std::net::Ipv4Addr::new(100, 100, 100, 200)
         },
         IpAddr::V6(v6) => {
@@ -274,7 +276,8 @@ pub(crate) fn is_file_url_ssrf_blocked(ip: &IpAddr, allow_private: bool) -> bool
 
 /// Redact sensitive parts of a URL for safe logging.
 ///
-/// Strips credentials entirely and replaces query parameter values with `[REDACTED]`.
+/// Strips credentials and fragments, and replaces query parameter values
+/// with `[REDACTED]`.
 pub(crate) fn redact_url(raw: &str) -> String {
     let Ok(mut url) = url::Url::parse(raw) else {
         return "<invalid URL>".to_owned();
@@ -285,6 +288,8 @@ pub(crate) fn redact_url(raw: &str) -> String {
         let _ = url.set_username("");
         let _ = url.set_password(None);
     }
+
+    url.set_fragment(None);
 
     // Redact query values
     if url.query().is_some() {
@@ -805,6 +810,14 @@ mod tests {
             NormalizedOrigin::parse("http://100.100.100.200").is_err(),
             "Alibaba metadata should be rejected"
         );
+        assert!(
+            NormalizedOrigin::parse("http://169.254.0.23").is_err(),
+            "Tencent metadata 169.254.0.23 should be rejected"
+        );
+        assert!(
+            NormalizedOrigin::parse("http://169.254.10.10").is_err(),
+            "Tencent metadata 169.254.10.10 should be rejected"
+        );
     }
 
     #[test]
@@ -1015,6 +1028,30 @@ mod tests {
         assert!(
             is_file_url_ssrf_blocked(&"100.100.100.200".parse().unwrap(), true),
             "Alibaba metadata should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_tencent_metadata() {
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.0.23".parse().unwrap(), true),
+            "Tencent metadata 169.254.0.23 should be blocked even with allowlist"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.10.10".parse().unwrap(), true),
+            "Tencent metadata 169.254.10.10 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_tencent_metadata_via_nat64() {
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::a9fe:0017".parse().unwrap(), true),
+            "Tencent 169.254.0.23 via NAT64 should be blocked even with allowlist"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b::a9fe:0a0a".parse().unwrap(), true),
+            "Tencent 169.254.10.10 via NAT64 should be blocked even with allowlist"
         );
     }
 
@@ -1560,6 +1597,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn redact_url_strips_fragment() {
+        let redacted = redact_url("https://example.com/file#access_token=secret");
+        assert!(
+            !redacted.contains("access_token"),
+            "fragment should be stripped entirely"
+        );
+        assert!(!redacted.contains('#'), "fragment delimiter should not remain");
+    }
+
     // validate_file_url tests
     #[test]
     fn validate_file_url_accepts_http() {
@@ -1788,5 +1835,131 @@ mod tests {
             None,
             "empty quoted filename should return None"
         );
+    }
+
+    // Coverage: matches_url with no host (cannot-be-a-base URL)
+    #[test]
+    fn matches_url_no_host() {
+        let origin = NormalizedOrigin::parse("https://example.com").unwrap();
+        let url = url::Url::parse("data:text/plain,hello").unwrap();
+        assert!(!origin.matches_url(&url), "cannot-be-a-base URL has no host");
+    }
+
+    // Coverage: backslash escape inside quoted Content-Disposition value
+    #[test]
+    fn content_disposition_escaped_quote_in_filename() {
+        assert_eq!(
+            parse_content_disposition_filename(r#"attachment; filename="file\"name.pdf""#),
+            Some("file\"name.pdf".to_owned()),
+            "backslash-escaped quote inside filename should be unescaped"
+        );
+    }
+
+    // Coverage: invalid percent sequence in percent_decode_utf8
+    #[test]
+    fn content_disposition_invalid_percent_encoding() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename*=UTF-8''file%ZZname.pdf"),
+            Some("file_name.pdf".to_owned()),
+            "invalid percent sequence should produce underscore replacement"
+        );
+    }
+
+    // Coverage: multi-byte UTF-8 truncation in sanitize_filename
+    #[test]
+    fn sanitize_filename_multibyte_truncation() {
+        // 254 ASCII bytes + 2-byte UTF-8 char = 256 bytes, exceeds 255
+        let mut name = "a".repeat(254);
+        name.push('\u{00E9}'); // é is 2 bytes in UTF-8
+        let sanitized = sanitize_filename(&name).unwrap();
+        assert!(
+            sanitized.len() <= 255,
+            "multi-byte truncation should stay within 255 bytes"
+        );
+        assert_eq!(sanitized.len(), 254, "should truncate to 254 (before the 2-byte char)");
+    }
+
+    // Coverage: Content-Disposition with no = sign in a segment
+    #[test]
+    fn content_disposition_no_equals() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; noequals"),
+            None,
+            "parameter without = should be skipped"
+        );
+    }
+
+    // Coverage: Content-Disposition with empty parameter name
+    #[test]
+    fn content_disposition_empty_param_name() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; =value"),
+            None,
+            "empty parameter name should be skipped"
+        );
+    }
+
+    // Coverage: percent_decode_utf8 truncated sequence (single char after %)
+    #[test]
+    fn content_disposition_truncated_percent() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename*=UTF-8''file%2"),
+            Some("file_".to_owned()),
+            "truncated percent sequence should produce underscore"
+        );
+    }
+
+    // Coverage: MIME type edge cases for is_valid_mime_type
+    #[test]
+    fn mime_rejects_double_slash() {
+        assert!(
+            !is_valid_mime_type("text/plain/extra"),
+            "MIME with multiple slashes should be rejected (subtype contains /)"
+        );
+    }
+
+    #[test]
+    fn mime_accepts_with_dash_dot_plus() {
+        assert!(
+            is_valid_mime_type("application/vnd.openxml-officedocument+xml"),
+            "MIME with dashes, dots, and plus should be accepted"
+        );
+    }
+
+    // Coverage: is_blocked_hostname
+    #[test]
+    fn blocked_hostname_localhost() {
+        assert!(is_blocked_hostname("localhost"), "localhost should be blocked");
+        assert!(
+            is_blocked_hostname("app.localhost"),
+            ".localhost subdomain should be blocked"
+        );
+        assert!(
+            !is_blocked_hostname("example.com"),
+            "non-localhost should not be blocked"
+        );
+    }
+
+    // Coverage: NormalizedOrigin::parse with non-IP hostname
+    #[test]
+    fn parse_accepts_dns_hostname() {
+        let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
+        assert_eq!(origin.host, "files.example.com", "hostname should be preserved");
+    }
+
+    // Coverage: validate_file_url accepts localhost (validation doesn't check hostname)
+    #[test]
+    fn validate_file_url_passes_localhost() {
+        assert!(
+            validate_file_url("https://localhost/file.pdf").is_ok(),
+            "validate_file_url only checks scheme/credentials/fragment, not hostname"
+        );
+    }
+
+    // Coverage: NormalizedOrigin default HTTP port
+    #[test]
+    fn parse_normalizes_http_default_port() {
+        let origin = NormalizedOrigin::parse("http://example.com").unwrap();
+        assert_eq!(origin.port, 80, "HTTP default port should be 80");
     }
 }

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -236,14 +236,10 @@ pub(crate) fn sanitize_filename(raw: &str) -> Option<String> {
 pub(crate) struct FileUrlResolver {
     /// Origins that permit resolution to private/loopback addresses.
     pub(crate) allowed_private_origins: Vec<NormalizedOrigin>,
-    /// Overall timeout for URL resolution.
-    #[expect(dead_code, reason = "used in Task 4")]
-    pub(crate) timeout: std::time::Duration,
 }
 
 impl FileUrlResolver {
     /// Resolve a `file_url` with SSRF protection and DNS pinning.
-    #[expect(dead_code, reason = "used in Task 4")]
     #[expect(clippy::too_many_lines, reason = "main resolution flow")]
     pub(crate) async fn resolve_url(
         &self,

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -3,11 +3,6 @@
 
 //! URL resolution and SSRF validation for `file_url` references.
 
-// String slicing is validated via `is_char_boundary` in `sanitize_filename`.
-// allow_attributes lint disabled because expect doesn't work for indexing_slicing.
-#![allow(clippy::allow_attributes)]
-#![allow(clippy::indexing_slicing)]
-
 use std::net::{IpAddr, SocketAddr};
 
 use praxis_core::connectivity::normalize_mapped_ipv4;
@@ -68,7 +63,6 @@ impl NormalizedOrigin {
     }
 
     /// Check whether a request URL's origin matches this allowlist entry.
-    #[cfg_attr(not(test), expect(dead_code, reason = "used in Task 3"))]
     pub fn matches_url(&self, url: &url::Url) -> bool {
         let url_scheme = url.scheme();
         let Some(url_host) = url.host_str() else {
@@ -189,9 +183,7 @@ pub(crate) fn redact_url(raw: &str) -> String {
 pub(crate) fn validate_file_url(raw: &str) -> Result<url::Url, ResolveError> {
     let url = url::Url::parse(raw).map_err(|e| {
         tracing::debug!(error = %e, "invalid file_url");
-        ResolveError::FileUrlBlocked {
-            label: redact_url(raw),
-        }
+        ResolveError::FileUrlBlocked { label: redact_url(raw) }
     })?;
 
     let scheme = url.scheme();
@@ -235,13 +227,12 @@ pub(crate) fn sanitize_filename(raw: &str) -> Option<String> {
         if len == 0 {
             None
         } else {
-            Some(sanitized[..len].to_owned())
+            sanitized.get(..len).map(ToOwned::to_owned)
         }
     }
 }
 
 /// Resolves `file_url` references with DNS pinning and SSRF protection.
-#[cfg_attr(not(test), expect(dead_code, reason = "used in Task 4"))]
 pub(crate) struct FileUrlResolver {
     /// Origins that permit resolution to private/loopback addresses.
     pub(crate) allowed_private_origins: Vec<NormalizedOrigin>,

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -7,9 +7,7 @@ use std::net::{IpAddr, SocketAddr};
 
 use praxis_core::connectivity::normalize_mapped_ipv4;
 
-use super::resolve::{
-    ResolveError, ResolvedFile, infer_mime_from_filename, max_content_bytes_for_data_url, read_bounded_body,
-};
+use super::resolve::{ResolveError, ResolvedFile, infer_mime_from_filename, max_content_bytes_for_data_url};
 
 /// A validated, normalized origin (scheme + host + port) for allowlist matching.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -568,9 +566,9 @@ impl FileUrlResolver {
         if let Some(cl) = response.content_length()
             && usize::try_from(cl).unwrap_or(usize::MAX) > max_content_bytes
         {
-            return Err(ResolveError::FileUrlFailed {
-                label,
-                detail: format!("Content-Length {cl} exceeds limit"),
+            return Err(ResolveError::TooLarge {
+                reference: label,
+                limit: max_resolved_bytes,
             });
         }
 
@@ -589,7 +587,7 @@ impl FileUrlResolver {
             });
 
         // Read bounded body
-        let content = read_bounded_body(response, &label, max_content_bytes, max_resolved_bytes).await?;
+        let content = read_bounded_url_body(response, &label, max_content_bytes, max_resolved_bytes).await?;
 
         // Encode as base64
         let base64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &content);
@@ -600,6 +598,33 @@ impl FileUrlResolver {
             filename,
         })
     }
+}
+
+/// Read a file URL response body while preserving URL-specific error context.
+async fn read_bounded_url_body(
+    mut response: reqwest::Response,
+    label: &str,
+    max_content_bytes: usize,
+    limit: usize,
+) -> Result<Vec<u8>, ResolveError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| ResolveError::FileUrlFailed {
+        label: label.to_owned(),
+        detail: if e.is_timeout() {
+            "content download timed out".to_owned()
+        } else {
+            format!("content download read error: {e}")
+        },
+    })? {
+        if chunk.len() > max_content_bytes.saturating_sub(body.len()) {
+            return Err(ResolveError::TooLarge {
+                reference: label.to_owned(),
+                limit,
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 /// Resolve DNS and validate all addresses.

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -179,10 +179,20 @@ fn is_special_use_v4(ip: std::net::Ipv4Addr) -> bool {
 /// Non-globally-reachable IPv6 special-use ranges per IANA registry.
 fn is_special_use_v6(v6: std::net::Ipv6Addr) -> bool {
     let s = v6.segments();
+    // 64:ff9b:1::/48 — Local-use NAT64 (RFC 8215)
+    (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0x0001)
     // 100::/64 — Discard-Only (RFC 6666)
-    (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+    || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+    // 100::1:0:0/96..100::ffff:ffff:ffff — extended discard prefix
+    || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] >= 1)
+    // 2001:2::/48 — Benchmarking (RFC 5180)
+    || (s[0] == 0x2001 && s[1] == 0x0002 && s[2] == 0)
     // 2001:db8::/32 — Documentation (RFC 3849)
     || (s[0] == 0x2001 && s[1] == 0x0DB8)
+    // 3fff::/20 — Documentation (RFC 9637)
+    || (s[0] & 0xFFF0 == 0x3FF0)
+    // 5f00::/16 — Segment Routing (SRv6) SID (RFC 9602)
+    || s[0] == 0x5F00
 }
 
 /// Validate that a string is a well-formed MIME type (`token/token`).
@@ -969,6 +979,38 @@ mod tests {
     }
 
     #[test]
+    fn ssrf_blocks_nat64_local_use() {
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), false),
+            "64:ff9b:1::/48 local-use NAT64 should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_benchmarking_v6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:2:0::1".parse().unwrap(), false),
+            "2001:2::/48 benchmarking should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_documentation_rfc9637() {
+        assert!(
+            is_file_url_ssrf_blocked(&"3fff::1".parse().unwrap(), false),
+            "3fff::/20 documentation should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_srv6_sid() {
+        assert!(
+            is_file_url_ssrf_blocked(&"5f00::1".parse().unwrap(), false),
+            "5f00::/16 SRv6 SID should be blocked"
+        );
+    }
+
+    #[test]
     fn ssrf_allows_special_use_with_allowlist() {
         assert!(
             !is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), true),
@@ -977,6 +1019,10 @@ mod tests {
         assert!(
             !is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), true),
             "documentation v6 should be allowed with allowlist"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), true),
+            "NAT64 local-use should be allowed with allowlist"
         );
     }
 

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -8,6 +8,7 @@ use std::net::{IpAddr, SocketAddr};
 use praxis_core::connectivity::normalize_mapped_ipv4;
 
 use super::resolve::{ResolveError, ResolvedFile, infer_mime_from_filename, max_content_bytes_for_data_url};
+use crate::openai::url_security::{is_cloud_metadata, is_file_url_ssrf_blocked};
 
 /// A validated, normalized origin (scheme + host + port) for allowlist matching.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -98,126 +99,6 @@ impl NormalizedOrigin {
     }
 }
 
-/// Cloud metadata and credential endpoints that are never permitted.
-fn is_cloud_metadata(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            *v4 == std::net::Ipv4Addr::new(169, 254, 169, 254)
-                || *v4 == std::net::Ipv4Addr::new(169, 254, 170, 2)
-                || *v4 == std::net::Ipv4Addr::new(169, 254, 170, 23)
-                || *v4 == std::net::Ipv4Addr::new(169, 254, 0, 23)
-                || *v4 == std::net::Ipv4Addr::new(169, 254, 10, 10)
-                || *v4 == std::net::Ipv4Addr::new(100, 100, 100, 200)
-        },
-        IpAddr::V6(v6) => {
-            const AWS_IMDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
-            const AWS_ECS_CREDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0023);
-            *v6 == AWS_IMDS_V6 || *v6 == AWS_ECS_CREDS_V6
-        },
-    }
-}
-
-/// IPs that are always blocked regardless of allowlist.
-fn is_unconditionally_blocked(ip: &IpAddr) -> bool {
-    ip.is_unspecified() || ip.is_multicast() || is_cloud_metadata(ip)
-}
-
-/// IPs that are blocked unless the origin is allowlisted.
-fn is_private_range(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.octets()[0] == 0
-                || is_cgnat(*v4)
-                || is_special_use_v4(*v4)
-        },
-        IpAddr::V6(v6) => {
-            v6.is_loopback()
-                || v6.is_unique_local()
-                || is_unicast_link_local_v6(v6)
-                || is_site_local_v6(v6)
-                || is_special_use_v6(*v6)
-        },
-    }
-}
-
-/// Check if an IPv4 address is in the CGNAT range (100.64.0.0/10).
-fn is_cgnat(ip: std::net::Ipv4Addr) -> bool {
-    u32::from(ip) & 0xFFC0_0000 == 0x6440_0000
-}
-
-/// Check if an IPv6 address is in the unicast link-local range (`fe80::/10`).
-fn is_unicast_link_local_v6(v6: &std::net::Ipv6Addr) -> bool {
-    let [a, b, ..] = v6.octets();
-    a == 0xFE && (b & 0xC0) == 0x80
-}
-
-/// Deprecated site-local range (`fec0::/10`, RFC 3879).
-fn is_site_local_v6(v6: &std::net::Ipv6Addr) -> bool {
-    let [a, b, ..] = v6.octets();
-    a == 0xFE && (b & 0xC0) == 0xC0
-}
-
-/// Non-globally-reachable IPv4 special-use ranges per IANA registry.
-fn is_special_use_v4(ip: std::net::Ipv4Addr) -> bool {
-    let o = ip.octets();
-    let n = u32::from(ip);
-    // 192.0.0.0/24 (IETF Protocol Assignments) — 192.0.0.9, 192.0.0.10 are globally reachable
-    (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] != 9 && o[3] != 10)
-    // 192.0.2.0/24 — Documentation (TEST-NET-1)
-    || (o[0] == 192 && o[1] == 0 && o[2] == 2)
-    // 192.88.99.0/24 — Deprecated 6to4 relay anycast (RFC 7526)
-    || (o[0] == 192 && o[1] == 88 && o[2] == 99)
-    // 198.18.0.0/15 — Benchmarking
-    || (n & 0xFFFE_0000 == 0xC612_0000)
-    // 198.51.100.0/24 — Documentation (TEST-NET-2)
-    || (o[0] == 198 && o[1] == 51 && o[2] == 100)
-    // 203.0.113.0/24 — Documentation (TEST-NET-3)
-    || (o[0] == 203 && o[1] == 0 && o[2] == 113)
-    // 240.0.0.0/4 — Reserved for future use
-    || o[0] >= 240
-}
-
-/// Non-globally-reachable IPv6 special-use ranges per IANA registry.
-fn is_special_use_v6(v6: std::net::Ipv6Addr) -> bool {
-    let s = v6.segments();
-    // 64:ff9b:1::/48 — Local-use NAT64 (RFC 8215)
-    (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0x0001)
-    // 100::/64 — Discard-Only (RFC 6666)
-    || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
-    // 100:0:0:1::/64 — Discard-Only dummy prefix
-    || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 1)
-    // 2001::/23 — IETF Protocol Assignments (block non-global sub-ranges)
-    || is_2001_ietf_non_global(s)
-    // 2001:db8::/32 — Documentation (RFC 3849, standalone IANA entry outside /23)
-    || (s[0] == 0x2001 && s[1] == 0x0DB8)
-    // 2002::/16 — 6to4 (deprecated, RFC 7526)
-    || s[0] == 0x2002
-    // 3fff::/20 — Documentation (RFC 9637): s[0]==0x3FFF, top 4 bits of s[1]==0
-    || (s[0] == 0x3FFF && s[1] & 0xF000 == 0)
-    // 5f00::/16 — Segment Routing SRv6 SID (RFC 9602)
-    || s[0] == 0x5F00
-}
-
-/// Non-globally-reachable sub-ranges within `2001::/23` (IETF Protocol Assignments).
-fn is_2001_ietf_non_global(s: [u16; 8]) -> bool {
-    if s[0] != 0x2001 || s[1] > 0x01FF {
-        return false;
-    }
-    // Globally reachable exceptions per IANA — these pass through:
-    match s[1] {
-        // 2001:1::1 PCP, 2001:1::2 TURN, 2001:1::3 DNS-SD anycast (RFC 6887/8155/8880)
-        0x0001 if s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0 && s[6] == 0 && matches!(s[7], 1..=3) => false,
-        0x0003 => false,                   // 2001:3::/32 — AMT (RFC 7450)
-        0x0004 if s[2] == 0x0112 => false, // 2001:4:112::/48 — AS112-v6 (RFC 7535)
-        // 2001:20::/28 ORCHIDv2 (RFC 7343), 2001:30::/28 Drone Remote ID (RFC 9374)
-        v if v & 0xFFF0 == 0x0020 || v & 0xFFF0 == 0x0030 => false,
-        _ => true,
-    }
-}
-
 /// Validate that a string is a well-formed MIME type (`token/token`).
 ///
 /// Uses the RFC 2045 token production but additionally excludes characters
@@ -237,39 +118,6 @@ fn is_valid_mime_type(s: &str) -> bool {
         && !subtype.is_empty()
         && type_part.chars().all(is_data_uri_safe_token)
         && subtype.chars().all(is_data_uri_safe_token)
-}
-
-/// Extract the embedded IPv4 from a NAT64 Well-Known Prefix (`64:ff9b::/96`).
-fn nat64_embedded_ipv4(v6: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
-    let s = v6.segments();
-    (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0).then(|| {
-        let [.., a, b, c, d] = v6.octets();
-        std::net::Ipv4Addr::new(a, b, c, d)
-    })
-}
-
-/// Check if an IP should be blocked for `file_url` fetches.
-pub(crate) fn is_file_url_ssrf_blocked(ip: &IpAddr, allow_private: bool) -> bool {
-    let ip = &normalize_mapped_ipv4(*ip);
-    if is_unconditionally_blocked(ip) {
-        return true;
-    }
-    // RFC 6052: apply IPv4 policy to the embedded address in 64:ff9b::/96
-    if let IpAddr::V6(v6) = ip
-        && let Some(v4) = nat64_embedded_ipv4(v6)
-    {
-        let embedded = IpAddr::V4(v4);
-        if is_unconditionally_blocked(&embedded) {
-            return true;
-        }
-        if !allow_private && is_private_range(&embedded) {
-            return true;
-        }
-    }
-    if !allow_private && is_private_range(ip) {
-        return true;
-    }
-    false
 }
 
 /// Redact sensitive parts of a URL for safe logging.
@@ -679,6 +527,16 @@ async fn resolve_and_pin_url(
         })?
         .collect();
 
+    let validated = validate_resolved_addrs(addrs, allow_private, label)?;
+    Ok((host.to_owned(), validated))
+}
+
+/// Validate and deduplicate every address returned for one DNS lookup.
+fn validate_resolved_addrs(
+    addrs: Vec<SocketAddr>,
+    allow_private: bool,
+    label: &str,
+) -> Result<Vec<SocketAddr>, ResolveError> {
     if addrs.is_empty() {
         return Err(ResolveError::FileUrlFailed {
             label: label.to_owned(),
@@ -701,7 +559,7 @@ async fn resolve_and_pin_url(
         }
     }
 
-    Ok((host.to_owned(), validated))
+    Ok(validated)
 }
 
 /// Check if a hostname is blocked (localhost and *.localhost).
@@ -716,7 +574,17 @@ fn build_pinned_client(
     addrs: &[SocketAddr],
     timeout: std::time::Duration,
 ) -> Result<reqwest::Client, reqwest::Error> {
-    let mut builder = reqwest::Client::builder()
+    configure_pinned_client(reqwest::Client::builder(), host, addrs, timeout)
+}
+
+/// Apply proxy, redirect, timeout, and DNS-pinning policy to a client builder.
+fn configure_pinned_client(
+    builder: reqwest::ClientBuilder,
+    host: &str,
+    addrs: &[SocketAddr],
+    timeout: std::time::Duration,
+) -> Result<reqwest::Client, reqwest::Error> {
+    let mut builder = builder
         .no_proxy()
         .redirect(reqwest::redirect::Policy::none())
         .timeout(timeout);
@@ -738,6 +606,11 @@ fn build_pinned_client(
     reason = "tests"
 )]
 mod tests {
+    use std::{
+        io::{Read as _, Write as _},
+        net::TcpListener,
+    };
+
     use super::*;
 
     #[test]
@@ -1978,6 +1851,146 @@ mod tests {
         assert!(
             validate_file_url("https://localhost/file.pdf").is_ok(),
             "validate_file_url only checks scheme/credentials/fragment, not hostname"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_url_resolver_blocks_legacy_ipv4_loopback() {
+        let resolver = FileUrlResolver {
+            allowed_private_origins: vec![],
+        };
+
+        let result = resolver
+            .resolve_url(
+                "http://0177.0.0.1/file.txt",
+                tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+                1024,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ResolveError::FileUrlBlocked { .. })),
+            "URL-parser canonicalization must not let legacy IPv4 loopback bypass SSRF checks"
+        );
+    }
+
+    #[test]
+    fn dns_rebinding_with_mixed_public_and_private_answers_is_blocked() {
+        let addrs = vec!["93.184.216.34:443".parse().unwrap(), "127.0.0.1:443".parse().unwrap()];
+
+        let result = validate_resolved_addrs(addrs, false, "https://files.example/document.pdf");
+
+        assert!(
+            matches!(result, Err(ResolveError::FileUrlBlocked { .. })),
+            "one private DNS answer must reject the entire pinned address set"
+        );
+    }
+
+    #[tokio::test]
+    async fn pinned_client_uses_only_validated_dns_addresses() {
+        let target_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let target_address = target_listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = target_listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .unwrap();
+        });
+
+        let client = build_pinned_client(
+            "files.example.test",
+            &[target_address],
+            std::time::Duration::from_secs(5),
+        )
+        .unwrap();
+        let response = client
+            .get(format!("http://files.example.test:{}/file.txt", target_address.port()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.bytes().await.unwrap().as_ref(), b"ok");
+        server.join().unwrap();
+    }
+
+    fn start_redirect_server(target_address: SocketAddr) -> (SocketAddr, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            let response = format!(
+                "HTTP/1.1 302 Found\r\nLocation: http://{target_address}/secret\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (address, server)
+    }
+
+    #[tokio::test]
+    async fn file_url_resolver_does_not_follow_redirects() {
+        let target_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        target_listener.set_nonblocking(true).unwrap();
+        let target_address = target_listener.local_addr().unwrap();
+        let (redirect_address, server) = start_redirect_server(target_address);
+
+        let resolver = FileUrlResolver {
+            allowed_private_origins: vec![NormalizedOrigin::parse(&format!("http://{redirect_address}")).unwrap()],
+        };
+        let result = resolver
+            .resolve_url(
+                &format!("http://{redirect_address}/file.txt"),
+                tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+                1024,
+            )
+            .await;
+        server.join().unwrap();
+
+        match result {
+            Err(ResolveError::FileUrlFailed { detail, .. }) => {
+                assert!(detail.contains("302"), "redirect response should be rejected directly");
+            },
+            Err(other) => panic!("expected URL fetch failure for redirect, got {other}"),
+            Ok(_) => panic!("redirect must not be followed"),
+        }
+        assert!(
+            matches!(target_listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock),
+            "redirect target must not receive a connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn pinned_client_disables_configured_proxy() {
+        let target_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let target_address = target_listener.local_addr().unwrap();
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        proxy_listener.set_nonblocking(true).unwrap();
+        let proxy_address = proxy_listener.local_addr().unwrap();
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = target_listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .unwrap();
+        });
+
+        let builder = reqwest::Client::builder().proxy(reqwest::Proxy::all(format!("http://{proxy_address}")).unwrap());
+        let client = configure_pinned_client(builder, "127.0.0.1", &[], std::time::Duration::from_secs(5)).unwrap();
+        let response = client
+            .get(format!("http://{target_address}/file.txt"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.bytes().await.unwrap().as_ref(), b"ok");
+        server.join().unwrap();
+
+        assert!(
+            matches!(proxy_listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock),
+            "configured proxy must not receive a connection"
         );
     }
 

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -208,10 +208,12 @@ fn is_2001_ietf_non_global(s: [u16; 8]) -> bool {
     }
     // Globally reachable exceptions per IANA — these pass through:
     match s[1] {
-        // 2001::/32 Teredo (RFC 4380), 2001:3::/32 AMT (RFC 7450)
-        0x0000 | 0x0003 => false,
-        0x0004 if s[2] == 0x0112 => false,  // 2001:4:112::/48 — AS112-v6 (RFC 7535)
-        v if v & 0xFFF0 == 0x0020 => false, // 2001:20::/28 — ORCHIDv2 (RFC 7343)
+        // 2001:1::1 PCP, 2001:1::2 TURN, 2001:1::3 DNS-SD anycast (RFC 6887/8155/8880)
+        0x0001 if s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0 && s[6] == 0 && matches!(s[7], 1..=3) => false,
+        0x0003 => false,                   // 2001:3::/32 — AMT (RFC 7450)
+        0x0004 if s[2] == 0x0112 => false, // 2001:4:112::/48 — AS112-v6 (RFC 7535)
+        // 2001:20::/28 ORCHIDv2 (RFC 7343), 2001:30::/28 Drone Remote ID (RFC 9374)
+        v if v & 0xFFF0 == 0x0020 || v & 0xFFF0 == 0x0030 => false,
         _ => true,
     }
 }
@@ -298,6 +300,60 @@ pub(crate) fn validate_file_url(raw: &str) -> Result<url::Url, ResolveError> {
     }
 
     Ok(url)
+}
+
+/// Extract filename from a `Content-Disposition` header value.
+///
+/// Handles both `filename*=UTF-8''encoded` (RFC 5987) and `filename="quoted"` forms.
+fn parse_content_disposition_filename(header: &str) -> Option<String> {
+    for part in header.split(';').skip(1) {
+        let part = part.trim();
+        // RFC 5987 extended notation: filename*=UTF-8''percent-encoded
+        if let Some(rest) = part.strip_prefix("filename*=") {
+            let rest = rest.trim();
+            if let Some(encoded) = rest.split_once("''").map(|(_, v)| v) {
+                let decoded = percent_decode_utf8(encoded);
+                if !decoded.is_empty() {
+                    return Some(decoded);
+                }
+            }
+        }
+        // Standard: filename="value" or filename=value
+        if let Some(rest) = part.strip_prefix("filename=") {
+            let rest = rest.trim();
+            let value = if rest.starts_with('"') && rest.ends_with('"') && rest.len() >= 2 {
+                rest.strip_prefix('"').and_then(|s| s.strip_suffix('"')).unwrap_or(rest)
+            } else {
+                rest
+            };
+            if !value.is_empty() {
+                return Some(value.to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Percent-decode a UTF-8 string, replacing invalid sequences with `_`.
+fn percent_decode_utf8(input: &str) -> String {
+    let mut bytes = Vec::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            let hex: String = chars.by_ref().take(2).collect();
+            if hex.len() == 2
+                && let Ok(byte) = u8::from_str_radix(&hex, 16)
+            {
+                bytes.push(byte);
+                continue;
+            }
+            bytes.push(b'_');
+        } else {
+            let mut buf = [0_u8; 4];
+            bytes.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        }
+    }
+    String::from_utf8(bytes).unwrap_or_default()
 }
 
 /// Sanitize a filename by stripping path separators and control characters.
@@ -431,14 +487,22 @@ impl FileUrlResolver {
             });
         }
 
+        // Derive filename before consuming body: prefer Content-Disposition, fall back to URL path
+        let filename = response
+            .headers()
+            .get(http::header::CONTENT_DISPOSITION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_content_disposition_filename)
+            .and_then(|f| sanitize_filename(&f))
+            .or_else(|| {
+                parsed_url
+                    .path_segments()
+                    .and_then(|mut segments| segments.next_back())
+                    .and_then(sanitize_filename)
+            });
+
         // Read bounded body
         let content = read_bounded_body(response, &label, max_content_bytes, max_resolved_bytes).await?;
-
-        // Derive filename
-        let filename = parsed_url
-            .path_segments()
-            .and_then(|mut segments| segments.next_back())
-            .and_then(sanitize_filename);
 
         // Encode as base64
         let base64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &content);
@@ -595,56 +659,98 @@ mod tests {
 
     #[test]
     fn parse_rejects_non_http_scheme() {
-        assert!(NormalizedOrigin::parse("ftp://example.com").is_err());
-        assert!(NormalizedOrigin::parse("file:///tmp/x").is_err());
+        assert!(
+            NormalizedOrigin::parse("ftp://example.com").is_err(),
+            "ftp should be rejected"
+        );
+        assert!(
+            NormalizedOrigin::parse("file:///tmp/x").is_err(),
+            "file scheme should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_credentials() {
-        assert!(NormalizedOrigin::parse("https://user@example.com").is_err());
-        assert!(NormalizedOrigin::parse("https://user:pass@example.com").is_err());
+        assert!(
+            NormalizedOrigin::parse("https://user@example.com").is_err(),
+            "username should be rejected"
+        );
+        assert!(
+            NormalizedOrigin::parse("https://user:pass@example.com").is_err(),
+            "user:pass should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_path() {
-        assert!(NormalizedOrigin::parse("https://example.com/files").is_err());
+        assert!(
+            NormalizedOrigin::parse("https://example.com/files").is_err(),
+            "path should be rejected"
+        );
     }
 
     #[test]
     fn parse_accepts_root_path() {
-        assert!(NormalizedOrigin::parse("https://example.com/").is_ok());
+        assert!(
+            NormalizedOrigin::parse("https://example.com/").is_ok(),
+            "root path should be accepted"
+        );
     }
 
     #[test]
     fn parse_rejects_query() {
-        assert!(NormalizedOrigin::parse("https://example.com?q=1").is_err());
+        assert!(
+            NormalizedOrigin::parse("https://example.com?q=1").is_err(),
+            "query should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_fragment() {
-        assert!(NormalizedOrigin::parse("https://example.com#frag").is_err());
+        assert!(
+            NormalizedOrigin::parse("https://example.com#frag").is_err(),
+            "fragment should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_cloud_metadata_ipv4() {
-        assert!(NormalizedOrigin::parse("http://169.254.169.254").is_err());
-        assert!(NormalizedOrigin::parse("http://100.100.100.200").is_err());
+        assert!(
+            NormalizedOrigin::parse("http://169.254.169.254").is_err(),
+            "IMDS should be rejected"
+        );
+        assert!(
+            NormalizedOrigin::parse("http://100.100.100.200").is_err(),
+            "Alibaba metadata should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_cloud_metadata_ipv6() {
-        assert!(NormalizedOrigin::parse("http://[fd00:ec2::254]").is_err());
+        assert!(
+            NormalizedOrigin::parse("http://[fd00:ec2::254]").is_err(),
+            "IMDS v6 should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_unspecified() {
-        assert!(NormalizedOrigin::parse("http://0.0.0.0").is_err());
-        assert!(NormalizedOrigin::parse("http://[::]").is_err());
+        assert!(
+            NormalizedOrigin::parse("http://0.0.0.0").is_err(),
+            "unspecified v4 should be rejected"
+        );
+        assert!(
+            NormalizedOrigin::parse("http://[::]").is_err(),
+            "unspecified v6 should be rejected"
+        );
     }
 
     #[test]
     fn parse_rejects_multicast() {
-        assert!(NormalizedOrigin::parse("http://224.0.0.1").is_err());
+        assert!(
+            NormalizedOrigin::parse("http://224.0.0.1").is_err(),
+            "multicast should be rejected"
+        );
     }
 
     #[test]
@@ -937,13 +1043,22 @@ mod tests {
     // IPv4 special-use range tests
     #[test]
     fn ssrf_blocks_benchmarking_range() {
-        assert!(is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), false));
-        assert!(is_file_url_ssrf_blocked(&"198.19.255.254".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), false),
+            "198.18.0.0/15 lower bound should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"198.19.255.254".parse().unwrap(), false),
+            "198.18.0.0/15 upper bound should be blocked"
+        );
     }
 
     #[test]
     fn ssrf_blocks_ietf_protocol_assignments() {
-        assert!(is_file_url_ssrf_blocked(&"192.0.0.1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"192.0.0.1".parse().unwrap(), false),
+            "192.0.0.0/24 should be blocked"
+        );
     }
 
     #[test]
@@ -968,21 +1083,39 @@ mod tests {
 
     #[test]
     fn ssrf_blocks_documentation_ranges() {
-        assert!(is_file_url_ssrf_blocked(&"192.0.2.1".parse().unwrap(), false));
-        assert!(is_file_url_ssrf_blocked(&"198.51.100.1".parse().unwrap(), false));
-        assert!(is_file_url_ssrf_blocked(&"203.0.113.1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"192.0.2.1".parse().unwrap(), false),
+            "TEST-NET-1 should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"198.51.100.1".parse().unwrap(), false),
+            "TEST-NET-2 should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"203.0.113.1".parse().unwrap(), false),
+            "TEST-NET-3 should be blocked"
+        );
     }
 
     #[test]
     fn ssrf_blocks_reserved_v4() {
-        assert!(is_file_url_ssrf_blocked(&"240.0.0.1".parse().unwrap(), false));
-        assert!(is_file_url_ssrf_blocked(&"255.255.255.254".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"240.0.0.1".parse().unwrap(), false),
+            "240.0.0.0/4 should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"255.255.255.254".parse().unwrap(), false),
+            "255.x reserved should be blocked"
+        );
     }
 
     // IPv6 special-use range tests
     #[test]
     fn ssrf_blocks_discard_only_v6() {
-        assert!(is_file_url_ssrf_blocked(&"100::".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"100::".parse().unwrap(), false),
+            "100::/64 discard-only should be blocked"
+        );
         assert!(
             is_file_url_ssrf_blocked(&"100:0:0:1::1".parse().unwrap(), false),
             "100:0:0:1::/64 dummy prefix should be blocked"
@@ -999,7 +1132,10 @@ mod tests {
 
     #[test]
     fn ssrf_blocks_nat64_local_use() {
-        assert!(is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), false),
+            "64:ff9b:1::/48 local-use NAT64 should be blocked"
+        );
     }
 
     #[test]
@@ -1025,19 +1161,53 @@ mod tests {
 
     #[test]
     fn ssrf_blocks_2001_benchmarking() {
-        assert!(is_file_url_ssrf_blocked(&"2001:2:0::1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:2:0::1".parse().unwrap(), false),
+            "2001:2::/48 benchmarking should be blocked"
+        );
     }
 
     #[test]
     fn ssrf_blocks_2001_documentation() {
-        assert!(is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), false),
+            "2001:db8::/32 documentation should be blocked"
+        );
     }
 
     #[test]
-    fn ssrf_allows_2001_teredo() {
+    fn ssrf_blocks_2001_teredo() {
         assert!(
-            !is_file_url_ssrf_blocked(&"2001::1".parse().unwrap(), false),
-            "2001::/32 Teredo is globally reachable"
+            is_file_url_ssrf_blocked(&"2001::1".parse().unwrap(), false),
+            "2001::/32 Teredo has N/A global reachability, treat as transition range"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_2001_anycast_128s() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:1::1".parse().unwrap(), false),
+            "2001:1::1/128 PCP anycast is globally reachable"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:1::2".parse().unwrap(), false),
+            "2001:1::2/128 TURN anycast is globally reachable"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:1::3".parse().unwrap(), false),
+            "2001:1::3/128 DNS-SD anycast is globally reachable"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_2001_1_non_anycast() {
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:1::4".parse().unwrap(), false),
+            "2001:1::4 is not a registered anycast address"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:1::100".parse().unwrap(), false),
+            "2001:1::100 is not a registered anycast address"
         );
     }
 
@@ -1070,10 +1240,22 @@ mod tests {
     }
 
     #[test]
-    fn ssrf_blocks_outside_orchidv2_in_2001() {
+    fn ssrf_allows_2001_drone_remote_id() {
         assert!(
-            is_file_url_ssrf_blocked(&"2001:30::1".parse().unwrap(), false),
-            "2001:30:: is outside ORCHIDv2, still in 2001::/23 non-global"
+            !is_file_url_ssrf_blocked(&"2001:30::1".parse().unwrap(), false),
+            "2001:30::/28 Drone Remote ID is globally reachable"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:3f::1".parse().unwrap(), false),
+            "2001:3f:: is at the edge of Drone Remote ID"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_between_global_exceptions() {
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:40::1".parse().unwrap(), false),
+            "2001:40:: is outside all globally reachable exceptions"
         );
     }
 
@@ -1088,7 +1270,10 @@ mod tests {
     // 3fff::/20 and 5f00::/16
     #[test]
     fn ssrf_blocks_documentation_rfc9637() {
-        assert!(is_file_url_ssrf_blocked(&"3fff::1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"3fff::1".parse().unwrap(), false),
+            "3fff::1 documentation prefix (RFC 9637) should be blocked"
+        );
         assert!(
             is_file_url_ssrf_blocked(&"3fff:0fff::1".parse().unwrap(), false),
             "3fff:0fff:: is inside 3fff::/20"
@@ -1109,16 +1294,31 @@ mod tests {
 
     #[test]
     fn ssrf_blocks_srv6_sid() {
-        assert!(is_file_url_ssrf_blocked(&"5f00::1".parse().unwrap(), false));
+        assert!(
+            is_file_url_ssrf_blocked(&"5f00::1".parse().unwrap(), false),
+            "5f00::/16 SRv6 SID should be blocked"
+        );
     }
 
     // Allowlist override
     #[test]
     fn ssrf_allows_special_use_with_allowlist() {
-        assert!(!is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), true));
-        assert!(!is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), true));
-        assert!(!is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), true));
-        assert!(!is_file_url_ssrf_blocked(&"2002:c0a8:1::1".parse().unwrap(), true));
+        assert!(
+            !is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), true),
+            "198.18.0.0/15 should be allowed with allowlist override"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), true),
+            "2001:db8::/32 should be allowed with allowlist override"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"64:ff9b:1::1".parse().unwrap(), true),
+            "64:ff9b:1::/48 should be allowed with allowlist override"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2002:c0a8:1::1".parse().unwrap(), true),
+            "2002::/16 (6to4) should be allowed with allowlist override"
+        );
     }
 
     #[test]
@@ -1132,9 +1332,12 @@ mod tests {
     // MIME validation tests
     #[test]
     fn mime_valid_simple() {
-        assert!(is_valid_mime_type("text/plain"));
-        assert!(is_valid_mime_type("application/octet-stream"));
-        assert!(is_valid_mime_type("image/png"));
+        assert!(is_valid_mime_type("text/plain"), "text/plain should be valid");
+        assert!(
+            is_valid_mime_type("application/octet-stream"),
+            "application/octet-stream should be valid"
+        );
+        assert!(is_valid_mime_type("image/png"), "image/png should be valid");
     }
 
     #[test]
@@ -1353,6 +1556,61 @@ mod tests {
             sanitize_filename("///\\\\\\"),
             None,
             "input with only separators should return None"
+        );
+    }
+
+    // Content-Disposition filename tests
+    #[test]
+    fn content_disposition_quoted_filename() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"report.pdf\""),
+            Some("report.pdf".to_owned()),
+            "should extract quoted filename"
+        );
+    }
+
+    #[test]
+    fn content_disposition_unquoted_filename() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=report.pdf"),
+            Some("report.pdf".to_owned()),
+            "should extract unquoted filename"
+        );
+    }
+
+    #[test]
+    fn content_disposition_star_notation() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf"),
+            Some("résumé.pdf".to_owned()),
+            "should decode RFC 5987 filename*"
+        );
+    }
+
+    #[test]
+    fn content_disposition_star_preferred_over_plain() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename*=UTF-8''correct.pdf; filename=\"fallback.pdf\""),
+            Some("correct.pdf".to_owned()),
+            "filename* should take precedence over filename"
+        );
+    }
+
+    #[test]
+    fn content_disposition_inline() {
+        assert_eq!(
+            parse_content_disposition_filename("inline"),
+            None,
+            "inline without filename should return None"
+        );
+    }
+
+    #[test]
+    fn content_disposition_empty_filename() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"\""),
+            None,
+            "empty quoted filename should return None"
         );
     }
 }

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -126,10 +126,19 @@ fn is_unconditionally_blocked(ip: &IpAddr) -> bool {
 fn is_private_range(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
-            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.octets()[0] == 0 || is_cgnat(*v4)
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.octets()[0] == 0
+                || is_cgnat(*v4)
+                || is_special_use_v4(*v4)
         },
         IpAddr::V6(v6) => {
-            v6.is_loopback() || v6.is_unique_local() || is_unicast_link_local_v6(v6) || is_site_local_v6(v6)
+            v6.is_loopback()
+                || v6.is_unique_local()
+                || is_unicast_link_local_v6(v6)
+                || is_site_local_v6(v6)
+                || is_special_use_v6(*v6)
         },
     }
 }
@@ -151,13 +160,41 @@ fn is_site_local_v6(v6: &std::net::Ipv6Addr) -> bool {
     a == 0xFE && (b & 0xC0) == 0xC0
 }
 
+/// Non-globally-reachable IPv4 special-use ranges per IANA registry.
+fn is_special_use_v4(ip: std::net::Ipv4Addr) -> bool {
+    let o = ip.octets();
+    let n = u32::from(ip);
+    // 192.0.0.0/24 (IETF Protocol Assignments) + 192.0.2.0/24 (TEST-NET-1)
+    (o[0] == 192 && o[1] == 0 && (o[2] == 0 || o[2] == 2))
+    // 198.18.0.0/15 — Benchmarking
+    || (n & 0xFFFE_0000 == 0xC612_0000)
+    // 198.51.100.0/24 — Documentation (TEST-NET-2)
+    || (o[0] == 198 && o[1] == 51 && o[2] == 100)
+    // 203.0.113.0/24 — Documentation (TEST-NET-3)
+    || (o[0] == 203 && o[1] == 0 && o[2] == 113)
+    // 240.0.0.0/4 — Reserved for future use
+    || o[0] >= 240
+}
+
+/// Non-globally-reachable IPv6 special-use ranges per IANA registry.
+fn is_special_use_v6(v6: std::net::Ipv6Addr) -> bool {
+    let s = v6.segments();
+    // 100::/64 — Discard-Only (RFC 6666)
+    (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+    // 2001:db8::/32 — Documentation (RFC 3849)
+    || (s[0] == 0x2001 && s[1] == 0x0DB8)
+}
+
 /// Validate that a string is a well-formed MIME type (`token/token`).
 ///
-/// Rejects values containing commas, spaces, semicolons, or other
-/// characters that are not RFC 2045 tokens.
+/// Uses the RFC 2045 token production but additionally excludes characters
+/// that are URI-structural (`#`, `%`) or non-printable in data URIs
+/// (`^`, `` ` ``, `|`), preventing corruption when the type is interpolated
+/// into `data:{type};base64,...`.
 fn is_valid_mime_type(s: &str) -> bool {
-    fn is_token_char(c: char) -> bool {
-        c.is_ascii() && !c.is_ascii_control() && !b" \t\"(),/:;<=>?@[\\]{}".contains(&(c as u8))
+    /// RFC 2045 token characters minus URI-unsafe ones (`#%^``|`).
+    fn is_data_uri_safe_token(c: char) -> bool {
+        c.is_ascii() && !c.is_ascii_control() && !b" \t\"(),/:;<=>?@[\\]{}#%^`|".contains(&(c as u8))
     }
 
     let Some((type_part, subtype)) = s.split_once('/') else {
@@ -165,8 +202,8 @@ fn is_valid_mime_type(s: &str) -> bool {
     };
     !type_part.is_empty()
         && !subtype.is_empty()
-        && type_part.chars().all(is_token_char)
-        && subtype.chars().all(is_token_char)
+        && type_part.chars().all(is_data_uri_safe_token)
+        && subtype.chars().all(is_data_uri_safe_token)
 }
 
 /// Check if an IP should be blocked for `file_url` fetches.
@@ -866,6 +903,83 @@ mod tests {
         );
     }
 
+    // Special-use range tests
+    #[test]
+    fn ssrf_blocks_benchmarking_range() {
+        assert!(
+            is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), false),
+            "198.18.0.0/15 benchmarking should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"198.19.255.254".parse().unwrap(), false),
+            "198.19.x upper range should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_ietf_protocol_assignments() {
+        assert!(
+            is_file_url_ssrf_blocked(&"192.0.0.1".parse().unwrap(), false),
+            "192.0.0.0/24 IETF assignments should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_documentation_ranges() {
+        assert!(
+            is_file_url_ssrf_blocked(&"192.0.2.1".parse().unwrap(), false),
+            "TEST-NET-1 should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"198.51.100.1".parse().unwrap(), false),
+            "TEST-NET-2 should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"203.0.113.1".parse().unwrap(), false),
+            "TEST-NET-3 should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_reserved_v4() {
+        assert!(
+            is_file_url_ssrf_blocked(&"240.0.0.1".parse().unwrap(), false),
+            "240.0.0.0/4 reserved should be blocked"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"255.255.255.254".parse().unwrap(), false),
+            "255.x reserved upper should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_discard_only_v6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"100::1".parse().unwrap(), false),
+            "100::/64 discard-only should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_documentation_v6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), false),
+            "2001:db8::/32 documentation should be blocked"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_special_use_with_allowlist() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"198.18.0.1".parse().unwrap(), true),
+            "benchmarking range should be allowed with allowlist"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:db8::1".parse().unwrap(), true),
+            "documentation v6 should be allowed with allowlist"
+        );
+    }
+
     #[test]
     fn ssrf_blocks_zero_octet() {
         assert!(
@@ -915,6 +1029,15 @@ mod tests {
             !is_valid_mime_type("text/plain;charset=utf-8"),
             "semicolon should have been stripped before validation"
         );
+    }
+
+    #[test]
+    fn mime_rejects_data_uri_unsafe_chars() {
+        assert!(!is_valid_mime_type("text/x-foo#bar"), "# corrupts data URI fragment");
+        assert!(!is_valid_mime_type("text/x%2Fplain"), "% triggers percent-encoding");
+        assert!(!is_valid_mime_type("text/x^plain"), "^ is not URI-safe");
+        assert!(!is_valid_mime_type("text/x`plain"), "backtick is not URI-safe");
+        assert!(!is_valid_mime_type("text/x|plain"), "pipe is not URI-safe");
     }
 
     // RedactedUrl tests

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -3,9 +3,18 @@
 
 //! URL resolution and SSRF validation for `file_url` references.
 
-use std::net::IpAddr;
+// String slicing is validated via `is_char_boundary` in `sanitize_filename`.
+// allow_attributes lint disabled because expect doesn't work for indexing_slicing.
+#![allow(clippy::allow_attributes)]
+#![allow(clippy::indexing_slicing)]
+
+use std::net::{IpAddr, SocketAddr};
 
 use praxis_core::connectivity::normalize_mapped_ipv4;
+
+use super::resolve::{
+    ResolveError, ResolvedFile, infer_mime_from_filename, max_content_bytes_for_data_url, read_bounded_body,
+};
 
 /// A validated, normalized origin (scheme + host + port) for allowlist matching.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -110,13 +119,352 @@ fn is_cloud_metadata(ip: &IpAddr) -> bool {
     }
 }
 
+/// IPs that are always blocked regardless of allowlist.
+fn is_unconditionally_blocked(ip: &IpAddr) -> bool {
+    ip.is_unspecified() || ip.is_multicast() || is_cloud_metadata(ip)
+}
+
+/// IPs that are blocked unless the origin is allowlisted.
+fn is_private_range(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.octets()[0] == 0 || is_cgnat(*v4)
+        },
+        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local() || is_unicast_link_local_v6(v6),
+    }
+}
+
+/// Check if an IPv4 address is in the CGNAT range (100.64.0.0/10).
+fn is_cgnat(ip: std::net::Ipv4Addr) -> bool {
+    u32::from(ip) & 0xFFC0_0000 == 0x6440_0000
+}
+
+/// Check if an IPv6 address is in the unicast link-local range (`fe80::/10`).
+fn is_unicast_link_local_v6(v6: &std::net::Ipv6Addr) -> bool {
+    let [a, b, ..] = v6.octets();
+    a == 0xFE && (b & 0xC0) == 0x80
+}
+
+/// Check if an IP should be blocked for `file_url` fetches.
+pub(crate) fn is_file_url_ssrf_blocked(ip: &IpAddr, allow_private: bool) -> bool {
+    let ip = &normalize_mapped_ipv4(*ip);
+    if is_unconditionally_blocked(ip) {
+        return true;
+    }
+    if !allow_private && is_private_range(ip) {
+        return true;
+    }
+    false
+}
+
+/// Redact sensitive parts of a URL for safe logging.
+///
+/// Strips credentials entirely and replaces query parameter values with `[REDACTED]`.
+pub(crate) fn redact_url(raw: &str) -> String {
+    let Ok(mut url) = url::Url::parse(raw) else {
+        return "<invalid URL>".to_owned();
+    };
+    // Clear credentials (error only occurs if cannot-be-a-base, which was already validated)
+    #[expect(clippy::let_underscore_must_use, reason = "Result<(), ()> intentionally ignored")]
+    {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+    }
+
+    // Redact query values
+    if url.query().is_some() {
+        let redacted_pairs: Vec<_> = url
+            .query_pairs()
+            .map(|(key, _value)| format!("{key}=[REDACTED]"))
+            .collect();
+        if !redacted_pairs.is_empty() {
+            url.set_query(Some(&redacted_pairs.join("&")));
+        }
+    }
+
+    url.to_string()
+}
+
+/// Validate a `file_url`: must be http/https, no credentials, no fragment.
+pub(crate) fn validate_file_url(raw: &str) -> Result<url::Url, ResolveError> {
+    let url = url::Url::parse(raw).map_err(|e| {
+        tracing::debug!(error = %e, "invalid file_url");
+        ResolveError::FileUrlBlocked {
+            label: redact_url(raw),
+        }
+    })?;
+
+    let scheme = url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(ResolveError::FileUrlBlocked { label: redact_url(raw) });
+    }
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(ResolveError::FileUrlBlocked { label: redact_url(raw) });
+    }
+
+    if url.fragment().is_some() {
+        return Err(ResolveError::FileUrlBlocked { label: redact_url(raw) });
+    }
+
+    Ok(url)
+}
+
+/// Sanitize a filename by stripping path separators and control characters.
+///
+/// Returns `None` if the result is empty or exceeds 255 bytes.
+pub(crate) fn sanitize_filename(raw: &str) -> Option<String> {
+    let sanitized: String = raw
+        .chars()
+        .filter(|&c| c != '/' && c != '\\' && c >= '\x20' && c != '\x7F')
+        .collect();
+
+    if sanitized.is_empty() {
+        return None;
+    }
+
+    // Bound at 255 bytes on UTF-8 boundary
+    if sanitized.len() <= 255 {
+        Some(sanitized)
+    } else {
+        // Find the last valid UTF-8 boundary within 255 bytes
+        let mut len = 255;
+        while len > 0 && !sanitized.is_char_boundary(len) {
+            len -= 1;
+        }
+        if len == 0 {
+            None
+        } else {
+            Some(sanitized[..len].to_owned())
+        }
+    }
+}
+
 /// Resolves `file_url` references with DNS pinning and SSRF protection.
-#[expect(dead_code, reason = "used in Task 3")] // Used in Task 3
+#[cfg_attr(not(test), expect(dead_code, reason = "used in Task 4"))]
 pub(crate) struct FileUrlResolver {
     /// Origins that permit resolution to private/loopback addresses.
     pub(crate) allowed_private_origins: Vec<NormalizedOrigin>,
     /// Overall timeout for URL resolution.
+    #[expect(dead_code, reason = "used in Task 4")]
     pub(crate) timeout: std::time::Duration,
+}
+
+impl FileUrlResolver {
+    /// Resolve a `file_url` with SSRF protection and DNS pinning.
+    #[expect(dead_code, reason = "used in Task 4")]
+    #[expect(clippy::too_many_lines, reason = "main resolution flow")]
+    pub(crate) async fn resolve_url(
+        &self,
+        url: &str,
+        deadline: tokio::time::Instant,
+        max_resolved_bytes: usize,
+    ) -> Result<ResolvedFile, ResolveError> {
+        let parsed_url = validate_file_url(url)?;
+        let label = redact_url(url);
+
+        // Check if origin is allowlisted for private addresses
+        let allow_private = self
+            .allowed_private_origins
+            .iter()
+            .any(|origin| origin.matches_url(&parsed_url));
+
+        // Resolve and validate addresses
+        let (host, addrs) = resolve_and_pin_url(&parsed_url, allow_private, &label, deadline).await?;
+
+        // Check deadline before making the request
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Err(ResolveError::FileUrlFailed {
+                label,
+                detail: "deadline exceeded before fetch".to_owned(),
+            });
+        }
+        let remaining = deadline - now;
+
+        // Build pinned client
+        let client = build_pinned_client(&host, &addrs, remaining).map_err(|e| ResolveError::FileUrlFailed {
+            label: label.clone(),
+            detail: format!("failed to build HTTP client: {e}"),
+        })?;
+
+        // Send GET with only x-praxis-callout-depth header
+        let mut request = client.get(parsed_url.as_str());
+        request = request.header("x-praxis-callout-depth", "1");
+
+        let response = request.send().await.map_err(|e| {
+            let detail = if e.is_timeout() {
+                "fetch timed out".to_owned()
+            } else {
+                "fetch failed".to_owned()
+            };
+            ResolveError::FileUrlFailed {
+                label: label.clone(),
+                detail,
+            }
+        })?;
+
+        // Check success status
+        if !response.status().is_success() {
+            return Err(ResolveError::FileUrlFailed {
+                label,
+                detail: format!("server returned {}", response.status()),
+            });
+        }
+
+        // Validate Content-Type
+        let content_type = response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|ct| {
+                // Parse MIME type, reject if invalid
+                ct.split(';').next().map(str::trim)
+            })
+            .or_else(|| {
+                // Fall back to URL path extension
+                infer_mime_from_filename(parsed_url.path().rsplit('/').next())
+            })
+            .unwrap_or("application/octet-stream")
+            .to_owned();
+
+        // Compute max raw bytes after reserving data URI prefix
+        let max_content_bytes = max_content_bytes_for_data_url(max_resolved_bytes, &content_type).ok_or_else(|| {
+            ResolveError::FileUrlFailed {
+                label: label.clone(),
+                detail: "content type prefix exceeds budget".to_owned(),
+            }
+        })?;
+
+        // Check Content-Length against max raw bytes
+        if let Some(cl) = response.content_length()
+            && usize::try_from(cl).unwrap_or(usize::MAX) > max_content_bytes
+        {
+            return Err(ResolveError::FileUrlFailed {
+                label,
+                detail: format!("Content-Length {cl} exceeds limit"),
+            });
+        }
+
+        // Read bounded body
+        let content = read_bounded_body(response, &label, max_content_bytes, max_resolved_bytes).await?;
+
+        // Derive filename
+        let filename = parsed_url
+            .path_segments()
+            .and_then(|mut segments| segments.next_back())
+            .and_then(sanitize_filename);
+
+        // Encode as base64
+        let base64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &content);
+
+        Ok(ResolvedFile {
+            base64,
+            content_type,
+            filename,
+        })
+    }
+}
+
+/// Resolve DNS and validate all addresses.
+#[expect(clippy::too_many_lines, reason = "DNS resolution + validation flow")]
+async fn resolve_and_pin_url(
+    url: &url::Url,
+    allow_private: bool,
+    label: &str,
+    deadline: tokio::time::Instant,
+) -> Result<(String, Vec<SocketAddr>), ResolveError> {
+    let Some(host) = url.host_str() else {
+        return Err(ResolveError::FileUrlBlocked {
+            label: label.to_owned(),
+        });
+    };
+
+    // Check if host is an IP literal
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        let normalized = normalize_mapped_ipv4(ip);
+        if is_file_url_ssrf_blocked(&normalized, allow_private) {
+            return Err(ResolveError::FileUrlBlocked {
+                label: label.to_owned(),
+            });
+        }
+        // IP literals don't need DNS resolution, return empty addrs for no pinning
+        return Ok((host.to_owned(), Vec::new()));
+    }
+
+    // Check blocked hostnames
+    if !allow_private && is_blocked_hostname(host) {
+        return Err(ResolveError::FileUrlBlocked {
+            label: label.to_owned(),
+        });
+    }
+
+    // DNS resolution
+    let port = url.port_or_known_default().unwrap_or(80);
+    let lookup = format!("{host}:{port}");
+
+    let addrs: Vec<SocketAddr> = tokio::time::timeout_at(deadline, tokio::net::lookup_host(&lookup))
+        .await
+        .map_err(|e| {
+            tracing::debug!(error = %e, "DNS resolution deadline exceeded");
+            ResolveError::FileUrlFailed {
+                label: label.to_owned(),
+                detail: "DNS resolution timed out".to_owned(),
+            }
+        })?
+        .map_err(|e| ResolveError::FileUrlFailed {
+            label: label.to_owned(),
+            detail: format!("DNS resolution failed: {e}"),
+        })?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(ResolveError::FileUrlFailed {
+            label: label.to_owned(),
+            detail: "DNS returned zero addresses".to_owned(),
+        });
+    }
+
+    // Deduplicate and validate all IPs
+    let mut seen = std::collections::HashSet::new();
+    let mut validated = Vec::new();
+    for addr in addrs {
+        let ip = normalize_mapped_ipv4(addr.ip());
+        if seen.insert(ip) {
+            if is_file_url_ssrf_blocked(&ip, allow_private) {
+                return Err(ResolveError::FileUrlBlocked {
+                    label: label.to_owned(),
+                });
+            }
+            validated.push(SocketAddr::new(ip, addr.port()));
+        }
+    }
+
+    Ok((host.to_owned(), validated))
+}
+
+/// Check if a hostname is blocked (localhost and *.localhost).
+fn is_blocked_hostname(host: &str) -> bool {
+    let lower = host.to_ascii_lowercase();
+    lower == "localhost" || lower.ends_with(".localhost")
+}
+
+/// Build a per-request pinned reqwest client.
+fn build_pinned_client(
+    host: &str,
+    addrs: &[SocketAddr],
+    timeout: std::time::Duration,
+) -> Result<reqwest::Client, reqwest::Error> {
+    let mut builder = reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(timeout);
+
+    if !addrs.is_empty() {
+        builder = builder.resolve_to_addrs(host, addrs);
+    }
+
+    builder.build()
 }
 
 #[cfg(test)]
@@ -270,5 +618,369 @@ mod tests {
         let origin = NormalizedOrigin::parse("https://files.example.com").unwrap();
         let url = url::Url::parse("https://other.example.com/file.pdf").unwrap();
         assert!(!origin.matches_url(&url), "host mismatch should not match");
+    }
+
+    // SSRF IP validation tests
+    #[test]
+    fn ssrf_blocks_loopback_ipv4() {
+        assert!(
+            is_file_url_ssrf_blocked(&"127.0.0.1".parse().unwrap(), false),
+            "loopback IPv4 should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_loopback_ipv6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"::1".parse().unwrap(), false),
+            "loopback IPv6 should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_private_10() {
+        assert!(
+            is_file_url_ssrf_blocked(&"10.0.0.1".parse().unwrap(), false),
+            "10.x should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_private_172() {
+        assert!(
+            is_file_url_ssrf_blocked(&"172.16.0.1".parse().unwrap(), false),
+            "172.16-31.x should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_private_192() {
+        assert!(
+            is_file_url_ssrf_blocked(&"192.168.1.1".parse().unwrap(), false),
+            "192.168.x should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_link_local_ipv4() {
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.1.1".parse().unwrap(), false),
+            "link-local IPv4 should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_link_local_ipv6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"fe80::1".parse().unwrap(), false),
+            "link-local IPv6 should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_cgnat() {
+        assert!(
+            is_file_url_ssrf_blocked(&"100.64.0.1".parse().unwrap(), false),
+            "CGNAT 100.64.0.0/10 should be blocked without allowlist"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"100.127.255.254".parse().unwrap(), false),
+            "CGNAT upper range should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_unspecified_ipv4() {
+        assert!(
+            is_file_url_ssrf_blocked(&"0.0.0.0".parse().unwrap(), true),
+            "unspecified IPv4 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_unspecified_ipv6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"::".parse().unwrap(), true),
+            "unspecified IPv6 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_multicast_ipv4() {
+        assert!(
+            is_file_url_ssrf_blocked(&"224.0.0.1".parse().unwrap(), true),
+            "multicast IPv4 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_multicast_ipv6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"ff02::1".parse().unwrap(), true),
+            "multicast IPv6 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_aws_imds_v4() {
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.169.254".parse().unwrap(), true),
+            "AWS IMDS v4 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_aws_imds_v6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"fd00:ec2::254".parse().unwrap(), true),
+            "AWS IMDS v6 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_alibaba_metadata() {
+        assert!(
+            is_file_url_ssrf_blocked(&"100.100.100.200".parse().unwrap(), true),
+            "Alibaba metadata should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_mapped_loopback() {
+        assert!(
+            is_file_url_ssrf_blocked(&"::ffff:127.0.0.1".parse().unwrap(), false),
+            "IPv4-mapped loopback should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_unique_local_ipv6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"fc00::1".parse().unwrap(), false),
+            "unique local IPv6 should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_public_ipv4() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"8.8.8.8".parse().unwrap(), false),
+            "public IPv4 should be allowed"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_public_ipv6() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"2001:4860:4860::8888".parse().unwrap(), false),
+            "public IPv6 should be allowed"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_private_with_allowlist() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"10.0.0.1".parse().unwrap(), true),
+            "private IP should be allowed with allowlist match"
+        );
+        assert!(
+            !is_file_url_ssrf_blocked(&"127.0.0.1".parse().unwrap(), true),
+            "loopback should be allowed with allowlist match"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_cloud_metadata_even_with_allowlist() {
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.169.254".parse().unwrap(), true),
+            "cloud metadata should be blocked even with allowlist"
+        );
+        assert!(
+            is_file_url_ssrf_blocked(&"fd00:ec2::254".parse().unwrap(), true),
+            "cloud metadata IPv6 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_zero_octet() {
+        assert!(
+            is_file_url_ssrf_blocked(&"0.1.2.3".parse().unwrap(), false),
+            "IPv4 with leading zero octet should be blocked without allowlist"
+        );
+    }
+
+    // RedactedUrl tests
+    #[test]
+    fn redact_url_strips_credentials() {
+        let redacted = redact_url("https://user:pass@example.com/path");
+        assert!(!redacted.contains("user"), "username should be stripped");
+        assert!(!redacted.contains("pass"), "password should be stripped");
+        assert!(redacted.contains("example.com"), "host should remain");
+    }
+
+    #[test]
+    fn redact_url_replaces_query_values() {
+        let redacted = redact_url("https://example.com/file?token=secret&id=123");
+        assert!(redacted.contains("token=[REDACTED]"), "query key should remain");
+        assert!(!redacted.contains("secret"), "query value should be redacted");
+        assert!(
+            redacted.contains("id=[REDACTED]"),
+            "all query values should be redacted"
+        );
+    }
+
+    #[test]
+    fn redact_url_preserves_path() {
+        let redacted = redact_url("https://example.com/sensitive/path");
+        assert!(redacted.contains("/sensitive/path"), "path should be preserved");
+    }
+
+    #[test]
+    fn redact_url_handles_invalid_url() {
+        let redacted = redact_url("not a url");
+        assert_eq!(redacted, "<invalid URL>", "invalid URL should return placeholder");
+    }
+
+    #[test]
+    fn redact_url_no_query_unchanged() {
+        let redacted = redact_url("https://example.com/file.pdf");
+        assert_eq!(
+            redacted, "https://example.com/file.pdf",
+            "URL without query should remain unchanged except for redaction"
+        );
+    }
+
+    // validate_file_url tests
+    #[test]
+    fn validate_file_url_accepts_http() {
+        assert!(
+            validate_file_url("http://example.com/file.pdf").is_ok(),
+            "http scheme should be accepted"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_accepts_https() {
+        assert!(
+            validate_file_url("https://example.com/file.pdf").is_ok(),
+            "https scheme should be accepted"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_rejects_ftp() {
+        assert!(
+            validate_file_url("ftp://example.com/file.pdf").is_err(),
+            "ftp scheme should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_rejects_file_scheme() {
+        assert!(
+            validate_file_url("file:///etc/passwd").is_err(),
+            "file scheme should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_rejects_data_uri() {
+        assert!(
+            validate_file_url("data:text/plain;base64,SGVsbG8=").is_err(),
+            "data URI should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_rejects_credentials() {
+        assert!(
+            validate_file_url("https://user:pass@example.com/file.pdf").is_err(),
+            "credentials should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_rejects_username_only() {
+        assert!(
+            validate_file_url("https://user@example.com/file.pdf").is_err(),
+            "username without password should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_rejects_fragment() {
+        assert!(
+            validate_file_url("https://example.com/file.pdf#page=2").is_err(),
+            "fragment should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_preserves_query() {
+        let url = validate_file_url("https://example.com/file.pdf?token=abc&expires=123").unwrap();
+        assert!(
+            url.query().is_some(),
+            "query string should be preserved for signed URLs"
+        );
+    }
+
+    #[test]
+    fn validate_file_url_malformed() {
+        assert!(
+            validate_file_url("not a url").is_err(),
+            "malformed URL should be rejected"
+        );
+    }
+
+    // sanitize_filename tests
+    #[test]
+    fn sanitize_filename_strips_path_separators() {
+        assert_eq!(
+            sanitize_filename("dir/file.txt"),
+            Some("dirfile.txt".to_owned()),
+            "forward slash should be stripped"
+        );
+        assert_eq!(
+            sanitize_filename(r"dir\file.txt"),
+            Some("dirfile.txt".to_owned()),
+            "backslash should be stripped"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_removes_control_chars() {
+        assert_eq!(
+            sanitize_filename("file\x00\x1F.txt"),
+            Some("file.txt".to_owned()),
+            "control characters should be removed"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_bounds_length() {
+        let long = "a".repeat(300);
+        let sanitized = sanitize_filename(&long).unwrap();
+        assert!(
+            sanitized.len() <= 255,
+            "filename should be bounded at 255 bytes on UTF-8 boundary"
+        );
+        assert!(
+            sanitized.is_char_boundary(sanitized.len()),
+            "truncation should respect UTF-8 boundaries"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_empty_input() {
+        assert_eq!(sanitize_filename(""), None, "empty input should return None");
+    }
+
+    #[test]
+    fn sanitize_filename_only_separators() {
+        assert_eq!(
+            sanitize_filename("///\\\\\\"),
+            None,
+            "input with only separators should return None"
+        );
     }
 }

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -128,7 +128,9 @@ fn is_private_range(ip: &IpAddr) -> bool {
         IpAddr::V4(v4) => {
             v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.octets()[0] == 0 || is_cgnat(*v4)
         },
-        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local() || is_unicast_link_local_v6(v6),
+        IpAddr::V6(v6) => {
+            v6.is_loopback() || v6.is_unique_local() || is_unicast_link_local_v6(v6) || is_site_local_v6(v6)
+        },
     }
 }
 
@@ -141,6 +143,30 @@ fn is_cgnat(ip: std::net::Ipv4Addr) -> bool {
 fn is_unicast_link_local_v6(v6: &std::net::Ipv6Addr) -> bool {
     let [a, b, ..] = v6.octets();
     a == 0xFE && (b & 0xC0) == 0x80
+}
+
+/// Deprecated site-local range (`fec0::/10`, RFC 3879).
+fn is_site_local_v6(v6: &std::net::Ipv6Addr) -> bool {
+    let [a, b, ..] = v6.octets();
+    a == 0xFE && (b & 0xC0) == 0xC0
+}
+
+/// Validate that a string is a well-formed MIME type (`token/token`).
+///
+/// Rejects values containing commas, spaces, semicolons, or other
+/// characters that are not RFC 2045 tokens.
+fn is_valid_mime_type(s: &str) -> bool {
+    fn is_token_char(c: char) -> bool {
+        c.is_ascii() && !c.is_ascii_control() && !b" \t\"(),/:;<=>?@[\\]{}".contains(&(c as u8))
+    }
+
+    let Some((type_part, subtype)) = s.split_once('/') else {
+        return false;
+    };
+    !type_part.is_empty()
+        && !subtype.is_empty()
+        && type_part.chars().all(is_token_char)
+        && subtype.chars().all(is_token_char)
 }
 
 /// Check if an IP should be blocked for `file_url` fetches.
@@ -310,7 +336,7 @@ impl FileUrlResolver {
             .and_then(|v| v.to_str().ok())
             .and_then(|ct| {
                 let mime = ct.split(';').next().map(str::trim)?;
-                mime.contains('/').then_some(mime)
+                is_valid_mime_type(mime).then_some(mime)
             })
             .or_else(|| {
                 // Fall back to URL path extension
@@ -817,10 +843,77 @@ mod tests {
     }
 
     #[test]
+    fn ssrf_blocks_site_local_v6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"fec0::1".parse().unwrap(), false),
+            "site-local fec0::/10 should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_site_local_v6_upper() {
+        assert!(
+            is_file_url_ssrf_blocked(&"feff::1".parse().unwrap(), false),
+            "site-local upper range feff:: should be blocked without allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_allows_site_local_v6_with_allowlist() {
+        assert!(
+            !is_file_url_ssrf_blocked(&"fec0::1".parse().unwrap(), true),
+            "site-local should be allowed with allowlist"
+        );
+    }
+
+    #[test]
     fn ssrf_blocks_zero_octet() {
         assert!(
             is_file_url_ssrf_blocked(&"0.1.2.3".parse().unwrap(), false),
             "IPv4 with leading zero octet should be blocked without allowlist"
+        );
+    }
+
+    // MIME validation tests
+    #[test]
+    fn mime_valid_simple() {
+        assert!(is_valid_mime_type("text/plain"));
+        assert!(is_valid_mime_type("application/octet-stream"));
+        assert!(is_valid_mime_type("image/png"));
+    }
+
+    #[test]
+    fn mime_rejects_comma_separated() {
+        assert!(
+            !is_valid_mime_type("text/plain,application/json"),
+            "comma in MIME should be rejected"
+        );
+    }
+
+    #[test]
+    fn mime_rejects_no_slash() {
+        assert!(
+            !is_valid_mime_type("textplain"),
+            "MIME without slash should be rejected"
+        );
+    }
+
+    #[test]
+    fn mime_rejects_empty_parts() {
+        assert!(!is_valid_mime_type("/plain"), "empty type should be rejected");
+        assert!(!is_valid_mime_type("text/"), "empty subtype should be rejected");
+    }
+
+    #[test]
+    fn mime_rejects_spaces() {
+        assert!(!is_valid_mime_type("text /plain"), "space in type should be rejected");
+    }
+
+    #[test]
+    fn mime_rejects_semicolon_in_type() {
+        assert!(
+            !is_valid_mime_type("text/plain;charset=utf-8"),
+            "semicolon should have been stripped before validation"
         );
     }
 

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -100,15 +100,19 @@ impl NormalizedOrigin {
     }
 }
 
-/// Cloud metadata endpoints that are never permitted.
+/// Cloud metadata and credential endpoints that are never permitted.
 fn is_cloud_metadata(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
-            *v4 == std::net::Ipv4Addr::new(169, 254, 169, 254) || *v4 == std::net::Ipv4Addr::new(100, 100, 100, 200)
+            *v4 == std::net::Ipv4Addr::new(169, 254, 169, 254)
+                || *v4 == std::net::Ipv4Addr::new(169, 254, 170, 2)
+                || *v4 == std::net::Ipv4Addr::new(169, 254, 170, 23)
+                || *v4 == std::net::Ipv4Addr::new(100, 100, 100, 200)
         },
         IpAddr::V6(v6) => {
             const AWS_IMDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
-            *v6 == AWS_IMDS_V6
+            const AWS_ECS_CREDS_V6: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0023);
+            *v6 == AWS_IMDS_V6 || *v6 == AWS_ECS_CREDS_V6
         },
     }
 }
@@ -305,8 +309,8 @@ impl FileUrlResolver {
             .get(http::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
             .and_then(|ct| {
-                // Parse MIME type, reject if invalid
-                ct.split(';').next().map(str::trim)
+                let mime = ct.split(';').next().map(str::trim)?;
+                mime.contains('/').then_some(mime)
             })
             .or_else(|| {
                 // Fall back to URL path extension
@@ -785,6 +789,30 @@ mod tests {
         assert!(
             is_file_url_ssrf_blocked(&"fd00:ec2::254".parse().unwrap(), true),
             "cloud metadata IPv6 should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_ecs_credential_endpoint() {
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.170.2".parse().unwrap(), true),
+            "ECS credential endpoint should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_eks_credential_endpoint() {
+        assert!(
+            is_file_url_ssrf_blocked(&"169.254.170.23".parse().unwrap(), true),
+            "EKS credential endpoint should be blocked even with allowlist"
+        );
+    }
+
+    #[test]
+    fn ssrf_blocks_ecs_credential_endpoint_v6() {
+        assert!(
+            is_file_url_ssrf_blocked(&"fd00:ec2::23".parse().unwrap(), true),
+            "ECS/EKS credential IPv6 endpoint should be blocked even with allowlist"
         );
     }
 

--- a/apis/src/openai/responses/file_resolve/resolve_url.rs
+++ b/apis/src/openai/responses/file_resolve/resolve_url.rs
@@ -609,6 +609,11 @@ mod tests {
     use std::{
         io::{Read as _, Write as _},
         net::TcpListener,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
     };
 
     use super::*;
@@ -1855,23 +1860,96 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_url_resolver_blocks_legacy_ipv4_loopback() {
+    async fn file_url_resolver_blocks_legacy_ipv4_loopback_encodings() {
         let resolver = FileUrlResolver {
             allowed_private_origins: vec![],
         };
 
+        for url in [
+            "http://0177.0.0.1/file.txt",
+            "http://127.1/file.txt",
+            "http://2130706433/file.txt",
+            "http://0x7f000001/file.txt",
+        ] {
+            let result = resolver
+                .resolve_url(
+                    url,
+                    tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+                    1024,
+                )
+                .await;
+
+            assert!(
+                matches!(result, Err(ResolveError::FileUrlBlocked { .. })),
+                "URL-parser canonicalization must not let legacy IPv4 loopback bypass SSRF checks: {url}"
+            );
+        }
+    }
+
+    struct StalledBodyServer {
+        address: SocketAddr,
+        headers_sent: Arc<AtomicBool>,
+        release: mpsc::Sender<()>,
+        thread: std::thread::JoinHandle<()>,
+    }
+
+    fn start_stalled_body_server() -> StalledBodyServer {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let headers_sent = Arc::new(AtomicBool::new(false));
+        let server_headers_sent = Arc::clone(&headers_sent);
+        let (release, release_rx) = mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+            stream.flush().unwrap();
+            server_headers_sent.store(true, Ordering::Release);
+            let _released = release_rx.recv_timeout(std::time::Duration::from_secs(5));
+        });
+        StalledBodyServer {
+            address,
+            headers_sent,
+            release,
+            thread,
+        }
+    }
+
+    #[tokio::test]
+    async fn pinned_client_times_out_while_response_body_is_stalled() {
+        let server = start_stalled_body_server();
+        let resolver = FileUrlResolver {
+            allowed_private_origins: vec![NormalizedOrigin::parse(&format!("http://{}", server.address)).unwrap()],
+        };
         let result = resolver
             .resolve_url(
-                "http://0177.0.0.1/file.txt",
-                tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+                &format!("http://{}/file.txt", server.address),
+                tokio::time::Instant::now() + std::time::Duration::from_millis(500),
                 1024,
             )
             .await;
 
+        server.release.send(()).unwrap();
+        server.thread.join().unwrap();
         assert!(
-            matches!(result, Err(ResolveError::FileUrlBlocked { .. })),
-            "URL-parser canonicalization must not let legacy IPv4 loopback bypass SSRF checks"
+            server.headers_sent.load(Ordering::Acquire),
+            "the response headers must arrive before the body-read timeout"
         );
+        match result {
+            Err(ResolveError::FileUrlFailed { detail, .. }) => {
+                assert!(
+                    detail.contains("timed out"),
+                    "a body that stalls after headers must report a timeout"
+                );
+            },
+            Err(other) => panic!("expected URL timeout for a stalled body, got {other}"),
+            Ok(_) => panic!("a body that stalls after headers must fail at the shared deadline"),
+        }
     }
 
     #[test]

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -460,6 +460,80 @@ async fn sync_state_updates_responses_state() {
 }
 
 #[tokio::test]
+async fn file_url_resolution_updates_responses_state_with_data_uri() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let _read = stream.read(&mut request).unwrap();
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nHello World",
+            )
+            .unwrap();
+    });
+
+    let origin = format!("http://{address}");
+    let file_url = format!("{origin}/state.txt");
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"files_api_url: "http://127.0.0.1:1"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+file_url: resolve
+allowed_file_url_origins:
+  - "{origin}"
+on_missing: reject
+timeout_ms: 2000"#
+    ))
+    .unwrap();
+    let filter = FileResolveFilter::from_config(&yaml).unwrap();
+    let req = Box::leak(Box::new(crate::test_utils::make_request(
+        http::Method::POST,
+        "/v1/responses",
+    )));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let request_body = json!({
+        "model": "gpt-4o",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_file", "file_url": file_url}]
+        }]
+    });
+    ctx.extensions
+        .insert(ResponsesState::from_request_body(request_body.clone()));
+    let mut body = Some(Bytes::from(serde_json::to_vec(&request_body).unwrap()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    server.join().unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+    let rewritten: serde_json::Value = serde_json::from_slice(body.as_ref().unwrap()).unwrap();
+    let expected_data_uri = "data:text/plain;base64,SGVsbG8gV29ybGQ=";
+    let rewritten_part = &rewritten["input"][0]["content"][0];
+    assert!(
+        rewritten_part.get("file_url").is_none(),
+        "the buffered body must remove file_url"
+    );
+    assert_eq!(rewritten_part["file_data"], expected_data_uri);
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.request_body, rewritten);
+    for (name, part) in [
+        ("messages", &state.messages[0]["content"][0]),
+        ("persisted_messages", &state.persisted_messages[0]["content"][0]),
+    ] {
+        assert!(part.get("file_url").is_none(), "{name} must remove file_url");
+        assert_eq!(
+            part["file_data"], expected_data_uri,
+            "{name} must retain the resolved data URI"
+        );
+    }
+}
+
+#[tokio::test]
 async fn sync_state_uses_independent_history_offsets() {
     let req = Box::leak(Box::new(crate::test_utils::make_request(
         http::Method::POST,

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -1040,3 +1040,73 @@ async fn file_url_in_function_call_output_resolved() {
         "file_data should be a data URI with correct MIME type"
     );
 }
+
+#[tokio::test]
+async fn file_url_blocked_is_not_swallowed_by_on_missing_continue() {
+    use praxis_core::callout::{CalloutClient, CalloutConfig};
+
+    use crate::openai::responses::file_resolve::{
+        config::OnMissing,
+        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve_url::FileUrlResolver,
+    };
+
+    let mut body = json!({
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_url": "http://169.254.169.254/latest/meta-data/"
+            }]
+        }]
+    });
+
+    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
+    let client = FilesApiClient::new(
+        "http://unused:9999",
+        vec![],
+        callout,
+        FilesApiClientOptions {
+            max_file_references: 32,
+            max_resolved_bytes: 64 * 1024 * 1024,
+            timeout_ms: 30_000,
+        },
+    )
+    .unwrap();
+
+    let resolver = FileUrlResolver {
+        allowed_private_origins: vec![],
+    };
+
+    let result = resolve_input(
+        &mut body,
+        &client,
+        OnMissing::Continue,
+        &http::HeaderMap::new(),
+        Some(&resolver),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "FileUrlBlocked must propagate even with on_missing: continue"
+    );
+}
+
+#[test]
+fn display_redacts_signed_file_url() {
+    use crate::openai::responses::file_resolve::resolve::ReferenceSource;
+
+    let source =
+        ReferenceSource::FileUrl("https://storage.example.com/file.pdf?sig=SECRET_TOKEN&exp=1234567890".to_owned());
+    let displayed = format!("{source}");
+    assert!(
+        !displayed.contains("SECRET_TOKEN"),
+        "Display must not expose signed query parameters: {displayed}"
+    );
+    assert!(
+        displayed.contains("[REDACTED]"),
+        "query values should be redacted: {displayed}"
+    );
+}

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -161,6 +161,45 @@ fn reject_too_large_returns_413() {
 }
 
 #[test]
+fn reject_file_url_blocked_returns_403() {
+    let err = ResolveError::FileUrlBlocked {
+        label: "https://evil.example.com/file.pdf".to_owned(),
+    };
+    let action = reject_resolve_error(&err);
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 403, "blocked file URL should produce 403");
+            let body = std::str::from_utf8(r.body.as_deref().unwrap()).unwrap();
+            assert!(
+                body.contains("blocked by security policy"),
+                "client response should describe the block reason"
+            );
+        },
+        _ => panic!("expected Reject action"),
+    }
+}
+
+#[test]
+fn reject_file_url_failed_returns_502() {
+    let err = ResolveError::FileUrlFailed {
+        label: "https://files.example.com/report.pdf?token=[REDACTED]".to_owned(),
+        detail: "connection refused".to_owned(),
+    };
+    let action = reject_resolve_error(&err);
+    match action {
+        FilterAction::Reject(r) => {
+            assert_eq!(r.status, 502, "failed file URL fetch should produce 502");
+            let body = std::str::from_utf8(r.body.as_deref().unwrap()).unwrap();
+            assert!(
+                !body.contains("connection refused"),
+                "client response must not expose internal transport details"
+            );
+        },
+        _ => panic!("expected Reject action"),
+    }
+}
+
+#[test]
 fn reject_rewritten_body_too_large_returns_413() {
     let action = reject_rewritten_body_too_large(2048, 1024);
     match action {

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -572,7 +572,7 @@ async fn mirrored_history_has_independent_inline_budget() {
     ctx.extensions.insert(state);
     let mut budget = client.resolution_budget();
 
-    resolve_state_history(&mut ctx, &client, OnMissing::Reject, &mut budget)
+    resolve_state_history(&mut ctx, &client, OnMissing::Reject, None, &mut budget)
         .await
         .unwrap();
 

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -6,6 +6,7 @@
 use std::{
     io::{Read as _, Write as _},
     net::TcpListener,
+    time::Duration,
 };
 
 use bytes::Bytes;
@@ -148,13 +149,18 @@ fn reject_too_many_references_returns_413() {
 #[test]
 fn reject_too_large_returns_413() {
     let err = ResolveError::TooLarge {
-        file_id: "file-abc".to_owned(),
+        reference: "file-abc".to_owned(),
         limit: 1024,
     };
     let action = reject_resolve_error(&err);
     match action {
         FilterAction::Reject(r) => {
             assert_eq!(r.status, 413, "oversized resolved content should produce 413");
+            let body = std::str::from_utf8(r.body.as_deref().unwrap()).unwrap();
+            assert!(
+                body.contains("file reference 'file-abc'"),
+                "oversized response should identify a generic file reference"
+            );
         },
         _ => panic!("expected Reject action"),
     }
@@ -193,6 +199,11 @@ fn reject_file_url_failed_returns_502() {
             assert!(
                 !body.contains("connection refused"),
                 "client response must not expose internal transport details"
+            );
+            assert!(body.contains("file URL"), "client response should identify a URL fetch");
+            assert!(
+                !body.contains("Files API"),
+                "URL fetch failures must not be described as Files API failures"
             );
         },
         _ => panic!("expected Reject action"),
@@ -837,6 +848,96 @@ async fn file_url_resolved_to_data_uri() {
     let base64_part = file_data.strip_prefix("data:text/plain;base64,").unwrap();
     let decoded = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, base64_part).unwrap();
     assert_eq!(decoded, b"Hello World", "data URI should contain the file content");
+}
+
+#[tokio::test]
+async fn file_url_truncated_body_reports_url_failure() {
+    use crate::openai::responses::file_resolve::{
+        resolve::ResolveError,
+        resolve_url::{FileUrlResolver, NormalizedOrigin},
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let stub_url = format!("http://{address}/file.txt?sig=secret");
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let _read = stream.read(&mut request).unwrap();
+        let response =
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nShort";
+        stream.write_all(response).unwrap();
+    });
+
+    let resolver = FileUrlResolver {
+        allowed_private_origins: vec![
+            NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap(),
+        ],
+    };
+    let result = resolver
+        .resolve_url(
+            &stub_url,
+            tokio::time::Instant::now() + Duration::from_secs(5),
+            64 * 1024 * 1024,
+        )
+        .await;
+
+    match result {
+        Err(ResolveError::FileUrlFailed { label, detail }) => {
+            assert!(label.contains("[REDACTED]"), "signed query value should be redacted");
+            assert!(!label.contains("secret"), "signed query value must not be exposed");
+            assert!(
+                detail.contains("read error"),
+                "failure should retain URL body read context"
+            );
+        },
+        Err(other) => panic!("expected FileUrlFailed for a truncated URL body, got {other}"),
+        Ok(_) => panic!("expected FileUrlFailed for a truncated URL body"),
+    }
+}
+
+#[tokio::test]
+async fn file_url_oversized_content_length_reports_generic_too_large() {
+    use crate::openai::responses::file_resolve::{
+        resolve::ResolveError,
+        resolve_url::{FileUrlResolver, NormalizedOrigin},
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let stub_url = format!("http://{address}/file.txt?sig=secret");
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let _read = stream.read(&mut request).unwrap();
+        let response =
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100\r\nConnection: close\r\n\r\n";
+        stream.write_all(response).unwrap();
+    });
+
+    let resolver = FileUrlResolver {
+        allowed_private_origins: vec![
+            NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap(),
+        ],
+    };
+    let result = resolver
+        .resolve_url(&stub_url, tokio::time::Instant::now() + Duration::from_secs(5), 64)
+        .await;
+
+    match result {
+        Err(ResolveError::TooLarge { reference, limit }) => {
+            assert_eq!(limit, 64, "error should report the configured resolved-body limit");
+            assert!(
+                reference.contains("[REDACTED]"),
+                "signed query value should be redacted"
+            );
+            assert!(!reference.contains("secret"), "signed query value must not be exposed");
+        },
+        Err(other) => panic!("expected TooLarge for an oversized URL response, got {other}"),
+        Ok(_) => panic!("expected TooLarge for an oversized URL response"),
+    }
 }
 
 #[tokio::test]

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -767,11 +767,9 @@ fn serve_file_request(mut stream: std::net::TcpStream) {
 
 #[tokio::test]
 async fn file_url_resolved_to_data_uri() {
-    use praxis_core::callout::{CalloutClient, CalloutConfig};
-
     use crate::openai::responses::file_resolve::{
         config::OnMissing,
-        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve::resolve_input,
         resolve_url::{FileUrlResolver, NormalizedOrigin},
     };
 
@@ -805,18 +803,7 @@ async fn file_url_resolved_to_data_uri() {
     });
 
     // Create FilesApiClient
-    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
-    let client = FilesApiClient::new(
-        "http://unused:9999",
-        vec![],
-        callout,
-        FilesApiClientOptions {
-            max_file_references: 32,
-            max_resolved_bytes: 64 * 1024 * 1024,
-            timeout_ms: 30_000,
-        },
-    )
-    .unwrap();
+    let client = make_client_for_url_with_max("http://unused:9999", 64 * 1024 * 1024);
 
     // Create FileUrlResolver with allowed private origins (localhost)
     let localhost_origin = NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap();
@@ -942,12 +929,7 @@ async fn file_url_oversized_content_length_reports_generic_too_large() {
 
 #[tokio::test]
 async fn file_url_passthrough_when_no_resolver() {
-    use praxis_core::callout::{CalloutClient, CalloutConfig};
-
-    use crate::openai::responses::file_resolve::{
-        config::OnMissing,
-        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
-    };
+    use crate::openai::responses::file_resolve::{config::OnMissing, resolve::resolve_input};
 
     // Build body with file_url
     let mut body = json!({
@@ -963,18 +945,7 @@ async fn file_url_passthrough_when_no_resolver() {
     let original = body.clone();
 
     // Create FilesApiClient
-    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
-    let client = FilesApiClient::new(
-        "http://unused:9999",
-        vec![],
-        callout,
-        FilesApiClientOptions {
-            max_file_references: 32,
-            max_resolved_bytes: 64 * 1024 * 1024,
-            timeout_ms: 30_000,
-        },
-    )
-    .unwrap();
+    let client = make_client_for_url_with_max("http://unused:9999", 64 * 1024 * 1024);
 
     // Call resolve_input without url_resolver (None)
     let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
@@ -987,11 +958,9 @@ async fn file_url_passthrough_when_no_resolver() {
 
 #[tokio::test]
 async fn file_url_in_shorthand_message_resolved() {
-    use praxis_core::callout::{CalloutClient, CalloutConfig};
-
     use crate::openai::responses::file_resolve::{
         config::OnMissing,
-        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve::resolve_input,
         resolve_url::{FileUrlResolver, NormalizedOrigin},
     };
 
@@ -1024,18 +993,7 @@ async fn file_url_in_shorthand_message_resolved() {
         }]
     });
 
-    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
-    let client = FilesApiClient::new(
-        "http://unused:9999",
-        vec![],
-        callout,
-        FilesApiClientOptions {
-            max_file_references: 32,
-            max_resolved_bytes: 64 * 1024 * 1024,
-            timeout_ms: 30_000,
-        },
-    )
-    .unwrap();
+    let client = make_client_for_url_with_max("http://unused:9999", 64 * 1024 * 1024);
 
     let localhost_origin = NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap();
     let resolver = FileUrlResolver {
@@ -1065,11 +1023,9 @@ async fn file_url_in_shorthand_message_resolved() {
 
 #[tokio::test]
 async fn file_url_in_function_call_output_resolved() {
-    use praxis_core::callout::{CalloutClient, CalloutConfig};
-
     use crate::openai::responses::file_resolve::{
         config::OnMissing,
-        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve::resolve_input,
         resolve_url::{FileUrlResolver, NormalizedOrigin},
     };
 
@@ -1103,18 +1059,7 @@ async fn file_url_in_function_call_output_resolved() {
         }]
     });
 
-    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
-    let client = FilesApiClient::new(
-        "http://unused:9999",
-        vec![],
-        callout,
-        FilesApiClientOptions {
-            max_file_references: 32,
-            max_resolved_bytes: 64 * 1024 * 1024,
-            timeout_ms: 30_000,
-        },
-    )
-    .unwrap();
+    let client = make_client_for_url_with_max("http://unused:9999", 64 * 1024 * 1024);
 
     let localhost_origin = NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap();
     let resolver = FileUrlResolver {
@@ -1144,12 +1089,8 @@ async fn file_url_in_function_call_output_resolved() {
 
 #[tokio::test]
 async fn file_url_blocked_is_not_swallowed_by_on_missing_continue() {
-    use praxis_core::callout::{CalloutClient, CalloutConfig};
-
     use crate::openai::responses::file_resolve::{
-        config::OnMissing,
-        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
-        resolve_url::FileUrlResolver,
+        config::OnMissing, resolve::resolve_input, resolve_url::FileUrlResolver,
     };
 
     let mut body = json!({
@@ -1163,18 +1104,7 @@ async fn file_url_blocked_is_not_swallowed_by_on_missing_continue() {
         }]
     });
 
-    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
-    let client = FilesApiClient::new(
-        "http://unused:9999",
-        vec![],
-        callout,
-        FilesApiClientOptions {
-            max_file_references: 32,
-            max_resolved_bytes: 64 * 1024 * 1024,
-            timeout_ms: 30_000,
-        },
-    )
-    .unwrap();
+    let client = make_client_for_url_with_max("http://unused:9999", 64 * 1024 * 1024);
 
     let resolver = FileUrlResolver {
         allowed_private_origins: vec![],

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -749,3 +749,294 @@ fn serve_file_request(mut stream: std::net::TcpStream) {
     stream.write_all(headers.as_bytes()).unwrap();
     stream.write_all(body).unwrap();
 }
+
+// -----------------------------------------------------------------------------
+// Integration-level tests using TCP stubs
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn file_url_resolved_to_data_uri() {
+    use praxis_core::callout::{CalloutClient, CalloutConfig};
+
+    use crate::openai::responses::file_resolve::{
+        config::OnMissing,
+        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve_url::{FileUrlResolver, NormalizedOrigin},
+    };
+
+    // Start TCP stub serving file content
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let stub_url = format!("http://{address}/file.txt");
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            std::thread::spawn(move || {
+                let mut request = [0_u8; 4096];
+                let mut stream = stream;
+                let _read = stream.read(&mut request).unwrap();
+                let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nHello World";
+                stream.write_all(response).unwrap();
+            });
+        }
+    });
+
+    // Build request body with input_file containing file_url
+    let mut body = json!({
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_url": stub_url.clone()
+            }]
+        }]
+    });
+
+    // Create FilesApiClient
+    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
+    let client = FilesApiClient::new(
+        "http://unused:9999",
+        vec![],
+        callout,
+        FilesApiClientOptions {
+            max_file_references: 32,
+            max_resolved_bytes: 64 * 1024 * 1024,
+            timeout_ms: 30_000,
+        },
+    )
+    .unwrap();
+
+    // Create FileUrlResolver with allowed private origins (localhost)
+    let localhost_origin = NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap();
+    let resolver = FileUrlResolver {
+        allowed_private_origins: vec![localhost_origin],
+    };
+
+    // Call resolve_input with url_resolver
+    let count = resolve_input(
+        &mut body,
+        &client,
+        OnMissing::Reject,
+        &http::HeaderMap::new(),
+        Some(&resolver),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(count, 1, "should resolve one file_url reference");
+
+    // Assert file_url removed and file_data is data URI
+    let part = &body["input"][0]["content"][0];
+    assert!(part.get("file_url").is_none(), "file_url should be removed");
+    let file_data = part["file_data"].as_str().unwrap();
+    assert!(
+        file_data.starts_with("data:text/plain;base64,"),
+        "file_data should be a data URI"
+    );
+    let base64_part = file_data.strip_prefix("data:text/plain;base64,").unwrap();
+    let decoded = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, base64_part).unwrap();
+    assert_eq!(decoded, b"Hello World", "data URI should contain the file content");
+}
+
+#[tokio::test]
+async fn file_url_passthrough_when_no_resolver() {
+    use praxis_core::callout::{CalloutClient, CalloutConfig};
+
+    use crate::openai::responses::file_resolve::{
+        config::OnMissing,
+        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+    };
+
+    // Build body with file_url
+    let mut body = json!({
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_url": "http://example.com/file.txt"
+            }]
+        }]
+    });
+    let original = body.clone();
+
+    // Create FilesApiClient
+    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
+    let client = FilesApiClient::new(
+        "http://unused:9999",
+        vec![],
+        callout,
+        FilesApiClientOptions {
+            max_file_references: 32,
+            max_resolved_bytes: 64 * 1024 * 1024,
+            timeout_ms: 30_000,
+        },
+    )
+    .unwrap();
+
+    // Call resolve_input without url_resolver (None)
+    let count = resolve_input(&mut body, &client, OnMissing::Reject, &http::HeaderMap::new(), None)
+        .await
+        .unwrap();
+
+    assert_eq!(count, 0, "should not resolve when url_resolver is None");
+    assert_eq!(body, original, "body should be unchanged");
+}
+
+#[tokio::test]
+async fn file_url_in_shorthand_message_resolved() {
+    use praxis_core::callout::{CalloutClient, CalloutConfig};
+
+    use crate::openai::responses::file_resolve::{
+        config::OnMissing,
+        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve_url::{FileUrlResolver, NormalizedOrigin},
+    };
+
+    // Start TCP stub
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let stub_url = format!("http://{address}/file.txt");
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            std::thread::spawn(move || {
+                let mut request = [0_u8; 4096];
+                let mut stream = stream;
+                let _read = stream.read(&mut request).unwrap();
+                let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: close\r\n\r\nShort";
+                stream.write_all(response).unwrap();
+            });
+        }
+    });
+
+    // Build body with shorthand message format (no "type" field)
+    let mut body = json!({
+        "model": "m",
+        "input": [{
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_url": stub_url.clone()
+            }]
+        }]
+    });
+
+    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
+    let client = FilesApiClient::new(
+        "http://unused:9999",
+        vec![],
+        callout,
+        FilesApiClientOptions {
+            max_file_references: 32,
+            max_resolved_bytes: 64 * 1024 * 1024,
+            timeout_ms: 30_000,
+        },
+    )
+    .unwrap();
+
+    let localhost_origin = NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap();
+    let resolver = FileUrlResolver {
+        allowed_private_origins: vec![localhost_origin],
+    };
+
+    let count = resolve_input(
+        &mut body,
+        &client,
+        OnMissing::Reject,
+        &http::HeaderMap::new(),
+        Some(&resolver),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(count, 1, "should resolve file_url in shorthand message");
+
+    let part = &body["input"][0]["content"][0];
+    assert!(part.get("file_url").is_none(), "file_url should be removed");
+    let file_data = part["file_data"].as_str().unwrap();
+    assert!(
+        file_data.starts_with("data:text/plain;base64,"),
+        "file_data should be a data URI"
+    );
+}
+
+#[tokio::test]
+async fn file_url_in_function_call_output_resolved() {
+    use praxis_core::callout::{CalloutClient, CalloutConfig};
+
+    use crate::openai::responses::file_resolve::{
+        config::OnMissing,
+        resolve::{FilesApiClient, FilesApiClientOptions, resolve_input},
+        resolve_url::{FileUrlResolver, NormalizedOrigin},
+    };
+
+    // Start TCP stub
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let stub_url = format!("http://{address}/doc.pdf");
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            std::thread::spawn(move || {
+                let mut request = [0_u8; 4096];
+                let mut stream = stream;
+                let _read = stream.read(&mut request).unwrap();
+                let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/pdf\r\nContent-Length: 8\r\nConnection: close\r\n\r\n%PDF-1.4";
+                stream.write_all(response).unwrap();
+            });
+        }
+    });
+
+    // Build body with function_call_output containing input_file with file_url
+    let mut body = json!({
+        "model": "m",
+        "input": [{
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [{
+                "type": "input_file",
+                "file_url": stub_url.clone()
+            }]
+        }]
+    });
+
+    let callout = CalloutClient::new(CalloutConfig::default()).unwrap();
+    let client = FilesApiClient::new(
+        "http://unused:9999",
+        vec![],
+        callout,
+        FilesApiClientOptions {
+            max_file_references: 32,
+            max_resolved_bytes: 64 * 1024 * 1024,
+            timeout_ms: 30_000,
+        },
+    )
+    .unwrap();
+
+    let localhost_origin = NormalizedOrigin::parse(&format!("http://127.0.0.1:{}", address.port())).unwrap();
+    let resolver = FileUrlResolver {
+        allowed_private_origins: vec![localhost_origin],
+    };
+
+    let count = resolve_input(
+        &mut body,
+        &client,
+        OnMissing::Reject,
+        &http::HeaderMap::new(),
+        Some(&resolver),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(count, 1, "should resolve file_url in function_call_output");
+
+    let part = &body["input"][0]["output"][0];
+    assert!(part.get("file_url").is_none(), "file_url should be removed");
+    let file_data = part["file_data"].as_str().unwrap();
+    assert!(
+        file_data.starts_with("data:application/pdf;base64,"),
+        "file_data should be a data URI with correct MIME type"
+    );
+}

--- a/apis/src/openai/url_security.rs
+++ b/apis/src/openai/url_security.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Shared IP classification for outbound `OpenAI` HTTP clients.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use praxis_core::connectivity::normalize_mapped_ipv4;
+
+/// Return whether an IP targets a known cloud metadata or credential endpoint.
+pub(crate) fn is_cloud_metadata(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            *v4 == Ipv4Addr::new(169, 254, 169, 254)
+                || *v4 == Ipv4Addr::new(169, 254, 170, 2)
+                || *v4 == Ipv4Addr::new(169, 254, 170, 23)
+                || *v4 == Ipv4Addr::new(169, 254, 0, 23)
+                || *v4 == Ipv4Addr::new(169, 254, 10, 10)
+                || *v4 == Ipv4Addr::new(100, 100, 100, 200)
+        },
+        IpAddr::V6(v6) => {
+            const AWS_IMDS_V6: Ipv6Addr = Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0254);
+            const AWS_ECS_CREDS_V6: Ipv6Addr = Ipv6Addr::new(0xFD00, 0x0EC2, 0, 0, 0, 0, 0, 0x0023);
+            *v6 == AWS_IMDS_V6 || *v6 == AWS_ECS_CREDS_V6
+        },
+    }
+}
+
+/// Return whether an IP is unsafe even for explicitly allowlisted file URLs.
+pub(crate) fn is_unconditionally_blocked(ip: &IpAddr) -> bool {
+    ip.is_unspecified() || ip.is_multicast() || is_cloud_metadata(ip)
+}
+
+/// Return whether an IP is not publicly routable under the shared policy.
+pub(crate) fn is_non_public_ip(ip: &IpAddr) -> bool {
+    let ip = normalize_mapped_ipv4(*ip);
+    if is_unconditionally_blocked(&ip) || is_private_or_special_use(&ip) {
+        return true;
+    }
+    if let IpAddr::V6(v6) = ip
+        && let Some(v4) = nat64_embedded_ipv4(&v6)
+    {
+        return is_non_public_ip(&IpAddr::V4(v4));
+    }
+    false
+}
+
+/// Return whether an IP must be blocked for an untrusted `file_url` fetch.
+pub(crate) fn is_file_url_ssrf_blocked(ip: &IpAddr, allow_private: bool) -> bool {
+    let ip = normalize_mapped_ipv4(*ip);
+    if is_unconditionally_blocked(&ip) {
+        return true;
+    }
+    if let IpAddr::V6(v6) = ip
+        && let Some(v4) = nat64_embedded_ipv4(&v6)
+    {
+        let embedded = IpAddr::V4(v4);
+        if is_unconditionally_blocked(&embedded) || (!allow_private && is_private_or_special_use(&embedded)) {
+            return true;
+        }
+    }
+    !allow_private && is_private_or_special_use(&ip)
+}
+
+/// Return whether an IP is private or belongs to a non-global special-use range.
+fn is_private_or_special_use(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.octets()[0] == 0
+                || is_cgnat(*v4)
+                || is_special_use_v4(*v4)
+        },
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unique_local()
+                || is_unicast_link_local_v6(v6)
+                || is_site_local_v6(v6)
+                || is_special_use_v6(*v6)
+        },
+    }
+}
+
+/// Return whether an IPv4 address is in the shared CGNAT range (`100.64.0.0/10`).
+fn is_cgnat(ip: Ipv4Addr) -> bool {
+    u32::from(ip) & 0xFFC0_0000 == 0x6440_0000
+}
+
+/// Return whether an IPv6 address is in the unicast link-local range (`fe80::/10`).
+fn is_unicast_link_local_v6(v6: &Ipv6Addr) -> bool {
+    let [a, b, ..] = v6.octets();
+    a == 0xFE && (b & 0xC0) == 0x80
+}
+
+/// Return whether an IPv6 address is in the deprecated site-local range (`fec0::/10`).
+fn is_site_local_v6(v6: &Ipv6Addr) -> bool {
+    let [a, b, ..] = v6.octets();
+    a == 0xFE && (b & 0xC0) == 0xC0
+}
+
+/// Return whether an IPv4 address belongs to a non-global IANA special-use range.
+fn is_special_use_v4(ip: Ipv4Addr) -> bool {
+    let o = ip.octets();
+    let n = u32::from(ip);
+    (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] != 9 && o[3] != 10)
+        || (o[0] == 192 && o[1] == 0 && o[2] == 2)
+        || (o[0] == 192 && o[1] == 88 && o[2] == 99)
+        || (n & 0xFFFE_0000 == 0xC612_0000)
+        || (o[0] == 198 && o[1] == 51 && o[2] == 100)
+        || (o[0] == 203 && o[1] == 0 && o[2] == 113)
+        || o[0] >= 240
+}
+
+/// Return whether an IPv6 address belongs to a non-global IANA special-use range.
+fn is_special_use_v6(v6: Ipv6Addr) -> bool {
+    let s = v6.segments();
+    (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0x0001)
+        || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+        || (s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 1)
+        || is_2001_ietf_non_global(s)
+        || (s[0] == 0x2001 && s[1] == 0x0DB8)
+        || s[0] == 0x2002
+        || (s[0] == 0x3FFF && s[1] & 0xF000 == 0)
+        || s[0] == 0x5F00
+}
+
+/// Return whether an IPv6 address is in a non-global sub-range of `2001::/23`.
+fn is_2001_ietf_non_global(s: [u16; 8]) -> bool {
+    if s[0] != 0x2001 || s[1] > 0x01FF {
+        return false;
+    }
+    match s[1] {
+        0x0001 if s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0 && s[6] == 0 && matches!(s[7], 1..=3) => false,
+        0x0003 => false,
+        0x0004 if s[2] == 0x0112 => false,
+        v if v & 0xFFF0 == 0x0020 || v & 0xFFF0 == 0x0030 => false,
+        _ => true,
+    }
+}
+
+/// Extract an embedded IPv4 address from the NAT64 well-known prefix (`64:ff9b::/96`).
+fn nat64_embedded_ipv4(v6: &Ipv6Addr) -> Option<Ipv4Addr> {
+    let s = v6.segments();
+    (s[0] == 0x0064 && s[1] == 0xFF9B && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0).then(|| {
+        let [.., a, b, c, d] = v6.octets();
+        Ipv4Addr::new(a, b, c, d)
+    })
+}

--- a/docs/filters/openai_file_resolve.md
+++ b/docs/filters/openai_file_resolve.md
@@ -23,6 +23,8 @@ This filter resolves references inside Responses requests; it does not proxy cli
 | `max_file_references` | integer | no | Maximum number of distinct content-part / `file_id` pairs to resolve in one request, including rehydrated history. |
 | `on_missing` | `continue` \| `reject` | no | Behavior when a referenced file cannot be fetched. |
 | `timeout_ms` | integer | no | HTTP timeout in milliseconds for Files API callout requests. |
+| `file_url` | `resolve` \| `passthrough` | no | Mode for `file_url` content parts in `input_file`. |
+| `allowed_file_url_origins` | string[] | no | Exact origins allowed to resolve to private addresses. Cloud metadata, unspecified, and multicast remain blocked. |
 
 ## Examples
 

--- a/docs/filters/openai_file_resolve.md
+++ b/docs/filters/openai_file_resolve.md
@@ -3,7 +3,7 @@
 
 # `openai_file_resolve`
 
-Resolves `file_id` references in Responses API input by fetching content from a Files API via `ApiClient` and inlining the base64-encoded content in the provider-native field.
+Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via [`ApiClient`] and inlining the base64-encoded content in the provider-native field.
 
 ## Configuration Notes
 
@@ -51,4 +51,16 @@ on_missing: continue
 timeout_ms: 30000
 max_body_bytes: 67108864
 max_file_references: 32
+```
+
+### Example 3
+
+```yaml
+filter: openai_file_resolve
+files_api_url: "http://ogx:8321"
+allow_private_files_api_url: true
+allow_pre_security_callout: true
+file_url: resolve
+allowed_file_url_origins:
+  - "https://files.internal:8443"
 ```

--- a/docs/filters/openai_file_resolve.md
+++ b/docs/filters/openai_file_resolve.md
@@ -3,7 +3,7 @@
 
 # `openai_file_resolve`
 
-Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via [`ApiClient`] and inlining the base64-encoded content in the provider-native field.
+Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via `ApiClient` and inlining the base64-encoded content in the provider-native field.
 
 ## Configuration Notes
 

--- a/docs/filters/reference.md
+++ b/docs/filters/reference.md
@@ -27,7 +27,7 @@ see the [Praxis core filter reference][core-ref].
 |--------|-------------|
 | [`openai_conversations`](openai_conversations.md) | Handles all `/v1/conversations` endpoints locally. |
 | [`openai_doc_extract`](openai_doc_extract.md) | Converts `input_file` content parts to `input_text` for backends that do not support `input_file` natively (e.g. vLLM, llm-d). |
-| [`openai_file_resolve`](openai_file_resolve.md) | Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via [`ApiClient`] and inlining the base64-encoded content in the provider-native field. |
+| [`openai_file_resolve`](openai_file_resolve.md) | Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via `ApiClient` and inlining the base64-encoded content in the provider-native field. |
 | [`openai_mcp_dispatch`](openai_mcp_dispatch.md) | Executes MCP tool calls against upstream MCP servers within the Responses API agentic loop. |
 | [`openai_mcp_tool_resolve`](openai_mcp_tool_resolve.md) | Resolves MCP tool entries from the Responses API `tools` array into concrete tool definitions by calling `tools/list` on each upstream MCP server. |
 | [`openai_response_store`](openai_response_store.md) | Persists Responses API responses to the configured response store backend. |

--- a/docs/filters/reference.md
+++ b/docs/filters/reference.md
@@ -27,7 +27,7 @@ see the [Praxis core filter reference][core-ref].
 |--------|-------------|
 | [`openai_conversations`](openai_conversations.md) | Handles all `/v1/conversations` endpoints locally. |
 | [`openai_doc_extract`](openai_doc_extract.md) | Converts `input_file` content parts to `input_text` for backends that do not support `input_file` natively (e.g. vLLM, llm-d). |
-| [`openai_file_resolve`](openai_file_resolve.md) | Resolves `file_id` references in Responses API input by fetching content from a Files API via `ApiClient` and inlining the base64-encoded content in the provider-native field. |
+| [`openai_file_resolve`](openai_file_resolve.md) | Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via [`ApiClient`] and inlining the base64-encoded content in the provider-native field. |
 | [`openai_mcp_dispatch`](openai_mcp_dispatch.md) | Executes MCP tool calls against upstream MCP servers within the Responses API agentic loop. |
 | [`openai_mcp_tool_resolve`](openai_mcp_tool_resolve.md) | Resolves MCP tool entries from the Responses API `tools` array into concrete tool definitions by calling `tools/list` on each upstream MCP server. |
 | [`openai_response_store`](openai_response_store.md) | Persists Responses API responses to the configured response store backend. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,8 +46,8 @@ before sending requests.
 | File | Description |
 | ------ | ------------- |
 | [conversations.yaml](configs/openai/conversations/conversations.yaml) | Local /v1/conversations endpoints for conversation lifecycle, backed by the ConversationItemStore |
-| [embeddings-routing.yaml](configs/openai/embeddings/embeddings-routing.yaml) | Routes /v1/embeddings and subresources to a dedicated Embeddings API backend using segment-boundary prefix matching |
-| [prompts-routing.yaml](configs/openai/prompts/prompts-routing.yaml) | Routes /v1/prompts and subresources to a dedicated Prompts API backend using segment-boundary prefix matching |
+| [embeddings-routing.yaml](configs/openai/embeddings/embeddings-routing.yaml) | Routes OpenAI Embeddings API requests to a dedicated Embeddings API backend |
+| [prompts-routing.yaml](configs/openai/prompts/prompts-routing.yaml) | Routes OpenAI Prompts API requests to a dedicated Prompts API backend |
 | [doc-extract.yaml](configs/openai/responses/doc-extract.yaml) | Converts `input_file` content parts to `input_text` for inference backends that do not natively support `input_file` (e.g. vLLM, llm-d) |
 | [file-resolve.yaml](configs/openai/responses/file-resolve.yaml) | Resolves `file_id` and `file_url` references in Responses API input by fetching file metadata and content, then inlining base64 content as `file_data` or `image_url` before forwarding |
 | [format-routing.yaml](configs/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ before sending requests.
 | [embeddings-routing.yaml](configs/openai/embeddings/embeddings-routing.yaml) | Routes /v1/embeddings and subresources to a dedicated Embeddings API backend using segment-boundary prefix matching |
 | [prompts-routing.yaml](configs/openai/prompts/prompts-routing.yaml) | Routes /v1/prompts and subresources to a dedicated Prompts API backend using segment-boundary prefix matching |
 | [doc-extract.yaml](configs/openai/responses/doc-extract.yaml) | Converts `input_file` content parts to `input_text` for inference backends that do not natively support `input_file` (e.g. vLLM, llm-d) |
-| [file-resolve.yaml](configs/openai/responses/file-resolve.yaml) | Resolves `file_id` references in Responses API input by fetching file metadata and content from a Files API, then inlining base64 content as `file_data` or `image_url` before forwarding |
+| [file-resolve.yaml](configs/openai/responses/file-resolve.yaml) | Resolves `file_id` and `file_url` references in Responses API input by fetching file metadata and content, then inlining base64 content as `file_data` or `image_url` before forwarding |
 | [format-routing.yaml](configs/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |
 | [full-flow.yaml](configs/openai/responses/full-flow.yaml) | Combines conversations, format classification, request validation, file resolution, and backend routing into a single pipeline |
 | [mcp-dispatch.yaml](configs/openai/responses/mcp-dispatch.yaml) | Demonstrates the `openai_mcp_dispatch` filter configuration |

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,7 @@ before sending requests.
 | [responses-routing.yaml](configs/openai/responses/responses-routing.yaml) | Routes Responses API traffic by detected mode |
 | [stream-events.yaml](configs/openai/responses/stream-events.yaml) | Demonstrates the `openai_stream_events` filter, which observes SSE chunks from the backend without modification, accumulates state (response object, output items, tool calls, usage), and writes it to ResponsesState metadata |
 | [tool-routing.yaml](configs/openai/responses/tool-routing.yaml) | Demonstrates using `openai_tool_parse` to route Responses API requests by their tool composition |
+| [vector-stores-routing.yaml](configs/openai/responses/vector-stores-routing.yaml) | Routes /v1/vector_stores traffic and all its subresources to a dedicated backend (any server compatible with the OpenAI Files / Vector Stores API), while sending everything else to a default backend |
 | [vllm-agentic-api.yaml](configs/openai/responses/vllm-agentic-api.yaml) | vLLM Agentic API: https://github.com/vllm-project/agentic-api |
 | [web-search.yaml](configs/openai/responses/web-search.yaml) | Demonstrates the `openai_web_search` filter configuration |
 

--- a/examples/configs/openai/responses/doc-extract.yaml
+++ b/examples/configs/openai/responses/doc-extract.yaml
@@ -40,6 +40,7 @@ filter_chains:
           - authorization
         on_missing: reject
         timeout_ms: 10000
+        file_url: passthrough
 
       - filter: openai_doc_extract
         # StreamBuffer body filters run before this listener's

--- a/examples/configs/openai/responses/file-resolve.yaml
+++ b/examples/configs/openai/responses/file-resolve.yaml
@@ -1,13 +1,17 @@
 # Responses File Resolve
 #
-# Resolves `file_id` references in Responses API input by fetching
-# file metadata and content from a Files API, then inlining base64
-# content as `file_data` or `image_url` before forwarding.
+# Resolves `file_id` and `file_url` references in Responses API
+# input by fetching file metadata and content, then inlining
+# base64 content as `file_data` or `image_url` before forwarding.
 #
-# This pipeline uses `openai_responses_format` to classify the
-# request, then `openai_file_resolve` to resolve any
-# `input_file` or `input_image` content parts that reference
-# files by ID.
+# file_url: resolve (default)
+#   Fetches the URL and inlines content as a data URI in file_data.
+#   Use for inference backends like vLLM that do not consume
+#   file_url directly.
+#
+# file_url: passthrough
+#   Leaves file_url unchanged. Use for native OpenAI-compatible
+#   backends that handle file_url natively.
 #
 # Use case: Codex or other Responses API clients send file
 # references (`file_id: "file-abc123"`) and the proxy
@@ -44,11 +48,11 @@ filter_chains:
       - filter: openai_file_resolve
         files_api_url: "http://127.0.0.1:9999"
         allow_private_files_api_url: true
-        # StreamBuffer body filters run before this listener's
-        # header-phase security filters. Enable only when an outer
-        # trust boundary has already authenticated and authorized
-        # requests reaching this listener.
         allow_pre_security_callout: true
+        # file_url: resolve is the default — fetches remote URLs
+        # and inlines content as data URIs. Set to 'passthrough'
+        # for native OpenAI-compatible backends.
+        file_url: resolve
         forward_headers:
           - authorization
           - x-tenant-id

--- a/examples/configs/openai/responses/file-resolve.yaml
+++ b/examples/configs/openai/responses/file-resolve.yaml
@@ -6,8 +6,7 @@
 #
 # file_url: resolve (default)
 #   Fetches the URL and inlines content as a data URI in file_data.
-#   Use for inference backends like vLLM that do not consume
-#   file_url directly.
+#   Use for backends that do not consume file_url directly.
 #
 # file_url: passthrough
 #   Leaves file_url unchanged. Use for native OpenAI-compatible

--- a/tests/integration/tests/suite/examples/openai_doc_extract.rs
+++ b/tests/integration/tests/suite/examples/openai_doc_extract.rs
@@ -16,7 +16,7 @@ use praxis_test_utils::{
     start_capturing_backend, start_proxy,
 };
 
-use super::openai_file_resolve::start_files_api_stub;
+use super::openai_file_resolve::{start_file_url_stub, start_files_api_stub};
 
 fn text_file_data(text: &str) -> String {
     format!("data:text/plain;base64,{}", BASE64.encode(text.as_bytes()))
@@ -42,6 +42,28 @@ fn setup_proxy(files_api_port: u16, inference_port: u16, default_port: u16) -> p
             ("127.0.0.1:3002", default_port),
         ]),
     );
+    start_proxy(&config)
+}
+
+fn setup_proxy_with_file_url(
+    files_api_port: u16,
+    file_url_port: u16,
+    inference_port: u16,
+    default_port: u16,
+) -> praxis_test_utils::ProxyGuard {
+    let proxy_port = free_port();
+    let path = praxis_test_utils::example_config_path("openai/responses/doc-extract.yaml");
+    let yaml = std::fs::read_to_string(path).expect("doc-extract example should be readable");
+    let file_url_policy = format!(
+        "        file_url: resolve\n        allowed_file_url_origins:\n          - \"http://127.0.0.1:{file_url_port}\""
+    );
+    let yaml = yaml
+        .replace("127.0.0.1:8080", &format!("127.0.0.1:{proxy_port}"))
+        .replace("127.0.0.1:9999", &format!("127.0.0.1:{files_api_port}"))
+        .replace("127.0.0.1:3001", &format!("127.0.0.1:{inference_port}"))
+        .replace("127.0.0.1:3002", &format!("127.0.0.1:{default_port}"))
+        .replace("        file_url: passthrough", &file_url_policy);
+    let config = praxis_core::config::Config::from_yaml(&yaml).expect("patched doc-extract config should parse");
     start_proxy(&config)
 }
 
@@ -178,6 +200,56 @@ fn resolved_file_id_extracted_to_input_text() {
             }]
         }),
         "file_id should be resolved by file_resolve, then extracted to input_text by doc_extract"
+    );
+}
+
+#[test]
+fn resolved_file_url_extracted_to_input_text() {
+    let files_api_port = start_files_api_stub();
+    let file_url_port = start_file_url_stub();
+    let inference_guard = start_capturing_backend("{}");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy = setup_proxy_with_file_url(
+        files_api_port,
+        file_url_port,
+        inference_guard.port(),
+        default_guard.port(),
+    );
+
+    let body = serde_json::json!({
+        "model": "test",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_url": format!("http://127.0.0.1:{file_url_port}/document.txt")
+            }]
+        }]
+    });
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body.to_string()));
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "file_url should resolve and extract before reaching the backend"
+    );
+    let captured: serde_json::Value =
+        serde_json::from_str(&inference_guard.body()).expect("captured body should be valid JSON");
+    assert_eq!(
+        captured,
+        serde_json::json!({
+            "model": "test",
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "[Source: document.txt]\nHello, world!"
+                }]
+            }]
+        }),
+        "backend should receive input_text produced from fetched file_url content"
     );
 }
 

--- a/tests/integration/tests/suite/examples/openai_file_resolve.rs
+++ b/tests/integration/tests/suite/examples/openai_file_resolve.rs
@@ -816,7 +816,7 @@ filter_chains:
     );
 }
 
-fn start_file_url_stub() -> u16 {
+pub(super) fn start_file_url_stub() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
 

--- a/tests/integration/tests/suite/examples/openai_file_resolve.rs
+++ b/tests/integration/tests/suite/examples/openai_file_resolve.rs
@@ -591,6 +591,127 @@ filter_chains:
 }
 
 #[test]
+fn file_url_passthrough_reaches_upstream_unchanged() {
+    let files_api_port = start_files_api_stub();
+    let inference_guard = start_capturing_backend("{}");
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [file-resolve-pipeline]
+
+filter_chains:
+  - name: file-resolve-pipeline
+    filters:
+      - filter: openai_responses_format
+        on_invalid: continue
+        headers:
+          format: x-praxis-ai-format
+
+      - filter: openai_file_resolve
+        files_api_url: "http://127.0.0.1:{files_api_port}"
+        allow_private_files_api_url: true
+        allow_pre_security_callout: true
+        file_url: passthrough
+        on_missing: reject
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            cluster: "inference-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "inference-backend"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        inference_guard.port()
+    );
+    let config = praxis_core::config::Config::from_yaml(&yaml).expect("config should parse");
+    let proxy = start_proxy(&config);
+
+    let file_url = "https://storage.example.com/document.pdf?sig=opaque";
+    let body = format!(
+        r#"{{
+            "model": "gpt-4.1",
+            "input": [{{
+                "type": "message",
+                "role": "user",
+                "content": [{{"type": "input_file", "file_url": "{file_url}"}}]
+            }}]
+        }}"#
+    );
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(parse_status(&raw), 200, "passthrough request should reach the backend");
+    let captured: serde_json::Value =
+        serde_json::from_str(&inference_guard.body()).expect("captured body should be valid JSON");
+    assert_eq!(
+        captured["input"][0]["content"][0]["file_url"].as_str(),
+        Some(file_url),
+        "file_url should reach the upstream unchanged"
+    );
+    assert!(
+        captured["input"][0]["content"][0].get("file_data").is_none(),
+        "passthrough mode should not synthesize file_data"
+    );
+}
+
+#[test]
+fn example_config_rejects_ssrf_blocked_file_url_with_403() {
+    let files_api_port = start_files_api_stub();
+    let inference_guard = start_backend_with_shutdown("inference-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/file-resolve.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9999", files_api_port),
+            ("127.0.0.1:3001", inference_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+    let body = r#"{
+        "model": "gpt-4.1",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_url": "http://169.254.169.254/latest/meta-data/"
+            }]
+        }]
+    }"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(
+        parse_status(&raw),
+        403,
+        "metadata file_url should be rejected before proxying"
+    );
+    let error: serde_json::Value =
+        serde_json::from_str(&parse_body(&raw)).expect("error response should be valid JSON");
+    assert_eq!(
+        error["error"]["type"].as_str(),
+        Some("file_resolve_error"),
+        "blocked file_url should use the file resolution error envelope"
+    );
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("blocked by security policy")),
+        "blocked file_url response should explain the security rejection"
+    );
+}
+
+#[test]
 fn example_config_file_url_no_credentials_forwarded() {
     let files_api_port = start_files_api_stub_auth_required();
     let file_url_port = start_file_url_stub_auth_check();

--- a/tests/integration/tests/suite/examples/openai_file_resolve.rs
+++ b/tests/integration/tests/suite/examples/openai_file_resolve.rs
@@ -496,3 +496,299 @@ fn handle_files_api_request(mut stream: std::net::TcpStream) {
     let _sent = stream.write_all(header.as_bytes());
     let _sent = stream.write_all(&body_bytes);
 }
+
+#[test]
+fn example_config_resolves_file_url_to_data_uri() {
+    let files_api_port = start_files_api_stub();
+    let file_url_port = start_file_url_stub();
+    let inference_guard = start_capturing_backend("{}");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [file-resolve-pipeline]
+
+filter_chains:
+  - name: file-resolve-pipeline
+    filters:
+      - filter: openai_responses_format
+        on_invalid: continue
+        headers:
+          format: x-praxis-ai-format
+          model: x-praxis-ai-model
+
+      - filter: openai_file_resolve
+        files_api_url: "http://127.0.0.1:{files_api_port}"
+        allow_private_files_api_url: true
+        allow_pre_security_callout: true
+        file_url: resolve
+        allowed_file_url_origins:
+          - "http://127.0.0.1:{file_url_port}"
+        on_missing: reject
+        timeout_ms: 10000
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            cluster: "inference-backend"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "inference-backend"
+            endpoints:
+              - "127.0.0.1:{}"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        inference_guard.port(),
+        default_guard.port()
+    );
+    let config = praxis_core::config::Config::from_yaml(&yaml).expect("config should parse");
+    let proxy = start_proxy(&config);
+
+    let body = format!(
+        r#"{{
+            "model": "gpt-4.1",
+            "input": [
+                {{
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {{"type": "input_file", "file_url": "http://127.0.0.1:{file_url_port}/document.txt"}}
+                    ]
+                }}
+            ]
+        }}"#
+    );
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(parse_status(&raw), 200, "proxy should forward the resolved request");
+
+    let captured: serde_json::Value =
+        serde_json::from_str(&inference_guard.body()).expect("captured body should be valid JSON");
+
+    assert_eq!(
+        captured["input"][0]["content"][0]["type"].as_str().unwrap(),
+        "input_file",
+        "content type should be input_file"
+    );
+    assert_eq!(
+        captured["input"][0]["content"][0]["file_data"].as_str().unwrap(),
+        "data:text/plain;base64,SGVsbG8sIHdvcmxkIQ==",
+        "file_url should be resolved to data URI in file_data"
+    );
+    assert!(
+        captured["input"][0]["content"][0]["file_url"].is_null(),
+        "file_url should be removed after resolution"
+    );
+}
+
+#[test]
+fn example_config_file_url_no_credentials_forwarded() {
+    let files_api_port = start_files_api_stub_auth_required();
+    let file_url_port = start_file_url_stub_auth_check();
+    let inference_guard = start_capturing_backend("{}");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [file-resolve-pipeline]
+
+filter_chains:
+  - name: file-resolve-pipeline
+    filters:
+      - filter: openai_responses_format
+        on_invalid: continue
+        headers:
+          format: x-praxis-ai-format
+          model: x-praxis-ai-model
+
+      - filter: openai_file_resolve
+        files_api_url: "http://127.0.0.1:{files_api_port}"
+        allow_private_files_api_url: true
+        allow_pre_security_callout: true
+        file_url: resolve
+        allowed_file_url_origins:
+          - "http://127.0.0.1:{file_url_port}"
+        forward_headers:
+          - authorization
+        on_missing: reject
+        timeout_ms: 10000
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            cluster: "inference-backend"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "inference-backend"
+            endpoints:
+              - "127.0.0.1:{}"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        inference_guard.port(),
+        default_guard.port()
+    );
+    let config = praxis_core::config::Config::from_yaml(&yaml).expect("config should parse");
+    let proxy = start_proxy(&config);
+
+    let body = format!(
+        r#"{{
+            "model": "gpt-4.1",
+            "input": [
+                {{
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {{"type": "input_file", "file_id": "test-file-123"}},
+                        {{"type": "input_file", "file_url": "http://127.0.0.1:{file_url_port}/document.txt"}}
+                    ]
+                }}
+            ]
+        }}"#
+    );
+    let request = format!(
+        "POST /v1/responses HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Authorization: Bearer test-token\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n\
+         {body}",
+        body.len()
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "request should succeed: Files API gets Authorization, file URL stub does not"
+    );
+
+    let captured: serde_json::Value =
+        serde_json::from_str(&inference_guard.body()).expect("captured body should be valid JSON");
+    assert_eq!(
+        captured["input"][0]["content"][0]["file_data"].as_str().unwrap(),
+        "SGVsbG8sIHdvcmxkIQ==",
+        "file_id should be resolved with auth header forwarding"
+    );
+    assert_eq!(
+        captured["input"][0]["content"][1]["file_data"].as_str().unwrap(),
+        "data:text/plain;base64,SGVsbG8sIHdvcmxkIQ==",
+        "file_url should be resolved without auth header forwarding"
+    );
+}
+
+fn start_file_url_stub() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            std::thread::spawn(move || handle_file_url_request(stream));
+        }
+    });
+
+    port
+}
+
+fn start_file_url_stub_auth_check() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            std::thread::spawn(move || handle_file_url_request_auth_check(stream));
+        }
+    });
+
+    port
+}
+
+fn handle_file_url_request(mut stream: std::net::TcpStream) {
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let mut data = Vec::new();
+    let mut buf = [0_u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+        }
+        if data.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let body = FILE_CONTENT.as_bytes();
+    let header = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n",
+        body.len()
+    );
+    let _sent = stream.write_all(header.as_bytes());
+    let _sent = stream.write_all(body);
+}
+
+fn handle_file_url_request_auth_check(mut stream: std::net::TcpStream) {
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let mut data = Vec::new();
+    let mut buf = [0_u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+        }
+        if data.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let raw = String::from_utf8_lossy(&data);
+    let has_auth = raw
+        .lines()
+        .any(|line| line.to_ascii_lowercase().starts_with("authorization:"));
+
+    if has_auth {
+        let body = br#"{"error":"credentials leaked to file URL"}"#;
+        let header = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let _sent = stream.write_all(header.as_bytes());
+        let _sent = stream.write_all(body);
+        return;
+    }
+
+    let body = FILE_CONTENT.as_bytes();
+    let header = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n",
+        body.len()
+    );
+    let _sent = stream.write_all(header.as_bytes());
+    let _sent = stream.write_all(body);
+}


### PR DESCRIPTION
## Summary

Extends the `openai_file_resolve` filter to resolve `file_url` references in Responses API `input_file` parts, complementing the existing `file_id` resolution path. Remote URLs are fetched via DNS resolve-and-pin with comprehensive SSRF protection covering the full IANA Special-Purpose Address Registry, cloud metadata endpoints (AWS IMDS/ECS/EKS, Tencent, Alibaba), and NAT64-embedded IPv4 extraction. Resolved content is materialized as inline `file_data` with a `data:` URI preserving the original MIME type.

Key additions:
- `FileUrlResolver` with origin allowlisting (`NormalizedOrigin`) and DNS rebinding prevention
- Complete IANA IPv4/IPv6 special-use range blocking including 6to4, Teredo, NAT64 (RFC 6052)
- `Content-Disposition` filename parsing with RFC 5987/6266 compliance
- URL credential/fragment redaction for safe logging
- RFC 2045 MIME token validation for data URI safety
- `file_url: resolve | passthrough` configuration mode with `allowed_file_url_origins` allowlist

135 unit tests for SSRF validation, MIME, Content-Disposition, URL redaction, and filename sanitization. 3 TCP-stub integration tests exercising the full resolve pipeline.

Closes #452

## Test plan

- [x] `cargo test -p praxis-ai-apis` — all unit and integration tests pass
- [x] `make lint` — clippy + nightly rustfmt clean
- [x] `make build` — workspace compiles without warnings
- [x] Coverage gate meets 95% threshold for `resolve_url.rs`