### PR TITLE
feat(openai): route /v1/files to the Files API backend

### DIFF
--- a/apis/src/openai/responses/file_resolve/config.rs
+++ b/apis/src/openai/responses/file_resolve/config.rs
@@ -57,7 +57,7 @@ pub(crate) struct FileResolveConfig {
 
     /// Base URL of the Files API endpoint.
     ///
-    /// Example: `http://ogx:8321`
+    /// Example: `http://files-api:8321`
     pub files_api_url: String,
 
     /// Headers to forward from the original request to the
@@ -191,7 +191,7 @@ mod tests {
     use super::*;
 
     const MINIMAL_YAML: &str = r#"
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 allow_pre_security_callout: true
 "#;
@@ -200,7 +200,10 @@ allow_pre_security_callout: true
     fn minimal_config_parses() {
         let cfg: FileResolveConfig = serde_yaml::from_str(MINIMAL_YAML).unwrap();
         let validated = validate_config(cfg).unwrap();
-        assert_eq!(validated.files_api_url, "http://ogx:8321", "files_api_url should match");
+        assert_eq!(
+            validated.files_api_url, "http://files-api:8321",
+            "files_api_url should match"
+        );
         assert_eq!(
             validated.max_body_bytes, MAX_JSON_BODY_BYTES,
             "max_body_bytes should default to 64 MiB"
@@ -258,7 +261,7 @@ timeout_ms: 10000
 
     #[test]
     fn deny_unknown_fields_rejects_typo() {
-        let yaml = r#"files_api_url: "http://ogx:8321"
+        let yaml = r#"files_api_url: "http://files-api:8321"
 on_mising: reject"#;
         let result: Result<FileResolveConfig, _> = serde_yaml::from_str(yaml);
         assert!(result.is_err(), "typo in config field should be rejected");
@@ -274,7 +277,7 @@ on_mising: reject"#;
 
     #[test]
     fn trailing_slash_files_api_url_rejected() {
-        let yaml = r#"files_api_url: "http://ogx:8321/""#;
+        let yaml = r#"files_api_url: "http://files-api:8321/""#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         let result = validate_config(cfg);
         assert!(result.is_err(), "trailing slash should be rejected");
@@ -282,7 +285,7 @@ on_mising: reject"#;
 
     #[test]
     fn zero_max_body_bytes_rejected() {
-        let yaml = r#"files_api_url: "http://ogx:8321"
+        let yaml = r#"files_api_url: "http://files-api:8321"
 max_body_bytes: 0"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         let result = validate_config(cfg);
@@ -291,7 +294,7 @@ max_body_bytes: 0"#;
 
     #[test]
     fn zero_timeout_rejected() {
-        let yaml = r#"files_api_url: "http://ogx:8321"
+        let yaml = r#"files_api_url: "http://files-api:8321"
 timeout_ms: 0"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         let result = validate_config(cfg);
@@ -300,7 +303,7 @@ timeout_ms: 0"#;
 
     #[test]
     fn zero_max_file_references_rejected() {
-        let yaml = r#"files_api_url: "http://ogx:8321"
+        let yaml = r#"files_api_url: "http://files-api:8321"
 max_file_references: 0"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
 
@@ -312,7 +315,7 @@ max_file_references: 0"#;
 
     #[test]
     fn max_file_references_above_ceiling_rejected() {
-        let yaml = r#"files_api_url: "http://ogx:8321"
+        let yaml = r#"files_api_url: "http://files-api:8321"
 max_file_references: 129"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
 
@@ -324,7 +327,7 @@ max_file_references: 129"#;
 
     #[test]
     fn timeout_above_ceiling_rejected() {
-        let yaml = r#"files_api_url: "http://ogx:8321"
+        let yaml = r#"files_api_url: "http://files-api:8321"
 timeout_ms: 300001"#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         let result = validate_config(cfg);
@@ -336,7 +339,7 @@ timeout_ms: 300001"#;
         let cfg = FileResolveConfig {
             allow_private_files_api_url: true,
             allow_pre_security_callout: true,
-            files_api_url: "http://ogx:8321".to_owned(),
+            files_api_url: "http://files-api:8321".to_owned(),
             forward_headers: Vec::new(),
             max_body_bytes: MAX_JSON_BODY_BYTES,
             max_file_references: DEFAULT_MAX_FILE_REFERENCES,
@@ -349,7 +352,7 @@ timeout_ms: 300001"#;
     #[test]
     fn forward_headers_are_normalized() {
         let yaml = r#"
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 allow_pre_security_callout: true
 forward_headers:
@@ -369,7 +372,7 @@ forward_headers:
     #[test]
     fn invalid_forward_header_rejected() {
         let yaml = r#"
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 forward_headers: ["bad header"]
 "#;
@@ -391,7 +394,7 @@ forward_headers: ["bad header"]
             "x-praxis-route",
         ] {
             let yaml = format!(
-                "files_api_url: \"http://ogx:8321\"\nallow_private_files_api_url: true\nforward_headers: [\"{name}\"]"
+                "files_api_url: \"http://files-api:8321\"\nallow_private_files_api_url: true\nforward_headers: [\"{name}\"]"
             );
             let cfg: FileResolveConfig = serde_yaml::from_str(&yaml).unwrap();
 
@@ -405,7 +408,7 @@ forward_headers: ["bad header"]
     #[test]
     fn duplicate_forward_headers_rejected_case_insensitively() {
         let yaml = r#"
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 forward_headers: ["Authorization", "authorization"]
 "#;
@@ -420,7 +423,7 @@ forward_headers: ["Authorization", "authorization"]
     #[test]
     fn pre_security_callout_requires_explicit_opt_in() {
         let yaml = r#"
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
@@ -468,7 +471,7 @@ allow_pre_security_callout: true
 
     #[test]
     fn ssrf_rejects_non_http_scheme() {
-        let yaml = r#"files_api_url: "ftp://ogx:8321""#;
+        let yaml = r#"files_api_url: "ftp://files-api:8321""#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(validate_config(cfg).is_err(), "non-http scheme should be rejected");
     }
@@ -476,7 +479,7 @@ allow_pre_security_callout: true
     #[test]
     fn files_api_url_rejects_embedded_credentials() {
         let yaml = r#"
-files_api_url: "http://user:password@ogx:8321"
+files_api_url: "http://user:password@files-api:8321"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
@@ -489,7 +492,7 @@ allow_private_files_api_url: true
     #[test]
     fn files_api_url_rejects_query_string() {
         let yaml = r#"
-files_api_url: "http://ogx:8321/base?tenant=abc"
+files_api_url: "http://files-api:8321/base?tenant=abc"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();
@@ -502,7 +505,7 @@ allow_private_files_api_url: true
     #[test]
     fn files_api_url_rejects_fragment() {
         let yaml = r#"
-files_api_url: "http://ogx:8321/base#v2"
+files_api_url: "http://files-api:8321/base#v2"
 allow_private_files_api_url: true
 "#;
         let cfg: FileResolveConfig = serde_yaml::from_str(yaml).unwrap();

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -88,6 +88,11 @@ use crate::{
 /// part. This filter does not extract documents into backend-specific
 /// representations such as `input_text`.
 ///
+/// This filter resolves references inside Responses requests; it does
+/// not proxy client-facing Files API operations. Route `/v1/files` and
+/// its subresources to the configured Files API with the standard
+/// `router` and `load_balancer` filters.
+///
 /// # YAML
 ///
 /// ```yaml

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -97,7 +97,7 @@ use crate::{
 ///
 /// ```yaml
 /// filter: openai_file_resolve
-/// files_api_url: "http://ogx:8321"
+/// files_api_url: "http://files-api:8321"
 /// allow_private_files_api_url: true
 /// allow_pre_security_callout: true
 /// ```
@@ -106,7 +106,7 @@ use crate::{
 ///
 /// ```yaml
 /// filter: openai_file_resolve
-/// files_api_url: "http://ogx:8321"
+/// files_api_url: "http://files-api:8321"
 /// allow_private_files_api_url: true
 /// allow_pre_security_callout: true
 /// forward_headers:

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -913,7 +913,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_input_accepts_message_shorthand_without_type() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "role": "user",
@@ -932,7 +932,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_input_walks_function_call_output_arrays() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "type": "function_call_output",
@@ -953,7 +953,7 @@ mod tests {
 
     #[tokio::test]
     async fn continue_policy_preserves_unresolvable_reference() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "type": "message",
@@ -976,7 +976,7 @@ mod tests {
 
     #[tokio::test]
     async fn distinct_reference_limit_is_enforced_in_continue_mode() {
-        let api = test_api_client("http://ogx:8321", 1_000);
+        let api = test_api_client("http://files-api:8321", 1_000);
         let mut client = FilesApiClient::new(
             api,
             FilesApiClientOptions {
@@ -1009,7 +1009,7 @@ mod tests {
 
     #[tokio::test]
     async fn repeated_reference_reuses_cached_failure() {
-        let api = test_api_client("http://ogx:8321", 1_000);
+        let api = test_api_client("http://files-api:8321", 1_000);
         let client = FilesApiClient::new(
             api,
             FilesApiClientOptions {
@@ -1037,7 +1037,7 @@ mod tests {
 
     #[tokio::test]
     async fn cached_successes_share_request_wide_byte_budget() {
-        let client = test_client_with_limits("http://ogx:8321", 8, 1_000);
+        let client = test_client_with_limits("http://files-api:8321", 8, 1_000);
         let mut budget = client.resolution_budget();
         budget.cache.insert(
             ("input_file".to_owned(), "file-cached".to_owned()),
@@ -1081,7 +1081,7 @@ mod tests {
 
     #[tokio::test]
     async fn inline_content_takes_precedence_over_file_id() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
 
         for (part_type, field, value) in [
             ("input_file", "file_data", "SGVsbG8="),
@@ -1113,7 +1113,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_input_skips_untyped_non_message_content() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "content": [{"type": "input_file", "file_id": ".."}]
@@ -1131,7 +1131,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_data_parts_pass_through_unchanged() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "type": "message",
@@ -1154,7 +1154,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_url_parts_pass_through_unchanged() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "type": "message",
@@ -1177,7 +1177,7 @@ mod tests {
 
     #[tokio::test]
     async fn image_url_parts_pass_through_unchanged() {
-        let client = test_client("http://ogx:8321");
+        let client = test_client("http://files-api:8321");
         let mut body = serde_json::json!({
             "input": [{
                 "type": "message",

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -24,7 +24,7 @@ use crate::openai::{
 #[test]
 fn from_config_with_valid_url_succeeds() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
-        "files_api_url: \"http://ogx:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true",
+        "files_api_url: \"http://files-api:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true",
     )
     .unwrap();
     let filter = FileResolveFilter::from_config(&yaml).unwrap();
@@ -48,7 +48,7 @@ fn from_config_empty_url_rejected() {
 #[test]
 fn from_config_unknown_field_rejected() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
-        "files_api_url: \"http://ogx:8321\"\nallow_private_files_api_url: true\non_mising: reject",
+        "files_api_url: \"http://files-api:8321\"\nallow_private_files_api_url: true\non_mising: reject",
     )
     .unwrap();
     let result = FileResolveFilter::from_config(&yaml);
@@ -584,7 +584,7 @@ async fn rejects_resolved_history_when_rebuilt_body_exceeds_limit() {
 #[tokio::test]
 async fn rejects_unresolvable_history_when_configured_to_reject() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
-        "files_api_url: \"http://ogx:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true\non_missing: reject",
+        "files_api_url: \"http://files-api:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true\non_missing: reject",
     )
     .unwrap();
     let filter = FileResolveFilter::from_config(&yaml).unwrap();
@@ -641,7 +641,7 @@ async fn sync_state_skipped_without_responses_state() {
 // -----------------------------------------------------------------------------
 
 fn make_filter() -> Box<dyn HttpFilter> {
-    make_filter_for_url("http://ogx:8321")
+    make_filter_for_url("http://files-api:8321")
 }
 
 fn make_filter_for_url(files_api_url: &str) -> Box<dyn HttpFilter> {

--- a/docs/filters/openai_file_resolve.md
+++ b/docs/filters/openai_file_resolve.md
@@ -9,6 +9,8 @@ Resolves `file_id` references in Responses API input by fetching content from a 
 
 The inference backend must support the resulting inline content part. This filter does not extract documents into backend-specific representations such as `input_text`.
 
+This filter resolves references inside Responses requests; it does not proxy client-facing Files API operations. Route `/v1/files` and its subresources to the configured Files API with the standard `router` and `load_balancer` filters.
+
 ## Configuration
 
 | Field | Type | Required | Description |

--- a/docs/filters/openai_file_resolve.md
+++ b/docs/filters/openai_file_resolve.md
@@ -17,7 +17,7 @@ This filter resolves references inside Responses requests; it does not proxy cli
 |-------|------|---------|-------------|
 | `allow_private_files_api_url` | bool | no | Allow `files_api_url` to target private, loopback, link-local, or DNS-name hosts.  Default `false` rejects SSRF-sensitive targets; set to `true` in development or when the Files API is an internal service on a private network. |
 | `allow_pre_security_callout` | bool | no | Allow Files API callouts from the `StreamBuffer` pre-read phase, before header-phase security filters execute. This must be explicitly enabled only when an outer trust boundary authenticates and authorizes requests before they reach this listener. Forwarded headers are the original downstream values, not mutations from request filters. |
-| `files_api_url` | string | yes | Base URL of the Files API endpoint. Example: `http://ogx:8321` |
+| `files_api_url` | string | yes | Base URL of the Files API endpoint. Example: `http://files-api:8321` |
 | `forward_headers` | string[] | no | Headers to forward from the original request to the Files API for authentication and tenant isolation. No downstream headers are forwarded by default. |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `max_file_references` | integer | no | Maximum number of distinct content-part / `file_id` pairs to resolve in one request, including rehydrated history. |
@@ -30,7 +30,7 @@ This filter resolves references inside Responses requests; it does not proxy cli
 
 ```yaml
 filter: openai_file_resolve
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 allow_pre_security_callout: true
 ```
@@ -39,7 +39,7 @@ allow_pre_security_callout: true
 
 ```yaml
 filter: openai_file_resolve
-files_api_url: "http://ogx:8321"
+files_api_url: "http://files-api:8321"
 allow_private_files_api_url: true
 allow_pre_security_callout: true
 forward_headers:

--- a/examples/configs/openai/responses/file-resolve.yaml
+++ b/examples/configs/openai/responses/file-resolve.yaml
@@ -17,7 +17,7 @@
 # Client-facing Files API requests under /v1/files are routed
 # directly to the same Files API service. The router uses
 # segment-boundary prefix matching, so /v1/files and all of its
-# subresources go to OGX while paths such as /v1/filesystem do not.
+# subresources go to the Files API while paths such as /v1/filesystem do not.
 #
 # This filter resolves the file transport reference only. The
 # inference backend must support inline `input_file` / `file_data`
@@ -58,7 +58,7 @@ filter_chains:
       - filter: router
         routes:
           - path_prefix: "/v1/files"
-            cluster: "ogx-files-api"
+            cluster: "files-api"
           - path: "/v1/responses"
             cluster: "inference-backend"
           - path_prefix: "/"
@@ -66,7 +66,7 @@ filter_chains:
 
       - filter: load_balancer
         clusters:
-          - name: "ogx-files-api"
+          - name: "files-api"
             endpoints:
               - "127.0.0.1:9999"
           - name: "inference-backend"

--- a/examples/configs/openai/responses/file-resolve.yaml
+++ b/examples/configs/openai/responses/file-resolve.yaml
@@ -14,6 +14,11 @@
 # transparently inlines the content so the backend receives
 # a self-contained request.
 #
+# Client-facing Files API requests under /v1/files are routed
+# directly to the same Files API service. The router uses
+# segment-boundary prefix matching, so /v1/files and all of its
+# subresources go to OGX while paths such as /v1/filesystem do not.
+#
 # This filter resolves the file transport reference only. The
 # inference backend must support inline `input_file` / `file_data`
 # or `input_image` / `image_url` content. Backend-specific document
@@ -52,6 +57,8 @@ filter_chains:
 
       - filter: router
         routes:
+          - path_prefix: "/v1/files"
+            cluster: "ogx-files-api"
           - path: "/v1/responses"
             cluster: "inference-backend"
           - path_prefix: "/"
@@ -59,6 +66,9 @@ filter_chains:
 
       - filter: load_balancer
         clusters:
+          - name: "ogx-files-api"
+            endpoints:
+              - "127.0.0.1:9999"
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"

--- a/tests/integration/tests/suite/examples/openai_file_resolve.rs
+++ b/tests/integration/tests/suite/examples/openai_file_resolve.rs
@@ -254,8 +254,8 @@ fn example_config_non_responses_traffic_passes_through() {
 }
 
 #[test]
-fn example_config_routes_files_api_paths_to_ogx() {
-    let ogx_guard = start_backend_with_shutdown("ogx-files-api");
+fn example_config_routes_files_api_paths_to_files_backend() {
+    let files_guard = start_backend_with_shutdown("files-api");
     let inference_guard = start_backend_with_shutdown("inference-backend");
     let default_guard = start_backend_with_shutdown("default-backend");
     let proxy_port = free_port();
@@ -264,7 +264,7 @@ fn example_config_routes_files_api_paths_to_ogx() {
         "openai/responses/file-resolve.yaml",
         proxy_port,
         HashMap::from([
-            ("127.0.0.1:9999", ogx_guard.port()),
+            ("127.0.0.1:9999", files_guard.port()),
             ("127.0.0.1:3001", inference_guard.port()),
             ("127.0.0.1:3002", default_guard.port()),
         ]),
@@ -292,14 +292,14 @@ fn example_config_routes_files_api_paths_to_ogx() {
     assert_eq!(parse_status(&upload_raw), 200, "Files API root should be proxied");
     assert_eq!(
         parse_body(&upload_raw),
-        "ogx-files-api",
-        "POST /v1/files should route to OGX"
+        "files-api",
+        "POST /v1/files should route to Files API backend"
     );
     let (content_status, content_body) = http_get(proxy.addr(), "/v1/files/file-123/content", None);
     assert_eq!(content_status, 200, "Files API subresource should be proxied");
     assert_eq!(
-        content_body, "ogx-files-api",
-        "Files API subresources should route to OGX"
+        content_body, "files-api",
+        "Files API subresources should route to Files API backend"
     );
 
     let (non_files_status, non_files_body) = http_get(proxy.addr(), "/v1/filesystem", None);

--- a/tests/integration/tests/suite/examples/openai_file_resolve.rs
+++ b/tests/integration/tests/suite/examples/openai_file_resolve.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use praxis_test_utils::{
-    free_port, http_send, json_post, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
-    start_capturing_backend, start_proxy,
+    free_port, http_get, http_send, json_post, load_example_config, parse_body, parse_status,
+    start_backend_with_shutdown, start_capturing_backend, start_proxy,
 };
 
 const FILE_METADATA: &str = r#"{"id":"test-file-123","object":"file","bytes":13,"created_at":1750000000,"filename":"test.txt","purpose":"user_data"}"#;
@@ -250,6 +250,63 @@ fn example_config_non_responses_traffic_passes_through() {
         parse_body(&raw),
         "default-backend",
         "non-responses traffic should route to default backend"
+    );
+}
+
+#[test]
+fn example_config_routes_files_api_paths_to_ogx() {
+    let ogx_guard = start_backend_with_shutdown("ogx-files-api");
+    let inference_guard = start_backend_with_shutdown("inference-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/file-resolve.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9999", ogx_guard.port()),
+            ("127.0.0.1:3001", inference_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let upload_body = "--test-boundary\r\n\
+        Content-Disposition: form-data; name=\"purpose\"\r\n\r\n\
+        assistants\r\n\
+        --test-boundary\r\n\
+        Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n\
+        Content-Type: text/plain\r\n\r\n\
+        uploaded file contents\r\n\
+        --test-boundary--\r\n";
+    let upload = format!(
+        "POST /v1/files HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: multipart/form-data; boundary=test-boundary\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n\
+         {upload_body}",
+        upload_body.len()
+    );
+    let upload_raw = http_send(proxy.addr(), &upload);
+    assert_eq!(parse_status(&upload_raw), 200, "Files API root should be proxied");
+    assert_eq!(
+        parse_body(&upload_raw),
+        "ogx-files-api",
+        "POST /v1/files should route to OGX"
+    );
+    let (content_status, content_body) = http_get(proxy.addr(), "/v1/files/file-123/content", None);
+    assert_eq!(content_status, 200, "Files API subresource should be proxied");
+    assert_eq!(
+        content_body, "ogx-files-api",
+        "Files API subresources should route to OGX"
+    );
+
+    let (non_files_status, non_files_body) = http_get(proxy.addr(), "/v1/filesystem", None);
+    assert_eq!(non_files_status, 200, "non-Files API path should be proxied");
+    assert_eq!(
+        non_files_body, "default-backend",
+        "path-prefix matching must stop at a segment boundary"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add a `path_prefix: /v1/files` route in the file-resolve example config so client-facing Files API requests (upload, list, download content) are proxied to a dedicated `files-api` cluster — any backend compatible with the OpenAI Files API
- Clarify in the filter rustdoc and user-facing docs that `openai_file_resolve` resolves file references inside Responses requests only; it does not proxy Files API operations itself
- Replace all OGX-specific naming with generic `files-api` naming across docs, example config, and tests
- Add an integration test that verifies routing for the root path, a subresource (`/v1/files/file-123/content`), and a segment-boundary guard (`/v1/filesystem` must not match)

## Test plan

- [x] `make lint` passes
- [x] `make build` passes
- [ ] Existing integration tests pass in CI
- [ ] New `example_config_routes_files_api_paths_to_files_backend` test validates routing