### PR TITLE
chore(deps): bump Praxis crates to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -147,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "apl-cmf"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3caf776592011d33f4d9d85834daf615de7c038549edbde4ad001c96e83d645d"
+checksum = "685a1bffb26e794b393daa3727be034f3343fd946a60a89f02604ef1c72abecf"
 dependencies = [
  "apl-core",
  "cpex-core",
@@ -158,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "apl-core"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae106c4bf2497c610b74ec7091f8facb8d82cd041a53ef6b4a7bbd3524c8ce50"
+checksum = "94b5847a0dd6ea9694862e899774c001e039b88df6e3113d5ee0736e2b4fc12d"
 dependencies = [
  "async-trait",
  "cpex-orchestration",
@@ -174,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "apl-cpex"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40e33d304dcf1d6d57ea91fd58bc6d4bfc4d473ad2c48b503b13696f2782bf"
+checksum = "dbf227ec0421e66496b039881391ac6aaa32bc340f7496dc74db78e51bb1f329"
 dependencies = [
  "apl-cmf",
  "apl-core",
@@ -862,9 +851,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpex"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3b05e323dc449d9e61e7ec9e72e6b35634a8c4f650c52d37b9bddd8827840d"
+checksum = "52e486736defb1437d0c65ea8dd3005bb5759ef9ed74e935a86bfc1a6e934a46"
 dependencies = [
  "apl-cmf",
  "apl-core",
@@ -875,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-builtins"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b58c609e23d080ee5d2a05630f40c860d02522f22db88450109eab572722b75"
+checksum = "83d686240389c3fab8a1895415dabe1571c253bfb58b98374fb7f7302d157451"
 dependencies = [
  "apl-core",
  "apl-cpex",
@@ -893,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-core"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de077ac4aacd2b33d89a8d430f24459f974e277688877a1e1f39eaf13d7f6cb6"
+checksum = "696544a387bb5c51e8cde5287f3812ff0ae228b5041319964d64a57cb73f5cad"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -916,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-orchestration"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9808b666ceab61a32281ba8801063e3729bc8f9b28959974cbbfc147382cc8ae"
+checksum = "39bd3b81889995d239d711e4876b079dabf21288eca79eb3bb4ed3004def1bbb"
 dependencies = [
  "futures",
  "tokio",
@@ -926,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-pdp-cedar-direct"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f086f6fc33a85f1470c26a792be2c8777b8a6682302a2931385197664117a6"
+checksum = "3c967821434d44a54ffb0430ba0dcbe08f8f419e5de43172f986589f4be7a51b"
 dependencies = [
  "apl-core",
  "async-trait",
@@ -941,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-pdp-cel"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044bc55e99fe2c6410457372803cb06e4980510493334806781a27ff2ae89c8d"
+checksum = "c8b8b72ae4039b7ebb85c6a9aa5e5c3c90418c2cb879760fb21e0b20e6636172"
 dependencies = [
  "apl-core",
  "async-trait",
@@ -955,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-plugin-audit-logger"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75967287c9d4c17fa1646fa5605b7fa03e84fdc62a8377ba2765a596a018b349"
+checksum = "3c07da9c81faf07b00d24ff59ffc5ff1e53add80b5ef16f453337ceb1320ad98"
 dependencies = [
  "async-trait",
  "chrono",
@@ -969,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-plugin-delegator-oauth"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64dfdabc4babdbd69ae401e633734c4c28040c21ca44038bee0a30db2eb751e6"
+checksum = "da8c0ce5ae33679beaeb582b6348b9f3ad4762a33dc503a7f872f269bf4804c7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -985,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-plugin-identity-jwt"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fd073546e1971aef7a38f8f07816cd3ce2f64a9dfc8bd0026b53ff48e3e201"
+checksum = "37f08a35f44b567c735571b1908881a8c714bc5b0d4f57d8a2939e2f33d26cc2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1004,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-plugin-pii-scanner"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba03f5513f8e60d12bec245e6cbbef504f16940dcaad263c5f1819bdb03ffce"
+checksum = "473f3e498e702b841c04249e5099e2f657c78f25581e0626929eb5a12925ec77"
 dependencies = [
  "async-trait",
  "cpex-core",
@@ -1017,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "cpex-session-valkey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d7ae8301d61ae6c558d28211faab4743a078f8da9b6fcee325aeea01aeb34c"
+checksum = "6b96da40ceb5e4f8a646d065b88efb9968115cd0b615a97dae20ea787b96ac5d"
 dependencies = [
  "apl-cpex",
  "async-trait",
@@ -1412,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1503,7 +1492,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1738,9 +1727,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2982,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b55887726e5e70269665a0dcb3a4864fc731b2db1675966508905cdeec089a"
+checksum = "130643048a6f3a94b1b48c361479a8f2833bf9d3a926cff9a9071bdcaa352552"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3003,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-core"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75736401a6dffbb9b068e1b4ee0a7527391fa292d4577c62d295e57c43c00561"
+checksum = "71a30c54be1367e63135c5b3b05f7365ab7d8940c3d5fdac9d97a316c04568c9"
 dependencies = [
  "dashmap 6.2.1",
  "http",
@@ -3024,19 +3010,22 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-filter"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3cd01e41cdde98c6a0c5f01c6cdc164f88af1748b6ccddfd6a5963574af50ad"
+checksum = "3b775e4c9673c53e967cce25e8e8959a9ff01cf18a17a90448f6601c77e8f050"
 dependencies = [
  "async-trait",
  "bytes",
  "cpex",
  "dashmap 6.2.1",
  "http",
+ "metrics",
  "percent-encoding",
  "praxis-proxy-core",
+ "praxis-proxy-tls",
  "rand 0.10.2",
  "regex",
+ "secrecy",
  "serde",
  "serde_json",
  "smallvec",
@@ -3049,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-protocol"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdf79e0fc50267702ac4211088831d29768689daf8716e0e46fa3e2ddfaf4e5"
+checksum = "3919b20d58ab7cf5af8ba6dc380641f217430061436511fb7b83e21646d3adb9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3066,6 +3055,7 @@ dependencies = [
  "quixotic-plecostomus-core",
  "quixotic-plecostomus-http",
  "quixotic-plecostomus-proxy",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3073,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-tls"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b45d3c1272b76948871950bf9df726dce67e533c495257a1a3cda2b2aa3d2ad"
+checksum = "93fcb6f2aad1284d40edf3ec7eb41f010ce48244c2caa74abd12b55f94edcad5"
 dependencies = [
  "arc-swap",
  "notify",
@@ -3279,7 +3269,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3288,7 +3278,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a820a1a3e59644b38bc03606b638b41f1c5a474215efcec37f94b15871a7e1c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "blake2",
  "bstr",
@@ -3323,7 +3313,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d6d9e04414ba6819c51ec210eddf17865c505431a492c86c6356338c2b4f60"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "brotli",
  "bstr",
@@ -3411,7 +3401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec55d3bcbd56e52b3424bc62739a237d43c14df8ed04aaf294ae187b60da348a"
 dependencies = [
  "arrayvec 0.7.8",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.7",
 ]
@@ -3938,7 +3928,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4019,7 +4009,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4771,10 +4761,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5472,7 +5462,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,11 +60,11 @@ wiremock = "0.6.5"
 zeroize = "1.9.0"
 
 # Praxis core dependencies
-praxis-core = { version = "0.4.0", package = "praxis-proxy-core", features = ["callout"] }
-praxis-filter = { version = "0.4.0", package = "praxis-proxy-filter" }
-praxis-protocol = { version = "0.4.0", package = "praxis-proxy-protocol" }
-praxis-tls = { version = "0.4.0", package = "praxis-proxy-tls" }
-praxis = { version = "0.4.0", package = "praxis-proxy" }
+praxis-core = { version = "0.4.1", package = "praxis-proxy-core", features = ["callout"] }
+praxis-filter = { version = "0.4.1", package = "praxis-proxy-filter" }
+praxis-protocol = { version = "0.4.1", package = "praxis-proxy-protocol" }
+praxis-tls = { version = "0.4.1", package = "praxis-proxy-tls" }
+praxis = { version = "0.4.1", package = "praxis-proxy" }
 praxis-test-utils = { path = "tests/utils" }
 
 # Praxis AI workspace dependencies

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -91,11 +91,8 @@ pub(crate) mod test_utils {
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,
             upstream: None,
-            #[cfg(feature = "praxis-main")]
             peer_identity: None,
-            #[cfg(feature = "praxis-main")]
             pre_read_mutations: Vec::new(),
-            #[cfg(feature = "praxis-main")]
             structured_metadata: std::collections::HashMap::new(),
         }
     }

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -885,24 +885,12 @@ fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {
         method: None,
     };
 
-    #[cfg(feature = "praxis-main")]
-    {
-        JsonRpcConfig {
-            batch_policy: BatchPolicy::Reject,
-            headers,
-            max_batch_size: 100,
-            max_body_bytes,
-            on_invalid: OnInvalidBehavior::Continue,
-        }
-    }
-    #[cfg(not(feature = "praxis-main"))]
-    {
-        JsonRpcConfig {
-            batch_policy: BatchPolicy::Reject,
-            headers,
-            max_body_bytes,
-            on_invalid: OnInvalidBehavior::Continue,
-        }
+    JsonRpcConfig {
+        batch_policy: BatchPolicy::Reject,
+        headers,
+        max_batch_size: 100,
+        max_body_bytes,
+        on_invalid: OnInvalidBehavior::Continue,
     }
 }
 

--- a/filters/src/agentic/mcp/broker/mod.rs
+++ b/filters/src/agentic/mcp/broker/mod.rs
@@ -925,23 +925,11 @@ fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {
         method: None,
     };
 
-    #[cfg(feature = "praxis-main")]
-    {
-        JsonRpcConfig {
-            batch_policy: BatchPolicy::Reject,
-            headers,
-            max_batch_size: 100,
-            max_body_bytes,
-            on_invalid: OnInvalidBehavior::Continue,
-        }
-    }
-    #[cfg(not(feature = "praxis-main"))]
-    {
-        JsonRpcConfig {
-            batch_policy: BatchPolicy::Reject,
-            headers,
-            max_body_bytes,
-            on_invalid: OnInvalidBehavior::Continue,
-        }
+    JsonRpcConfig {
+        batch_policy: BatchPolicy::Reject,
+        headers,
+        max_batch_size: 100,
+        max_body_bytes,
+        on_invalid: OnInvalidBehavior::Continue,
     }
 }

--- a/filters/src/agentic/mcp/mod.rs
+++ b/filters/src/agentic/mcp/mod.rs
@@ -200,24 +200,12 @@ fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {
         method: None,
     };
 
-    #[cfg(feature = "praxis-main")]
-    {
-        JsonRpcConfig {
-            batch_policy: BatchPolicy::Reject,
-            headers,
-            max_batch_size: 100,
-            max_body_bytes,
-            on_invalid: OnInvalidBehavior::Continue,
-        }
-    }
-    #[cfg(not(feature = "praxis-main"))]
-    {
-        JsonRpcConfig {
-            batch_policy: BatchPolicy::Reject,
-            headers,
-            max_body_bytes,
-            on_invalid: OnInvalidBehavior::Continue,
-        }
+    JsonRpcConfig {
+        batch_policy: BatchPolicy::Reject,
+        headers,
+        max_batch_size: 100,
+        max_body_bytes,
+        on_invalid: OnInvalidBehavior::Continue,
     }
 }
 

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -86,11 +86,8 @@ pub(crate) mod test_utils {
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,
             upstream: None,
-            #[cfg(feature = "praxis-main")]
             peer_identity: None,
-            #[cfg(feature = "praxis-main")]
             pre_read_mutations: Vec::new(),
-            #[cfg(feature = "praxis-main")]
             structured_metadata: std::collections::HashMap::new(),
         }
     }

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use praxis_core::config::Config;
+use praxis_core::config::{Config, InsecureOptions};
 use praxis_filter::{FilterPipeline, FilterRegistry};
 use praxis_protocol::ListenerPipelines;
 
@@ -49,9 +49,7 @@ pub fn resolve_pipelines(
         let mut pipeline = FilterPipeline::build_with_chains(&mut entries, registry, &chains)?;
         configure_pipeline(&mut pipeline, config, health_registry, kv_stores)?;
 
-        let skip = config.insecure_options.skip_pipeline_validation;
-        let allow_open_security = config.insecure_options.allow_open_security_filters;
-        validate_pipeline(&pipeline, &entries, &listener.name, skip, allow_open_security)?;
+        validate_pipeline(&pipeline, &entries, &listener.name, &config.insecure_options)?;
 
         pipelines.insert(listener.name.clone(), Arc::new(pipeline));
     }
@@ -94,19 +92,15 @@ fn validate_pipeline(
     pipeline: &FilterPipeline,
     entries: &[praxis_core::config::FilterEntry],
     listener_name: &str,
-    skip: bool,
-    allow_open_security: bool,
+    insecure_options: &InsecureOptions,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    #[cfg(feature = "praxis-main")]
     let errors = pipeline.ordering_errors(
         entries,
-        allow_open_security,
-        &praxis_core::config::SkipPipelineChecks::default(),
+        insecure_options.allow_open_security_filters,
+        &insecure_options.effective_pipeline_checks(),
     );
-    #[cfg(not(feature = "praxis-main"))]
-    let errors = pipeline.ordering_errors(entries, allow_open_security);
 
-    if skip {
+    if insecure_options.skip_pipeline_validation {
         for msg in &errors {
             tracing::warn!(listener = %listener_name, "{msg}");
         }

--- a/tests/schema/tests/suite/cluster.rs
+++ b/tests/schema/tests/suite/cluster.rs
@@ -103,13 +103,10 @@ clusters:
       sni: ""
 "#;
     let err = Config::from_yaml(yaml).unwrap_err();
-    #[cfg(feature = "praxis-main")]
     assert!(
         err.to_string().contains("sni must be a valid DNS hostname"),
         "got: {err}"
     );
-    #[cfg(not(feature = "praxis-main"))]
-    assert!(err.to_string().contains("sni is empty"), "got: {err}");
 }
 
 #[test]
@@ -135,13 +132,10 @@ clusters:
 "#
     );
     let err = Config::from_yaml(&yaml).unwrap_err();
-    #[cfg(feature = "praxis-main")]
     assert!(
         err.to_string().contains("sni must be a valid DNS hostname"),
         "got: {err}"
     );
-    #[cfg(not(feature = "praxis-main"))]
-    assert!(err.to_string().contains("exceeds 253 characters"), "got: {err}");
 }
 
 #[test]
@@ -167,13 +161,10 @@ clusters:
 "#
     );
     let err = Config::from_yaml(&yaml).unwrap_err();
-    #[cfg(feature = "praxis-main")]
     assert!(
         err.to_string().contains("sni must be a valid DNS hostname"),
         "got: {err}"
     );
-    #[cfg(not(feature = "praxis-main"))]
-    assert!(err.to_string().contains("invalid label length"), "got: {err}");
 }
 
 #[test]
@@ -195,13 +186,10 @@ clusters:
       sni: "api..example.com"
 "#;
     let err = Config::from_yaml(yaml).unwrap_err();
-    #[cfg(feature = "praxis-main")]
     assert!(
         err.to_string().contains("sni must be a valid DNS hostname"),
         "got: {err}"
     );
-    #[cfg(not(feature = "praxis-main"))]
-    assert!(err.to_string().contains("invalid label length"), "got: {err}");
 }
 
 #[test]
@@ -223,13 +211,10 @@ clusters:
       sni: "api.exam ple.com"
 "#;
     let err = Config::from_yaml(yaml).unwrap_err();
-    #[cfg(feature = "praxis-main")]
     assert!(
         err.to_string().contains("sni must be a valid DNS hostname"),
         "got: {err}"
     );
-    #[cfg(not(feature = "praxis-main"))]
-    assert!(err.to_string().contains("invalid characters"), "got: {err}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

  Bumps the AI workspace from Praxis `0.4.0` to the published Praxis `0.4.1` crates.

  Praxis `0.4.1` updates several filter and pipeline APIs consumed by AI, so this PR includes the corresponding compatibility updates.

  ## What Changed

  - Updated Praxis workspace dependencies from `0.4.0` to `0.4.1`.
  - Updated `Cargo.lock`.
  - Removed obsolete `praxis-main` conditional `JsonRpcConfig` construction in:
    - `filters/src/agentic/a2a/mod.rs`
    - `filters/src/agentic/mcp/mod.rs`
    - `filters/src/agentic/mcp/broker/mod.rs`
  - Updated test `HttpFilterContext` initializers for Praxis `0.4.1` fields.
  - Updated pipeline validation to pass `InsecureOptions::effective_pipeline_checks()` since in Praxis 0.4.1, that method now requires the skip-check configuration.
  - The SNI schema tests still cover the same invalid cases; this only updates their expected error text to match the unified Praxis 0.4.1 validation message.

  ## Validation

  - `git diff --check`
  - `cargo +nightly fmt --all -- --check`
  - `make lint`
