### PR TITLE
Support OpenAI Responses WebSocket passthrough

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -128,6 +128,10 @@ jobs:
   # ----------------------------------------------------------------------------
 
   codex-websocket:
+    needs: [changes]
+    if: |
+      always() &&
+      (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -136,7 +140,7 @@ jobs:
       CODEX_ARCHIVE: codex-x86_64-unknown-linux-musl.tar.gz
       CODEX_BIN: codex-x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@6190aa5fb88a88ee71c12769924bbe63a9ab152e # 1.96.0

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -122,3 +122,69 @@ jobs:
 
       - name: Integration tests
         run: make test-integration
+
+  # ----------------------------------------------------------------------------
+  # Pinned Codex CLI WebSocket acceptance
+  # ----------------------------------------------------------------------------
+
+  codex-websocket:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CODEX_ARCHIVE: codex-x86_64-unknown-linux-musl.tar.gz
+      CODEX_BIN: codex-x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@6190aa5fb88a88ee71c12769924bbe63a9ab152e # 1.96.0
+
+      - name: Cache pinned Codex CLI
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.tool_cache }}/codex/0.144.1/x86_64-unknown-linux-musl
+          key: codex-0.144.1-x86_64-unknown-linux-musl-84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28
+
+      - name: Download pinned Codex CLI
+        run: |
+          codex_cache_dir="$RUNNER_TOOL_CACHE/codex/0.144.1/x86_64-unknown-linux-musl"
+          mkdir -p "$codex_cache_dir"
+          if [ ! -f "$codex_cache_dir/$CODEX_ARCHIVE" ]; then
+            curl --proto '=https' --tlsv1.2 --fail --location --retry 3 \
+              --output "$codex_cache_dir/$CODEX_ARCHIVE" \
+              "https://github.com/openai/codex/releases/download/rust-v0.144.1/$CODEX_ARCHIVE"
+          fi
+
+      - name: Verify and extract pinned Codex CLI
+        run: |
+          codex_cache_dir="$RUNNER_TOOL_CACHE/codex/0.144.1/x86_64-unknown-linux-musl"
+          cd "$codex_cache_dir"
+          sha256sum --check \
+            "$GITHUB_WORKSPACE/tests/integration/fixtures/codex-cli/0.144.1-x86_64-unknown-linux-musl.sha256"
+          tar --extract --gzip --file "$CODEX_ARCHIVE"
+          chmod +x "$CODEX_BIN"
+          test -x "$CODEX_BIN"
+          test "$("./$CODEX_BIN" --version)" = "codex-cli 0.144.1"
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-rust-1.96.0-codex-websocket-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-1.96.0-codex-websocket-cargo-
+          save-always: true
+
+      - name: Run pinned Codex WebSocket acceptance test
+        env:
+          PRAXIS_TEST_CODEX_BIN: ${{ runner.tool_cache }}/codex/0.144.1/x86_64-unknown-linux-musl/${{ env.CODEX_BIN }}
+        run: |
+          test -x "$PRAXIS_TEST_CODEX_BIN"
+          cargo test -p praxis-tests-integration --test suite \
+            codex_websocket::pinned_codex_uses_responses_websocket_through_full_flow -- --exact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,6 +3104,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite",
  "tracing",
  "yaml_serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,7 @@ dependencies = [
  "futures",
  "http",
  "jsonwebtoken",
+ "nix",
  "praxis-ai-apis",
  "praxis-proxy-core",
  "praxis-proxy-filter",

--- a/apis/src/classifier/mod.rs
+++ b/apis/src/classifier/mod.rs
@@ -124,6 +124,32 @@ pub(crate) fn is_responses_create(method: &http::Method, path: &str) -> bool {
     method == http::Method::POST && normalize_trailing_slash(path) == "/v1/responses"
 }
 
+/// Check whether a request is a Responses API `WebSocket` handshake.
+///
+/// The handshake uses `GET /v1/responses` and the standard HTTP/1.1
+/// upgrade headers. `Connection` is token-valued, so matching handles
+/// comma-separated and repeated header lines without allocating.
+pub(crate) fn is_responses_websocket_handshake(method: &http::Method, path: &str, headers: &http::HeaderMap) -> bool {
+    if method != http::Method::GET || normalize_trailing_slash(path) != "/v1/responses" {
+        return false;
+    }
+
+    let connection_upgrades = headers
+        .get_all(http::header::CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .any(|token| token.trim().eq_ignore_ascii_case("upgrade"));
+    let mut upgrade_values = headers.get_all(http::header::UPGRADE).iter();
+    let upgrades_to_websocket = upgrade_values
+        .next()
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("websocket"))
+        && upgrade_values.next().is_none();
+
+    connection_upgrades && upgrades_to_websocket
+}
+
 // -----------------------------------------------------------------------------
 // Body Classification
 // -----------------------------------------------------------------------------
@@ -862,6 +888,120 @@ mod tests {
             !is_responses_path(&http::Method::GET, "/v1/responses/"),
             "GET /v1/responses/ is not a public API endpoint"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Responses WebSocket Handshake Classification
+    // -------------------------------------------------------------------------
+
+    fn websocket_headers(connection: &'static str, upgrade: &'static str) -> http::HeaderMap {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::CONNECTION, connection.parse().unwrap());
+        headers.insert(http::header::UPGRADE, upgrade.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn responses_websocket_handshake_matches_standard_upgrade() {
+        let headers = websocket_headers("Upgrade", "websocket");
+
+        assert!(is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &headers
+        ));
+    }
+
+    #[test]
+    fn responses_websocket_handshake_is_case_insensitive_and_allows_trailing_slash() {
+        let headers = websocket_headers("keep-alive, UpGrAdE", "WebSocket");
+
+        assert!(is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses/",
+            &headers
+        ));
+    }
+
+    #[test]
+    fn responses_websocket_handshake_finds_token_across_repeated_connection_headers() {
+        let mut headers = websocket_headers("keep-alive", "websocket");
+        headers.append(http::header::CONNECTION, "upgrade".parse().unwrap());
+
+        assert!(is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &headers
+        ));
+    }
+
+    #[test]
+    fn responses_websocket_handshake_rejects_wrong_method_or_path() {
+        let headers = websocket_headers("upgrade", "websocket");
+
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::POST,
+            "/v1/responses",
+            &headers
+        ));
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses/resp_123",
+            &headers
+        ));
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/chat/completions",
+            &headers
+        ));
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses-other",
+            &headers
+        ));
+    }
+
+    #[test]
+    fn responses_websocket_handshake_requires_both_upgrade_headers() {
+        let mut connection_only = http::HeaderMap::new();
+        connection_only.insert(http::header::CONNECTION, "upgrade".parse().unwrap());
+        let mut upgrade_only = http::HeaderMap::new();
+        upgrade_only.insert(http::header::UPGRADE, "websocket".parse().unwrap());
+
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &connection_only
+        ));
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &upgrade_only
+        ));
+    }
+
+    #[test]
+    fn responses_websocket_handshake_rejects_non_websocket_upgrade_and_substring_token() {
+        let wrong_upgrade = websocket_headers("upgrade", "h2c");
+        let substring_connection = websocket_headers("upgrader", "websocket");
+        let mut repeated_upgrade = websocket_headers("upgrade", "websocket");
+        repeated_upgrade.append(http::header::UPGRADE, "h2c".parse().unwrap());
+
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &wrong_upgrade
+        ));
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &substring_connection
+        ));
+        assert!(!is_responses_websocket_handshake(
+            &http::Method::GET,
+            "/v1/responses",
+            &repeated_upgrade
+        ));
     }
 
     #[test]

--- a/apis/src/classifier/mod.rs
+++ b/apis/src/classifier/mod.rs
@@ -126,9 +126,13 @@ pub(crate) fn is_responses_create(method: &http::Method, path: &str) -> bool {
 
 /// Check whether a request is a Responses API `WebSocket` handshake.
 ///
-/// The handshake uses `GET /v1/responses` and the standard HTTP/1.1
-/// upgrade headers. `Connection` is token-valued, so matching handles
-/// comma-separated and repeated header lines without allocating.
+/// The handshake uses `GET /v1/responses` and the opening handshake from
+/// [RFC 6455 Section 4.1]. `Connection` options follow the token-list
+/// semantics in [RFC 9110 Section 7.6.1], including comma-separated and
+/// repeated field lines.
+///
+/// [RFC 6455 Section 4.1]: https://datatracker.ietf.org/doc/html/rfc6455#section-4.1
+/// [RFC 9110 Section 7.6.1]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
 pub(crate) fn is_responses_websocket_handshake(method: &http::Method, path: &str, headers: &http::HeaderMap) -> bool {
     if method != http::Method::GET || normalize_trailing_slash(path) != "/v1/responses" {
         return false;
@@ -894,73 +898,64 @@ mod tests {
     // Responses WebSocket Handshake Classification
     // -------------------------------------------------------------------------
 
-    fn websocket_headers(connection: &'static str, upgrade: &'static str) -> http::HeaderMap {
-        let mut headers = http::HeaderMap::new();
-        headers.insert(http::header::CONNECTION, connection.parse().unwrap());
-        headers.insert(http::header::UPGRADE, upgrade.parse().unwrap());
-        headers
-    }
-
+    /// Accept the canonical Responses opening handshake.
     #[test]
     fn responses_websocket_handshake_matches_standard_upgrade() {
         let headers = websocket_headers("Upgrade", "websocket");
 
-        assert!(is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &headers
-        ));
+        assert!(
+            is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &headers),
+            "the canonical Responses WebSocket handshake should match"
+        );
     }
 
+    /// Treat protocol tokens case-insensitively and normalize a trailing slash.
     #[test]
     fn responses_websocket_handshake_is_case_insensitive_and_allows_trailing_slash() {
         let headers = websocket_headers("keep-alive, UpGrAdE", "WebSocket");
 
-        assert!(is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses/",
-            &headers
-        ));
+        assert!(
+            is_responses_websocket_handshake(&http::Method::GET, "/v1/responses/", &headers),
+            "field tokens should ignore case and the endpoint should allow a trailing slash"
+        );
     }
 
+    /// Find an upgrade token across repeated `Connection` field lines.
     #[test]
     fn responses_websocket_handshake_finds_token_across_repeated_connection_headers() {
         let mut headers = websocket_headers("keep-alive", "websocket");
         headers.append(http::header::CONNECTION, "upgrade".parse().unwrap());
 
-        assert!(is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &headers
-        ));
+        assert!(
+            is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &headers),
+            "a repeated Connection field should contribute its upgrade token"
+        );
     }
 
+    /// Limit handshake classification to the exact Responses endpoint and method.
     #[test]
     fn responses_websocket_handshake_rejects_wrong_method_or_path() {
         let headers = websocket_headers("upgrade", "websocket");
 
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::POST,
-            "/v1/responses",
-            &headers
-        ));
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses/resp_123",
-            &headers
-        ));
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/chat/completions",
-            &headers
-        ));
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses-other",
-            &headers
-        ));
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::POST, "/v1/responses", &headers),
+            "a POST request is not a WebSocket opening handshake"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses/resp_123", &headers),
+            "a response subresource must not match the opening endpoint"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/chat/completions", &headers),
+            "an unrelated API endpoint must not match"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses-other", &headers),
+            "a path that merely shares the Responses prefix must not match"
+        );
     }
 
+    /// Require both HTTP upgrade fields before classifying a handshake.
     #[test]
     fn responses_websocket_handshake_requires_both_upgrade_headers() {
         let mut connection_only = http::HeaderMap::new();
@@ -968,18 +963,17 @@ mod tests {
         let mut upgrade_only = http::HeaderMap::new();
         upgrade_only.insert(http::header::UPGRADE, "websocket".parse().unwrap());
 
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &connection_only
-        ));
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &upgrade_only
-        ));
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &connection_only),
+            "Connection alone must not classify a WebSocket handshake"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &upgrade_only),
+            "Upgrade alone must not classify a WebSocket handshake"
+        );
     }
 
+    /// Reject lookalike tokens, other protocols, and ambiguous upgrade fields.
     #[test]
     fn responses_websocket_handshake_rejects_non_websocket_upgrade_and_substring_token() {
         let wrong_upgrade = websocket_headers("upgrade", "h2c");
@@ -987,21 +981,39 @@ mod tests {
         let mut repeated_upgrade = websocket_headers("upgrade", "websocket");
         repeated_upgrade.append(http::header::UPGRADE, "h2c".parse().unwrap());
 
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &wrong_upgrade
-        ));
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &substring_connection
-        ));
-        assert!(!is_responses_websocket_handshake(
-            &http::Method::GET,
-            "/v1/responses",
-            &repeated_upgrade
-        ));
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &wrong_upgrade),
+            "an h2c upgrade must not classify as WebSocket"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &substring_connection),
+            "an upgrade substring must not match the Connection token"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &repeated_upgrade),
+            "multiple Upgrade field lines are ambiguous and must not match"
+        );
+    }
+
+    /// Reject field values that cannot contain valid UTF-8 protocol tokens.
+    #[test]
+    fn responses_websocket_handshake_rejects_non_utf8_upgrade_headers() {
+        let mut invalid_connection = websocket_headers("upgrade", "websocket");
+        invalid_connection.insert(
+            http::header::CONNECTION,
+            http::HeaderValue::from_bytes(&[0xFF]).unwrap(),
+        );
+        let mut invalid_upgrade = websocket_headers("upgrade", "websocket");
+        invalid_upgrade.insert(http::header::UPGRADE, http::HeaderValue::from_bytes(&[0xFF]).unwrap());
+
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &invalid_connection),
+            "a non-UTF-8 Connection value cannot contain a valid upgrade token"
+        );
+        assert!(
+            !is_responses_websocket_handshake(&http::Method::GET, "/v1/responses", &invalid_upgrade),
+            "a non-UTF-8 Upgrade value cannot identify the WebSocket protocol"
+        );
     }
 
     #[test]
@@ -1163,5 +1175,16 @@ mod tests {
             Some("bad\nmodel"),
             "model with control chars should still be extracted by classifier"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    fn websocket_headers(connection: &'static str, upgrade: &'static str) -> http::HeaderMap {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::CONNECTION, connection.parse().unwrap());
+        headers.insert(http::header::UPGRADE, upgrade.parse().unwrap());
+        headers
     }
 }

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -190,7 +190,7 @@ impl HttpFilter for ResponsesFormatFilter {
         debug!(
             format = classified.format.as_str(),
             model = ?classified.model,
-            "classified request body"
+            "classified request"
         );
 
         if let Some(action) = handle_invalid_format(classified.format, &self.config) {
@@ -223,6 +223,7 @@ fn classify_request(ctx: &HttpFilterContext<'_>, bytes: &[u8]) -> (ClassifiedReq
         debug!(
             method = %ctx.request.method,
             path = ctx.request.uri.path(),
+            websocket_handshake,
             "classified request by method and path"
         );
         (empty_result(AiRequestFormat::Responses), websocket_handshake)

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -9,7 +9,9 @@
 //! `/v1/responses/{id}/input_items`, `/v1/responses/{id}/cancel`,
 //! `/v1/responses/input_tokens`, `/v1/responses/compact`) are
 //! classified by method and path without inspecting the body.
-//! `POST /v1/responses` (create) is classified by body content.
+//! `POST /v1/responses` (create) is classified by body content. A
+//! `GET /v1/responses` `WebSocket` upgrade is classified from the method,
+//! path, and upgrade headers without inferring body-derived facts.
 //! Promotes classification facts to configurable headers, durable
 //! metadata, and filter results for routing. Does not mutate the
 //! request body.
@@ -64,7 +66,10 @@ use praxis_filter::{
 use tracing::{debug, trace};
 
 use self::config::{ResponsesFormatConfig, build_config};
-use crate::classifier::{AiRequestFormat, ClassifiedRequest, classify_request_body, empty_result, is_responses_path};
+use crate::classifier::{
+    AiRequestFormat, ClassifiedRequest, classify_request_body, empty_result, is_responses_path,
+    is_responses_websocket_handshake,
+};
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -92,6 +97,12 @@ pub(crate) const DEFAULT_TENANT_ID: &str = "default";
 ///
 /// Classification formats: `openai_responses`, `openai_chat_completions`,
 /// `unknown_json`, `invalid_json`, `non_json`.
+///
+/// A `GET /v1/responses` request with valid HTTP `WebSocket` upgrade headers
+/// is classified as `openai_responses` without inspecting a body. This
+/// handshake classification promotes only the format: model, stream, store,
+/// and mode facts remain absent. An ordinary bodyless `GET /v1/responses`
+/// remains unclassified.
 ///
 /// Routing mode for Responses API: `stateful` when the request contains
 /// `previous_response_id`, non-empty `tools`, `store=true` (default when
@@ -174,16 +185,7 @@ impl HttpFilter for ResponsesFormatFilter {
             None => &[],
         };
 
-        let classified = if is_responses_path(&ctx.request.method, ctx.request.uri.path()) {
-            debug!(
-                method = %ctx.request.method,
-                path = ctx.request.uri.path(),
-                "classified request by method and path"
-            );
-            empty_result(AiRequestFormat::Responses)
-        } else {
-            classify_request_body(bytes)
-        };
+        let (classified, websocket_handshake) = classify_request(ctx, bytes);
 
         debug!(
             format = classified.format.as_str(),
@@ -195,7 +197,11 @@ impl HttpFilter for ResponsesFormatFilter {
             return Ok(action);
         }
 
-        let mode = compute_mode(&classified);
+        let mode = if websocket_handshake {
+            None
+        } else {
+            compute_mode(&classified)
+        };
 
         write_metadata(ctx, &classified, mode);
         promote_headers(ctx, &classified, &self.config, mode);
@@ -208,6 +214,22 @@ impl HttpFilter for ResponsesFormatFilter {
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
+
+/// Classify a request from a recognized path/handshake or its body.
+fn classify_request(ctx: &HttpFilterContext<'_>, bytes: &[u8]) -> (ClassifiedRequest, bool) {
+    let websocket_handshake =
+        is_responses_websocket_handshake(&ctx.request.method, ctx.request.uri.path(), &ctx.request.headers);
+    if websocket_handshake || is_responses_path(&ctx.request.method, ctx.request.uri.path()) {
+        debug!(
+            method = %ctx.request.method,
+            path = ctx.request.uri.path(),
+            "classified request by method and path"
+        );
+        (empty_result(AiRequestFormat::Responses), websocket_handshake)
+    } else {
+        (classify_request_body(bytes), false)
+    }
+}
 
 /// Check whether the format requires rejection.
 fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig) -> Option<FilterAction> {

--- a/apis/src/openai/responses/tests.rs
+++ b/apis/src/openai/responses/tests.rs
@@ -695,6 +695,7 @@ async fn post_v1_responses_classifies_body_normally() {
     );
 }
 
+/// Promote only the format fact for a Responses `WebSocket` handshake.
 #[tokio::test]
 async fn responses_websocket_handshake_promotes_only_format() {
     let ctx = run_filter_with_request_headers(
@@ -711,14 +712,23 @@ async fn responses_websocket_handshake_promotes_only_format() {
     let headers = collect_headers(&ctx);
     let results = ctx.filter_results.get("openai_responses_format").unwrap();
 
-    assert_eq!(headers.get("x-praxis-ai-format"), Some(&"openai_responses"));
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"openai_responses"),
+        "the handshake should promote the Responses format header"
+    );
     assert_eq!(
         ctx.filter_metadata
             .get("openai_responses_format.format")
             .map(String::as_str),
-        Some("openai_responses")
+        Some("openai_responses"),
+        "the handshake should write the Responses format metadata"
     );
-    assert_eq!(results.get("format"), Some("openai_responses"));
+    assert_eq!(
+        results.get("format"),
+        Some("openai_responses"),
+        "the handshake should publish the Responses format result"
+    );
 
     for header in ["x-praxis-ai-model", "x-praxis-ai-stream", "x-praxis-responses-mode"] {
         assert!(!headers.contains_key(header), "handshake should not promote {header}");
@@ -747,6 +757,7 @@ async fn responses_websocket_handshake_promotes_only_format() {
     }
 }
 
+/// Leave an ordinary bodyless Responses GET on the normal body path.
 #[tokio::test]
 async fn get_responses_without_websocket_headers_classifies_body_normally() {
     let ctx = run_filter_with_method("{}", "", http::Method::GET, "/v1/responses").await;

--- a/apis/src/openai/responses/tests.rs
+++ b/apis/src/openai/responses/tests.rs
@@ -695,6 +695,71 @@ async fn post_v1_responses_classifies_body_normally() {
     );
 }
 
+#[tokio::test]
+async fn responses_websocket_handshake_promotes_only_format() {
+    let ctx = run_filter_with_request_headers(
+        "{}",
+        "",
+        http::Method::GET,
+        "/v1/responses",
+        &[
+            (http::header::CONNECTION, "keep-alive, Upgrade"),
+            (http::header::UPGRADE, "websocket"),
+        ],
+    )
+    .await;
+    let headers = collect_headers(&ctx);
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(headers.get("x-praxis-ai-format"), Some(&"openai_responses"));
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.format")
+            .map(String::as_str),
+        Some("openai_responses")
+    );
+    assert_eq!(results.get("format"), Some("openai_responses"));
+
+    for header in ["x-praxis-ai-model", "x-praxis-ai-stream", "x-praxis-responses-mode"] {
+        assert!(!headers.contains_key(header), "handshake should not promote {header}");
+    }
+    for fact in [
+        "model",
+        "stream",
+        "store",
+        "background",
+        "max_output_tokens",
+        "has_previous_response_id",
+        "has_conversation",
+        "has_tools",
+        "has_prompt_id",
+        "mode",
+    ] {
+        assert!(
+            !ctx.filter_metadata
+                .contains_key(&format!("openai_responses_format.{fact}")),
+            "handshake should not write {fact} metadata"
+        );
+        assert!(
+            results.get(fact).is_none(),
+            "handshake should not promote {fact} result"
+        );
+    }
+}
+
+#[tokio::test]
+async fn get_responses_without_websocket_headers_classifies_body_normally() {
+    let ctx = run_filter_with_method("{}", "", http::Method::GET, "/v1/responses").await;
+
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.format")
+            .map(String::as_str),
+        Some("non_json"),
+        "an ordinary GET list request must not be promoted as a WebSocket handshake"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Mode Computation
 // -----------------------------------------------------------------------------
@@ -893,6 +958,29 @@ async fn run_filter_with_method(
 ) -> HttpFilterContext<'static> {
     let filter = make_filter(config_yaml);
     let req = crate::test_utils::make_request(method, path);
+
+    let req: &'static praxis_filter::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(body_str.to_owned()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "filter should release");
+    ctx
+}
+
+/// Run the filter with custom request headers.
+async fn run_filter_with_request_headers(
+    config_yaml: &str,
+    body_str: &str,
+    method: http::Method,
+    path: &str,
+    headers: &[(http::header::HeaderName, &'static str)],
+) -> HttpFilterContext<'static> {
+    let filter = make_filter(config_yaml);
+    let mut req = crate::test_utils::make_request(method, path);
+    for (name, value) in headers {
+        req.headers.append(name, value.parse().unwrap());
+    }
 
     let req: &'static praxis_filter::Request = Box::leak(Box::new(req));
     let mut ctx = crate::test_utils::make_filter_context(req);

--- a/docs/filters/openai_responses_format.md
+++ b/docs/filters/openai_responses_format.md
@@ -9,6 +9,8 @@ Classifies AI API request bodies and promotes routing facts to headers, metadata
 
 Classification formats: `openai_responses`, `openai_chat_completions`, `unknown_json`, `invalid_json`, `non_json`.
 
+A `GET /v1/responses` request with valid HTTP `WebSocket` upgrade headers is classified as `openai_responses` without inspecting a body. This handshake classification promotes only the format: model, stream, store, and mode facts remain absent. An ordinary bodyless `GET /v1/responses` remains unclassified.
+
 Routing mode for Responses API: `stateful` when the request contains `previous_response_id`, non-empty `tools`, `store=true` (default when omitted), `background=true`, `conversation`, or `prompt.id`; `stateless` when `store=false` with no other stateful markers.
 
 Use with branch chains to route stateful and stateless requests to different clusters.

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -127,6 +127,34 @@
 # Configured downstream read and upstream idle/read/write timeouts remain
 # active after a 101 upgrade and can terminate long-lived WebSockets.
 #
+# Direct OpenAI upstream variant:
+#   - Replace the local inference-backend endpoint with api.openai.com:443 and
+#     configure tls.sni: api.openai.com.
+#   - Add this headers filter after the router to replace the downstream Host:
+#
+#       - filter: headers
+#         request_set:
+#           - name: Host
+#             value: api.openai.com
+#
+#   - Either pass through the client's Authorization header or add this filter
+#     after the router to inject a server-owned credential:
+#
+#       - filter: credential_injection
+#         clusters:
+#           - name: inference-backend
+#             header: Authorization
+#             env_var: OPENAI_API_KEY
+#             header_prefix: "Bearer "
+#
+#   - Configure the inference cluster as:
+#
+#       - name: "inference-backend"
+#         endpoints:
+#           - "api.openai.com:443"
+#         tls:
+#           sni: api.openai.com
+#
 # Build:
 #   cargo build -p praxis-ai-proxy
 

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -66,11 +66,12 @@
 #      (already resolved by rehydrate). Passthrough when no
 #      ResponsesState exists.
 #
-#   12. The router sends valid Responses API create requests to the
-#      inference backend and routes /v1/prompts and /v1/embeddings
-#      (and subresources) to dedicated API services. The promoted
-#      mode remains available as headers/metadata for downstream
-#      filters; it does not change backend selection in this example.
+#   12. The router sends all valid Responses API create requests and
+#      GET /v1/responses WebSocket upgrades to the same inference
+#      backend, while /v1/prompts, /v1/embeddings, and
+#      /v1/vector_stores use dedicated services. The promoted mode
+#      remains available for HTTP create requests; WebSocket
+#      handshakes are format-only and have no mode.
 #
 # Security: StreamBuffer body callouts run before this listener's
 # header-phase filters. Deploy this example behind an outer
@@ -117,6 +118,14 @@
 #   curl -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
 #     -d '{"model":"gpt-4.1","input":"test","stream":true,"background":true}'
+#
+#   # Responses WebSocket (requires a WebSocket-capable backend)
+#   websocat -H="Authorization: Bearer $OPENAI_API_KEY" \
+#     ws://localhost:8080/v1/responses
+#
+# Listener and cluster transport timeouts are intentionally omitted.
+# Configured downstream read and upstream idle/read/write timeouts remain
+# active after a 101 upgrade and can terminate long-lived WebSockets.
 #
 # Build:
 #   cargo build -p praxis-ai-proxy

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -25,6 +25,7 @@ http = { workspace = true }
 # Used only by the cpex example test to mint HS256 JWTs for the
 # happy-path case (matches the filter crate's signing dependency).
 jsonwebtoken = "10"
+nix = { workspace = true }
 praxis-ai-apis = { path = "../../apis" }
 praxis-core = { workspace = true }
 praxis-filter = { workspace = true }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -37,6 +37,6 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "process"] }
 tokio-rustls = { workspace = true }
 tokio-tungstenite = { workspace = true }

--- a/tests/integration/fixtures/codex-cli/0.144.1-x86_64-unknown-linux-musl.sha256
+++ b/tests/integration/fixtures/codex-cli/0.144.1-x86_64-unknown-linux-musl.sha256
@@ -1,0 +1,1 @@
+84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28  codex-x86_64-unknown-linux-musl.tar.gz

--- a/tests/integration/fixtures/openai/responses/websocket-codex-0.144.1.json
+++ b/tests/integration/fixtures/openai/responses/websocket-codex-0.144.1.json
@@ -1,0 +1,168 @@
+{
+  "metadata": {
+    "fixture_version": 1,
+    "created_at": "2026-07-19",
+    "codex_cli_version": "0.144.1",
+    "wire_protocol_source": "OpenAI Codex rust-v0.144.1 Responses WebSocket test shapes and Responses streaming event schema",
+    "sanitization": [
+      "uses synthetic response and item identifiers",
+      "omits authorization, cookies, account, organization, project, and deployment metadata",
+      "omits timestamps and request identifiers",
+      "normalizes token usage to zero",
+      "replaces the user prompt and model output with fixed test values"
+    ]
+  },
+  "client": {
+    "kind": "text",
+    "type": "response.create",
+    "expected_prompt": "Reply with exactly PONG. Do not call tools."
+  },
+  "server_messages": [
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.created",
+        "sequence_number": 0,
+        "response": {
+          "id": "resp_praxis_fixture",
+          "object": "response",
+          "status": "in_progress"
+        }
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.in_progress",
+        "sequence_number": 1,
+        "response": {
+          "id": "resp_praxis_fixture",
+          "object": "response",
+          "status": "in_progress"
+        }
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.output_item.added",
+        "sequence_number": 2,
+        "output_index": 0,
+        "item": {
+          "id": "msg_praxis_fixture",
+          "type": "message",
+          "role": "assistant",
+          "status": "in_progress",
+          "content": []
+        }
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.content_part.added",
+        "sequence_number": 3,
+        "item_id": "msg_praxis_fixture",
+        "output_index": 0,
+        "content_index": 0,
+        "part": {
+          "type": "output_text",
+          "text": "",
+          "annotations": []
+        }
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.output_text.delta",
+        "sequence_number": 4,
+        "item_id": "msg_praxis_fixture",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "PONG"
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.output_text.done",
+        "sequence_number": 5,
+        "item_id": "msg_praxis_fixture",
+        "output_index": 0,
+        "content_index": 0,
+        "text": "PONG"
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.content_part.done",
+        "sequence_number": 6,
+        "item_id": "msg_praxis_fixture",
+        "output_index": 0,
+        "content_index": 0,
+        "part": {
+          "type": "output_text",
+          "text": "PONG",
+          "annotations": []
+        }
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.output_item.done",
+        "sequence_number": 7,
+        "output_index": 0,
+        "item": {
+          "id": "msg_praxis_fixture",
+          "type": "message",
+          "role": "assistant",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "text": "PONG",
+              "annotations": []
+            }
+          ]
+        }
+      }
+    },
+    {
+      "kind": "text",
+      "payload": {
+        "type": "response.completed",
+        "sequence_number": 8,
+        "response": {
+          "id": "resp_praxis_fixture",
+          "object": "response",
+          "status": "completed",
+          "output": [
+            {
+              "id": "msg_praxis_fixture",
+              "type": "message",
+              "role": "assistant",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "text": "PONG",
+                  "annotations": []
+                }
+              ]
+            }
+          ],
+          "usage": {
+            "input_tokens": 0,
+            "input_tokens_details": null,
+            "output_tokens": 0,
+            "output_tokens_details": null,
+            "total_tokens": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/integration/tests/suite/codex_websocket.rs
+++ b/tests/integration/tests/suite/codex_websocket.rs
@@ -33,55 +33,22 @@ use praxis_test_utils::{
 use serde::Deserialize;
 use tokio::io::AsyncReadExt as _;
 
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Maximum time allowed for process and pipe cleanup after termination.
+const CHILD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+/// Required output from the pinned executable.
+const CODEX_VERSION: &str = "codex-cli 0.144.1";
 /// Fixed prompt shared by the fixture and child process.
 const PROMPT: &str = "Reply with exactly PONG. Do not call tools.";
 /// Synthetic credential that must reach the test backend.
 const TEST_API_KEY: &str = "praxis-websocket-test-key";
-/// Required output from the pinned executable.
-const CODEX_VERSION: &str = "codex-cli 0.144.1";
-/// Maximum time allowed for process and pipe cleanup after termination.
-const CHILD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+/// Codex output item types that would indicate an attempted tool call.
+const TOOL_ITEM_TYPES: &[&str] = &["command_execution", "file_change", "mcp_tool_call", "web_search"];
 
-/// Typed subset of the deterministic protocol fixture.
-#[derive(Debug, Deserialize)]
-struct CodexWsFixture {
-    /// Fixture provenance and sanitization metadata.
-    metadata: FixtureMetadata,
-    /// Expected client request facts.
-    client: FixtureClient,
-    /// Ordered server messages.
-    server_messages: Vec<FixtureServerMessage>,
-}
-
-/// Metadata that makes fixture pin updates reviewable.
-#[derive(Debug, Deserialize)]
-struct FixtureMetadata {
-    /// Fixture schema revision.
-    fixture_version: u64,
-    /// Pinned Codex version.
-    codex_cli_version: String,
-}
-
-/// Expected facts in the Codex request frame.
-#[derive(Debug, Deserialize)]
-struct FixtureClient {
-    /// WebSocket frame kind.
-    kind: String,
-    /// Responses request type.
-    r#type: String,
-    /// Exact synthetic prompt.
-    expected_prompt: String,
-}
-
-/// One server-side fixture frame.
-#[derive(Debug, Deserialize)]
-struct FixtureServerMessage {
-    /// WebSocket frame kind.
-    kind: String,
-    /// Responses event JSON.
-    payload: serde_json::Value,
-}
-
+/// Prove the pinned Codex client completes an offline turn over WebSocket.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pinned_codex_uses_responses_websocket_through_full_flow() {
     let Some(codex_bin) = std::env::var_os("PRAXIS_TEST_CODEX_BIN") else {
@@ -91,11 +58,26 @@ async fn pinned_codex_uses_responses_websocket_through_full_flow() {
     assert_pinned_codex_version(&codex_bin).await;
 
     let fixture = load_fixture();
-    assert_eq!(fixture.metadata.fixture_version, 1);
-    assert_eq!(fixture.metadata.codex_cli_version, "0.144.1");
-    assert_eq!(fixture.client.kind, "text");
-    assert_eq!(fixture.client.r#type, "response.create");
-    assert_eq!(fixture.client.expected_prompt, PROMPT);
+    assert_eq!(
+        fixture.metadata.fixture_version, 1,
+        "the fixture schema version should match the harness"
+    );
+    assert_eq!(
+        fixture.metadata.codex_cli_version, "0.144.1",
+        "the fixture should identify the pinned Codex version"
+    );
+    assert_eq!(
+        fixture.client.kind, "text",
+        "the pinned request fixture should use a text frame"
+    );
+    assert_eq!(
+        fixture.client.r#type, "response.create",
+        "the pinned request fixture should describe a response.create frame"
+    );
+    assert_eq!(
+        fixture.client.expected_prompt, PROMPT,
+        "the fixture prompt should match the child-process prompt"
+    );
 
     let mut script: Vec<_> = fixture
         .server_messages
@@ -143,10 +125,22 @@ async fn pinned_codex_uses_responses_websocket_through_full_flow() {
 
     let requests = observe_codex_requests(&mut backend).await;
     assert_eq!(requests.len(), 2, "Codex should send prewarm and turn requests");
-    assert_eq!(requests[0]["type"], "response.create");
-    assert_eq!(requests[0]["generate"], false);
-    assert_eq!(requests[1]["type"], "response.create");
-    assert_ne!(requests[1]["generate"], false);
+    assert_eq!(
+        requests[0]["type"], "response.create",
+        "the prewarm frame should create a response"
+    );
+    assert_eq!(
+        requests[0]["generate"], false,
+        "the first frame should be Codex's non-generating prewarm request"
+    );
+    assert_eq!(
+        requests[1]["type"], "response.create",
+        "the turn frame should create a response"
+    );
+    assert_ne!(
+        requests[1]["generate"], false,
+        "the turn frame should request generation"
+    );
     assert!(
         value_contains_exact_string(&requests[1], PROMPT),
         "the generating response.create frame should contain the exact fixed prompt"
@@ -154,26 +148,96 @@ async fn pinned_codex_uses_responses_websocket_through_full_flow() {
     assert_no_unexpected_http(&mut backend).await;
 }
 
+/// A timed-out child must not leave descendants holding its captured pipes.
+#[cfg(unix)]
+#[tokio::test]
+async fn timed_out_child_kills_process_group_and_closes_inherited_pipes() {
+    let mut command = tokio::process::Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg("sleep 30 & wait")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    configure_isolated_process_group(&mut command);
+    let child = command.spawn().expect("shell fixture should start");
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(2),
+        capture_child_output(child, Duration::from_millis(25)),
+    )
+    .await
+    .expect("process-group cleanup and pipe collection should be bounded");
+
+    assert!(output.timed_out, "shell fixture should hit the test timeout");
+    assert!(!output.status.success(), "terminated shell fixture should fail");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Typed subset of the deterministic protocol fixture.
+#[derive(Debug, Deserialize)]
+struct CodexWsFixture {
+    /// Expected client request facts.
+    client: FixtureClient,
+    /// Fixture provenance and sanitization metadata.
+    metadata: FixtureMetadata,
+    /// Ordered server messages.
+    server_messages: Vec<FixtureServerMessage>,
+}
+
 /// Captured child-process result with decoded output.
 struct CodexOutput {
     /// Exit status.
     status: std::process::ExitStatus,
-    /// UTF-8-lossy standard output.
-    stdout: String,
     /// UTF-8-lossy standard error.
     stderr: String,
+    /// UTF-8-lossy standard output.
+    stdout: String,
 }
 
 /// Raw child-process output plus timeout state.
 struct CapturedChildOutput {
     /// Child exit status.
     status: std::process::ExitStatus,
-    /// Captured standard output.
-    stdout: Vec<u8>,
     /// Captured standard error.
     stderr: Vec<u8>,
+    /// Captured standard output.
+    stdout: Vec<u8>,
     /// Whether the child exceeded its execution timeout.
     timed_out: bool,
+}
+
+/// Expected facts in the Codex request frame.
+#[derive(Debug, Deserialize)]
+struct FixtureClient {
+    /// Exact synthetic prompt.
+    expected_prompt: String,
+    /// WebSocket frame kind.
+    kind: String,
+    /// Responses request type.
+    r#type: String,
+}
+
+/// Metadata that makes fixture pin updates reviewable.
+#[derive(Debug, Deserialize)]
+struct FixtureMetadata {
+    /// Pinned Codex version.
+    codex_cli_version: String,
+    /// Fixture schema revision.
+    fixture_version: u64,
+}
+
+/// One server-side fixture frame.
+#[derive(Debug, Deserialize)]
+struct FixtureServerMessage {
+    /// WebSocket frame kind.
+    kind: String,
+    /// Responses event JSON.
+    payload: serde_json::Value,
 }
 
 /// Confirm that the explicitly provided binary matches the fixture pin.
@@ -236,8 +300,8 @@ env_key = "PRAXIS_TEST_API_KEY"
 
     let output = CodexOutput {
         status: captured.status,
-        stdout: String::from_utf8_lossy(&captured.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&captured.stderr).into_owned(),
+        stdout: String::from_utf8_lossy(&captured.stdout).into_owned(),
     };
     assert!(
         !captured.timed_out,
@@ -290,8 +354,8 @@ async fn capture_child_output(mut child: tokio::process::Child, execution_timeou
     let stderr = collect_pipe(&mut stderr_task, process_group_id, "stderr").await;
     CapturedChildOutput {
         status,
-        stdout,
         stderr,
+        stdout,
         timed_out,
     }
 }
@@ -357,7 +421,7 @@ async fn observe_codex_requests(backend: &mut praxis_test_utils::WsBackendGuard)
             .expect("backend observation should not time out")
             .expect("backend observation channel should remain open");
         match event {
-            WsBackendEvent::Handshake { path, headers, .. } => {
+            WsBackendEvent::Handshake { headers, path, .. } => {
                 assert!(!saw_handshake, "acceptance turn should use one WebSocket connection");
                 saw_handshake = true;
                 assert_eq!(
@@ -408,7 +472,6 @@ fn value_contains_exact_string(value: &serde_json::Value, expected: &str) -> boo
 
 /// Validate the completed output and ensure Codex attempted no tool.
 fn assert_codex_jsonl(stdout: &str) {
-    const TOOL_ITEM_TYPES: &[&str] = &["command_execution", "file_change", "mcp_tool_call", "web_search"];
     let mut saw_final_message = false;
     let mut saw_completed_turn = false;
     for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
@@ -428,30 +491,4 @@ fn assert_codex_jsonl(stdout: &str) {
         "Codex should complete an agent message whose exact text is PONG"
     );
     assert!(saw_completed_turn, "Codex should report a completed turn");
-}
-
-/// A timed-out child must not leave descendants holding its captured pipes.
-#[cfg(unix)]
-#[tokio::test]
-async fn timed_out_child_kills_process_group_and_closes_inherited_pipes() {
-    let mut command = tokio::process::Command::new("/bin/sh");
-    command
-        .arg("-c")
-        .arg("sleep 30 & wait")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    configure_isolated_process_group(&mut command);
-    let child = command.spawn().expect("shell fixture should start");
-
-    let output = tokio::time::timeout(
-        Duration::from_secs(2),
-        capture_child_output(child, Duration::from_millis(25)),
-    )
-    .await
-    .expect("process-group cleanup and pipe collection should be bounded");
-
-    assert!(output.timed_out, "shell fixture should hit the test timeout");
-    assert!(!output.status.success(), "terminated shell fixture should fail");
 }

--- a/tests/integration/tests/suite/codex_websocket.rs
+++ b/tests/integration/tests/suite/codex_websocket.rs
@@ -2,9 +2,30 @@
 // Copyright (c) 2026 Praxis Contributors
 
 //! Black-box Codex CLI acceptance test for Responses WebSocket passthrough.
+//!
+//! Run the pinned compatibility test locally with:
+//!
+//! ```console
+//! PRAXIS_TEST_CODEX_BIN=/absolute/path/to/codex \
+//!   cargo test -p praxis-tests-integration --test suite \
+//!   codex_websocket::pinned_codex_uses_responses_websocket_through_full_flow -- --exact
+//! ```
+//!
+//! The executable must report the version in [`CODEX_VERSION`]. To update the
+//! pin, update that constant, the fixture filename and metadata, the checksum
+//! manifest, and every version, archive, cache path/key, and version assertion
+//! in `.github/workflows/integration.yaml`. Recapture and sanitize the fixture
+//! when the client's wire protocol changes, then run this test with the new
+//! verified binary before committing the coordinated update.
 
 use std::{collections::HashMap, ffi::OsStr, process::Stdio, time::Duration};
 
+#[cfg(unix)]
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, kill},
+    unistd::Pid,
+};
 use praxis_test_utils::{
     CapturedWsMessage, TempSqlite, WsBackendEvent, WsServerAction, example_config_path, free_port, patch_yaml,
     start_proxy, start_scripted_websocket_backend_turns,
@@ -18,6 +39,8 @@ const PROMPT: &str = "Reply with exactly PONG. Do not call tools.";
 const TEST_API_KEY: &str = "praxis-websocket-test-key";
 /// Required output from the pinned executable.
 const CODEX_VERSION: &str = "codex-cli 0.144.1";
+/// Maximum time allowed for process and pipe cleanup after termination.
+const CHILD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Typed subset of the deterministic protocol fixture.
 #[derive(Debug, Deserialize)]
@@ -125,10 +148,8 @@ async fn pinned_codex_uses_responses_websocket_through_full_flow() {
     assert_eq!(requests[1]["type"], "response.create");
     assert_ne!(requests[1]["generate"], false);
     assert!(
-        requests
-            .iter()
-            .any(|request| value_contains_exact_string(request, PROMPT)),
-        "a response.create frame should contain the exact fixed prompt"
+        value_contains_exact_string(&requests[1], PROMPT),
+        "the generating response.create frame should contain the exact fixed prompt"
     );
     assert_no_unexpected_http(&mut backend).await;
 }
@@ -141,6 +162,18 @@ struct CodexOutput {
     stdout: String,
     /// UTF-8-lossy standard error.
     stderr: String,
+}
+
+/// Raw child-process output plus timeout state.
+struct CapturedChildOutput {
+    /// Child exit status.
+    status: std::process::ExitStatus,
+    /// Captured standard output.
+    stdout: Vec<u8>,
+    /// Captured standard error.
+    stderr: Vec<u8>,
+    /// Whether the child exceeded its execution timeout.
+    timed_out: bool,
 }
 
 /// Confirm that the explicitly provided binary matches the fixture pin.
@@ -197,40 +230,111 @@ env_key = "PRAXIS_TEST_API_KEY"
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    let mut child = child.spawn().expect("pinned Codex should start");
+    configure_isolated_process_group(&mut child);
+    let child = child.spawn().expect("pinned Codex should start");
+    let captured = capture_child_output(child, Duration::from_secs(30)).await;
+
+    let output = CodexOutput {
+        status: captured.status,
+        stdout: String::from_utf8_lossy(&captured.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&captured.stderr).into_owned(),
+    };
+    assert!(
+        !captured.timed_out,
+        "Codex process exceeded 30-second acceptance-test timeout\nstdout:\n{}\nstderr:\n{}",
+        output.stdout, output.stderr
+    );
+    output
+}
+
+/// Put a child in its own process group so timeout cleanup includes descendants.
+#[cfg(unix)]
+fn configure_isolated_process_group(command: &mut tokio::process::Command) {
+    use std::os::unix::process::CommandExt as _;
+
+    command.as_std_mut().process_group(0);
+}
+
+/// Preserve the cross-platform direct-child behavior where process groups are unavailable.
+#[cfg(not(unix))]
+fn configure_isolated_process_group(_command: &mut tokio::process::Command) {}
+
+/// Wait for a child, terminate its process group on timeout, and collect both pipes.
+async fn capture_child_output(mut child: tokio::process::Child, execution_timeout: Duration) -> CapturedChildOutput {
+    let process_group_id = child.id();
     let mut stdout = child.stdout.take().expect("stdout should be piped");
     let mut stderr = child.stderr.take().expect("stderr should be piped");
-    let stdout_task = tokio::spawn(async move {
+    let mut stdout_task = tokio::spawn(async move {
         let mut bytes = Vec::new();
         stdout.read_to_end(&mut bytes).await.expect("stdout should be readable");
         bytes
     });
-    let stderr_task = tokio::spawn(async move {
+    let mut stderr_task = tokio::spawn(async move {
         let mut bytes = Vec::new();
         stderr.read_to_end(&mut bytes).await.expect("stderr should be readable");
         bytes
     });
 
-    let (status, timed_out) = if let Ok(result) = tokio::time::timeout(Duration::from_secs(30), child.wait()).await {
+    let (status, timed_out) = if let Ok(result) = tokio::time::timeout(execution_timeout, child.wait()).await {
         (result.expect("Codex process should be waitable"), false)
     } else {
-        child.kill().await.expect("timed-out Codex process should be killable");
-        (child.wait().await.expect("killed Codex process should be reaped"), true)
+        terminate_process_group(process_group_id, &mut child);
+        let status = tokio::time::timeout(CHILD_CLEANUP_TIMEOUT, child.wait())
+            .await
+            .expect("killed child should be reaped within the cleanup timeout")
+            .expect("killed child should be waitable");
+        (status, true)
     };
-    let stdout = stdout_task.await.expect("stdout reader should finish");
-    let stderr = stderr_task.await.expect("stderr reader should finish");
 
-    let output = CodexOutput {
+    let stdout = collect_pipe(&mut stdout_task, process_group_id, "stdout").await;
+    let stderr = collect_pipe(&mut stderr_task, process_group_id, "stderr").await;
+    CapturedChildOutput {
         status,
-        stdout: String::from_utf8_lossy(&stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        stdout,
+        stderr,
+        timed_out,
+    }
+}
+
+/// Terminate an isolated child process group, falling back to the direct child.
+fn terminate_process_group(process_group_id: Option<u32>, child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(id) = process_group_id {
+        let id = i32::try_from(id).expect("child PID should fit in i32");
+        match kill(Pid::from_raw(-id), Signal::SIGKILL) {
+            Ok(()) | Err(Errno::ESRCH) => return,
+            Err(error) => panic!("timed-out child process group should be killable: {error}"),
+        }
+    }
+
+    child.start_kill().expect("timed-out child process should be killable");
+}
+
+/// Collect one pipe within a bound, killing inherited descendants if necessary.
+async fn collect_pipe(
+    task: &mut tokio::task::JoinHandle<Vec<u8>>,
+    process_group_id: Option<u32>,
+    name: &str,
+) -> Vec<u8> {
+    if let Ok(result) = tokio::time::timeout(CHILD_CLEANUP_TIMEOUT, &mut *task).await {
+        return result.unwrap_or_else(|error| panic!("{name} reader should finish: {error}"));
+    }
+
+    #[cfg(unix)]
+    if let Some(id) = process_group_id {
+        let id = i32::try_from(id).expect("child PID should fit in i32");
+        match kill(Pid::from_raw(-id), Signal::SIGKILL) {
+            Ok(()) | Err(Errno::ESRCH) => {},
+            Err(error) => panic!("descendant process group holding {name} should be killable: {error}"),
+        }
+    }
+
+    let result = tokio::time::timeout(CHILD_CLEANUP_TIMEOUT, &mut *task).await;
+    let Ok(result) = result else {
+        task.abort();
+        panic!("{name} reader exceeded the cleanup timeout")
     };
-    assert!(
-        !timed_out,
-        "Codex process exceeded 30-second acceptance-test timeout\nstdout:\n{}\nstderr:\n{}",
-        output.stdout, output.stderr
-    );
-    output
+    result.unwrap_or_else(|error| panic!("{name} reader should finish: {error}"))
 }
 
 /// Load and deserialize the committed deterministic fixture.
@@ -324,4 +428,30 @@ fn assert_codex_jsonl(stdout: &str) {
         "Codex should complete an agent message whose exact text is PONG"
     );
     assert!(saw_completed_turn, "Codex should report a completed turn");
+}
+
+/// A timed-out child must not leave descendants holding its captured pipes.
+#[cfg(unix)]
+#[tokio::test]
+async fn timed_out_child_kills_process_group_and_closes_inherited_pipes() {
+    let mut command = tokio::process::Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg("sleep 30 & wait")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    configure_isolated_process_group(&mut command);
+    let child = command.spawn().expect("shell fixture should start");
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(2),
+        capture_child_output(child, Duration::from_millis(25)),
+    )
+    .await
+    .expect("process-group cleanup and pipe collection should be bounded");
+
+    assert!(output.timed_out, "shell fixture should hit the test timeout");
+    assert!(!output.status.success(), "terminated shell fixture should fail");
 }

--- a/tests/integration/tests/suite/codex_websocket.rs
+++ b/tests/integration/tests/suite/codex_websocket.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Black-box Codex CLI acceptance test for Responses WebSocket passthrough.
+
+use std::{collections::HashMap, ffi::OsStr, process::Stdio, time::Duration};
+
+use praxis_test_utils::{
+    CapturedWsMessage, TempSqlite, WsBackendEvent, WsServerAction, example_config_path, free_port, patch_yaml,
+    start_proxy, start_scripted_websocket_backend_turns,
+};
+use serde::Deserialize;
+use tokio::io::AsyncReadExt as _;
+
+/// Fixed prompt shared by the fixture and child process.
+const PROMPT: &str = "Reply with exactly PONG. Do not call tools.";
+/// Synthetic credential that must reach the test backend.
+const TEST_API_KEY: &str = "praxis-websocket-test-key";
+/// Required output from the pinned executable.
+const CODEX_VERSION: &str = "codex-cli 0.144.1";
+
+/// Typed subset of the deterministic protocol fixture.
+#[derive(Debug, Deserialize)]
+struct CodexWsFixture {
+    /// Fixture provenance and sanitization metadata.
+    metadata: FixtureMetadata,
+    /// Expected client request facts.
+    client: FixtureClient,
+    /// Ordered server messages.
+    server_messages: Vec<FixtureServerMessage>,
+}
+
+/// Metadata that makes fixture pin updates reviewable.
+#[derive(Debug, Deserialize)]
+struct FixtureMetadata {
+    /// Fixture schema revision.
+    fixture_version: u64,
+    /// Pinned Codex version.
+    codex_cli_version: String,
+}
+
+/// Expected facts in the Codex request frame.
+#[derive(Debug, Deserialize)]
+struct FixtureClient {
+    /// WebSocket frame kind.
+    kind: String,
+    /// Responses request type.
+    r#type: String,
+    /// Exact synthetic prompt.
+    expected_prompt: String,
+}
+
+/// One server-side fixture frame.
+#[derive(Debug, Deserialize)]
+struct FixtureServerMessage {
+    /// WebSocket frame kind.
+    kind: String,
+    /// Responses event JSON.
+    payload: serde_json::Value,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pinned_codex_uses_responses_websocket_through_full_flow() {
+    let Some(codex_bin) = std::env::var_os("PRAXIS_TEST_CODEX_BIN") else {
+        eprintln!("skipping pinned Codex acceptance test; PRAXIS_TEST_CODEX_BIN is unset");
+        return;
+    };
+    assert_pinned_codex_version(&codex_bin).await;
+
+    let fixture = load_fixture();
+    assert_eq!(fixture.metadata.fixture_version, 1);
+    assert_eq!(fixture.metadata.codex_cli_version, "0.144.1");
+    assert_eq!(fixture.client.kind, "text");
+    assert_eq!(fixture.client.r#type, "response.create");
+    assert_eq!(fixture.client.expected_prompt, PROMPT);
+
+    let mut script: Vec<_> = fixture
+        .server_messages
+        .iter()
+        .map(|message| {
+            assert_eq!(message.kind, "text", "fixture supports text frames only");
+            WsServerAction::Text(serde_json::to_string(&message.payload).unwrap())
+        })
+        .collect();
+    script.push(WsServerAction::Close {
+        code: 1000,
+        reason: "fixture complete".to_owned(),
+    });
+    let prewarm = vec![
+        WsServerAction::Text(
+            r#"{"type":"response.created","response":{"id":"resp_praxis_prewarm"}}"#.to_owned(),
+        ),
+        WsServerAction::Text(
+            r#"{"type":"response.completed","response":{"id":"resp_praxis_prewarm","usage":{"input_tokens":0,"input_tokens_details":null,"output_tokens":0,"output_tokens_details":null,"total_tokens":0}}}"#
+                .to_owned(),
+        ),
+    ];
+    let mut backend = start_scripted_websocket_backend_turns(vec![prewarm, script]).await;
+    let proxy_port = free_port();
+    let db = TempSqlite::new("codex_websocket");
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/full-flow.yaml"))
+        .expect("full-flow example should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", db.url()),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let _proxy = start_proxy(&config);
+
+    let output = run_codex(&codex_bin, proxy_port).await;
+    assert!(
+        output.status.success(),
+        "Codex failed with status {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        status = output.status.code(),
+        stdout = output.stdout,
+        stderr = output.stderr
+    );
+    assert_codex_jsonl(&output.stdout);
+
+    let requests = observe_codex_requests(&mut backend).await;
+    assert_eq!(requests.len(), 2, "Codex should send prewarm and turn requests");
+    assert_eq!(requests[0]["type"], "response.create");
+    assert_eq!(requests[0]["generate"], false);
+    assert_eq!(requests[1]["type"], "response.create");
+    assert_ne!(requests[1]["generate"], false);
+    assert!(
+        requests
+            .iter()
+            .any(|request| value_contains_exact_string(request, PROMPT)),
+        "a response.create frame should contain the exact fixed prompt"
+    );
+    assert_no_unexpected_http(&mut backend).await;
+}
+
+/// Captured child-process result with decoded output.
+struct CodexOutput {
+    /// Exit status.
+    status: std::process::ExitStatus,
+    /// UTF-8-lossy standard output.
+    stdout: String,
+    /// UTF-8-lossy standard error.
+    stderr: String,
+}
+
+/// Confirm that the explicitly provided binary matches the fixture pin.
+async fn assert_pinned_codex_version(codex_bin: &OsStr) {
+    let output = tokio::process::Command::new(codex_bin)
+        .arg("--version")
+        .output()
+        .await
+        .expect("PRAXIS_TEST_CODEX_BIN should execute");
+    assert!(output.status.success(), "codex --version should succeed");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        CODEX_VERSION,
+        "acceptance fixture and executable pin must match"
+    );
+}
+
+/// Run Codex with isolated configuration, credentials, input, and workspace.
+async fn run_codex(codex_bin: &OsStr, proxy_port: u16) -> CodexOutput {
+    let codex_home = tempfile::tempdir().expect("temporary CODEX_HOME should be created");
+    let working_dir = tempfile::tempdir().expect("temporary working directory should be created");
+    let config = format!(
+        r#"model = "test-model"
+model_provider = "praxis"
+
+[model_providers.praxis]
+name = "Praxis test gateway"
+base_url = "http://127.0.0.1:{proxy_port}/v1"
+wire_api = "responses"
+supports_websockets = true
+env_key = "PRAXIS_TEST_API_KEY"
+"#
+    );
+    std::fs::write(codex_home.path().join("config.toml"), config).expect("test config should be written");
+
+    let mut child = tokio::process::Command::new(codex_bin);
+    child
+        .arg("exec")
+        .arg("--ephemeral")
+        .arg("--strict-config")
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("read-only")
+        .arg("--json")
+        .arg(PROMPT)
+        .current_dir(working_dir.path())
+        .env_clear()
+        .env("CODEX_HOME", codex_home.path())
+        .env("HOME", codex_home.path())
+        .env("PATH", "/usr/bin:/bin:/usr/local/bin")
+        .env("PRAXIS_TEST_API_KEY", TEST_API_KEY)
+        .env("RUST_LOG", "error")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = child.spawn().expect("pinned Codex should start");
+    let mut stdout = child.stdout.take().expect("stdout should be piped");
+    let mut stderr = child.stderr.take().expect("stderr should be piped");
+    let stdout_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).await.expect("stdout should be readable");
+        bytes
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        stderr.read_to_end(&mut bytes).await.expect("stderr should be readable");
+        bytes
+    });
+
+    let (status, timed_out) = if let Ok(result) = tokio::time::timeout(Duration::from_secs(30), child.wait()).await {
+        (result.expect("Codex process should be waitable"), false)
+    } else {
+        child.kill().await.expect("timed-out Codex process should be killable");
+        (child.wait().await.expect("killed Codex process should be reaped"), true)
+    };
+    let stdout = stdout_task.await.expect("stdout reader should finish");
+    let stderr = stderr_task.await.expect("stderr reader should finish");
+
+    let output = CodexOutput {
+        status,
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+    };
+    assert!(
+        !timed_out,
+        "Codex process exceeded 30-second acceptance-test timeout\nstdout:\n{}\nstderr:\n{}",
+        output.stdout, output.stderr
+    );
+    output
+}
+
+/// Load and deserialize the committed deterministic fixture.
+fn load_fixture() -> CodexWsFixture {
+    let path = format!(
+        "{}/fixtures/openai/responses/websocket-codex-0.144.1.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let bytes = std::fs::read(path).expect("Codex WebSocket fixture should exist");
+    serde_json::from_slice(&bytes).expect("Codex WebSocket fixture should parse")
+}
+
+/// Observe one handshake and the prewarm plus generating request frames.
+async fn observe_codex_requests(backend: &mut praxis_test_utils::WsBackendGuard) -> Vec<serde_json::Value> {
+    let mut saw_handshake = false;
+    let mut requests = Vec::new();
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), backend.next_event())
+            .await
+            .expect("backend observation should not time out")
+            .expect("backend observation channel should remain open");
+        match event {
+            WsBackendEvent::Handshake { path, headers, .. } => {
+                assert!(!saw_handshake, "acceptance turn should use one WebSocket connection");
+                saw_handshake = true;
+                assert_eq!(
+                    path, "/v1/responses",
+                    "Codex should use the Responses WebSocket endpoint"
+                );
+                assert_eq!(
+                    headers.get(http::header::AUTHORIZATION).unwrap(),
+                    "Bearer praxis-websocket-test-key",
+                    "synthetic provider credential should reach the backend"
+                );
+            },
+            WsBackendEvent::ClientMessage(CapturedWsMessage::Text(text)) => {
+                assert!(saw_handshake, "request frame must follow the handshake");
+                requests.push(serde_json::from_str(&text).expect("Codex request frame should be JSON"));
+                if requests.len() == 2 {
+                    return requests;
+                }
+            },
+            WsBackendEvent::UnexpectedHttpRequest { method, path } => {
+                panic!("Codex attempted unexpected HTTP fallback: {method} {path}");
+            },
+            WsBackendEvent::ClientMessage(_) => {},
+        }
+    }
+}
+
+/// Drain queued observations and reject any HTTP fallback request.
+async fn assert_no_unexpected_http(backend: &mut praxis_test_utils::WsBackendGuard) {
+    while let Ok(Some(event)) = tokio::time::timeout(Duration::from_millis(100), backend.next_event()).await {
+        if let WsBackendEvent::UnexpectedHttpRequest { method, path } = event {
+            panic!("Codex attempted unexpected HTTP fallback: {method} {path}");
+        }
+    }
+}
+
+/// Search a JSON value recursively for an exact string.
+fn value_contains_exact_string(value: &serde_json::Value, expected: &str) -> bool {
+    match value {
+        serde_json::Value::String(actual) => actual == expected,
+        serde_json::Value::Array(values) => values.iter().any(|value| value_contains_exact_string(value, expected)),
+        serde_json::Value::Object(values) => values
+            .values()
+            .any(|value| value_contains_exact_string(value, expected)),
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => false,
+    }
+}
+
+/// Validate the completed output and ensure Codex attempted no tool.
+fn assert_codex_jsonl(stdout: &str) {
+    const TOOL_ITEM_TYPES: &[&str] = &["command_execution", "file_change", "mcp_tool_call", "web_search"];
+    let mut saw_final_message = false;
+    let mut saw_completed_turn = false;
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let event: serde_json::Value = serde_json::from_str(line).expect("Codex --json output should be JSONL");
+        let item_type = event.pointer("/item/type").and_then(serde_json::Value::as_str);
+        assert!(
+            item_type.is_none_or(|kind| !TOOL_ITEM_TYPES.contains(&kind)),
+            "Codex attempted a tool: {event}"
+        );
+        saw_final_message |= event["type"] == "item.completed"
+            && item_type == Some("agent_message")
+            && event.pointer("/item/text").and_then(serde_json::Value::as_str) == Some("PONG");
+        saw_completed_turn |= event["type"] == "turn.completed";
+    }
+    assert!(
+        saw_final_message,
+        "Codex should complete an agent message whose exact text is PONG"
+    );
+    assert!(saw_completed_turn, "Codex should report a completed turn");
+}

--- a/tests/integration/tests/suite/examples/full_flow.rs
+++ b/tests/integration/tests/suite/examples/full_flow.rs
@@ -33,9 +33,6 @@ const FIRST_RESPONSE_JSON: &str = r#"{"id":"resp_first","created_at":1000,"model
 /// Maximum time allowed for a test client to complete a WebSocket handshake.
 const WEBSOCKET_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Successful WebSocket client connection and handshake response.
-type WebSocketConnectResult = Result<(WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, Response), Error>;
-
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -286,6 +283,7 @@ async fn full_flow_previous_response_id_rebuilds_body_with_history() {
     drop(proxy2);
 }
 
+/// Bound a stalled opening handshake so the integration suite cannot hang.
 #[tokio::test]
 async fn websocket_handshake_timeout_is_bounded() {
     let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
@@ -309,6 +307,7 @@ async fn websocket_handshake_timeout_is_bounded() {
     stalled_server.abort();
 }
 
+/// Preserve handshake metadata, ordered text frames, and the close frame.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn full_flow_websocket_upgrade_preserves_handshake_and_ordered_text() {
     let first = r#"{"type":"response.created","sequence_number":0}"#;
@@ -339,32 +338,100 @@ async fn full_flow_websocket_upgrade_preserves_handshake_and_ordered_text() {
     let (mut socket, response) = connect_websocket(request)
         .await
         .expect("WebSocket handshake should succeed");
-    assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(
+        response.status(),
+        http::StatusCode::SWITCHING_PROTOCOLS,
+        "the full-flow backend should accept the opening handshake"
+    );
 
     let create = r#"{"type":"response.create","response":{"input":"PING"}}"#;
     socket.send(Message::Text(create.into())).await.unwrap();
-    assert_eq!(next_ws_message(&mut socket).await.into_text().unwrap(), first);
-    assert_eq!(next_ws_message(&mut socket).await.into_text().unwrap(), second);
+    assert_eq!(
+        next_ws_message(&mut socket).await.into_text().unwrap(),
+        first,
+        "the first server frame should preserve its payload and order"
+    );
+    assert_eq!(
+        next_ws_message(&mut socket).await.into_text().unwrap(),
+        second,
+        "the second server frame should preserve its payload and order"
+    );
     let close = next_ws_message(&mut socket).await;
     let Message::Close(Some(frame)) = close else {
         panic!("expected close frame, got {close:?}");
     };
-    assert_eq!(u16::from(frame.code), 1000);
-    assert_eq!(frame.reason, "complete");
+    assert_eq!(
+        u16::from(frame.code),
+        1000,
+        "the close status should pass through unchanged"
+    );
+    assert_eq!(
+        frame.reason, "complete",
+        "the close reason should pass through unchanged"
+    );
 
     let handshake = next_backend_event(&mut backend).await;
-    let WsBackendEvent::Handshake { method, path, headers } = handshake else {
+    let WsBackendEvent::Handshake { headers, method, path } = handshake else {
         panic!("expected handshake event, got {handshake:?}");
     };
-    assert_eq!(method, http::Method::GET);
-    assert_eq!(path, "/v1/responses");
-    assert_eq!(headers.get(http::header::AUTHORIZATION).unwrap(), "Bearer test-token");
+    assert_eq!(method, http::Method::GET, "the backend should receive the opening GET");
+    assert_eq!(
+        path, "/v1/responses",
+        "the backend should receive the Responses endpoint"
+    );
+    assert_eq!(
+        headers.get(http::header::AUTHORIZATION).unwrap(),
+        "Bearer test-token",
+        "the authorization header should reach the backend"
+    );
     assert_eq!(
         next_backend_event(&mut backend).await,
-        WsBackendEvent::ClientMessage(CapturedWsMessage::Text(create.to_owned()))
+        WsBackendEvent::ClientMessage(CapturedWsMessage::Text(create.to_owned())),
+        "the client text frame should pass through unchanged"
     );
 }
 
+/// Preserve arbitrary binary payloads in both tunnel directions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_websocket_preserves_binary_frames_bidirectionally() {
+    let server_payload = bytes::Bytes::from_static(&[0x00, 0x7F, 0x80, 0xFF]);
+    let mut backend = start_scripted_websocket_backend(vec![WsServerAction::Binary(server_payload.clone())]).await;
+    let proxy_port = free_port();
+    let (config, _db) = isolated_full_flow_config(
+        "websocket_binary",
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend.port())]),
+    );
+    let _proxy = start_proxy(&config);
+    let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
+    let (mut socket, _) = connect_websocket(url)
+        .await
+        .expect("binary-frame WebSocket handshake should succeed");
+    let client_payload = bytes::Bytes::from_static(&[0xFF, 0x80, 0x7F, 0x00]);
+
+    socket
+        .send(Message::Binary(client_payload.clone()))
+        .await
+        .expect("client binary frame should be sent");
+
+    assert_eq!(
+        next_ws_message(&mut socket).await,
+        Message::Binary(server_payload),
+        "server binary payload should pass through unchanged"
+    );
+    let handshake = next_backend_event(&mut backend).await;
+    assert!(
+        matches!(handshake, WsBackendEvent::Handshake { .. }),
+        "backend should observe the WebSocket handshake before data frames"
+    );
+    assert_eq!(
+        next_backend_event(&mut backend).await,
+        WsBackendEvent::ClientMessage(CapturedWsMessage::Binary(client_payload)),
+        "client binary payload should pass through unchanged"
+    );
+}
+
+/// Keep an idle upgraded connection alive while relaying control frames.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn full_flow_websocket_survives_idle_and_relays_ping_pong() {
     let mut backend = start_scripted_websocket_backend(vec![
@@ -384,14 +451,22 @@ async fn full_flow_websocket_survives_idle_and_relays_ping_pong() {
     let (mut socket, _) = connect_websocket(url).await.unwrap();
 
     socket.send(Message::Text("start".into())).await.unwrap();
-    assert_eq!(next_ws_message(&mut socket).await, Message::Ping(vec![7, 8, 9].into()));
+    assert_eq!(
+        next_ws_message(&mut socket).await,
+        Message::Ping(vec![7, 8, 9].into()),
+        "the server ping should pass through unchanged"
+    );
     socket.flush().await.unwrap();
     let after_idle = tokio::time::timeout(Duration::from_secs(5), socket.next())
         .await
         .expect("connection should remain alive during the idle window")
         .unwrap()
         .unwrap();
-    assert_eq!(after_idle.into_text().unwrap(), "after-idle");
+    assert_eq!(
+        after_idle.into_text().unwrap(),
+        "after-idle",
+        "the connection should carry data after the idle interval"
+    );
 
     let mut saw_pong = false;
     for _ in 0..3 {
@@ -417,10 +492,12 @@ async fn full_flow_websocket_survives_idle_and_relays_ping_pong() {
         WsBackendEvent::ClientMessage(CapturedWsMessage::Close {
             code: Some(1001),
             reason: Some("client done".to_owned()),
-        })
+        }),
+        "the client close frame should pass through unchanged"
     );
 }
 
+/// Propagate an abrupt upstream disconnect within the test timeout.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn full_flow_websocket_early_backend_disconnect_is_bounded() {
     let backend = start_scripted_websocket_backend(vec![WsServerAction::Disconnect]).await;
@@ -446,10 +523,15 @@ async fn full_flow_websocket_early_backend_disconnect_is_bounded() {
     let (second, response) = connect_websocket(&url)
         .await
         .expect("backend listener should remain healthy");
-    assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(
+        response.status(),
+        http::StatusCode::SWITCHING_PROTOCOLS,
+        "an abrupt connection must not terminate the backend listener"
+    );
     drop(second);
 }
 
+/// Preserve an upstream HTTP rejection instead of entering tunnel mode.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn full_flow_websocket_non_101_backend_response_remains_http() {
     let backend = Backend::status(426, "upgrade rejected").start_with_shutdown();
@@ -468,16 +550,28 @@ async fn full_flow_websocket_non_101_backend_response_remains_http() {
     let Error::Http(response) = error else {
         panic!("expected HTTP handshake error, got {error:?}");
     };
-    assert_eq!(response.status(), http::StatusCode::UPGRADE_REQUIRED);
+    assert_eq!(
+        response.status(),
+        http::StatusCode::UPGRADE_REQUIRED,
+        "the upstream non-101 status should remain an HTTP response"
+    );
     assert_eq!(
         response.headers().get(http::header::CONTENT_TYPE).unwrap(),
-        "application/json"
+        "application/json",
+        "the normal error filter should format the HTTP rejection as JSON"
     );
     let body: serde_json::Value = serde_json::from_slice(response.body().as_deref().unwrap()).unwrap();
-    assert_eq!(body["error"]["code"], "426");
-    assert_eq!(body["error"]["message"], "upstream error (HTTP 426)");
+    assert_eq!(
+        body["error"]["code"], "426",
+        "the formatted error should retain the upstream status code"
+    );
+    assert_eq!(
+        body["error"]["message"], "upstream error (HTTP 426)",
+        "the formatted error should describe the upstream rejection"
+    );
 }
 
+/// Keep the bodyless handshake out of the HTTP stateful branch.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn full_flow_websocket_handshake_does_not_take_stateful_route() {
     let ws_backend = start_scripted_websocket_backend(vec![WsServerAction::Text("native".to_owned())]).await;
@@ -515,10 +609,25 @@ async fn full_flow_websocket_handshake_does_not_take_stateful_route() {
 
     let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
     let (mut socket, response) = connect_websocket(url).await.expect("handshake should use native route");
-    assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(
+        response.status(),
+        http::StatusCode::SWITCHING_PROTOCOLS,
+        "the handshake should reach the format-only inference route"
+    );
     socket.send(Message::Text("start".into())).await.unwrap();
-    assert_eq!(next_ws_message(&mut socket).await.into_text().unwrap(), "native");
+    assert_eq!(
+        next_ws_message(&mut socket).await.into_text().unwrap(),
+        "native",
+        "the handshake should not enter the stateful HTTP route"
+    );
 }
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Successful WebSocket client connection and handshake response.
+type WebSocketConnectResult = Result<(WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, Response), Error>;
 
 /// Receive one proxied `WebSocket` message with the plan's test bound.
 async fn next_ws_message<S>(socket: &mut WebSocketStream<S>) -> Message

--- a/tests/integration/tests/suite/examples/full_flow.rs
+++ b/tests/integration/tests/suite/examples/full_flow.rs
@@ -3,11 +3,22 @@
 
 //! Functional tests for the Responses API full-flow example config.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
+use futures::{SinkExt as _, StreamExt as _};
 use praxis_test_utils::{
-    Backend, TempSqlite, example_config_path, free_port, http_send, json_post, load_example_config, parse_body,
-    parse_status, patch_yaml, start_backend_with_shutdown, start_echo_backend, start_proxy,
+    Backend, CapturedWsMessage, TempSqlite, WsBackendEvent, WsServerAction, example_config_path, free_port, http_send,
+    json_post, load_example_config, parse_body, parse_status, patch_yaml, start_backend_with_shutdown,
+    start_echo_backend, start_proxy, start_scripted_websocket_backend,
+};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async,
+    tungstenite::{
+        Error, Message,
+        client::IntoClientRequest as _,
+        handshake::client::Response,
+        protocol::{CloseFrame, frame::coding::CloseCode},
+    },
 };
 
 use super::openai_file_resolve::start_files_api_stub;
@@ -18,6 +29,12 @@ use super::openai_file_resolve::start_files_api_stub;
 
 /// Backend response for the first turn — stored by response_store.
 const FIRST_RESPONSE_JSON: &str = r#"{"id":"resp_first","created_at":1000,"model":"gpt-4.1","object":"response","status":"completed","input":"Hello","output":[{"type":"message","content":[{"type":"output_text","text":"Hi there"}]}]}"#;
+
+/// Maximum time allowed for a test client to complete a WebSocket handshake.
+const WEBSOCKET_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Successful WebSocket client connection and handshake response.
+type WebSocketConnectResult = Result<(WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, Response), Error>;
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -267,4 +284,299 @@ async fn full_flow_previous_response_id_rebuilds_body_with_history() {
     );
 
     drop(proxy2);
+}
+
+#[tokio::test]
+async fn websocket_handshake_timeout_is_bounded() {
+    let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let stalled_server = tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+
+    let error =
+        connect_websocket_with_timeout(format!("ws://127.0.0.1:{port}/v1/responses"), Duration::from_millis(25))
+            .await
+            .expect_err("stalled WebSocket handshake should time out");
+
+    assert!(
+        matches!(&error, Error::Io(error) if error.kind() == std::io::ErrorKind::TimedOut),
+        "expected timed-out I/O error, got {error:?}"
+    );
+    stalled_server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_websocket_upgrade_preserves_handshake_and_ordered_text() {
+    let first = r#"{"type":"response.created","sequence_number":0}"#;
+    let second = r#"{"type":"response.output_text.delta","sequence_number":1,"delta":"PONG"}"#;
+    let mut backend = start_scripted_websocket_backend(vec![
+        WsServerAction::Text(first.to_owned()),
+        WsServerAction::Text(second.to_owned()),
+        WsServerAction::Close {
+            code: 1000,
+            reason: "complete".to_owned(),
+        },
+    ])
+    .await;
+    let proxy_port = free_port();
+    let (config, _db) = isolated_full_flow_config(
+        "websocket_upgrade",
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend.port())]),
+    );
+    let _proxy = start_proxy(&config);
+
+    let mut request = format!("ws://127.0.0.1:{proxy_port}/v1/responses")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert(http::header::AUTHORIZATION, "Bearer test-token".parse().unwrap());
+    let (mut socket, response) = connect_websocket(request)
+        .await
+        .expect("WebSocket handshake should succeed");
+    assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+
+    let create = r#"{"type":"response.create","response":{"input":"PING"}}"#;
+    socket.send(Message::Text(create.into())).await.unwrap();
+    assert_eq!(next_ws_message(&mut socket).await.into_text().unwrap(), first);
+    assert_eq!(next_ws_message(&mut socket).await.into_text().unwrap(), second);
+    let close = next_ws_message(&mut socket).await;
+    let Message::Close(Some(frame)) = close else {
+        panic!("expected close frame, got {close:?}");
+    };
+    assert_eq!(u16::from(frame.code), 1000);
+    assert_eq!(frame.reason, "complete");
+
+    let handshake = next_backend_event(&mut backend).await;
+    let WsBackendEvent::Handshake { method, path, headers } = handshake else {
+        panic!("expected handshake event, got {handshake:?}");
+    };
+    assert_eq!(method, http::Method::GET);
+    assert_eq!(path, "/v1/responses");
+    assert_eq!(headers.get(http::header::AUTHORIZATION).unwrap(), "Bearer test-token");
+    assert_eq!(
+        next_backend_event(&mut backend).await,
+        WsBackendEvent::ClientMessage(CapturedWsMessage::Text(create.to_owned()))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_websocket_survives_idle_and_relays_ping_pong() {
+    let mut backend = start_scripted_websocket_backend(vec![
+        WsServerAction::Ping(vec![7, 8, 9].into()),
+        WsServerAction::Delay(Duration::from_millis(750)),
+        WsServerAction::Text("after-idle".to_owned()),
+    ])
+    .await;
+    let proxy_port = free_port();
+    let (config, _db) = isolated_full_flow_config(
+        "websocket_idle",
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend.port())]),
+    );
+    let _proxy = start_proxy(&config);
+    let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
+    let (mut socket, _) = connect_websocket(url).await.unwrap();
+
+    socket.send(Message::Text("start".into())).await.unwrap();
+    assert_eq!(next_ws_message(&mut socket).await, Message::Ping(vec![7, 8, 9].into()));
+    socket.flush().await.unwrap();
+    let after_idle = tokio::time::timeout(Duration::from_secs(5), socket.next())
+        .await
+        .expect("connection should remain alive during the idle window")
+        .unwrap()
+        .unwrap();
+    assert_eq!(after_idle.into_text().unwrap(), "after-idle");
+
+    let mut saw_pong = false;
+    for _ in 0..3 {
+        if let WsBackendEvent::ClientMessage(CapturedWsMessage::Pong(payload)) = next_backend_event(&mut backend).await
+            && payload == bytes::Bytes::from_static(&[7, 8, 9])
+        {
+            saw_pong = true;
+            break;
+        }
+    }
+    assert!(saw_pong, "backend should receive the client's automatic pong");
+
+    socket
+        .send(Message::Close(Some(CloseFrame {
+            code: CloseCode::Away,
+            reason: "client done".into(),
+        })))
+        .await
+        .unwrap();
+    let close = next_backend_event(&mut backend).await;
+    assert_eq!(
+        close,
+        WsBackendEvent::ClientMessage(CapturedWsMessage::Close {
+            code: Some(1001),
+            reason: Some("client done".to_owned()),
+        })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_websocket_early_backend_disconnect_is_bounded() {
+    let backend = start_scripted_websocket_backend(vec![WsServerAction::Disconnect]).await;
+    let proxy_port = free_port();
+    let (config, _db) = isolated_full_flow_config(
+        "websocket_disconnect",
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend.port())]),
+    );
+    let _proxy = start_proxy(&config);
+    let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
+    let (mut socket, _) = connect_websocket(&url).await.unwrap();
+
+    socket.send(Message::Text("disconnect".into())).await.unwrap();
+    let ended = tokio::time::timeout(Duration::from_secs(5), socket.next())
+        .await
+        .expect("early backend disconnect should propagate promptly");
+    assert!(
+        ended.is_none() || ended.is_some_and(|result| result.is_err()),
+        "disconnect should end the stream without a successful data message"
+    );
+
+    let (second, response) = connect_websocket(&url)
+        .await
+        .expect("backend listener should remain healthy");
+    assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+    drop(second);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_websocket_non_101_backend_response_remains_http() {
+    let backend = Backend::status(426, "upgrade rejected").start_with_shutdown();
+    let proxy_port = free_port();
+    let (config, _db) = isolated_full_flow_config(
+        "websocket_non_101",
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend.port())]),
+    );
+    let _proxy = start_proxy(&config);
+    let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
+
+    let error = connect_websocket(url)
+        .await
+        .expect_err("backend should reject the upgrade");
+    let Error::Http(response) = error else {
+        panic!("expected HTTP handshake error, got {error:?}");
+    };
+    assert_eq!(response.status(), http::StatusCode::UPGRADE_REQUIRED);
+    assert_eq!(
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
+        "application/json"
+    );
+    let body: serde_json::Value = serde_json::from_slice(response.body().as_deref().unwrap()).unwrap();
+    assert_eq!(body["error"]["code"], "426");
+    assert_eq!(body["error"]["message"], "upstream error (HTTP 426)");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_websocket_handshake_does_not_take_stateful_route() {
+    let ws_backend = start_scripted_websocket_backend(vec![WsServerAction::Text("native".to_owned())]).await;
+    let stateful_backend = Backend::fixed("stateful-backend").start_with_shutdown();
+    let proxy_port = free_port();
+    let db = TempSqlite::new("websocket_routing");
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/full-flow.yaml"))
+        .expect("example config should exist")
+        .replace("sqlite://responses.db?mode=rwc", db.url())
+        .replace(
+            "          - path: \"/v1/responses\"\n            headers:\n              x-praxis-ai-format: \"openai_responses\"",
+            "          - path: \"/v1/responses\"\n            headers:\n              x-praxis-responses-mode: \"stateful\"\n            cluster: \"stateful-backend\"\n\n          - path: \"/v1/responses\"\n            headers:\n              x-praxis-ai-format: \"openai_responses\"",
+        )
+        .replace(
+            "              - \"127.0.0.1:3001\"",
+            "              - \"127.0.0.1:3001\"\n          - name: \"stateful-backend\"\n            endpoints:\n              - \"127.0.0.1:3002\"",
+        );
+    let patched = patch_yaml(
+        &yaml,
+        proxy_port,
+        &HashMap::from([
+            ("127.0.0.1:3001", ws_backend.port()),
+            ("127.0.0.1:3002", stateful_backend.port()),
+        ]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("routing config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", r#"{"input":"stateful"}"#));
+    assert_eq!(
+        parse_body(&raw),
+        "stateful-backend",
+        "control request should use stateful route"
+    );
+
+    let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
+    let (mut socket, response) = connect_websocket(url).await.expect("handshake should use native route");
+    assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+    socket.send(Message::Text("start".into())).await.unwrap();
+    assert_eq!(next_ws_message(&mut socket).await.into_text().unwrap(), "native");
+}
+
+/// Receive one proxied `WebSocket` message with the plan's test bound.
+async fn next_ws_message<S>(socket: &mut WebSocketStream<S>) -> Message
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    tokio::time::timeout(Duration::from_secs(5), socket.next())
+        .await
+        .expect("WebSocket receive should complete within five seconds")
+        .expect("WebSocket stream should remain open")
+        .expect("WebSocket message should be valid")
+}
+
+/// Connect a test client within the standard handshake timeout.
+async fn connect_websocket<R>(request: R) -> WebSocketConnectResult
+where
+    R: tokio_tungstenite::tungstenite::client::IntoClientRequest + Unpin,
+{
+    connect_websocket_with_timeout(request, WEBSOCKET_HANDSHAKE_TIMEOUT).await
+}
+
+/// Connect a test client within an explicit handshake timeout.
+async fn connect_websocket_with_timeout<R>(request: R, timeout: Duration) -> WebSocketConnectResult
+where
+    R: tokio_tungstenite::tungstenite::client::IntoClientRequest + Unpin,
+{
+    tokio::time::timeout(timeout, Box::pin(connect_async(request)))
+        .await
+        .map_err(|_elapsed| {
+            Error::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "WebSocket handshake exceeded test timeout",
+            ))
+        })?
+}
+
+/// Receive one backend observation with the plan's test bound.
+async fn next_backend_event(backend: &mut praxis_test_utils::WsBackendGuard) -> WsBackendEvent {
+    tokio::time::timeout(Duration::from_secs(5), backend.next_event())
+        .await
+        .expect("backend observation should arrive within five seconds")
+        .expect("backend observation channel should remain open")
+}
+
+/// Load the full-flow example with isolated persistence and patched ports.
+fn isolated_full_flow_config(
+    test_name: &str,
+    proxy_port: u16,
+    ports: &HashMap<&str, u16>,
+) -> (praxis_core::config::Config, TempSqlite) {
+    let db = TempSqlite::new(test_name);
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/full-flow.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", db.url()),
+        proxy_port,
+        ports,
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    (config, db)
 }

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -40,6 +40,7 @@
 mod a2a;
 mod agentic_mocks;
 mod anthropic_messages;
+mod codex_websocket;
 mod conversations_rehydrate;
 mod examples;
 mod failure_mode;

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -38,3 +38,4 @@ tokio = { workspace = true, features = ["rt", "net", "io-util", "time", "sync"] 
 tracing = { workspace = true }
 futures = { workspace = true }
 tokio-rustls = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/tests/utils/src/net/backend/mod.rs
+++ b/tests/utils/src/net/backend/mod.rs
@@ -6,6 +6,7 @@
 mod echo;
 mod simple;
 mod specialized;
+mod websocket;
 
 pub use echo::{
     CapturingBackendGuard, start_capturing_backend, start_echo_backend, start_header_echo_backend,
@@ -15,3 +16,7 @@ pub use simple::{
     Backend, ChunkedBackend, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown,
 };
 pub use specialized::BackendGuard;
+pub use websocket::{
+    CapturedWsMessage, WsBackendEvent, WsBackendGuard, WsServerAction, start_scripted_websocket_backend,
+    start_scripted_websocket_backend_turns,
+};

--- a/tests/utils/src/net/backend/websocket.rs
+++ b/tests/utils/src/net/backend/websocket.rs
@@ -20,8 +20,17 @@ use tokio_tungstenite::{
 };
 use tracing::debug;
 
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Maximum HTTP request-head size accepted by the scripted backend.
+const MAX_HEAD_BYTES: usize = 16_384; // 16 KiB
+/// Maximum unexpected HTTP request-body size drained before rejection.
+const MAX_UNEXPECTED_BODY_BYTES: usize = 16_777_216; // 16 MiB
+
 /// A message captured from a test client.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CapturedWsMessage {
     /// UTF-8 text message.
     Text(String),
@@ -41,16 +50,16 @@ pub enum CapturedWsMessage {
 }
 
 /// An observation emitted by the scripted backend.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WsBackendEvent {
     /// A completed `WebSocket` HTTP handshake.
     Handshake {
+        /// Request headers observed by the backend.
+        headers: HeaderMap,
         /// Request method observed by the backend.
         method: Method,
         /// Path and query observed by the backend.
         path: String,
-        /// Request headers observed by the backend.
-        headers: HeaderMap,
     },
     /// A message received from the connected client.
     ClientMessage(CapturedWsMessage),
@@ -64,8 +73,10 @@ pub enum WsBackendEvent {
 }
 
 /// A deterministic action performed after the first client data message.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WsServerAction {
+    /// Send a binary message.
+    Binary(Bytes),
     /// Send a UTF-8 text message.
     Text(String),
     /// Send a ping control message.
@@ -87,25 +98,25 @@ pub enum WsServerAction {
 ///
 /// Dropping the guard stops the listener and aborts all connection tasks.
 pub struct WsBackendGuard {
-    /// Port allocated by the operating system.
-    port: u16,
     /// Stream of backend observations.
     events: mpsc::Receiver<WsBackendEvent>,
-    /// Listener shutdown signal.
-    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
     /// Listener task, which owns all connection tasks.
     handle: Option<tokio::task::JoinHandle<()>>,
+    /// Port allocated by the operating system.
+    port: u16,
+    /// Listener shutdown signal.
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 impl WsBackendGuard {
-    /// Return the allocated port.
-    pub fn port(&self) -> u16 {
-        self.port
-    }
-
     /// Wait for the next handshake or client-message observation.
     pub async fn next_event(&mut self) -> Option<WsBackendEvent> {
         self.events.recv().await
+    }
+
+    /// Return the allocated port.
+    pub fn port(&self) -> u16 {
+        self.port
     }
 }
 
@@ -160,10 +171,10 @@ pub async fn start_scripted_websocket_backend_turns(turns: Vec<Vec<WsServerActio
     debug!(port, "scripted WebSocket backend listening");
 
     WsBackendGuard {
-        port,
         events: event_rx,
-        shutdown: Some(shutdown_tx),
         handle: Some(handle),
+        port,
+        shutdown: Some(shutdown_tx),
     }
 }
 
@@ -265,9 +276,9 @@ async fn accept_connection(
         // The callback borrows its request. Owning the header map is required
         // because test assertions run after the handshake completes.
         let event = WsBackendEvent::Handshake {
+            headers: request.headers().clone(),
             method: request.method().clone(),
             path: request.uri().to_string(),
-            headers: request.headers().clone(),
         };
         let _queued = handshake_events.try_send(event);
         Ok(response)
@@ -277,16 +288,16 @@ async fn accept_connection(
 
 /// Parsed facts needed before handing the stream to Tungstenite.
 struct PeekedHttpRequest {
+    /// Declared request body length.
+    body_bytes: usize,
+    /// Number of bytes through the terminating blank header line.
+    head_bytes: usize,
     /// Request method.
     method: String,
     /// Request target.
     path: String,
     /// Whether the request declares a `WebSocket` upgrade.
     websocket_upgrade: bool,
-    /// Number of bytes through the terminating blank header line.
-    head_bytes: usize,
-    /// Declared request body length.
-    body_bytes: usize,
 }
 
 /// Inspect an HTTP head without consuming bytes from the TCP stream.
@@ -295,7 +306,6 @@ struct PeekedHttpRequest {
     reason = "the bounded parser keeps all unexpected-request checks together"
 )]
 async fn peek_http_request(stream: &tokio::net::TcpStream) -> Option<PeekedHttpRequest> {
-    const MAX_HEAD_BYTES: usize = 16_384;
     let mut buffer = vec![0_u8; MAX_HEAD_BYTES];
     let head_bytes = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
@@ -337,13 +347,14 @@ async fn peek_http_request(stream: &tokio::net::TcpStream) -> Option<PeekedHttpR
             body_bytes = value.trim().parse().ok()?;
         }
     }
+    let websocket_upgrade = method == "GET" && connection_upgrade && websocket_upgrade;
 
     Some(PeekedHttpRequest {
-        websocket_upgrade: method == "GET" && connection_upgrade && websocket_upgrade,
+        body_bytes,
+        head_bytes,
         method,
         path,
-        head_bytes,
-        body_bytes,
+        websocket_upgrade,
     })
 }
 
@@ -353,7 +364,6 @@ async fn drain_unexpected_request(
     head_bytes: usize,
     mut body_bytes: usize,
 ) -> bool {
-    const MAX_UNEXPECTED_BODY_BYTES: usize = 16 * 1024 * 1024;
     if body_bytes > MAX_UNEXPECTED_BODY_BYTES {
         return false;
     }
@@ -385,6 +395,11 @@ async fn run_script(
 ) -> bool {
     for action in script {
         match action {
+            WsServerAction::Binary(data) => {
+                if socket.send(Message::Binary(data.clone())).await.is_err() {
+                    return false;
+                }
+            },
             WsServerAction::Text(text) => {
                 if socket.send(Message::Text(text.as_str().into())).await.is_err() {
                     return false;
@@ -484,26 +499,7 @@ mod tests {
 
     use super::*;
 
-    /// Receive one message without allowing a broken test backend to hang.
-    async fn next_message<S>(socket: &mut WebSocketStream<S>) -> Message
-    where
-        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
-    {
-        tokio::time::timeout(Duration::from_secs(5), socket.next())
-            .await
-            .expect("WebSocket receive should complete within five seconds")
-            .expect("WebSocket stream should remain open")
-            .expect("WebSocket message should be valid")
-    }
-
-    /// Receive one observation without allowing a broken listener to hang.
-    async fn next_event(backend: &mut WsBackendGuard) -> WsBackendEvent {
-        tokio::time::timeout(Duration::from_secs(5), backend.next_event())
-            .await
-            .expect("backend observation should arrive within five seconds")
-            .expect("backend observation channel should remain open")
-    }
-
+    /// Capture the opening handshake and the first client data message.
     #[tokio::test]
     async fn scripted_backend_captures_handshake_and_client_text() {
         let mut backend = start_scripted_websocket_backend(vec![
@@ -517,7 +513,11 @@ mod tests {
 
         let url = format!("ws://127.0.0.1:{}/v1/responses?model=gpt-5", backend.port());
         let (mut socket, response) = connect_async(&url).await.unwrap();
-        assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(
+            response.status(),
+            http::StatusCode::SWITCHING_PROTOCOLS,
+            "the scripted backend should accept a valid opening handshake"
+        );
 
         socket
             .send(Message::Text(r#"{"type":"response.create"}"#.into()))
@@ -525,23 +525,36 @@ mod tests {
             .unwrap();
         assert_eq!(
             next_message(&mut socket).await.into_text().unwrap(),
-            r#"{"type":"response.created"}"#
+            r#"{"type":"response.created"}"#,
+            "the backend should replay its scripted text frame"
         );
-        assert!(next_message(&mut socket).await.is_close());
+        assert!(
+            next_message(&mut socket).await.is_close(),
+            "the backend should replay its scripted close frame"
+        );
 
         let handshake = next_event(&mut backend).await;
-        let WsBackendEvent::Handshake { method, path, headers } = handshake else {
+        let WsBackendEvent::Handshake { headers, method, path } = handshake else {
             panic!("expected handshake event, got {handshake:?}");
         };
-        assert_eq!(method, Method::GET);
-        assert_eq!(path, "/v1/responses?model=gpt-5");
-        assert_eq!(headers.get(http::header::UPGRADE).unwrap(), "websocket");
+        assert_eq!(method, Method::GET, "the backend should observe the GET method");
+        assert_eq!(
+            path, "/v1/responses?model=gpt-5",
+            "the backend should preserve the request target"
+        );
+        assert_eq!(
+            headers.get(http::header::UPGRADE).unwrap(),
+            "websocket",
+            "the backend should observe the WebSocket upgrade protocol"
+        );
         assert_eq!(
             next_event(&mut backend).await,
-            WsBackendEvent::ClientMessage(CapturedWsMessage::Text(r#"{"type":"response.create"}"#.to_owned()))
+            WsBackendEvent::ClientMessage(CapturedWsMessage::Text(r#"{"type":"response.create"}"#.to_owned())),
+            "the backend should capture the client text frame"
         );
     }
 
+    /// Service client control traffic while a scripted turn is delayed.
     #[tokio::test]
     async fn scripted_backend_services_ping_during_delay() {
         let backend = start_scripted_websocket_backend(vec![
@@ -555,10 +568,19 @@ mod tests {
         socket.send(Message::Text("start".into())).await.unwrap();
         socket.send(Message::Ping(vec![1, 2, 3].into())).await.unwrap();
 
-        assert_eq!(next_message(&mut socket).await, Message::Pong(vec![1, 2, 3].into()));
-        assert_eq!(next_message(&mut socket).await.into_text().unwrap(), "ready");
+        assert_eq!(
+            next_message(&mut socket).await,
+            Message::Pong(vec![1, 2, 3].into()),
+            "the backend should answer a ping during a delay"
+        );
+        assert_eq!(
+            next_message(&mut socket).await.into_text().unwrap(),
+            "ready",
+            "the script should resume after the delay"
+        );
     }
 
+    /// Reject non-upgrade HTTP traffic without leaving the client hanging.
     #[tokio::test]
     async fn scripted_backend_records_and_rejects_unexpected_http_request() {
         let mut backend = start_scripted_websocket_backend(Vec::new()).await;
@@ -576,13 +598,41 @@ mod tests {
             .expect("HTTP rejection should complete within five seconds")
             .unwrap();
 
-        assert!(String::from_utf8(response).unwrap().starts_with("HTTP/1.1 400"));
+        assert!(
+            String::from_utf8(response).unwrap().starts_with("HTTP/1.1 400"),
+            "the backend should return a bounded HTTP rejection"
+        );
         assert_eq!(
             next_event(&mut backend).await,
             WsBackendEvent::UnexpectedHttpRequest {
                 method: "POST".to_owned(),
                 path: "/v1/responses".to_owned(),
-            }
+            },
+            "the backend should report the rejected method and path"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    /// Receive one observation without allowing a broken listener to hang.
+    async fn next_event(backend: &mut WsBackendGuard) -> WsBackendEvent {
+        tokio::time::timeout(Duration::from_secs(5), backend.next_event())
+            .await
+            .expect("backend observation should arrive within five seconds")
+            .expect("backend observation channel should remain open")
+    }
+
+    /// Receive one message without allowing a broken test backend to hang.
+    async fn next_message<S>(socket: &mut WebSocketStream<S>) -> Message
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        tokio::time::timeout(Duration::from_secs(5), socket.next())
+            .await
+            .expect("WebSocket receive should complete within five seconds")
+            .expect("WebSocket stream should remain open")
+            .expect("WebSocket message should be valid")
     }
 }

--- a/tests/utils/src/net/backend/websocket.rs
+++ b/tests/utils/src/net/backend/websocket.rs
@@ -1,0 +1,588 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Scripted `WebSocket` backend for integration testing.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::{SinkExt as _, StreamExt as _};
+use http::{HeaderMap, Method};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::TcpListener,
+    sync::mpsc,
+    task::JoinSet,
+};
+use tokio_tungstenite::{
+    WebSocketStream, accept_hdr_async,
+    tungstenite::{Message, protocol::CloseFrame},
+};
+use tracing::debug;
+
+/// A message captured from a test client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapturedWsMessage {
+    /// UTF-8 text message.
+    Text(String),
+    /// Binary message.
+    Binary(Bytes),
+    /// Ping control message.
+    Ping(Bytes),
+    /// Pong control message.
+    Pong(Bytes),
+    /// Close control message.
+    Close {
+        /// Numeric close code, when supplied.
+        code: Option<u16>,
+        /// Close reason, when supplied.
+        reason: Option<String>,
+    },
+}
+
+/// An observation emitted by the scripted backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsBackendEvent {
+    /// A completed `WebSocket` HTTP handshake.
+    Handshake {
+        /// Request method observed by the backend.
+        method: Method,
+        /// Path and query observed by the backend.
+        path: String,
+        /// Request headers observed by the backend.
+        headers: HeaderMap,
+    },
+    /// A message received from the connected client.
+    ClientMessage(CapturedWsMessage),
+    /// A non-upgrade HTTP request sent to the backend listener.
+    UnexpectedHttpRequest {
+        /// Request method parsed from the request line.
+        method: String,
+        /// Request target parsed from the request line.
+        path: String,
+    },
+}
+
+/// A deterministic action performed after the first client data message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsServerAction {
+    /// Send a UTF-8 text message.
+    Text(String),
+    /// Send a ping control message.
+    Ping(Bytes),
+    /// Wait while continuing to service client control frames.
+    Delay(Duration),
+    /// Send a close control message and end the connection.
+    Close {
+        /// Numeric close code.
+        code: u16,
+        /// Human-readable close reason.
+        reason: String,
+    },
+    /// Drop the TCP connection without a `WebSocket` close frame.
+    Disconnect,
+}
+
+/// RAII guard for a scripted asynchronous `WebSocket` backend.
+///
+/// Dropping the guard stops the listener and aborts all connection tasks.
+pub struct WsBackendGuard {
+    /// Port allocated by the operating system.
+    port: u16,
+    /// Stream of backend observations.
+    events: mpsc::Receiver<WsBackendEvent>,
+    /// Listener shutdown signal.
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    /// Listener task, which owns all connection tasks.
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl WsBackendGuard {
+    /// Return the allocated port.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Wait for the next handshake or client-message observation.
+    pub async fn next_event(&mut self) -> Option<WsBackendEvent> {
+        self.events.recv().await
+    }
+}
+
+impl Drop for WsBackendGuard {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _sent = shutdown.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Start a `WebSocket` backend that replays `script` after the first
+/// client text or binary message.
+///
+/// Each accepted connection receives an independent copy of the script.
+/// The returned guard exposes handshake and client-message observations.
+///
+/// # Panics
+///
+/// Panics if the loopback listener cannot bind or report its local address.
+pub async fn start_scripted_websocket_backend(script: Vec<WsServerAction>) -> WsBackendGuard {
+    start_scripted_websocket_backend_turns(vec![script]).await
+}
+
+/// Start a backend that replays one action sequence for each sequential client
+/// data message on a connection.
+///
+/// This supports protocols that perform a prewarm request before the real
+/// turn. A turn begins after the previous action sequence completes. Data
+/// messages received during a scripted delay are captured but do not start a
+/// nested turn. Each accepted connection receives an independent copy of
+/// `turns`.
+///
+/// # Panics
+///
+/// Panics if the loopback listener cannot bind or report its local address.
+pub async fn start_scripted_websocket_backend_turns(turns: Vec<Vec<WsServerAction>>) -> WsBackendGuard {
+    let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("scripted WebSocket backend should bind");
+    let port = listener
+        .local_addr()
+        .expect("scripted WebSocket backend should have a local address")
+        .port();
+    let (event_tx, event_rx) = mpsc::channel(256);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let handle = tokio::spawn(run_listener(listener, turns, event_tx, shutdown_rx));
+    debug!(port, "scripted WebSocket backend listening");
+
+    WsBackendGuard {
+        port,
+        events: event_rx,
+        shutdown: Some(shutdown_tx),
+        handle: Some(handle),
+    }
+}
+
+/// Accept connections until the guard signals shutdown.
+async fn run_listener(
+    listener: TcpListener,
+    turns: Vec<Vec<WsServerAction>>,
+    event_tx: mpsc::Sender<WsBackendEvent>,
+    mut shutdown: tokio::sync::oneshot::Receiver<()>,
+) {
+    let mut connections = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => break,
+            accepted = listener.accept() => {
+                let Ok((stream, peer)) = accepted else {
+                    break;
+                };
+                debug!(%peer, "scripted WebSocket backend accepted connection");
+                connections.spawn(Box::pin(handle_connection(stream, turns.clone(), event_tx.clone())));
+            },
+            completed = connections.join_next(), if !connections.is_empty() => {
+                if completed.is_none() {
+                    break;
+                }
+            },
+        }
+    }
+
+    connections.abort_all();
+    while connections.join_next().await.is_some() {}
+}
+
+/// Complete a handshake, capture client messages, and run one script.
+async fn handle_connection(
+    stream: tokio::net::TcpStream,
+    turns: Vec<Vec<WsServerAction>>,
+    event_tx: mpsc::Sender<WsBackendEvent>,
+) {
+    let Some(mut socket) = Box::pin(accept_connection(stream, &event_tx)).await else {
+        return;
+    };
+    let mut next_turn = 0;
+
+    while let Some(result) = socket.next().await {
+        let Ok(message) = result else {
+            return;
+        };
+        let starts_script = matches!(message, Message::Text(_) | Message::Binary(_));
+        if !capture_and_service_message(&mut socket, &event_tx, message).await {
+            return;
+        }
+        if starts_script && let Some(script) = turns.get(next_turn) {
+            next_turn += 1;
+            if !run_script(&mut socket, &event_tx, script).await {
+                return;
+            }
+        }
+    }
+}
+
+/// Validate the HTTP request and complete a `WebSocket` handshake.
+#[expect(
+    clippy::too_many_lines,
+    reason = "preflight rejection and handshake capture form one ownership boundary"
+)]
+async fn accept_connection(
+    mut stream: tokio::net::TcpStream,
+    event_tx: &mpsc::Sender<WsBackendEvent>,
+) -> Option<WebSocketStream<tokio::net::TcpStream>> {
+    let request = Box::pin(peek_http_request(&stream)).await?;
+    if !request.websocket_upgrade {
+        let _queued = event_tx.try_send(WsBackendEvent::UnexpectedHttpRequest {
+            method: request.method,
+            path: request.path,
+        });
+        if !Box::pin(drain_unexpected_request(
+            &mut stream,
+            request.head_bytes,
+            request.body_bytes,
+        ))
+        .await
+        {
+            return None;
+        }
+        let _written = stream
+            .write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await;
+        return None;
+    }
+
+    let handshake_events = event_tx.clone();
+    #[expect(
+        clippy::result_large_err,
+        reason = "Tungstenite's callback requires its HTTP error response type"
+    )]
+    let callback = move |request: &http::Request<()>, response| {
+        // The callback borrows its request. Owning the header map is required
+        // because test assertions run after the handshake completes.
+        let event = WsBackendEvent::Handshake {
+            method: request.method().clone(),
+            path: request.uri().to_string(),
+            headers: request.headers().clone(),
+        };
+        let _queued = handshake_events.try_send(event);
+        Ok(response)
+    };
+    accept_hdr_async(stream, callback).await.ok()
+}
+
+/// Parsed facts needed before handing the stream to Tungstenite.
+struct PeekedHttpRequest {
+    /// Request method.
+    method: String,
+    /// Request target.
+    path: String,
+    /// Whether the request declares a `WebSocket` upgrade.
+    websocket_upgrade: bool,
+    /// Number of bytes through the terminating blank header line.
+    head_bytes: usize,
+    /// Declared request body length.
+    body_bytes: usize,
+}
+
+/// Inspect an HTTP head without consuming bytes from the TCP stream.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the bounded parser keeps all unexpected-request checks together"
+)]
+async fn peek_http_request(stream: &tokio::net::TcpStream) -> Option<PeekedHttpRequest> {
+    const MAX_HEAD_BYTES: usize = 16_384;
+    let mut buffer = vec![0_u8; MAX_HEAD_BYTES];
+    let head_bytes = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let count = stream.peek(&mut buffer).await.ok()?;
+            if count == 0 {
+                return None;
+            }
+            if let Some(offset) = buffer[..count].windows(4).position(|window| window == b"\r\n\r\n") {
+                return Some(offset + 4);
+            }
+            if count == MAX_HEAD_BYTES {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .ok()??;
+    let head = std::str::from_utf8(&buffer[..head_bytes]).ok()?;
+    let mut lines = head.split("\r\n");
+    let mut request_line = lines.next()?.split_whitespace();
+    let method = request_line.next()?.to_owned();
+    let path = request_line.next()?.to_owned();
+    let mut connection_upgrade = false;
+    let mut websocket_upgrade = false;
+    let mut body_bytes = 0;
+
+    for line in lines.take_while(|line| !line.is_empty()) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("connection") {
+            connection_upgrade |= value
+                .split(',')
+                .any(|token| token.trim().eq_ignore_ascii_case("upgrade"));
+        } else if name.eq_ignore_ascii_case("upgrade") {
+            websocket_upgrade |= value.trim().eq_ignore_ascii_case("websocket");
+        } else if name.eq_ignore_ascii_case("content-length") {
+            body_bytes = value.trim().parse().ok()?;
+        }
+    }
+
+    Some(PeekedHttpRequest {
+        websocket_upgrade: method == "GET" && connection_upgrade && websocket_upgrade,
+        method,
+        path,
+        head_bytes,
+        body_bytes,
+    })
+}
+
+/// Consume an unexpected request so the HTTP rejection is delivered cleanly.
+async fn drain_unexpected_request(
+    stream: &mut tokio::net::TcpStream,
+    head_bytes: usize,
+    mut body_bytes: usize,
+) -> bool {
+    const MAX_UNEXPECTED_BODY_BYTES: usize = 16 * 1024 * 1024;
+    if body_bytes > MAX_UNEXPECTED_BODY_BYTES {
+        return false;
+    }
+
+    let mut head = vec![0_u8; head_bytes];
+    if stream.read_exact(&mut head).await.is_err() {
+        return false;
+    }
+    let mut buffer = vec![0_u8; 8_192];
+    while body_bytes > 0 {
+        let chunk = body_bytes.min(buffer.len());
+        if stream.read_exact(&mut buffer[..chunk]).await.is_err() {
+            return false;
+        }
+        body_bytes -= chunk;
+    }
+    true
+}
+
+/// Execute scripted actions, servicing control frames during delays.
+#[expect(
+    clippy::too_many_lines,
+    reason = "each explicit script action has distinct protocol behavior"
+)]
+async fn run_script(
+    socket: &mut WebSocketStream<tokio::net::TcpStream>,
+    event_tx: &mpsc::Sender<WsBackendEvent>,
+    script: &[WsServerAction],
+) -> bool {
+    for action in script {
+        match action {
+            WsServerAction::Text(text) => {
+                if socket.send(Message::Text(text.as_str().into())).await.is_err() {
+                    return false;
+                }
+            },
+            WsServerAction::Ping(payload) => {
+                if socket.send(Message::Ping(payload.clone())).await.is_err() {
+                    return false;
+                }
+            },
+            WsServerAction::Delay(duration) => {
+                if !delay_while_servicing(socket, event_tx, *duration).await {
+                    return false;
+                }
+            },
+            WsServerAction::Close { code, reason } => {
+                let frame = CloseFrame {
+                    code: (*code).into(),
+                    reason: reason.as_str().into(),
+                };
+                let _sent = socket.send(Message::Close(Some(frame))).await;
+                return false;
+            },
+            WsServerAction::Disconnect => return false,
+        }
+    }
+    true
+}
+
+/// Wait for a scripted duration without starving client control frames.
+async fn delay_while_servicing(
+    socket: &mut WebSocketStream<tokio::net::TcpStream>,
+    event_tx: &mpsc::Sender<WsBackendEvent>,
+    duration: Duration,
+) -> bool {
+    let delay = tokio::time::sleep(duration);
+    tokio::pin!(delay);
+
+    loop {
+        tokio::select! {
+            () = &mut delay => return true,
+            incoming = socket.next() => {
+                let Some(Ok(message)) = incoming else {
+                    return false;
+                };
+                if !capture_and_service_message(socket, event_tx, message).await {
+                    return false;
+                }
+            },
+        }
+    }
+}
+
+/// Capture one client message and flush automatic control replies.
+async fn capture_and_service_message(
+    socket: &mut WebSocketStream<tokio::net::TcpStream>,
+    event_tx: &mpsc::Sender<WsBackendEvent>,
+    message: Message,
+) -> bool {
+    let (captured, is_control, is_close) = match message {
+        Message::Text(text) => (CapturedWsMessage::Text(text.to_string()), false, false),
+        Message::Binary(data) => (CapturedWsMessage::Binary(data), false, false),
+        Message::Ping(data) => (CapturedWsMessage::Ping(data), true, false),
+        Message::Pong(data) => (CapturedWsMessage::Pong(data), false, false),
+        Message::Close(frame) => {
+            let (code, reason) = frame.map_or((None, None), |frame| {
+                (Some(frame.code.into()), Some(frame.reason.to_string()))
+            });
+            (CapturedWsMessage::Close { code, reason }, true, true)
+        },
+        Message::Frame(_) => return true,
+    };
+    let _queued = event_tx.try_send(WsBackendEvent::ClientMessage(captured));
+
+    if is_control && socket.flush().await.is_err() {
+        return false;
+    }
+    !is_close
+}
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::too_many_lines,
+    clippy::unwrap_used,
+    reason = "tests"
+)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::{SinkExt as _, StreamExt as _};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+    use super::*;
+
+    /// Receive one message without allowing a broken test backend to hang.
+    async fn next_message<S>(socket: &mut WebSocketStream<S>) -> Message
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        tokio::time::timeout(Duration::from_secs(5), socket.next())
+            .await
+            .expect("WebSocket receive should complete within five seconds")
+            .expect("WebSocket stream should remain open")
+            .expect("WebSocket message should be valid")
+    }
+
+    /// Receive one observation without allowing a broken listener to hang.
+    async fn next_event(backend: &mut WsBackendGuard) -> WsBackendEvent {
+        tokio::time::timeout(Duration::from_secs(5), backend.next_event())
+            .await
+            .expect("backend observation should arrive within five seconds")
+            .expect("backend observation channel should remain open")
+    }
+
+    #[tokio::test]
+    async fn scripted_backend_captures_handshake_and_client_text() {
+        let mut backend = start_scripted_websocket_backend(vec![
+            WsServerAction::Text(r#"{"type":"response.created"}"#.to_owned()),
+            WsServerAction::Close {
+                code: 1000,
+                reason: "complete".to_owned(),
+            },
+        ])
+        .await;
+
+        let url = format!("ws://127.0.0.1:{}/v1/responses?model=gpt-5", backend.port());
+        let (mut socket, response) = connect_async(&url).await.unwrap();
+        assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
+
+        socket
+            .send(Message::Text(r#"{"type":"response.create"}"#.into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            next_message(&mut socket).await.into_text().unwrap(),
+            r#"{"type":"response.created"}"#
+        );
+        assert!(next_message(&mut socket).await.is_close());
+
+        let handshake = next_event(&mut backend).await;
+        let WsBackendEvent::Handshake { method, path, headers } = handshake else {
+            panic!("expected handshake event, got {handshake:?}");
+        };
+        assert_eq!(method, Method::GET);
+        assert_eq!(path, "/v1/responses?model=gpt-5");
+        assert_eq!(headers.get(http::header::UPGRADE).unwrap(), "websocket");
+        assert_eq!(
+            next_event(&mut backend).await,
+            WsBackendEvent::ClientMessage(CapturedWsMessage::Text(r#"{"type":"response.create"}"#.to_owned()))
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_backend_services_ping_during_delay() {
+        let backend = start_scripted_websocket_backend(vec![
+            WsServerAction::Delay(Duration::from_millis(50)),
+            WsServerAction::Text("ready".to_owned()),
+        ])
+        .await;
+        let url = format!("ws://127.0.0.1:{}/v1/responses", backend.port());
+        let (mut socket, _) = connect_async(&url).await.unwrap();
+
+        socket.send(Message::Text("start".into())).await.unwrap();
+        socket.send(Message::Ping(vec![1, 2, 3].into())).await.unwrap();
+
+        assert_eq!(next_message(&mut socket).await, Message::Pong(vec![1, 2, 3].into()));
+        assert_eq!(next_message(&mut socket).await.into_text().unwrap(), "ready");
+    }
+
+    #[tokio::test]
+    async fn scripted_backend_records_and_rejects_unexpected_http_request() {
+        let mut backend = start_scripted_websocket_backend(Vec::new()).await;
+        let mut stream = tokio::net::TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, backend.port()))
+            .await
+            .unwrap();
+
+        stream
+            .write_all(b"POST /v1/responses HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
+            .await
+            .expect("HTTP rejection should complete within five seconds")
+            .unwrap();
+
+        assert!(String::from_utf8(response).unwrap().starts_with("HTTP/1.1 400"));
+        assert_eq!(
+            next_event(&mut backend).await,
+            WsBackendEvent::UnexpectedHttpRequest {
+                method: "POST".to_owned(),
+                path: "/v1/responses".to_owned(),
+            }
+        );
+    }
+}

--- a/tests/utils/src/net/mod.rs
+++ b/tests/utils/src/net/mod.rs
@@ -12,8 +12,10 @@ pub mod tls;
 pub mod wait;
 
 pub use backend::{
-    Backend, CapturingBackendGuard, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown,
-    start_capturing_backend, start_echo_backend, start_header_echo_backend, start_uri_echo_backend,
+    Backend, CapturedWsMessage, CapturingBackendGuard, RoutedBackend, WsBackendEvent, WsBackendGuard, WsServerAction,
+    start_backend, start_backend_v6, start_backend_with_shutdown, start_capturing_backend, start_echo_backend,
+    start_header_echo_backend, start_scripted_websocket_backend, start_scripted_websocket_backend_turns,
+    start_uri_echo_backend,
 };
 pub use http_client::{
     http_get, http_get_retry, http_get_v6, http_post, http_send, json_post, parse_body, parse_header, parse_header_all,


### PR DESCRIPTION
## Summary

- classify valid `GET /v1/responses` WebSocket upgrades as format-only Responses traffic so the full-flow router selects the inference backend
- add deterministic protocol coverage for upgrade routing, frame/control propagation, idle connections, non-101 responses, disconnects, and stateful-route avoidance
- add a pinned Codex CLI 0.144.1 compatibility fixture, checksum verification, isolated black-box acceptance test, and dedicated CI job

## Why

Praxis core already tunnels frames after a successful HTTP upgrade, but PraxisAI's full-flow router could not classify the bodyless Responses WebSocket handshake. Codex therefore could not select the configured inference backend through the production-style pipeline.

## Validation

- `make lint`
- `make test`
- targeted WebSocket tests, including a bounded stalled-handshake regression

The local Codex test remains optional when `PRAXIS_TEST_CODEX_BIN` is unset; the dedicated CI job downloads and verifies the pinned Linux binary before running it.

Parent: #439
Closes #440
Closes #441

Demo with this working.
<img width="1920" height="1397" alt="Screenshot 2026-07-22 at 1 51 46 PM" src="https://github.com/user-attachments/assets/f302602c-658b-4c7b-be61-05651a0a13d3" />

