### PR TITLE
ci: validate GitHub Actions workflows

### DIFF
--- a/.github/actions/install-actionlint/action.yml
+++ b/.github/actions/install-actionlint/action.yml
@@ -1,0 +1,23 @@
+name: Install actionlint
+description: Install the pinned actionlint release with checksum verification
+
+runs:
+  using: composite
+  steps:
+    - name: Download actionlint
+      shell: bash
+      env:
+        ACTIONLINT_VERSION: "1.7.12"
+        ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+      run: |
+        set -euo pipefail
+        archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+        base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+
+        curl -fsSL "${base_url}/${archive}" -o "/tmp/${archive}"
+        echo "${ACTIONLINT_SHA256}  /tmp/${archive}" | sha256sum --check --strict
+
+        mkdir -p /tmp/actionlint-bin
+        tar -xzf "/tmp/${archive}" -C /tmp/actionlint-bin actionlint
+        chmod +x /tmp/actionlint-bin/actionlint
+        echo "/tmp/actionlint-bin" >> "$GITHUB_PATH"

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -36,6 +36,7 @@ jobs:
               echo "Container is healthy"
               exit 0
             fi
+            echo "Waiting for container health (${i}/30): ${status}"
             sleep 2
           done
           echo "Container failed to become healthy"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Install actionlint
+        uses: ./.github/actions/install-actionlint
+
+      - name: Lint GitHub Actions workflows
+        run: actionlint
+
       - name: Setup Rust (lint)
         uses: praxis-proxy/conventions/.github/actions/setup-rust-lint@7e1e8d97c2dc820d24b31f9a65b119c4d0e5342c # v0.1.0
         with:


### PR DESCRIPTION
## Summary

- install a pinned `actionlint` release with SHA-256 verification
- run workflow validation in the existing CI lint job
- report container health polling progress, resolving the existing ShellCheck warning exposed by actionlint

## Validation

- `actionlint` against a clean checkout of the committed branch
- verified the `actionlint_1.7.12_linux_amd64.tar.gz` SHA-256 checksum
- `git diff --check origin/main...HEAD`
- Codex review against `origin/main`

## Related issue

None.

## Breaking changes

None.
