### PR TITLE
ci(coverage): update step name to reflect 95% threshold

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -61,5 +61,5 @@ jobs:
             ${{ runner.os }}-rust-1.96.0-coverage-
           save-always: true
 
-      - name: Check coverage (≥93% lines)
+      - name: Check coverage (≥95% lines)
         run: make coverage-check


### PR DESCRIPTION
The Makefile `coverage-check` target already enforces a 95% line-coverage
threshold, but the workflow step name still read "≥93%". This aligns the
CI step label with the actual enforced threshold.

Signed-off-by: Sébastien Han <seb@redhat.com>