### PR TITLE
feat(openai): route /v1/prompts to a dedicated Prompts API backend

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,7 @@ before sending requests.
 | File | Description |
 | ------ | ------------- |
 | [conversations.yaml](configs/openai/conversations/conversations.yaml) | Local /v1/conversations endpoints for conversation lifecycle, backed by the ConversationItemStore |
+| [prompts-routing.yaml](configs/openai/prompts/prompts-routing.yaml) | Routes /v1/prompts and subresources to a dedicated Prompts API backend using segment-boundary prefix matching |
 | [doc-extract.yaml](configs/openai/responses/doc-extract.yaml) | Converts `input_file` content parts to `input_text` for inference backends that do not natively support `input_file` (e.g. vLLM, llm-d) |
 | [file-resolve.yaml](configs/openai/responses/file-resolve.yaml) | Resolves `file_id` references in Responses API input by fetching file metadata and content from a Files API, then inlining base64 content as `file_data` or `image_url` before forwarding |
 | [format-routing.yaml](configs/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |

--- a/examples/configs/openai/prompts/prompts-routing.yaml
+++ b/examples/configs/openai/prompts/prompts-routing.yaml
@@ -1,0 +1,46 @@
+# Prompts API Routing
+#
+# Routes OpenAI Prompts API requests to a dedicated Prompts API
+# backend. The router uses segment-boundary prefix matching, so
+# /v1/prompts and all of its subresources (e.g.
+# /v1/prompts/{prompt_id}, /v1/prompts/{prompt_id}/versions)
+# are routed to the prompts-api cluster, while paths such as
+# /v1/promptsomething do not match and fall through to the
+# default backend.
+#
+# Example requests:
+#
+#   # List prompts
+#   curl http://localhost:8080/v1/prompts
+#
+#   # Get a specific prompt
+#   curl http://localhost:8080/v1/prompts/prompt-abc123
+#
+#   # Create a prompt
+#   curl http://localhost:8080/v1/prompts \
+#     -H "Content-Type: application/json" \
+#     -d '{"name": "greeting", "prompt": {"messages": [{"role": "user", "content": "Hello"}]}}'
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [prompts-routing]
+
+filter_chains:
+  - name: prompts-routing
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/v1/prompts"
+            cluster: "prompts-api"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "prompts-api"
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:3002"

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -66,10 +66,11 @@
 #      (already resolved by rehydrate). Passthrough when no
 #      ResponsesState exists.
 #
-#   12. The router sends all valid Responses API create requests to
-#      the same inference backend. The promoted mode remains available
-#      as headers/metadata for downstream filters; it does not change
-#      backend selection in this example.
+#   12. The router sends valid Responses API create requests to the
+#      inference backend and routes /v1/prompts (and subresources) to
+#      a dedicated Prompts API service. The promoted mode remains
+#      available as headers/metadata for downstream filters; it does
+#      not change backend selection in this example.
 #
 # Security: StreamBuffer body callouts run before this listener's
 # header-phase filters. Deploy this example behind an outer
@@ -180,6 +181,8 @@ filter_chains:
 
       - filter: router
         routes:
+          - path_prefix: "/v1/prompts"
+            cluster: "prompts-api"
           - path: "/v1/responses"
             headers:
               x-praxis-ai-format: "openai_responses"
@@ -187,6 +190,9 @@ filter_chains:
 
       - filter: load_balancer
         clusters:
+          - name: "prompts-api"
+            endpoints:
+              - "127.0.0.1:9998"
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -18,6 +18,7 @@ mod openai_doc_extract;
 mod openai_file_resolve;
 mod openai_mcp_dispatch;
 mod openai_mcp_tool_resolve;
+mod openai_prompts_routing;
 mod openai_response_store;
 mod openai_response_store_postgres;
 mod openai_responses_format;

--- a/tests/integration/tests/suite/examples/openai_prompts_routing.rs
+++ b/tests/integration/tests/suite/examples/openai_prompts_routing.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the OpenAI Prompts routing example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{free_port, http_get, load_example_config, start_backend_with_shutdown, start_proxy};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn example_config_routes_prompts_root_to_prompts_backend() {
+    let prompts_guard = start_backend_with_shutdown("prompts-api");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/prompts/prompts-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", prompts_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/prompts", None);
+    assert_eq!(status, 200, "Prompts API root should be proxied");
+    assert_eq!(
+        body, "prompts-api",
+        "GET /v1/prompts should route to prompts-api backend"
+    );
+}
+
+#[test]
+fn example_config_routes_prompts_subresource_to_prompts_backend() {
+    let prompts_guard = start_backend_with_shutdown("prompts-api");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/prompts/prompts-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", prompts_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/prompts/prompt-abc123/versions", None);
+    assert_eq!(status, 200, "Prompts API subresource should be proxied");
+    assert_eq!(
+        body, "prompts-api",
+        "Prompts API subresources should route to prompts-api backend"
+    );
+}
+
+#[test]
+fn example_config_segment_boundary_falls_to_default() {
+    let prompts_guard = start_backend_with_shutdown("prompts-api");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/prompts/prompts-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", prompts_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/promptsomething", None);
+    assert_eq!(status, 200, "non-Prompts API path should be proxied");
+    assert_eq!(
+        body, "default-backend",
+        "path-prefix matching must stop at a segment boundary"
+    );
+}


### PR DESCRIPTION
## Summary

- Add a `path_prefix: /v1/prompts` route so Prompts API requests and subresources are proxied to a dedicated `prompts-api` cluster using the standard `router` and `load_balancer` filters
- New standalone example config at `openai/prompts/prompts-routing.yaml` for pure path-based routing
- Add the same prompts-api route to `full-flow.yaml` alongside the existing inference-backend
- Integration tests verify the root endpoint, a nested subresource (`/v1/prompts/prompt-abc123/versions`), and a segment-boundary guard (`/v1/promptsomething` → default backend)

## Test plan

- [x] `make lint` passes (clippy, nightly rustfmt, separator lint, filter docs lint)
- [x] `make build` passes
- [x] New `openai_prompts_routing` integration tests pass (3 tests)
- [x] Existing `full_flow` integration tests pass (5 tests)
- [ ] CI passes