### PR TITLE
fix(ci): add buildx setup and integration tests to release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,12 @@ jobs:
       - name: Run all tests
         run: make test
 
+      - name: Schema tests
+        run: make test-schema
+
+      - name: Integration tests
+        run: make test-integration
+
   # ----------------------------------------------------------------------------
   # Build and publish container image
   # ----------------------------------------------------------------------------
@@ -91,6 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0


### PR DESCRIPTION
## Summary

- Add `docker/setup-buildx-action` to both `release.yaml` and `publish.yaml` workflows — the default docker driver does not support `type=gha` cache, which caused the v0.1.0 release container build to fail
- Add `test-schema` and `test-integration` steps to the release workflow so the full test suite runs before publishing

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, re-tag `v0.1.0` and confirm the release workflow completes successfully