### PR TITLE
fix(openai_mcp_tool_resolve): rewrite type:mcp tools to type:function

### DIFF
--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -7,8 +7,23 @@
 //! Runs after `openai_tool_parse`, gated on `openai_tool_parse.has_mcp`.
 //! Reads MCP entries from the buffered request body, checks
 //! `previous_tools` for cached listings, calls `tools/list` via
-//! the `mcp_client` module, and writes `mcp_tool_map` to
-//! [`ResponsesState`].
+//! the `mcp_client` module, writes `mcp_tool_map` to
+//! [`ResponsesState`], and rewrites `type: "mcp"` entries in the
+//! request body to `type: "function"`.
+//!
+//! # Function name encoding
+//!
+//! Each rewritten function tool is named
+//! `{server_label}__{tool_name}`. The prefix is required because
+//! the backend does not know about MCP servers: without it, two
+//! servers exposing a tool with the same name (e.g. `search`)
+//! would produce duplicate `type: "function"` entries, and the
+//! proxy would have no way to dispatch tool-call responses back
+//! to the correct server. Names are sanitized to match the
+//! OpenAI schema (`^[a-zA-Z0-9_-]+$`, max 64 chars) and
+//! truncated when necessary; because truncation is lossy,
+//! [`detect_name_collisions`] runs after building the full tools
+//! array to reject ambiguous results.
 //!
 //! [`ResponsesState`]: super::state::ResponsesState
 
@@ -25,7 +40,11 @@ mod config;
 )]
 mod tests;
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -37,6 +56,10 @@ use tracing::debug;
 use self::config::{McpToolResolveConfig, build_config};
 use super::{error::responses_error_rejection, state::ResponsesState};
 use crate::mcp_client;
+
+/// Maximum length for generated function names per the OpenAI
+/// Responses POST schema (`^[a-zA-Z0-9_-]+$`, max 64 chars).
+const MAX_FUNCTION_NAME_LEN: usize = 64;
 
 // -----------------------------------------------------------------------------
 // McpToolResolveFilter
@@ -96,15 +119,16 @@ impl McpToolResolveFilter {
     }
 
     /// Core resolution: parse MCP entries, check cache, call
-    /// `tools/list`, build `mcp_tool_map`, and rewrite the request
-    /// body to replace `type: "mcp"` entries with `type: "function"`.
+    /// `tools/list`, build `mcp_tool_map`, rewrite the request
+    /// body to replace `type: "mcp"` entries with `type: "function"`,
+    /// and synchronize the rewritten body into `ResponsesState`.
     async fn resolve_mcp_tools(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
-        original_bytes: &[u8],
+        original_bytes: Bytes,
     ) -> Result<FilterAction, ResolveError> {
-        let mcp_entries = extract_mcp_entries(original_bytes);
+        let mcp_entries = extract_mcp_entries(&original_bytes);
         if mcp_entries.is_empty() {
             return Ok(FilterAction::Continue);
         }
@@ -119,40 +143,50 @@ impl McpToolResolveFilter {
 
         let previous_tools = ctx.extensions.get::<ResponsesState>().map(|s| &s.previous_tools);
 
-        let map = self.build_tool_map(&mcp_entries, previous_tools).await?;
+        let resolution = self.resolve_all_entries(&mcp_entries, previous_tools).await?;
 
-        if map.is_empty() {
+        if resolution.tool_map.is_empty() {
             return Ok(FilterAction::Continue);
         }
 
-        debug!(tool_count = map.len(), "mcp_tool_map built");
+        debug!(tool_count = resolution.tool_map.len(), "mcp_tool_map built");
 
-        rewrite_request_body(ctx, body, original_bytes, &map)?;
+        let Resolution { per_entry, tool_map } = resolution;
+        rewrite_request_body(ctx, body, &original_bytes, per_entry, &tool_map)?;
 
-        let body_for_state = body.as_ref().map_or(original_bytes, |b| b.as_ref());
-        write_tool_map(ctx, body_for_state, map);
+        let body_for_state = body.as_ref().map_or_else(|| original_bytes.as_ref(), |b| b.as_ref());
+        write_state(ctx, body_for_state, tool_map);
         Ok(FilterAction::Continue)
     }
 
-    /// Build tool map from all MCP entries, resolving each
-    /// server once and applying per-entry filters.
-    async fn build_tool_map(
+    /// Resolve all MCP entries, building both the global dispatch
+    /// map and pre-built function tools for body rewriting.
+    async fn resolve_all_entries(
         &self,
         entries: &[serde_json::Value],
         previous_tools: Option<&Vec<serde_json::Value>>,
-    ) -> Result<HashMap<(String, String), serde_json::Value>, ResolveError> {
+    ) -> Result<Resolution, ResolveError> {
         let mut tool_map = HashMap::new();
+        let mut per_entry = Vec::with_capacity(entries.len());
         let mut fetched: HashMap<(&str, &str), Vec<serde_json::Value>> = HashMap::new();
 
         for entry in entries {
             let Some(tools) = self.resolve_entry(entry, previous_tools, &mut fetched).await? else {
+                per_entry.push(Vec::new());
                 continue;
             };
             let allowed = extract_allowed_tools(entry);
-            insert_tools(&apply_allowed_tools_filter(tools, &allowed), entry, &mut tool_map);
+            let filtered = apply_allowed_tools_filter(tools, &allowed);
+            let label = server_label(entry);
+            let function_tools: Vec<serde_json::Value> = filtered
+                .iter()
+                .map(|def| mcp_tool_to_function_tool(label, def))
+                .collect();
+            insert_tools(filtered, entry, &mut tool_map);
+            per_entry.push(function_tools);
         }
 
-        Ok(tool_map)
+        Ok(Resolution { per_entry, tool_map })
     }
 
     /// Resolve tools for a single entry, reusing within-request
@@ -223,13 +257,13 @@ impl HttpFilter for McpToolResolveFilter {
             return Ok(FilterAction::Continue);
         }
 
-        let Some(bytes) = body.as_ref().map(|b| b.to_vec()) else {
+        let Some(bytes) = body.as_ref().cloned() else {
             return Ok(FilterAction::Continue);
         };
 
         let streaming = is_streaming(ctx);
 
-        match Box::pin(self.resolve_mcp_tools(ctx, body, &bytes)).await {
+        match Box::pin(self.resolve_mcp_tools(ctx, body, bytes)).await {
             Ok(action) => Ok(action),
             Err(e) => Ok(resolve_error_rejection(&e, streaming)),
         }
@@ -247,6 +281,15 @@ enum ResolveError {
     #[error("{0}")]
     Client(#[from] mcp_client::McpClientError),
 
+    /// Generated function names collide after sanitization or
+    /// truncation.
+    #[error("generated function name collision: \"{0}\" maps to multiple tools")]
+    NameCollision(String),
+
+    /// Failed to serialize the rewritten request body.
+    #[error("failed to serialize rewritten request body: {0}")]
+    Serialization(serde_json::Error),
+
     /// Too many distinct MCP servers in one request.
     #[error("too many MCP servers: {count} exceeds limit of {max}")]
     TooManyServers {
@@ -255,10 +298,15 @@ enum ResolveError {
         /// Configured maximum.
         max: usize,
     },
+}
 
-    /// Failed to serialize the rewritten request body.
-    #[error("failed to serialize rewritten request body: {0}")]
-    Serialization(serde_json::Error),
+/// Result of resolving all MCP entries.
+struct Resolution {
+    /// Pre-built function tools parallel to the input MCP entries.
+    /// Empty vec means the entry was not resolved.
+    per_entry: Vec<Vec<serde_json::Value>>,
+    /// Global dispatch map keyed by `(server_label, tool_name)`.
+    tool_map: HashMap<(String, String), serde_json::Value>,
 }
 
 // -----------------------------------------------------------------------------
@@ -267,31 +315,14 @@ enum ResolveError {
 
 /// Map a [`ResolveError`] to an appropriate rejection response.
 fn resolve_error_rejection(err: &ResolveError, streaming: bool) -> FilterAction {
-    match err {
-        ResolveError::TooManyServers { count, max } => {
-            let msg = format!("too many MCP servers: {count} exceeds limit of {max}");
-            debug!(error = %msg, "openai_mcp_tool_resolve rejected");
-            FilterAction::Reject(responses_error_rejection(400, "invalid_request_error", &msg, streaming))
-        },
-        ResolveError::Client(e) => {
-            debug!(error = %e, "openai_mcp_tool_resolve failed");
-            FilterAction::Reject(responses_error_rejection(
-                502,
-                "server_error",
-                &err.to_string(),
-                streaming,
-            ))
-        },
-        ResolveError::Serialization(e) => {
-            debug!(error = %e, "openai_mcp_tool_resolve serialization failed");
-            FilterAction::Reject(responses_error_rejection(
-                500,
-                "server_error",
-                &err.to_string(),
-                streaming,
-            ))
-        },
-    }
+    let (status, error_type) = match err {
+        ResolveError::TooManyServers { .. } | ResolveError::NameCollision(_) => (400, "invalid_request_error"),
+        ResolveError::Client(_) => (502, "server_error"),
+        ResolveError::Serialization(_) => (500, "server_error"),
+    };
+    let msg = err.to_string();
+    debug!(error = %msg, "openai_mcp_tool_resolve rejected");
+    FilterAction::Reject(responses_error_rejection(status, error_type, &msg, streaming))
 }
 
 /// Return the `server_url` if the entry should be eagerly
@@ -316,7 +347,7 @@ fn resolvable_server_url(entry: &serde_json::Value) -> Option<&str> {
 
 /// Count distinct resolvable `(server_label, server_url)` pairs.
 fn count_distinct_servers(entries: &[serde_json::Value]) -> usize {
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     for entry in entries {
         if let Some(url) = resolvable_server_url(entry) {
             seen.insert((server_label(entry), url));
@@ -349,7 +380,8 @@ async fn fetch_tools(
 }
 
 /// Rewrite the request body, replacing resolved `type: "mcp"`
-/// entries with `type: "function"` entries.
+/// entries with `type: "function"` entries and translating any
+/// MCP `tool_choice` references.
 ///
 /// MCP entries that were not resolved (no `server_url`, deferred,
 /// or `connector_id` only) are left unchanged for upstream to
@@ -358,26 +390,32 @@ fn rewrite_request_body(
     ctx: &mut HttpFilterContext<'_>,
     body: &mut Option<Bytes>,
     original_bytes: &[u8],
+    per_entry: Vec<Vec<serde_json::Value>>,
     tool_map: &HashMap<(String, String), serde_json::Value>,
 ) -> Result<(), ResolveError> {
     let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(original_bytes) else {
         return Ok(());
     };
 
-    let Some(tools) = parsed.get("tools").and_then(serde_json::Value::as_array) else {
+    let Some(obj) = parsed.as_object_mut() else {
         return Ok(());
     };
 
-    let rewritten = rewrite_tools_array(tools, tool_map);
+    let Some(serde_json::Value::Array(tools)) = obj.remove("tools") else {
+        return Ok(());
+    };
+
+    let (rewritten, generated_names) = rewrite_tools_array(tools, per_entry);
 
     if rewritten.is_empty() {
         return Ok(());
     }
 
+    detect_name_collisions(&rewritten, &generated_names)?;
+
     let rewritten_count = rewritten.len();
-    if let Some(obj) = parsed.as_object_mut() {
-        obj.insert("tools".to_owned(), serde_json::Value::Array(rewritten));
-    }
+    obj.insert("tools".to_owned(), serde_json::Value::Array(rewritten));
+    rewrite_tool_choice(obj, tool_map);
 
     let serialized = serde_json::to_vec(&parsed).map_err(|e| {
         debug!(error = %e, "failed to serialize rewritten body");
@@ -387,87 +425,215 @@ fn rewrite_request_body(
     let len = serialized.len();
     *body = Some(Bytes::from(serialized));
     ctx.extra_request_headers
-        .push((std::borrow::Cow::Borrowed("content-length"), len.to_string()));
+        .push((Cow::Borrowed("content-length"), len.to_string()));
 
     debug!(tool_count = rewritten_count, "rewrote MCP tools to function tools");
     Ok(())
 }
 
 /// Rewrite a tools array, replacing resolved MCP entries with
-/// function entries derived from the tool map.
+/// pre-built function tools from `per_entry`.
 fn rewrite_tools_array(
-    tools: &[serde_json::Value],
-    tool_map: &HashMap<(String, String), serde_json::Value>,
-) -> Vec<serde_json::Value> {
+    tools: Vec<serde_json::Value>,
+    per_entry: Vec<Vec<serde_json::Value>>,
+) -> (Vec<serde_json::Value>, HashSet<String>) {
     let mut result = Vec::with_capacity(tools.len());
+    let mut generated_names = HashSet::new();
+    let mut entries = per_entry.into_iter();
 
     for tool in tools {
-        let tool_type = tool.get("type").and_then(serde_json::Value::as_str);
-        if tool_type != Some("mcp") {
-            result.push(tool.clone());
+        if tool.get("type").and_then(serde_json::Value::as_str) != Some("mcp") {
+            result.push(tool);
             continue;
         }
 
-        let label = server_label(tool);
+        let function_tools = entries.next().unwrap_or_default();
 
-        let function_tools = convert_mcp_to_function_tools(label, tool, tool_map);
         if function_tools.is_empty() {
-            result.push(tool.clone());
-        } else {
-            result.extend(function_tools);
+            result.push(tool);
+            continue;
+        }
+
+        for ft in function_tools {
+            if let Some(name) = ft.get("name").and_then(serde_json::Value::as_str) {
+                generated_names.insert(name.to_owned());
+            }
+            result.push(ft);
         }
     }
 
-    result
+    (result, generated_names)
 }
 
-/// Convert an MCP entry into one or more function tool entries.
+/// Detect duplicate function names involving at least one
+/// generated name.
 ///
-/// Returns an empty vec if this MCP entry was not resolved (e.g.,
-/// `connector_id` only, deferred, or no matching tools in the map).
-fn convert_mcp_to_function_tools(
-    label: &str,
-    mcp_entry: &serde_json::Value,
-    tool_map: &HashMap<(String, String), serde_json::Value>,
-) -> Vec<serde_json::Value> {
-    let mut function_tools = Vec::new();
-
-    for ((map_label, tool_name), map_value) in tool_map {
-        if map_label != label {
+/// Client-supplied duplicate functions are the backend's concern.
+/// This only rejects collisions where lossy encoding produced a
+/// generated name that clashes with another tool.
+fn detect_name_collisions(tools: &[serde_json::Value], generated_names: &HashSet<String>) -> Result<(), ResolveError> {
+    let mut seen = HashSet::new();
+    for tool in tools {
+        if tool.get("type").and_then(serde_json::Value::as_str) != Some("function") {
             continue;
         }
+        let Some(name) = tool.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if !seen.insert(name) && generated_names.contains(name) {
+            return Err(ResolveError::NameCollision(name.to_owned()));
+        }
+    }
+    Ok(())
+}
 
-        if let Some(definition) = map_value.get("tool_definition") {
-            let function_tool = mcp_tool_to_function_tool(label, tool_name, definition, mcp_entry);
-            function_tools.push(function_tool);
+/// Rewrite `tool_choice` when it references MCP tools.
+///
+/// Handles three cases:
+///
+/// - **Named MCP**: `{"type":"mcp","server_label":"X","name":"Y"}` → `{"type":"function","name":"X__Y"}`.
+///
+/// - **Server-level MCP**: `{"type":"mcp","server_label":"X"}` →
+///   `{"type":"allowed_tools","mode":"required","tools":[...]}`.
+///
+/// - **MCP selectors in `allowed_tools`**: expands each MCP selector to its generated function equivalents.
+fn rewrite_tool_choice(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) {
+    let Some(serde_json::Value::Object(choice_obj)) = obj.get("tool_choice").cloned() else {
+        return;
+    };
+    let choice_type = choice_obj.get("type").and_then(serde_json::Value::as_str);
+
+    match choice_type {
+        Some("mcp") => rewrite_mcp_tool_choice(obj, &choice_obj, tool_map),
+        Some("allowed_tools") => rewrite_allowed_tools_choice(obj, &choice_obj, tool_map),
+        _ => {},
+    }
+}
+
+/// Rewrite an MCP-typed `tool_choice` to its function equivalent.
+fn rewrite_mcp_tool_choice(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    choice_obj: &serde_json::Map<String, serde_json::Value>,
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) {
+    let label = choice_obj
+        .get("server_label")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+
+    if let Some(name) = choice_obj.get("name").and_then(serde_json::Value::as_str) {
+        if tool_map.contains_key(&(label.to_owned(), name.to_owned())) {
+            let function_name = encode_function_name(label, name);
+            obj.insert(
+                "tool_choice".to_owned(),
+                serde_json::json!({"type": "function", "name": function_name}),
+            );
+        }
+        return;
+    }
+
+    let function_refs = collect_function_refs_for_label(label, tool_map);
+    if !function_refs.is_empty() {
+        obj.insert(
+            "tool_choice".to_owned(),
+            serde_json::json!({"type": "allowed_tools", "mode": "required", "tools": function_refs}),
+        );
+    }
+}
+
+/// Rewrite MCP selectors inside an `allowed_tools`-typed
+/// `tool_choice`.
+fn rewrite_allowed_tools_choice(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    choice_obj: &serde_json::Map<String, serde_json::Value>,
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) {
+    let Some(tools_arr) = choice_obj.get("tools").and_then(serde_json::Value::as_array) else {
+        return;
+    };
+
+    let mut new_tools = Vec::with_capacity(tools_arr.len());
+    let mut changed = false;
+
+    for tool_ref in tools_arr {
+        if tool_ref.get("type").and_then(serde_json::Value::as_str) != Some("mcp") {
+            new_tools.push(tool_ref.clone());
+            continue;
+        }
+        let before = new_tools.len();
+        expand_mcp_selector(tool_ref, tool_map, &mut new_tools);
+        if new_tools.len() > before {
+            changed = true;
+        } else {
+            new_tools.push(tool_ref.clone());
         }
     }
 
-    function_tools
+    if changed {
+        let mut new_choice = choice_obj.clone();
+        new_choice.insert("tools".to_owned(), serde_json::Value::Array(new_tools));
+        obj.insert("tool_choice".to_owned(), serde_json::Value::Object(new_choice));
+    }
+}
+
+/// Expand a single MCP selector into function tool references.
+fn expand_mcp_selector(
+    selector: &serde_json::Value,
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+    out: &mut Vec<serde_json::Value>,
+) {
+    let label = selector
+        .get("server_label")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+
+    if let Some(name) = selector.get("name").and_then(serde_json::Value::as_str) {
+        if tool_map.contains_key(&(label.to_owned(), name.to_owned())) {
+            out.push(serde_json::json!({"type": "function", "name": encode_function_name(label, name)}));
+        }
+    } else {
+        out.extend(collect_function_refs_for_label(label, tool_map));
+    }
+}
+
+/// Collect `{"type":"function","name":"..."}` refs for all tools
+/// belonging to a given server label.
+fn collect_function_refs_for_label(
+    label: &str,
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    tool_map
+        .keys()
+        .filter(|(l, _)| l == label)
+        .map(|(l, n)| serde_json::json!({"type": "function", "name": encode_function_name(l, n)}))
+        .collect()
 }
 
 /// Convert a single MCP tool definition to a Responses API
 /// function tool.
 ///
-/// The tool name is prefixed with `{server_label}__` to ensure
-/// uniqueness across MCP servers and enable dispatch routing.
-fn mcp_tool_to_function_tool(
-    label: &str,
-    tool_name: &str,
-    definition: &serde_json::Value,
-    _mcp_entry: &serde_json::Value,
-) -> serde_json::Value {
-    let prefixed_name = format!("{label}__{tool_name}");
+/// The tool name is encoded as a bounded, schema-valid identifier
+/// via [`encode_function_name`].
+fn mcp_tool_to_function_tool(label: &str, definition: &serde_json::Value) -> serde_json::Value {
+    let tool_name = definition
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let encoded_name = encode_function_name(label, tool_name);
 
     let description = definition.get("description").cloned();
     let parameters = definition
         .get("inputSchema")
+        .or_else(|| definition.get("input_schema"))
         .cloned()
         .unwrap_or_else(|| serde_json::json!({"type": "object"}));
 
     let mut obj = serde_json::Map::new();
     obj.insert("type".to_owned(), serde_json::json!("function"));
-    obj.insert("name".to_owned(), serde_json::json!(prefixed_name));
+    obj.insert("name".to_owned(), serde_json::json!(encoded_name));
     if let Some(desc) = description {
         obj.insert("description".to_owned(), desc);
     }
@@ -476,11 +642,63 @@ fn mcp_tool_to_function_tool(
     serde_json::Value::Object(obj)
 }
 
-/// Write the resolved tool map to `ResponsesState`, creating
-/// the state from the request body if none exists yet.
-fn write_tool_map(ctx: &mut HttpFilterContext<'_>, body: &[u8], map: HashMap<(String, String), serde_json::Value>) {
+/// Encode `(label, tool_name)` into a bounded, schema-valid
+/// function name matching `^[a-zA-Z0-9_-]+$` with max 64 chars.
+///
+/// The `{label}__{tool_name}` prefix is required for dispatch:
+/// the backend has no concept of MCP servers, so the proxy must
+/// embed the server identity in the function name to route
+/// tool-call responses back to the correct upstream server.
+///
+/// Replaces invalid characters with `_` and truncates to fit
+/// within [`MAX_FUNCTION_NAME_LEN`]. Lossy: distinct inputs can
+/// produce the same output. Use [`detect_name_collisions`] after
+/// building the full tools array to catch this.
+fn encode_function_name(label: &str, tool_name: &str) -> String {
+    let raw = format!("{label}__{tool_name}");
+    let sanitized: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.len() <= MAX_FUNCTION_NAME_LEN {
+        sanitized
+    } else {
+        sanitized.chars().take(MAX_FUNCTION_NAME_LEN).collect()
+    }
+}
+
+/// Write the resolved tool map and rewritten body to
+/// `ResponsesState`, creating the state from the body if none
+/// exists yet.
+///
+/// When a state already exists (e.g. from rehydration),
+/// synchronizes `request_body`, `tools`, and `tool_choice` so
+/// downstream filters (`openai_responses_proxy`) use the
+/// rewritten body.
+///
+/// Skips state creation when the body carries
+/// `previous_response_id` to avoid the downstream rebuild
+/// path in `openai_responses_proxy` which would strip it.
+fn write_state(ctx: &mut HttpFilterContext<'_>, body: &[u8], map: HashMap<(String, String), serde_json::Value>) {
     if let Some(state) = ctx.extensions.get_mut::<ResponsesState>() {
         state.mcp_tool_map = map;
+        if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body) {
+            state.tools = parsed
+                .get("tools")
+                .and_then(serde_json::Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(tc) = parsed.get("tool_choice") {
+                state.tool_choice = tc.clone();
+            }
+            state.request_body = parsed;
+        }
     } else if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body) {
         let mut state = ResponsesState::from_request_body(parsed);
         state.mcp_tool_map = map;
@@ -691,9 +909,9 @@ fn tool_read_only_hint(tool: &serde_json::Value) -> bool {
 }
 
 /// Insert resolved tools into the tool map keyed by
-/// `(server_label, tool_name)`.
+/// `(server_label, tool_name)`, consuming the definitions.
 fn insert_tools(
-    tools: &[serde_json::Value],
+    tools: Vec<serde_json::Value>,
     entry: &serde_json::Value,
     tool_map: &mut HashMap<(String, String), serde_json::Value>,
 ) {
@@ -702,16 +920,17 @@ fn insert_tools(
         .get("server_url")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
-    let headers = entry.get("headers");
-    let authorization = entry.get("authorization");
-    let require_approval = entry.get("require_approval");
+    let headers = entry.get("headers").cloned();
+    let authorization = entry.get("authorization").cloned();
+    let require_approval = entry.get("require_approval").cloned();
 
     for tool in tools {
-        let Some(tool_name) = tool.get("name").and_then(serde_json::Value::as_str) else {
+        let tool_name = tool.get("name").and_then(serde_json::Value::as_str).map(str::to_owned);
+        let Some(tool_name) = tool_name else {
             continue;
         };
 
-        let key = (label.to_owned(), tool_name.to_owned());
+        let key = (label.to_owned(), tool_name);
         tool_map.insert(
             key,
             serde_json::json!({

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -96,13 +96,15 @@ impl McpToolResolveFilter {
     }
 
     /// Core resolution: parse MCP entries, check cache, call
-    /// `tools/list`, build `mcp_tool_map`.
+    /// `tools/list`, build `mcp_tool_map`, and rewrite the request
+    /// body to replace `type: "mcp"` entries with `type: "function"`.
     async fn resolve_mcp_tools(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        body: &[u8],
+        body: &mut Option<Bytes>,
+        original_bytes: &[u8],
     ) -> Result<FilterAction, ResolveError> {
-        let mcp_entries = extract_mcp_entries(body);
+        let mcp_entries = extract_mcp_entries(original_bytes);
         if mcp_entries.is_empty() {
             return Ok(FilterAction::Continue);
         }
@@ -124,7 +126,11 @@ impl McpToolResolveFilter {
         }
 
         debug!(tool_count = map.len(), "mcp_tool_map built");
-        write_tool_map(ctx, body, map);
+
+        rewrite_request_body(ctx, body, original_bytes, &map)?;
+
+        let body_for_state = body.as_ref().map_or(original_bytes, |b| b.as_ref());
+        write_tool_map(ctx, body_for_state, map);
         Ok(FilterAction::Continue)
     }
 
@@ -190,7 +196,7 @@ impl HttpFilter for McpToolResolveFilter {
     }
 
     fn request_body_access(&self) -> BodyAccess {
-        BodyAccess::ReadOnly
+        BodyAccess::ReadWrite
     }
 
     fn request_body_mode(&self) -> BodyMode {
@@ -217,13 +223,13 @@ impl HttpFilter for McpToolResolveFilter {
             return Ok(FilterAction::Continue);
         }
 
-        let Some(bytes) = body.as_ref() else {
+        let Some(bytes) = body.as_ref().map(|b| b.to_vec()) else {
             return Ok(FilterAction::Continue);
         };
 
         let streaming = is_streaming(ctx);
 
-        match Box::pin(self.resolve_mcp_tools(ctx, bytes)).await {
+        match Box::pin(self.resolve_mcp_tools(ctx, body, &bytes)).await {
             Ok(action) => Ok(action),
             Err(e) => Ok(resolve_error_rejection(&e, streaming)),
         }
@@ -249,6 +255,10 @@ enum ResolveError {
         /// Configured maximum.
         max: usize,
     },
+
+    /// Failed to serialize the rewritten request body.
+    #[error("failed to serialize rewritten request body: {0}")]
+    Serialization(serde_json::Error),
 }
 
 // -----------------------------------------------------------------------------
@@ -267,6 +277,15 @@ fn resolve_error_rejection(err: &ResolveError, streaming: bool) -> FilterAction 
             debug!(error = %e, "openai_mcp_tool_resolve failed");
             FilterAction::Reject(responses_error_rejection(
                 502,
+                "server_error",
+                &err.to_string(),
+                streaming,
+            ))
+        },
+        ResolveError::Serialization(e) => {
+            debug!(error = %e, "openai_mcp_tool_resolve serialization failed");
+            FilterAction::Reject(responses_error_rejection(
+                500,
                 "server_error",
                 &err.to_string(),
                 streaming,
@@ -327,6 +346,134 @@ async fn fetch_tools(
     )
     .await
     .map_err(ResolveError::Client)
+}
+
+/// Rewrite the request body, replacing resolved `type: "mcp"`
+/// entries with `type: "function"` entries.
+///
+/// MCP entries that were not resolved (no `server_url`, deferred,
+/// or `connector_id` only) are left unchanged for upstream to
+/// handle.
+fn rewrite_request_body(
+    ctx: &mut HttpFilterContext<'_>,
+    body: &mut Option<Bytes>,
+    original_bytes: &[u8],
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) -> Result<(), ResolveError> {
+    let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(original_bytes) else {
+        return Ok(());
+    };
+
+    let Some(tools) = parsed.get("tools").and_then(serde_json::Value::as_array) else {
+        return Ok(());
+    };
+
+    let rewritten = rewrite_tools_array(tools, tool_map);
+
+    if rewritten.is_empty() {
+        return Ok(());
+    }
+
+    let rewritten_count = rewritten.len();
+    if let Some(obj) = parsed.as_object_mut() {
+        obj.insert("tools".to_owned(), serde_json::Value::Array(rewritten));
+    }
+
+    let serialized = serde_json::to_vec(&parsed).map_err(|e| {
+        debug!(error = %e, "failed to serialize rewritten body");
+        ResolveError::Serialization(e)
+    })?;
+
+    let len = serialized.len();
+    *body = Some(Bytes::from(serialized));
+    ctx.extra_request_headers
+        .push((std::borrow::Cow::Borrowed("content-length"), len.to_string()));
+
+    debug!(tool_count = rewritten_count, "rewrote MCP tools to function tools");
+    Ok(())
+}
+
+/// Rewrite a tools array, replacing resolved MCP entries with
+/// function entries derived from the tool map.
+fn rewrite_tools_array(
+    tools: &[serde_json::Value],
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let mut result = Vec::with_capacity(tools.len());
+
+    for tool in tools {
+        let tool_type = tool.get("type").and_then(serde_json::Value::as_str);
+        if tool_type != Some("mcp") {
+            result.push(tool.clone());
+            continue;
+        }
+
+        let label = server_label(tool);
+
+        let function_tools = convert_mcp_to_function_tools(label, tool, tool_map);
+        if function_tools.is_empty() {
+            result.push(tool.clone());
+        } else {
+            result.extend(function_tools);
+        }
+    }
+
+    result
+}
+
+/// Convert an MCP entry into one or more function tool entries.
+///
+/// Returns an empty vec if this MCP entry was not resolved (e.g.,
+/// `connector_id` only, deferred, or no matching tools in the map).
+fn convert_mcp_to_function_tools(
+    label: &str,
+    mcp_entry: &serde_json::Value,
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let mut function_tools = Vec::new();
+
+    for ((map_label, tool_name), map_value) in tool_map {
+        if map_label != label {
+            continue;
+        }
+
+        if let Some(definition) = map_value.get("tool_definition") {
+            let function_tool = mcp_tool_to_function_tool(label, tool_name, definition, mcp_entry);
+            function_tools.push(function_tool);
+        }
+    }
+
+    function_tools
+}
+
+/// Convert a single MCP tool definition to a Responses API
+/// function tool.
+///
+/// The tool name is prefixed with `{server_label}__` to ensure
+/// uniqueness across MCP servers and enable dispatch routing.
+fn mcp_tool_to_function_tool(
+    label: &str,
+    tool_name: &str,
+    definition: &serde_json::Value,
+    _mcp_entry: &serde_json::Value,
+) -> serde_json::Value {
+    let prefixed_name = format!("{label}__{tool_name}");
+
+    let description = definition.get("description").cloned();
+    let parameters = definition
+        .get("inputSchema")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({"type": "object"}));
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("type".to_owned(), serde_json::json!("function"));
+    obj.insert("name".to_owned(), serde_json::json!(prefixed_name));
+    if let Some(desc) = description {
+        obj.insert("description".to_owned(), desc);
+    }
+    obj.insert("parameters".to_owned(), parameters);
+
+    serde_json::Value::Object(obj)
 }
 
 /// Write the resolved tool map to `ResponsesState`, creating

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -341,6 +341,7 @@ fn filter_writable_only_excludes_read_only_tools() {
 // Pipeline Regression: no spurious ResponsesState creation
 // =========================================================================
 
+/// Build a minimal MCP request body targeting `server_url`.
 fn mcp_body(server_url: &str) -> serde_json::Value {
     serde_json::json!({
         "model": "gpt-4o", "input": "test",
@@ -497,10 +498,10 @@ async fn defer_loading_true_skips_eager_resolution() {
     );
 }
 
-/// `write_tool_map` creates `ResponsesState` from body when none
+/// `write_state` creates `ResponsesState` from body when none
 /// exists, preserving `request_body` and populating `mcp_tool_map`.
 #[test]
-fn write_tool_map_creates_state_when_missing() {
+fn write_state_creates_state_when_missing() {
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let body_json = mcp_body("http://10.0.0.5/mcp");
@@ -511,7 +512,7 @@ fn write_tool_map_creates_state_when_missing() {
         ("weather".to_owned(), "get_weather".to_owned()),
         serde_json::json!({"tool": true}),
     );
-    write_tool_map(&mut ctx, &body_bytes, map);
+    write_state(&mut ctx, &body_bytes, map);
 
     let state = ctx.extensions.get::<ResponsesState>().expect("state should be created");
     assert!(
@@ -527,9 +528,9 @@ fn write_tool_map_creates_state_when_missing() {
     assert!(!state.request_body.is_null(), "request_body must not be null");
 }
 
-/// `write_tool_map` updates existing state without replacing it.
+/// `write_state` updates existing state without replacing it.
 #[test]
-fn write_tool_map_updates_existing_state() {
+fn write_state_updates_existing_state() {
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let body_json = mcp_body("http://10.0.0.5/mcp");
@@ -544,7 +545,7 @@ fn write_tool_map_updates_existing_state() {
         ("weather".to_owned(), "get_weather".to_owned()),
         serde_json::json!({"tool": true}),
     );
-    write_tool_map(&mut ctx, &body_bytes, map);
+    write_state(&mut ctx, &body_bytes, map);
 
     let state = ctx.extensions.get::<ResponsesState>().expect("state should exist");
     assert!(
@@ -711,10 +712,10 @@ fn duplicate_tool_name_across_servers_accepted() {
     let mut tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
 
     let entry_a = serde_json::json!({"server_label": "server_a", "server_url": "http://10.0.0.1/mcp"});
-    insert_tools(&tools, &entry_a, &mut tool_map);
+    insert_tools(tools.clone(), &entry_a, &mut tool_map);
 
     let entry_b = serde_json::json!({"server_label": "server_b", "server_url": "http://10.0.0.2/mcp"});
-    insert_tools(&tools, &entry_b, &mut tool_map);
+    insert_tools(tools, &entry_b, &mut tool_map);
 
     assert_eq!(
         tool_map.len(),
@@ -779,7 +780,7 @@ fn insert_tools_preserves_authorization_and_require_approval() {
         "headers": {"x-custom": "val"}
     });
     let mut tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
-    insert_tools(&tools, &entry, &mut tool_map);
+    insert_tools(tools, &entry, &mut tool_map);
 
     let val = &tool_map[&("db".to_owned(), "run_query".to_owned())];
     assert_eq!(
@@ -858,13 +859,15 @@ fn count_distinct_servers_excludes_connector_and_deferred() {
     );
 }
 
+/// Apply `allowed_tools` filtering and insert results into the
+/// tool map — mirrors the per-entry flow in `resolve_all_entries`.
 fn filter_and_insert(
     tools: Vec<serde_json::Value>,
     entry: &serde_json::Value,
     tool_map: &mut HashMap<(String, String), serde_json::Value>,
 ) {
     let allowed = extract_allowed_tools(entry);
-    insert_tools(&apply_allowed_tools_filter(tools, &allowed), entry, tool_map);
+    insert_tools(apply_allowed_tools_filter(tools, &allowed), entry, tool_map);
 }
 
 #[test]
@@ -981,7 +984,7 @@ async fn deferred_entries_not_counted_against_max_servers() {
 // =========================================================================
 
 #[test]
-fn write_tool_map_creates_state_with_previous_response_id() {
+fn write_state_skips_state_creation_with_previous_response_id() {
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let body_json = serde_json::json!({
@@ -996,7 +999,7 @@ fn write_tool_map_creates_state_with_previous_response_id() {
         ("w".to_owned(), "get_weather".to_owned()),
         serde_json::json!({"tool": true}),
     );
-    write_tool_map(&mut ctx, &body_bytes, map);
+    write_state(&mut ctx, &body_bytes, map);
 
     let state = ctx
         .extensions
@@ -1009,6 +1012,7 @@ fn write_tool_map_creates_state_with_previous_response_id() {
 // Body Rewrite: MCP to Function
 // =========================================================================
 
+/// Build a tool map with a single `(weather, get_weather)` entry.
 fn weather_tool_map() -> HashMap<(String, String), serde_json::Value> {
     let mut map = HashMap::new();
     map.insert(
@@ -1025,22 +1029,68 @@ fn weather_tool_map() -> HashMap<(String, String), serde_json::Value> {
     map
 }
 
+/// Build a [`Resolution`] from raw MCP definitions, pre-building
+/// function tools for `per_entry` and dispatch entries for
+/// `tool_map`, using `"weather"` as the server label.
+fn make_resolution(raw_per_entry: &[Vec<serde_json::Value>]) -> Resolution {
+    let label = "weather";
+    let mut tool_map = HashMap::new();
+    let mut per_entry = Vec::new();
+    for raw_tools in raw_per_entry {
+        let function_tools: Vec<serde_json::Value> = raw_tools
+            .iter()
+            .map(|def| mcp_tool_to_function_tool(label, def))
+            .collect();
+        for tool in raw_tools {
+            let name = tool
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
+            tool_map.insert(
+                (label.to_owned(), name.to_owned()),
+                serde_json::json!({"server_label": label, "tool_definition": tool}),
+            );
+        }
+        per_entry.push(function_tools);
+    }
+    Resolution { per_entry, tool_map }
+}
+
+/// Pre-built function tools in `per_entry` are moved into the
+/// rewritten array; non-MCP tools pass through unchanged.
 #[test]
 fn rewrite_tools_array_converts_mcp_to_function() {
     let tools = vec![
         serde_json::json!({"type": "function", "name": "calc"}),
         serde_json::json!({"type": "mcp", "server_label": "weather"}),
     ];
-    let rewritten = rewrite_tools_array(&tools, &weather_tool_map());
+    let raw = vec![vec![serde_json::json!({
+        "name": "get_weather",
+        "description": "Get current weather",
+        "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}}
+    })]];
+    let resolution = make_resolution(&raw);
+    let (rewritten, generated) = rewrite_tools_array(tools, resolution.per_entry);
 
     assert_eq!(rewritten.len(), 2, "should have 2 tools");
     assert_eq!(rewritten[0]["name"], "calc", "first tool unchanged");
     assert_eq!(rewritten[1]["type"], "function", "MCP converted to function");
     assert_eq!(rewritten[1]["name"], "weather__get_weather", "prefixed name");
-    assert_eq!(rewritten[1]["description"], "Get current weather");
-    assert!(rewritten[1]["parameters"]["properties"]["city"].is_object());
+    assert_eq!(
+        rewritten[1]["description"], "Get current weather",
+        "description preserved from MCP definition"
+    );
+    assert!(
+        rewritten[1]["parameters"]["properties"]["city"].is_object(),
+        "inputSchema mapped to parameters"
+    );
+    assert!(
+        generated.contains("weather__get_weather"),
+        "generated names should track rewritten tools"
+    );
 }
 
+/// Unresolved MCP entries (empty `per_entry`) are left unchanged.
 #[test]
 fn rewrite_tools_array_preserves_unresolved_mcp() {
     let tools = vec![serde_json::json!({
@@ -1049,56 +1099,589 @@ fn rewrite_tools_array_preserves_unresolved_mcp() {
         "server_url": "http://10.0.0.99/mcp"
     })];
 
-    let tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
-    let rewritten = rewrite_tools_array(&tools, &tool_map);
+    let (rewritten, generated) = rewrite_tools_array(tools, vec![Vec::new()]);
 
     assert_eq!(rewritten.len(), 1, "should preserve unresolved entry");
     assert_eq!(rewritten[0]["type"], "mcp", "unresolved MCP left unchanged");
+    assert!(generated.is_empty(), "no generated names for unresolved");
 }
 
+/// Missing `inputSchema` defaults to `{"type":"object"}`.
 #[test]
 fn mcp_tool_to_function_tool_adds_default_parameters() {
     let definition = serde_json::json!({"name": "simple_tool", "description": "Does something"});
 
-    let function_tool = mcp_tool_to_function_tool("srv", "simple_tool", &definition, &serde_json::json!({}));
+    let function_tool = mcp_tool_to_function_tool("srv", &definition);
 
-    assert_eq!(function_tool["type"], "function");
-    assert_eq!(function_tool["name"], "srv__simple_tool");
-    assert_eq!(function_tool["description"], "Does something");
+    assert_eq!(function_tool["type"], "function", "type set to function");
+    assert_eq!(
+        function_tool["name"], "srv__simple_tool",
+        "name encoded with label prefix"
+    );
+    assert_eq!(function_tool["description"], "Does something", "description preserved");
     assert_eq!(
         function_tool["parameters"]["type"], "object",
         "default parameters when inputSchema absent"
     );
 }
 
+/// A single MCP entry resolving to multiple tools expands into
+/// multiple function tools in the output.
 #[test]
-fn rewrite_tools_array_expands_multiple_tools_from_one_server() {
+fn rewrite_tools_array_expands_multiple_tools() {
     let tools = vec![serde_json::json!({
         "type": "mcp",
         "server_label": "math",
         "server_url": "http://10.0.0.5/mcp"
     })];
 
-    let mut tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
-    tool_map.insert(
-        ("math".to_owned(), "add".to_owned()),
-        serde_json::json!({
-            "server_label": "math",
-            "tool_definition": {"name": "add", "description": "Add numbers"}
-        }),
-    );
-    tool_map.insert(
-        ("math".to_owned(), "subtract".to_owned()),
-        serde_json::json!({
-            "server_label": "math",
-            "tool_definition": {"name": "subtract", "description": "Subtract numbers"}
-        }),
-    );
+    let per_entry = vec![vec![
+        mcp_tool_to_function_tool(
+            "math",
+            &serde_json::json!({"name": "add", "description": "Add numbers"}),
+        ),
+        mcp_tool_to_function_tool(
+            "math",
+            &serde_json::json!({"name": "subtract", "description": "Subtract numbers"}),
+        ),
+    ]];
 
-    let rewritten = rewrite_tools_array(&tools, &tool_map);
+    let (rewritten, generated) = rewrite_tools_array(tools, per_entry);
 
     assert_eq!(rewritten.len(), 2, "one MCP entry expands to multiple function tools");
     let names: Vec<&str> = rewritten.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(names.contains(&"math__add"), "should have add tool");
     assert!(names.contains(&"math__subtract"), "should have subtract tool");
+    assert_eq!(generated.len(), 2, "both names tracked as generated");
+}
+
+// =========================================================================
+// Body Rewrite: input_schema fallback (cached tool format)
+// =========================================================================
+
+/// Falls back to `input_schema` when `inputSchema` is absent
+/// (cached API listing format).
+#[test]
+fn mcp_tool_to_function_tool_reads_input_schema_snake_case() {
+    let definition = serde_json::json!({
+        "name": "cached_tool",
+        "description": "Cached from API",
+        "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+    });
+
+    let function_tool = mcp_tool_to_function_tool("srv", &definition);
+
+    assert_eq!(function_tool["type"], "function", "type set to function");
+    assert_eq!(function_tool["name"], "srv__cached_tool", "name encoded");
+    assert_eq!(
+        function_tool["parameters"]["properties"]["q"]["type"], "string",
+        "should read input_schema when inputSchema is absent"
+    );
+}
+
+/// `inputSchema` takes precedence over `input_schema` when both
+/// fields are present.
+#[test]
+fn mcp_tool_to_function_tool_prefers_input_schema_camel_case() {
+    let definition = serde_json::json!({
+        "name": "both_schemas",
+        "inputSchema": {"type": "object", "properties": {"a": {"type": "string"}}},
+        "input_schema": {"type": "object", "properties": {"b": {"type": "string"}}}
+    });
+
+    let function_tool = mcp_tool_to_function_tool("srv", &definition);
+
+    assert!(
+        function_tool["parameters"]["properties"]["a"].is_object(),
+        "inputSchema (camelCase) should take precedence"
+    );
+}
+
+// =========================================================================
+// Function Name Encoding
+// =========================================================================
+
+/// Invalid characters (dots, slashes) are replaced with
+/// underscores to satisfy the `^[a-zA-Z0-9_-]+$` schema.
+#[test]
+fn encode_function_name_sanitizes_invalid_chars() {
+    let name = encode_function_name("my.server", "get/weather");
+    assert_eq!(name, "my_server__get_weather", "dots and slashes replaced with _");
+}
+
+/// Combined label + tool name exceeding 64 characters is truncated
+/// to the `MAX_FUNCTION_NAME_LEN` limit.
+#[test]
+fn encode_function_name_truncates_long_names() {
+    let long_label = "a".repeat(40);
+    let long_tool = "b".repeat(40);
+    let name = encode_function_name(&long_label, &long_tool);
+    assert!(
+        name.len() <= MAX_FUNCTION_NAME_LEN,
+        "name should be truncated to {} chars, got {}",
+        MAX_FUNCTION_NAME_LEN,
+        name.len()
+    );
+}
+
+/// Alphanumeric characters, hyphens, and underscores pass through
+/// without sanitization.
+#[test]
+fn encode_function_name_preserves_valid_chars() {
+    let name = encode_function_name("label-1", "tool_2");
+    assert_eq!(name, "label-1__tool_2", "valid chars preserved");
+}
+
+// =========================================================================
+// tool_choice Rewrite
+// =========================================================================
+
+/// Named MCP `tool_choice` is translated to a function-typed
+/// choice with the encoded name.
+#[test]
+fn rewrite_tool_choice_translates_mcp_to_function() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "weather", "name": "get_weather"}),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let choice = &obj["tool_choice"];
+    assert_eq!(choice["type"], "function", "type rewritten to function");
+    assert_eq!(choice["name"], "weather__get_weather", "name encoded");
+}
+
+/// Non-object `tool_choice` values (like `"auto"`) are left
+/// unchanged.
+#[test]
+fn rewrite_tool_choice_ignores_non_mcp() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert("tool_choice".to_owned(), serde_json::json!("auto"));
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    assert_eq!(obj["tool_choice"], "auto", "non-MCP tool_choice unchanged");
+}
+
+/// Missing `tool_choice` field is a no-op.
+#[test]
+fn rewrite_tool_choice_ignores_missing() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    assert!(obj.get("tool_choice").is_none(), "no tool_choice inserted");
+}
+
+/// Named MCP `tool_choice` referencing a tool not in `tool_map`
+/// is left unchanged.
+#[test]
+fn rewrite_tool_choice_skips_unknown_mcp_tool() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "weather", "name": "nonexistent"}),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    assert_eq!(
+        obj["tool_choice"]["type"], "mcp",
+        "unknown MCP tool_choice left unchanged"
+    );
+}
+
+// =========================================================================
+// State Sync: write_state synchronizes request_body and tools
+// =========================================================================
+
+/// Build a rewritten body with function tools and `tool_choice`
+/// already translated from MCP form.
+fn rewritten_body_json() -> serde_json::Value {
+    serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [{"type": "function", "name": "weather__get_weather", "parameters": {"type": "object"}}],
+        "tool_choice": {"type": "function", "name": "weather__get_weather"}
+    })
+}
+
+/// `write_state` synchronizes `request_body`, `tools`, and
+/// `tool_choice` on an existing `ResponsesState`.
+#[test]
+fn write_state_syncs_request_body_and_tools_on_existing_state() {
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let original_body = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [{"type": "mcp", "server_label": "weather"}],
+        "tool_choice": {"type": "mcp", "server_label": "weather", "name": "get_weather"}
+    });
+    ctx.extensions.insert(ResponsesState::from_request_body(original_body));
+
+    let body_bytes = serde_json::to_vec(&rewritten_body_json()).unwrap();
+    write_state(&mut ctx, &body_bytes, weather_tool_map());
+
+    let state = ctx.extensions.get::<ResponsesState>().expect("state should exist");
+    assert_eq!(state.tools.len(), 1, "tools synced from rewritten body");
+    assert_eq!(state.tools[0]["type"], "function", "synced tool is function type");
+    assert_eq!(state.tool_choice["type"], "function", "tool_choice synced");
+    assert_eq!(
+        state.request_body["tools"][0]["type"], "function",
+        "request_body rewritten"
+    );
+}
+
+// =========================================================================
+// Per-entry expansion respects allowed_tools
+// =========================================================================
+
+/// Per-entry `per_entry` lists are consumed independently,
+/// respecting per-entry `allowed_tools` filtering.
+#[test]
+fn rewrite_per_entry_respects_allowed_tools_filter() {
+    let tools = vec![
+        serde_json::json!({"type": "mcp", "server_label": "s", "allowed_tools": ["tool_a"]}),
+        serde_json::json!({"type": "mcp", "server_label": "s", "allowed_tools": ["tool_b"]}),
+    ];
+
+    let per_entry = vec![
+        vec![mcp_tool_to_function_tool(
+            "s",
+            &serde_json::json!({"name": "tool_a", "description": "A"}),
+        )],
+        vec![mcp_tool_to_function_tool(
+            "s",
+            &serde_json::json!({"name": "tool_b", "description": "B"}),
+        )],
+    ];
+
+    let (rewritten, _) = rewrite_tools_array(tools, per_entry);
+
+    assert_eq!(rewritten.len(), 2, "each entry expands independently");
+    assert_eq!(rewritten[0]["name"], "s__tool_a", "first entry only has tool_a");
+    assert_eq!(rewritten[1]["name"], "s__tool_b", "second entry only has tool_b");
+}
+
+// =========================================================================
+// Server-level MCP tool_choice → allowed_tools
+// =========================================================================
+
+/// Server-level MCP `tool_choice` `{"type":"mcp","server_label":"X"}`
+/// (without `name`) rewrites to an `allowed_tools` form scoped to
+/// that server's generated functions.
+#[test]
+fn rewrite_tool_choice_server_level_becomes_allowed_tools() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "weather"}),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let choice = &obj["tool_choice"];
+    assert_eq!(
+        choice["type"], "allowed_tools",
+        "server-level MCP tool_choice should become allowed_tools"
+    );
+    assert_eq!(choice["mode"], "required", "mode should be required");
+    let tool_refs = choice["tools"].as_array().expect("tools should be array");
+    assert!(
+        tool_refs.iter().all(|t| t["type"] == "function"),
+        "all entries should be function type"
+    );
+    assert!(
+        tool_refs.iter().any(|t| t["name"] == "weather__get_weather"),
+        "should include weather server's function"
+    );
+}
+
+/// Server-level MCP `tool_choice` for an unknown server is left
+/// unchanged when no tools from that server exist.
+#[test]
+fn rewrite_tool_choice_server_level_unknown_label_unchanged() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "nonexistent"}),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    assert_eq!(
+        obj["tool_choice"]["type"], "mcp",
+        "unknown server-level MCP tool_choice left unchanged"
+    );
+}
+
+// =========================================================================
+// MCP selectors inside allowed_tools tool_choice
+// =========================================================================
+
+/// MCP selectors inside an `allowed_tools` `tool_choice` are
+/// expanded to their generated function equivalents.
+#[test]
+fn rewrite_tool_choice_expands_mcp_selectors_in_allowed_tools() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [
+                {"type": "mcp", "server_label": "weather"},
+                {"type": "function", "name": "calc"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let choice = &obj["tool_choice"];
+    assert_eq!(choice["type"], "allowed_tools", "type preserved");
+    assert_eq!(choice["mode"], "auto", "mode preserved");
+    let tool_refs = choice["tools"].as_array().expect("tools should be array");
+    let names: Vec<&str> = tool_refs.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"calc"), "non-MCP selector preserved");
+    assert!(
+        names.contains(&"weather__get_weather"),
+        "MCP selector expanded to function"
+    );
+}
+
+/// Named MCP selectors inside `allowed_tools` are translated to
+/// their specific function equivalent.
+#[test]
+fn rewrite_tool_choice_translates_named_mcp_selector_in_allowed_tools() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [
+                {"type": "mcp", "server_label": "weather", "name": "get_weather"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
+    assert_eq!(tool_refs.len(), 1, "one selector → one function ref");
+    assert_eq!(tool_refs[0]["type"], "function", "translated to function");
+    assert_eq!(tool_refs[0]["name"], "weather__get_weather", "name encoded");
+}
+
+/// `allowed_tools` `tool_choice` without MCP selectors is left
+/// unchanged.
+#[test]
+fn rewrite_tool_choice_allowed_tools_without_mcp_unchanged() {
+    let tool_map = weather_tool_map();
+    let original = serde_json::json!({
+        "type": "allowed_tools",
+        "mode": "auto",
+        "tools": [{"type": "function", "name": "calc"}]
+    });
+    let mut obj = serde_json::Map::new();
+    obj.insert("tool_choice".to_owned(), original.clone());
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    assert_eq!(obj["tool_choice"], original, "no MCP selectors → unchanged");
+}
+
+/// An unresolved named MCP selector inside `allowed_tools` is
+/// preserved when no matching entry exists in `tool_map`.
+#[test]
+fn rewrite_tool_choice_preserves_unresolved_named_mcp_selector() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [
+                {"type": "mcp", "server_label": "weather", "name": "nonexistent"},
+                {"type": "function", "name": "calc"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
+    assert_eq!(tool_refs.len(), 2, "unresolved selector preserved alongside function");
+    let mcp_ref = tool_refs.iter().find(|t| t["type"] == "mcp");
+    assert!(mcp_ref.is_some(), "unresolved MCP selector should be preserved");
+    assert_eq!(
+        mcp_ref.unwrap()["name"],
+        "nonexistent",
+        "original selector fields preserved"
+    );
+}
+
+/// An unresolved server-level MCP selector inside `allowed_tools`
+/// is preserved when no tools from that server exist in `tool_map`.
+#[test]
+fn rewrite_tool_choice_preserves_unresolved_server_mcp_selector() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [
+                {"type": "mcp", "server_label": "unknown_server"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
+    assert_eq!(tool_refs.len(), 1, "unresolved server selector preserved");
+    assert_eq!(tool_refs[0]["type"], "mcp", "original MCP type preserved");
+    assert_eq!(
+        tool_refs[0]["server_label"], "unknown_server",
+        "original server_label preserved"
+    );
+}
+
+/// Mixed resolved and unresolved MCP selectors: resolved ones
+/// expand, unresolved ones are preserved.
+#[test]
+fn rewrite_tool_choice_mixed_resolved_and_unresolved_selectors() {
+    let tool_map = weather_tool_map();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [
+                {"type": "mcp", "server_label": "weather"},
+                {"type": "mcp", "server_label": "deferred_server"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map);
+
+    let choice = &obj["tool_choice"];
+    let tool_refs = choice["tools"].as_array().expect("tools array");
+    let has_expanded = tool_refs
+        .iter()
+        .any(|t| t["type"] == "function" && t["name"].as_str().is_some_and(|n| n.starts_with("weather__")));
+    assert!(has_expanded, "resolved MCP selector should expand");
+    let has_preserved = tool_refs
+        .iter()
+        .any(|t| t["type"] == "mcp" && t["server_label"] == "deferred_server");
+    assert!(has_preserved, "unresolved MCP selector should be preserved");
+}
+
+// =========================================================================
+// Name Collision Detection
+// =========================================================================
+
+/// Duplicate generated function names are detected and rejected.
+#[test]
+fn detect_name_collisions_rejects_generated_duplicates() {
+    let tools = vec![
+        serde_json::json!({"type": "function", "name": "my_server__get"}),
+        serde_json::json!({"type": "function", "name": "my_server__get"}),
+    ];
+    let generated = HashSet::from(["my_server__get".to_owned()]);
+
+    let result = detect_name_collisions(&tools, &generated);
+    assert!(result.is_err(), "duplicate generated names should be rejected");
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("my_server__get"),
+        "error should identify the colliding name"
+    );
+}
+
+/// Distinct function names pass collision detection.
+#[test]
+fn detect_name_collisions_accepts_distinct_names() {
+    let tools = vec![
+        serde_json::json!({"type": "function", "name": "server_a__tool"}),
+        serde_json::json!({"type": "function", "name": "server_b__tool"}),
+    ];
+    let generated = HashSet::from(["server_a__tool".to_owned(), "server_b__tool".to_owned()]);
+
+    assert!(
+        detect_name_collisions(&tools, &generated).is_ok(),
+        "distinct names should pass collision check"
+    );
+}
+
+/// Non-function tools are skipped during collision detection.
+#[test]
+fn detect_name_collisions_ignores_non_function_tools() {
+    let tools = vec![
+        serde_json::json!({"type": "mcp", "server_label": "x"}),
+        serde_json::json!({"type": "function", "name": "only_one"}),
+    ];
+    let generated = HashSet::from(["only_one".to_owned()]);
+
+    assert!(
+        detect_name_collisions(&tools, &generated).is_ok(),
+        "non-function tools should be skipped"
+    );
+}
+
+/// Client-supplied duplicate function names are not rejected when
+/// no generated name is involved.
+#[test]
+fn detect_name_collisions_ignores_client_duplicates() {
+    let tools = vec![
+        serde_json::json!({"type": "function", "name": "client_func"}),
+        serde_json::json!({"type": "function", "name": "client_func"}),
+    ];
+    let generated = HashSet::new();
+
+    assert!(
+        detect_name_collisions(&tools, &generated).is_ok(),
+        "client-only duplicates should pass — backend validates these"
+    );
+}
+
+/// A generated name colliding with a client-supplied name is
+/// rejected.
+#[test]
+fn detect_name_collisions_rejects_generated_vs_client_collision() {
+    let tools = vec![
+        serde_json::json!({"type": "function", "name": "my_func"}),
+        serde_json::json!({"type": "function", "name": "my_func"}),
+    ];
+    let generated = HashSet::from(["my_func".to_owned()]);
+
+    assert!(
+        detect_name_collisions(&tools, &generated).is_err(),
+        "generated name colliding with client name should be rejected"
+    );
+}
+
+/// Lossy sanitization can cause collisions when special characters
+/// in labels map to the same encoded name.
+#[test]
+fn encode_function_name_lossy_collision_example() {
+    let name_a = encode_function_name("my.server", "get");
+    let name_b = encode_function_name("my_server", "get");
+    assert_eq!(name_a, name_b, "dots sanitized to underscores create identical names");
 }

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -1004,3 +1004,101 @@ fn write_tool_map_creates_state_with_previous_response_id() {
         .expect("state should be created even with previous_response_id");
     assert!(!state.mcp_tool_map.is_empty(), "tool map should be populated");
 }
+
+// =========================================================================
+// Body Rewrite: MCP to Function
+// =========================================================================
+
+fn weather_tool_map() -> HashMap<(String, String), serde_json::Value> {
+    let mut map = HashMap::new();
+    map.insert(
+        ("weather".to_owned(), "get_weather".to_owned()),
+        serde_json::json!({
+            "server_label": "weather",
+            "tool_definition": {
+                "name": "get_weather",
+                "description": "Get current weather",
+                "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}}
+            }
+        }),
+    );
+    map
+}
+
+#[test]
+fn rewrite_tools_array_converts_mcp_to_function() {
+    let tools = vec![
+        serde_json::json!({"type": "function", "name": "calc"}),
+        serde_json::json!({"type": "mcp", "server_label": "weather"}),
+    ];
+    let rewritten = rewrite_tools_array(&tools, &weather_tool_map());
+
+    assert_eq!(rewritten.len(), 2, "should have 2 tools");
+    assert_eq!(rewritten[0]["name"], "calc", "first tool unchanged");
+    assert_eq!(rewritten[1]["type"], "function", "MCP converted to function");
+    assert_eq!(rewritten[1]["name"], "weather__get_weather", "prefixed name");
+    assert_eq!(rewritten[1]["description"], "Get current weather");
+    assert!(rewritten[1]["parameters"]["properties"]["city"].is_object());
+}
+
+#[test]
+fn rewrite_tools_array_preserves_unresolved_mcp() {
+    let tools = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "unknown",
+        "server_url": "http://10.0.0.99/mcp"
+    })];
+
+    let tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
+    let rewritten = rewrite_tools_array(&tools, &tool_map);
+
+    assert_eq!(rewritten.len(), 1, "should preserve unresolved entry");
+    assert_eq!(rewritten[0]["type"], "mcp", "unresolved MCP left unchanged");
+}
+
+#[test]
+fn mcp_tool_to_function_tool_adds_default_parameters() {
+    let definition = serde_json::json!({"name": "simple_tool", "description": "Does something"});
+
+    let function_tool = mcp_tool_to_function_tool("srv", "simple_tool", &definition, &serde_json::json!({}));
+
+    assert_eq!(function_tool["type"], "function");
+    assert_eq!(function_tool["name"], "srv__simple_tool");
+    assert_eq!(function_tool["description"], "Does something");
+    assert_eq!(
+        function_tool["parameters"]["type"], "object",
+        "default parameters when inputSchema absent"
+    );
+}
+
+#[test]
+fn rewrite_tools_array_expands_multiple_tools_from_one_server() {
+    let tools = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "math",
+        "server_url": "http://10.0.0.5/mcp"
+    })];
+
+    let mut tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
+    tool_map.insert(
+        ("math".to_owned(), "add".to_owned()),
+        serde_json::json!({
+            "server_label": "math",
+            "tool_definition": {"name": "add", "description": "Add numbers"}
+        }),
+    );
+    tool_map.insert(
+        ("math".to_owned(), "subtract".to_owned()),
+        serde_json::json!({
+            "server_label": "math",
+            "tool_definition": {"name": "subtract", "description": "Subtract numbers"}
+        }),
+    );
+
+    let rewritten = rewrite_tools_array(&tools, &tool_map);
+
+    assert_eq!(rewritten.len(), 2, "one MCP entry expands to multiple function tools");
+    let names: Vec<&str> = rewritten.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"math__add"), "should have add tool");
+    assert!(names.contains(&"math__subtract"), "should have subtract tool");
+}

--- a/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
+++ b/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
@@ -407,6 +407,50 @@ fn mcp_mock_server_echoes_resolved_body() {
 }
 
 #[test]
+fn mcp_tools_rewritten_to_function_type() {
+    let mcp_config = McpMockConfig {
+        tools: vec![
+            McpToolFixture::new("get_weather").with_description("Get weather"),
+            McpToolFixture::new("set_alarm"),
+        ],
+        ..McpMockConfig::default()
+    };
+    let mcp_server = start_mcp_mock_server_with_config(mcp_config);
+    let backend_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let yaml = resolve_yaml_loopback_with_proxy(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let mcp_url = format!("http://127.0.0.1:{}/mcp", mcp_server.port());
+    let body = format!(
+        r#"{{"model":"gpt-4.1","input":"test","tools":[{{"type":"function","name":"calc"}},{{"type":"mcp","server_label":"home","server_url":"{mcp_url}","allowed_tools":["get_weather"]}}]}}"#
+    );
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(parse_status(&raw), 200, "should return 200");
+    let echoed = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&echoed).unwrap();
+
+    let tools = parsed["tools"].as_array().expect("tools should be an array");
+    assert_eq!(tools.len(), 2, "should have 2 tools (1 function + 1 rewritten MCP)");
+
+    assert_eq!(tools[0]["type"], "function", "first tool type unchanged");
+    assert_eq!(tools[0]["name"], "calc", "first tool name unchanged");
+
+    assert_eq!(tools[1]["type"], "function", "MCP tool rewritten to function");
+    assert_eq!(tools[1]["name"], "home__get_weather", "MCP tool name prefixed");
+    assert_eq!(tools[1]["description"], "Get weather", "description preserved");
+    assert!(tools[1]["parameters"].is_object(), "parameters added");
+
+    assert!(
+        mcp_server.method_count("tools/list") >= 1,
+        "should have called tools/list"
+    );
+}
+
+#[test]
 fn mcp_invalid_authorization_rejected() {
     let mcp_config = McpMockConfig {
         tools: vec![McpToolFixture::new("tool_a")],

--- a/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
+++ b/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
@@ -406,6 +406,8 @@ fn mcp_mock_server_echoes_resolved_body() {
     );
 }
 
+/// Verify end-to-end that `type: "mcp"` tools are rewritten to
+/// `type: "function"` before being forwarded upstream.
 #[test]
 fn mcp_tools_rewritten_to_function_type() {
     let mcp_config = McpMockConfig {


### PR DESCRIPTION
## Summary

Closes #425.

The `openai_mcp_tool_resolve` filter now rewrites `type: "mcp"` tool entries in the Responses API request body to `type: "function"` before forwarding upstream, since inference backends have no concept of MCP tools.

- Resolves MCP tool definitions via `tools/list`, builds a dispatch map (`mcp_tool_map`), and replaces MCP entries with function tools using `{server_label}__{tool_name}` encoding for unique dispatch
- Rewrites `tool_choice` MCP references: named MCP → function, server-level MCP → `allowed_tools` scoped to that server, MCP selectors inside `allowed_tools` → expanded function refs (unresolved selectors are preserved)
- Detects generated function name collisions from lossy sanitization/truncation while allowing client-supplied duplicates to pass through to the backend
- Synchronizes rewritten body, tools, and `tool_choice` into `ResponsesState` for downstream filters
- 87 unit tests and integration test coverage for the rewrite, caching, collision detection, `tool_choice` translation, and state sync

## Test plan

- [x] `cargo test -p praxis-ai-apis -- openai_mcp_tool_resolve` — 87 tests pass
- [x] `make lint` — clippy, rustfmt, separator, and filter-doc checks pass
- [x] Integration test `mcp_tools_rewritten_to_function_type` validates end-to-end rewrite