### PR TITLE
feat(openai): route /v1/embeddings to a dedicated Embeddings API backend

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,7 @@ before sending requests.
 | File | Description |
 | ------ | ------------- |
 | [conversations.yaml](configs/openai/conversations/conversations.yaml) | Local /v1/conversations endpoints for conversation lifecycle, backed by the ConversationItemStore |
+| [embeddings-routing.yaml](configs/openai/embeddings/embeddings-routing.yaml) | Routes /v1/embeddings and subresources to a dedicated Embeddings API backend using segment-boundary prefix matching |
 | [prompts-routing.yaml](configs/openai/prompts/prompts-routing.yaml) | Routes /v1/prompts and subresources to a dedicated Prompts API backend using segment-boundary prefix matching |
 | [doc-extract.yaml](configs/openai/responses/doc-extract.yaml) | Converts `input_file` content parts to `input_text` for inference backends that do not natively support `input_file` (e.g. vLLM, llm-d) |
 | [file-resolve.yaml](configs/openai/responses/file-resolve.yaml) | Resolves `file_id` references in Responses API input by fetching file metadata and content from a Files API, then inlining base64 content as `file_data` or `image_url` before forwarding |

--- a/examples/configs/openai/embeddings/embeddings-routing.yaml
+++ b/examples/configs/openai/embeddings/embeddings-routing.yaml
@@ -1,0 +1,38 @@
+# Embeddings API Routing
+#
+# Routes OpenAI Embeddings API requests to a dedicated Embeddings API
+# backend. The router uses segment-boundary prefix matching, so
+# /v1/embeddings and all of its subresources are routed to the
+# embeddings-api cluster, while paths such as /v1/embeddingsomething
+# do not match and fall through to the default backend.
+#
+# Example requests:
+#
+#   # Create embeddings
+#   curl http://localhost:8080/v1/embeddings \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"text-embedding-3-small","input":"Hello, world!"}'
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [embeddings-routing]
+
+filter_chains:
+  - name: embeddings-routing
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/v1/embeddings"
+            cluster: "embeddings-api"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "embeddings-api"
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:3002"

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -67,10 +67,10 @@
 #      ResponsesState exists.
 #
 #   12. The router sends valid Responses API create requests to the
-#      inference backend and routes /v1/prompts (and subresources) to
-#      a dedicated Prompts API service. The promoted mode remains
-#      available as headers/metadata for downstream filters; it does
-#      not change backend selection in this example.
+#      inference backend and routes /v1/prompts and /v1/embeddings
+#      (and subresources) to dedicated API services. The promoted
+#      mode remains available as headers/metadata for downstream
+#      filters; it does not change backend selection in this example.
 #
 # Security: StreamBuffer body callouts run before this listener's
 # header-phase filters. Deploy this example behind an outer
@@ -183,6 +183,8 @@ filter_chains:
         routes:
           - path_prefix: "/v1/prompts"
             cluster: "prompts-api"
+          - path_prefix: "/v1/embeddings"
+            cluster: "embeddings-api"
           - path: "/v1/responses"
             headers:
               x-praxis-ai-format: "openai_responses"
@@ -195,6 +197,9 @@ filter_chains:
           - name: "prompts-api"
             endpoints:
               - "127.0.0.1:9998"
+          - name: "embeddings-api"
+            endpoints:
+              - "127.0.0.1:9997"
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -15,6 +15,7 @@ mod mcp_broker;
 mod model_to_header;
 mod openai_conversations;
 mod openai_doc_extract;
+mod openai_embeddings_routing;
 mod openai_file_resolve;
 mod openai_mcp_dispatch;
 mod openai_mcp_tool_resolve;

--- a/tests/integration/tests/suite/examples/openai_embeddings_routing.rs
+++ b/tests/integration/tests/suite/examples/openai_embeddings_routing.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the OpenAI Embeddings routing example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{free_port, http_get, load_example_config, start_backend_with_shutdown, start_proxy};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn example_config_routes_embeddings_root_to_embeddings_backend() {
+    let embeddings_guard = start_backend_with_shutdown("embeddings-api");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/embeddings/embeddings-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", embeddings_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/embeddings", None);
+    assert_eq!(status, 200, "Embeddings API root should be proxied");
+    assert_eq!(
+        body, "embeddings-api",
+        "GET /v1/embeddings should route to embeddings-api backend"
+    );
+}
+
+#[test]
+fn example_config_routes_embeddings_subresource_to_embeddings_backend() {
+    let embeddings_guard = start_backend_with_shutdown("embeddings-api");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/embeddings/embeddings-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", embeddings_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/embeddings/emb-abc123", None);
+    assert_eq!(status, 200, "Embeddings API subresource should be proxied");
+    assert_eq!(
+        body, "embeddings-api",
+        "Embeddings API subresources should route to embeddings-api backend"
+    );
+}
+
+#[test]
+fn example_config_segment_boundary_falls_to_default() {
+    let embeddings_guard = start_backend_with_shutdown("embeddings-api");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "openai/embeddings/embeddings-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", embeddings_guard.port()),
+            ("127.0.0.1:3002", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/v1/embeddingsomething", None);
+    assert_eq!(status, 200, "non-Embeddings API path should be proxied");
+    assert_eq!(
+        body, "default-backend",
+        "path-prefix matching must stop at a segment boundary"
+    );
+}


### PR DESCRIPTION
## Summary

- Add a `path_prefix: /v1/embeddings` route so Embeddings API requests and subresources are proxied to a dedicated `embeddings-api` cluster using the standard `router` and `load_balancer` filters
- New standalone example config at `openai/embeddings/embeddings-routing.yaml` for pure path-based routing
- Add the same route to `full-flow.yaml` alongside the existing prompts-api and inference-backend routes
- Integration tests cover root endpoint, nested subresource, and segment-boundary guard (`/v1/embeddingsomething` → default)

## Test plan

- [x] `cargo test -p praxis-tests-integration -- openai_embeddings_routing` — 3 tests pass
- [x] `cargo test -p praxis-tests-integration -- examples::full_flow` — 5 existing tests pass (no regressions)
- [x] `make lint` — clippy, nightly fmt, separator lint, filter docs lint all clean
- [x] `make build` — workspace builds cleanly