### PR TITLE
test(openai): stabilize websocket non-101 response assertion

### DIFF
--- a/tests/integration/tests/suite/examples/full_flow.rs
+++ b/tests/integration/tests/suite/examples/full_flow.rs
@@ -542,25 +542,27 @@ async fn full_flow_websocket_non_101_backend_response_remains_http() {
         &HashMap::from([("127.0.0.1:3001", backend.port())]),
     );
     let _proxy = start_proxy(&config);
-    let url = format!("ws://127.0.0.1:{proxy_port}/v1/responses");
-
-    let error = connect_websocket(url)
-        .await
-        .expect_err("backend should reject the upgrade");
-    let Error::Http(response) = error else {
-        panic!("expected HTTP handshake error, got {error:?}");
-    };
+    let raw = http_send(
+        &format!("127.0.0.1:{proxy_port}"),
+        "GET /v1/responses HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         \r\n",
+    );
     assert_eq!(
-        response.status(),
-        http::StatusCode::UPGRADE_REQUIRED,
+        parse_status(&raw),
+        http::StatusCode::UPGRADE_REQUIRED.as_u16(),
         "the upstream non-101 status should remain an HTTP response"
     );
-    assert_eq!(
-        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
-        "application/json",
+    assert!(
+        raw.to_ascii_lowercase().contains("content-type: application/json"),
         "the normal error filter should format the HTTP rejection as JSON"
     );
-    let body: serde_json::Value = serde_json::from_slice(response.body().as_deref().unwrap()).unwrap();
+    let body: serde_json::Value =
+        serde_json::from_str(&parse_body(&raw)).expect("formatted error body should be valid JSON");
     assert_eq!(
         body["error"]["code"], "426",
         "the formatted error should retain the upstream status code"


### PR DESCRIPTION
  ## Summary

  This is a test-only change for the OpenAI Responses full-flow WebSocket example coverage.

  The existing test verifies that when a backend rejects a WebSocket upgrade with a non-101 response, Praxis preserves that as a normal HTTP error response. The test previously used `tokio-tungstenite` to initiate the failed handshake and then parsed the body from the WebSocket client’s `Error::Http` response. In CI, that body can be empty even when the HTTP status and headers are correct, causing a flaky JSON parse failure.

  This PR keeps the same behavior under test, but sends the WebSocket upgrade request as raw HTTP via the existing `http_send` helper. That makes the response body capture deterministic.

  No functional code changed. No proxy, filter, routing, or WebSocket behavior changed. Only the integration test assertion path changed.

 ## Validation

  - `cargo test -p praxis-tests-integration --test suite examples::full_flow::full_flow_websocket_non_101_backend_response_remains_http -- --exact
  --nocapture`
  - `cargo +nightly fmt --all --check`
  - `git diff --check`

  ## Notes

  The flaky CI failure was observed here:

  https://github.com/praxis-proxy/ai/actions/runs/30015272396/job/89233502538?pr=340

  The failed test was:

  `examples::full_flow::full_flow_websocket_non_101_backend_response_remains_http`

  The test was already asserting the correct behavior: upstream non-`101` WebSocket upgrade rejections should remain HTTP responses and still pass through the normal JSON error formatting path.

  This PR avoids relying on the WebSocket client library to retain the HTTP rejection body on handshake failure. The test now inspects the raw HTTP response directly, which is the actual behavior being asserted.