### PR TITLE
feat(routing): add /v1/vector_stores routing to dedicated backend

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,7 @@ before sending requests.
 | [responses-routing.yaml](configs/openai/responses/responses-routing.yaml) | Routes Responses API traffic by detected mode |
 | [stream-events.yaml](configs/openai/responses/stream-events.yaml) | Demonstrates the `openai_stream_events` filter, which observes SSE chunks from the backend without modification, accumulates state (response object, output items, tool calls, usage), and writes it to ResponsesState metadata |
 | [tool-routing.yaml](configs/openai/responses/tool-routing.yaml) | Demonstrates using `openai_tool_parse` to route Responses API requests by their tool composition |
+| [vector-stores-routing.yaml](configs/openai/responses/vector-stores-routing.yaml) | Routes /v1/vector_stores traffic and all its subresources to a dedicated backend (any server compatible with the OpenAI Files / Vector Stores API), while sending everything else to a default backend |
 | [vllm-agentic-api.yaml](configs/openai/responses/vllm-agentic-api.yaml) | vLLM Agentic API: https://github.com/vllm-project/agentic-api |
 | [web-search.yaml](configs/openai/responses/web-search.yaml) | Demonstrates the `openai_web_search` filter configuration |
 

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -184,9 +184,14 @@ filter_chains:
             headers:
               x-praxis-ai-format: "openai_responses"
             cluster: "inference-backend"
+          - path_prefix: "/v1/vector_stores"
+            cluster: "vector-stores-backend"
 
       - filter: load_balancer
         clusters:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"
+          - name: "vector-stores-backend"
+            endpoints:
+              - "127.0.0.1:3002"

--- a/examples/configs/openai/responses/vector-stores-routing.yaml
+++ b/examples/configs/openai/responses/vector-stores-routing.yaml
@@ -1,0 +1,59 @@
+# Vector Stores API Routing
+#
+# Routes /v1/vector_stores traffic and all its subresources to a
+# dedicated backend (any server compatible with the OpenAI Files /
+# Vector Stores API), while sending everything else to a default
+# backend.
+#
+# The `path_prefix` match uses Gateway API segment-boundary semantics:
+#   /v1/vector_stores      → vector-stores-backend  (exact)
+#   /v1/vector_stores/     → vector-stores-backend  (trailing slash)
+#   /v1/vector_stores/vs_1 → vector-stores-backend  (resource by ID)
+#   /v1/vector_stores/vs_1/files       → vector-stores-backend  (nested)
+#   /v1/vector_stores/vs_1/file_batches → vector-stores-backend  (nested)
+#   /v1/vector_stores_extra            → default-backend (different segment)
+#
+# No AI-specific filters are needed — only the standard router and
+# load_balancer from praxis core.
+#
+# Example requests:
+#
+#   # List vector stores → vector-stores-backend
+#   curl http://localhost:8080/v1/vector_stores
+#
+#   # Get a vector store → vector-stores-backend
+#   curl http://localhost:8080/v1/vector_stores/vs_abc
+#
+#   # Create a vector store file → vector-stores-backend
+#   curl -X POST http://localhost:8080/v1/vector_stores/vs_abc/files \
+#     -H "Content-Type: application/json" \
+#     -d '{"file_id":"file-abc"}'
+#
+#   # Unrelated path → default-backend
+#   curl -X POST http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"gpt-4.1","input":"Hello"}'
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [vector-stores-routing]
+
+filter_chains:
+  - name: vector-stores-routing
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/v1/vector_stores"
+            cluster: "vector-stores-backend"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "vector-stores-backend"
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:3002"

--- a/tests/integration/tests/suite/examples/full_flow.rs
+++ b/tests/integration/tests/suite/examples/full_flow.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    Backend, TempSqlite, example_config_path, free_port, http_send, json_post, load_example_config, parse_body,
-    parse_status, patch_yaml, start_backend_with_shutdown, start_echo_backend, start_proxy,
+    Backend, TempSqlite, example_config_path, free_port, http_get, http_send, json_post, load_example_config,
+    parse_body, parse_status, patch_yaml, start_backend_with_shutdown, start_echo_backend, start_proxy,
 };
 
 use super::openai_file_resolve::start_files_api_stub;
@@ -191,6 +191,31 @@ fn full_flow_chat_completions_body_on_responses_path_does_not_reach_backend() {
         parse_status(&raw),
         404,
         "chat completions bodies should not match the Responses-only route"
+    );
+}
+
+#[test]
+fn full_flow_vector_stores_routes_to_dedicated_backend() {
+    let inference = start_backend_with_shutdown("inference-backend");
+    let vs_backend = start_backend_with_shutdown("vector-stores-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/full-flow.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", inference.port()),
+            ("127.0.0.1:3002", vs_backend.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/vector_stores/vs_abc/files", None);
+
+    assert_eq!(status, 200, "vector stores subresource should return 200");
+    assert_eq!(
+        body, "vector-stores-backend",
+        "vector stores traffic should bypass AI filters and route to vector-stores-backend"
     );
 }
 

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -33,5 +33,6 @@ mod session_replay;
 mod token_count;
 mod token_counting;
 mod token_usage_headers;
+mod vector_stores_routing;
 mod vllm_agentic_api;
 mod web_search;

--- a/tests/integration/tests/suite/examples/vector_stores_routing.rs
+++ b/tests/integration/tests/suite/examples/vector_stores_routing.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the vector-stores-routing example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{free_port, http_get, load_example_config, start_backend_with_shutdown, start_proxy};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn vector_stores_root_routes_to_dedicated_backend() {
+    let vs_backend = start_backend_with_shutdown("vector-stores-backend");
+    let default = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/vector-stores-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", vs_backend.port()),
+            ("127.0.0.1:3002", default.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/vector_stores", None);
+
+    assert_eq!(status, 200, "root should return 200");
+    assert_eq!(
+        body, "vector-stores-backend",
+        "/v1/vector_stores should route to vector-stores-backend"
+    );
+}
+
+#[test]
+fn vector_stores_nested_subresource_routes_to_dedicated_backend() {
+    let vs_backend = start_backend_with_shutdown("vector-stores-backend");
+    let default = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/vector-stores-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", vs_backend.port()),
+            ("127.0.0.1:3002", default.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/vector_stores/vs_abc/files", None);
+
+    assert_eq!(status, 200, "nested subresource should return 200");
+    assert_eq!(
+        body, "vector-stores-backend",
+        "/v1/vector_stores/vs_abc/files should route to vector-stores-backend"
+    );
+}
+
+#[test]
+fn vector_stores_extra_segment_boundary_routes_to_default() {
+    let vs_backend = start_backend_with_shutdown("vector-stores-backend");
+    let default = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/vector-stores-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", vs_backend.port()),
+            ("127.0.0.1:3002", default.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/vector_stores_extra", None);
+
+    assert_eq!(status, 200, "segment boundary path should return 200");
+    assert_eq!(
+        body, "default-backend",
+        "/v1/vector_stores_extra must NOT match /v1/vector_stores prefix"
+    );
+}

--- a/tests/integration/tests/suite/examples/vector_stores_routing.rs
+++ b/tests/integration/tests/suite/examples/vector_stores_routing.rs
@@ -62,6 +62,31 @@ fn vector_stores_nested_subresource_routes_to_dedicated_backend() {
 }
 
 #[test]
+fn vector_stores_trailing_slash_routes_to_dedicated_backend() {
+    let vs_backend = start_backend_with_shutdown("vector-stores-backend");
+    let default = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/responses/vector-stores-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", vs_backend.port()),
+            ("127.0.0.1:3002", default.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/vector_stores/", None);
+
+    assert_eq!(status, 200, "trailing slash should return 200");
+    assert_eq!(
+        body, "vector-stores-backend",
+        "/v1/vector_stores/ should route to vector-stores-backend"
+    );
+}
+
+#[test]
 fn vector_stores_extra_segment_boundary_routes_to_default() {
     let vs_backend = start_backend_with_shutdown("vector-stores-backend");
     let default = start_backend_with_shutdown("default-backend");


### PR DESCRIPTION
## Summary

- Add `path_prefix: "/v1/vector_stores"` route to a dedicated backend using
  the standard `router` and `load_balancer` filters (no new Rust filter).
  Segment-boundary semantics ensure `/v1/vector_stores_extra` falls through
  to the default backend.
- Add standalone example config (`vector-stores-routing.yaml`) and wire the
  route into the `full-flow.yaml` pipeline.
- Add three integration tests: root endpoint, nested subresource
  (`/v1/vector_stores/vs_abc/files`), and segment-boundary case.

## Test plan

- [x] `vector_stores_root_routes_to_dedicated_backend` — verifies `/v1/vector_stores` → vector-stores-backend
- [x] `vector_stores_nested_subresource_routes_to_dedicated_backend` — verifies `/v1/vector_stores/vs_abc/files` → vector-stores-backend
- [x] `vector_stores_extra_segment_boundary_routes_to_default` — verifies `/v1/vector_stores_extra` → default-backend
- [x] `make` passes (build + clippy + rustfmt + lint-separators + lint-filter-docs + lint-example-tests + all 375 tests)