### PR TITLE
build(container): use UBI 10 minimal runtime

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -7,6 +7,11 @@ name: Container
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  merge_group:
+    branches: [main]
 
 permissions: {}
 

--- a/Containerfile
+++ b/Containerfile
@@ -70,15 +70,24 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Stage 2: Runtime
 # ------------------------------------------------------------------------------
 
-FROM alpine:3.24
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source="https://github.com/praxis-proxy/ai" \
     org.opencontainers.image.description="Praxis AI proxy server" \
     org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S praxis \
-    && adduser -S -G praxis -h /nonexistent -s /sbin/nologin praxis \
+RUN microdnf install -y \
+        --setopt install_weak_deps=0 \
+        ca-certificates curl shadow-utils \
+    && groupadd --system praxis \
+    && useradd --system \
+        --gid praxis \
+        --no-create-home \
+        --home-dir /nonexistent \
+        --shell /sbin/nologin \
+        praxis \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all \
     && mkdir -p /etc/praxis
 
 COPY --from=builder --chown=root:root --chmod=0555 \
@@ -91,6 +100,7 @@ WORKDIR /etc/praxis
 EXPOSE 8080 9901
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=2s \
-    CMD wget -qO- http://127.0.0.1:9901/healthy || exit 1
+    CMD curl --fail --silent --show-error \
+        http://127.0.0.1:9901/healthy || exit 1
 
 ENTRYPOINT ["praxis-ai"]

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,7 +41,7 @@ Container images are published to
 After pushing a tag, manually trigger the **Publish**
 workflow via the GitHub Actions UI
 (`workflow_dispatch`). The workflow builds a multi-stage
-Alpine image from the `Containerfile` and pushes it to
+image from the `Containerfile` and pushes it to
 `ghcr.io/praxis-proxy/ai`.
 
 [ghcr]: https://ghcr.io/praxis-proxy/ai
@@ -82,14 +82,20 @@ triggered as usual.
 
 ## Container Details
 
-The production image is a minimal Alpine container:
+The production image uses Red Hat UBI 10 Minimal as the
+runtime base. The static musl binary is built in a
+separate `rust:1.97-alpine` builder stage whose layers
+are not included in the published image.
 
 - Static musl build with LTO, single codegen unit,
   and stripped symbols
-- Runs as non-root user (`praxis-ai`)
+- Runs as non-root user (`praxis`)
 - Exposes ports `8080` (proxy) and `9901` (admin)
 - Built-in health check at
   `http://127.0.0.1:9901/healthy`
-- Config directory: `/etc/praxis-ai`
+- Config directory: `/etc/praxis`
 
-> **Note**: This is subject to change.
+> **Note**: The builder stage uses Alpine because Red Hat
+> Rust Toolset is currently below the project's MSRV.
+> This will be revisited when Red Hat packages a
+> compatible Rust version.


### PR DESCRIPTION
## Summary

- Replace the Alpine runtime stage with Red Hat UBI 10 Minimal (`registry.access.redhat.com/ubi10/ubi-minimal:latest`). The static musl binary from the Alpine builder runs unchanged on UBI.
- Install `shadow-utils` to create the non-root `praxis` user, then remove it to keep the image lean. Switch the healthcheck from `wget` to `curl`.
- Add `pull_request` and `merge_group` triggers to the container CI workflow so Containerfile breakages are caught before merge.
- Update `docs/release.md` to describe the UBI 10 runtime and document why the builder remains Alpine.

## Test plan

- [x] `podman build --format docker -t praxis-ai:ubi10 -f Containerfile .` succeeds
- [x] Binary is statically linked (`ldd` reports `not a dynamic executable`)
- [x] Container runs as non-root `praxis` user (uid 999)
- [x] CA certificates present (`rpm -q ca-certificates`)
- [x] `cat /etc/redhat-release` reports RHEL 10
- [x] `git diff --check` passes
- [x] `make lint` passes