### PR TITLE
chore: add rust_out to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Cargo build output
 target
 
+# Default rustc output
+rust_out
+
 # Test artifacts
 **/*.db
 **/postgres.rs.tmp*


### PR DESCRIPTION
## Summary
- Add `rust_out` (default `rustc` output name) to `.gitignore` to prevent accidental commits

Addresses praxis-bot review feedback on #534.