### PR TITLE
feat(ci): add OGX file_id integration tests to vLLM workflow

### DIFF
--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -139,6 +139,11 @@ jobs:
             --reasoning-parser deepseek_r1 \
             --gpu-memory-utilization 0.7
 
+      - name: Start OGX
+        run: |
+          uv run --with 'ogx[starter]' ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          echo $! > /tmp/ogx.pid
+
       - name: Build Praxis
         run: cargo build -p praxis-ai-proxy
 
@@ -151,6 +156,14 @@ jobs:
           done'
           echo "vLLM is ready"
 
+      - name: Wait for OGX readiness
+        run: |
+          echo "Waiting for OGX server..."
+          timeout 120 bash -c 'until curl -sf http://127.0.0.1:8321/v1/files > /dev/null 2>&1; do
+            sleep 2
+          done'
+          echo "OGX is ready"
+
       - name: Run vLLM integration tests
         run: |
           uv run tests/integration/sdk/openai/test_openai_responses_vllm.py -s
@@ -159,6 +172,17 @@ jobs:
         if: failure()
         run: docker logs vllm
 
+      - name: OGX logs
+        if: failure()
+        run: cat /tmp/ogx.log 2>/dev/null || echo "No OGX log found"
+
       - name: Stop vLLM
         if: always()
         run: docker rm -f vllm || true
+
+      - name: Stop OGX
+        if: always()
+        run: |
+          if [ -f /tmp/ogx.pid ]; then
+            kill "$(cat /tmp/ogx.pid)" 2>/dev/null || true
+          fi

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -185,6 +185,8 @@ filter_chains:
             cluster: "prompts-api"
           - path_prefix: "/v1/embeddings"
             cluster: "embeddings-api"
+          - path_prefix: "/v1/files"
+            cluster: "files-api"
           - path: "/v1/responses"
             headers:
               x-praxis-ai-format: "openai_responses"
@@ -200,6 +202,9 @@ filter_chains:
           - name: "embeddings-api"
             endpoints:
               - "127.0.0.1:9997"
+          - name: "files-api"
+            endpoints:
+              - "127.0.0.1:9999"
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -164,17 +164,6 @@ def openai_client(praxis_proxy):
     )
 
 
-@pytest.fixture(scope="session")
-def ogx_client():
-    """Return an OpenAI client pointed directly at the OGX Files API."""
-    return OpenAI(
-        base_url=f"{OGX_BASE_URL}/v1",
-        api_key="test",
-        max_retries=0,
-        timeout=30,
-    )
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -289,8 +278,8 @@ class TestOpenAIResponsesVLLM:
             f"marker '{marker}'; got: {response.output_text}"
         )
 
-    def test_file_id_resolution_through_ogx(self, openai_client, ogx_client):
-        """End-to-end: upload to OGX, reference by file_id through Praxis,
+    def test_file_id_resolution_through_ogx(self, openai_client):
+        """End-to-end: upload to OGX via Praxis, reference by file_id,
         verify vLLM output contains the file content.
 
         Pipeline: file_resolve (OGX) -> doc_extract -> responses_proxy -> vLLM
@@ -300,7 +289,7 @@ class TestOpenAIResponsesVLLM:
         marker = "PRAXIS-OGX-FILE-4829"
         file_content = f"The secret marker is: {marker}"
 
-        uploaded = ogx_client.files.create(
+        uploaded = openai_client.files.create(
             file=("marker-document.txt", io.BytesIO(file_content.encode())),
             purpose="user_data",
         )
@@ -339,7 +328,7 @@ class TestOpenAIResponsesVLLM:
             )
         finally:
             try:
-                ogx_client.files.delete(file_id)
+                openai_client.files.delete(file_id)
             except Exception:
                 pass
 

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -36,6 +36,7 @@ from openai import OpenAI
 
 VLLM_BASE_URL = os.environ.get("VLLM_BASE_URL", "http://127.0.0.1:8000")
 VLLM_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-0.6B")
+OGX_BASE_URL = os.environ.get("OGX_BASE_URL", "http://127.0.0.1:8321")
 PRAXIS_AI_BIN = os.environ.get("PRAXIS_AI_BIN")
 CONFIG_PATH = "examples/configs/openai/responses/full-flow.yaml"
 
@@ -72,12 +73,20 @@ def _vllm_endpoint() -> str:
     return f"{host}:{port}"
 
 
+def _ogx_endpoint() -> str:
+    parsed = urlparse(OGX_BASE_URL)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8321
+    return f"{host}:{port}"
+
+
 def _write_config(praxis_port: int, db_path: str) -> str:
     with open(CONFIG_PATH) as f:
         config = f.read()
 
     config = config.replace("127.0.0.1:8080", f"127.0.0.1:{praxis_port}")
     config = config.replace("127.0.0.1:3001", _vllm_endpoint())
+    config = config.replace("127.0.0.1:9999", _ogx_endpoint())
     config = config.replace(
         "sqlite://responses.db?mode=rwc",
         f"sqlite://{db_path}?mode=rwc",
@@ -152,6 +161,17 @@ def openai_client(praxis_proxy):
         api_key="test",
         max_retries=0,
         timeout=180,
+    )
+
+
+@pytest.fixture(scope="session")
+def ogx_client():
+    """Return an OpenAI client pointed directly at the OGX Files API."""
+    return OpenAI(
+        base_url=f"{OGX_BASE_URL}/v1",
+        api_key="test",
+        max_retries=0,
+        timeout=30,
     )
 
 
@@ -268,6 +288,60 @@ class TestOpenAIResponsesVLLM:
             f"vLLM should produce output containing the document "
             f"marker '{marker}'; got: {response.output_text}"
         )
+
+    def test_file_id_resolution_through_ogx(self, openai_client, ogx_client):
+        """End-to-end: upload to OGX, reference by file_id through Praxis,
+        verify vLLM output contains the file content.
+
+        Pipeline: file_resolve (OGX) -> doc_extract -> responses_proxy -> vLLM
+        """
+        import io
+
+        marker = "PRAXIS-OGX-FILE-4829"
+        file_content = f"The secret marker is: {marker}"
+
+        uploaded = ogx_client.files.create(
+            file=("marker-document.txt", io.BytesIO(file_content.encode())),
+            purpose="user_data",
+        )
+        file_id = uploaded.id
+
+        try:
+            response = openai_client.responses.create(
+                model=VLLM_MODEL,
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_file",
+                                "file_id": file_id,
+                            },
+                            {
+                                "type": "input_text",
+                                "text": (
+                                    "What marker appears in the document? "
+                                    "Repeat it exactly. /no_think"
+                                ),
+                            },
+                        ],
+                    }
+                ],
+                store=False,
+                max_output_tokens=128,
+            )
+
+            assert response.status == "completed"
+            assert marker in response.output_text, (
+                f"vLLM should produce output containing the file marker "
+                f"'{marker}'; got: {response.output_text}"
+            )
+        finally:
+            try:
+                ogx_client.files.delete(file_id)
+            except Exception:
+                pass
 
     def test_streaming(self, openai_client):
         stream = openai_client.responses.create(


### PR DESCRIPTION
## Summary

- Adds an end-to-end integration test (`test_file_id_resolution_through_ogx`) that validates the `openai_file_resolve` filter against a real OGX Files API, exercising the full pipeline: upload file to OGX, reference by `file_id` through Praxis, file_resolve fetches from OGX, doc_extract converts to input_text, vLLM inference.
- Updates the vLLM CI workflow to start and manage an OGX server alongside vLLM, with readiness checks, failure logging, and cleanup.
- Patches `_write_config` to point the `files_api_url` at OGX (configurable via `OGX_BASE_URL` env var, default `http://127.0.0.1:8321`).

## Test plan

- [ ] CI: vLLM integration workflow passes with OGX started and file_id test exercised
- [ ] Local: `uv run ogx run starter --insecure` + vLLM running, then `uv run tests/integration/sdk/openai/test_openai_responses_vllm.py -s -k test_file_id`
- [ ] Existing tests remain unaffected (file_resolve filter only activates on `file_id` references)