### PR TITLE
docs: strengthen community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,8 +23,11 @@ body:
   - type: input
     id: version
     attributes:
-      label: Praxis Version
-      placeholder: "v0.4.0"
+      label: Praxis AI Version
+      description: Release tag, container tag, or commit SHA
+      placeholder: "v0.1.0"
+    validations:
+      required: true
   - type: dropdown
     id: area
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Discussions
-    url: https://github.com/praxis-proxy/ai/discussions
-    about: Ask questions or start a discussion
+  - name: Praxis Discussions
+    url: https://github.com/praxis-proxy/praxis/discussions
+    about: Ask questions or start a discussion with the Praxis community

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,22 @@
+name: Question
+description: Ask for help using or configuring Praxis AI
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: attempted
+    attributes:
+      label: What have you tried?
+      description: Include relevant configuration, commands, and errors.
+  - type: input
+    id: version
+    attributes:
+      label: Praxis AI Version
+      description: Release tag, container tag, or commit SHA, if relevant
+      placeholder: "v0.1.0"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,27 @@
-### What does this PR do?
+## Summary
 
-### Which issue(s) does this relate to?
+<!-- What changed, and why is this the smallest complete change? -->
 
-Fixes #
+## Related issue
 
-### Checklist
+<!-- Contributors must be assigned to the issue before opening a PR. -->
 
-- [ ] Signed off all commits (`git commit -s`)
-- [ ] Tests added or updated
-- [ ] Documentation updated (if applicable)
-- [ ] `make lint && make test` passes locally
+Closes #
 
-### Does this introduce a breaking change?
+## Validation
 
-<!-- If yes, describe the impact and migration
-path. -->
+<!-- List exact commands and results, including manual or backend-backed proof.
+Explain any checks that were not run. -->
+
+## Checklist
+
+- [ ] I reviewed every changed line and can explain the change.
+- [ ] Tests are added or updated when behavior changes.
+- [ ] New capabilities include an example config and functional example test.
+- [ ] User-facing behavior and generated documentation are updated.
+- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
+- [ ] Commits are signed and include a `Signed-off-by` trailer.
+
+## Breaking changes
+
+<!-- If applicable, describe the impact and migration path. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+Praxis AI follows the [CNCF Code of Conduct][cncf-coc], consistent with
+Praxis core.
+
+To report an issue, contact the [Praxis maintainers][maintainers] or the
+[CNCF Code of Conduct Committee][conduct-email].
+
+[cncf-coc]: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
+[maintainers]: https://github.com/praxis-proxy/praxis/blob/main/MAINTAINERS.md
+[conduct-email]: mailto:conduct@cncf.io

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ filters and protocol support. Before opening a pull request, please read the
 [contributing guide](CONTRIBUTING.md) and
 [development setup](docs/developing/getting-started.md).
 
-For larger changes, open a [feature request] and follow the
+For larger changes, start a [discussion] and follow the
 [proposal process](docs/proposals.md) so we can shape the idea together.
 
-[Open an issue][issues] · [Request a feature][feature request] ·
+[Open an issue][issues] · [Start a discussion][discussion] ·
 [Open a pull request][pull requests]
 
 [issues]: https://github.com/praxis-proxy/ai/issues/new
 [pull requests]: https://github.com/praxis-proxy/ai/compare
-[feature request]: https://github.com/praxis-proxy/ai/issues/new?template=feature-request.yml
+[discussion]: https://github.com/praxis-proxy/praxis/discussions
 [container images]: https://github.com/praxis-proxy/ai/pkgs/container/ai
 [development guide]: docs/developing/getting-started.md
 [quickstart]: docs/quickstart.md

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ filters and protocol support. Before opening a pull request, please read the
 [contributing guide](CONTRIBUTING.md) and
 [development setup](docs/developing/getting-started.md).
 
-For larger changes, start a [discussion] and follow the
+For larger changes, open a [feature request] and follow the
 [proposal process](docs/proposals.md) so we can shape the idea together.
 
-[Open an issue][issues] · [Start a discussion][discussion] ·
+[Open an issue][issues] · [Request a feature][feature request] ·
 [Open a pull request][pull requests]
 
 [issues]: https://github.com/praxis-proxy/ai/issues/new
 [pull requests]: https://github.com/praxis-proxy/ai/compare
-[discussion]: https://github.com/praxis-proxy/ai/discussions
+[feature request]: https://github.com/praxis-proxy/ai/issues/new?template=feature-request.yml
 [container images]: https://github.com/praxis-proxy/ai/pkgs/container/ai
 [development guide]: docs/developing/getting-started.md
 [quickstart]: docs/quickstart.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported Versions
 
-| Version | Supported |
-| ------- | --------- |
+| Version | Supported   |
+| ------- | ----------- |
 | 0.1.x   | Yes (Alpha) |
 
 Praxis AI is pre-`1.0.0`. Only the latest patch release of the current
@@ -39,6 +39,7 @@ We use the following severity levels:
 
 ## Safe Harbor
 
-We consider security research conducted in good faith to be authorized. We will not pursue legal action
-against researchers who follow this policy and report findings responsibly. In fact, we really appreciate
-the help in making Praxis more secure, thank you for your efforts!
+We consider security research conducted in good faith to be authorized.
+We will not pursue legal action against researchers who follow this policy
+and report findings responsibly. We appreciate your help making Praxis AI
+more secure.

--- a/docs/proposals/template.md
+++ b/docs/proposals/template.md
@@ -44,8 +44,8 @@ Why this change is needed.
 
 ### Implementation
 
-- [#NNN](link) — brief description
-- [#NNN](link) — brief description
+- [#NNN](https://github.com/praxis-proxy/ai/pull/NNN) — brief description
+- [#NNN](https://github.com/praxis-proxy/ai/pull/NNN) — brief description
 
 <!-- Option B: full design (always accepted) -->
 


### PR DESCRIPTION
## Summary

- add a Code of Conduct adapted from the Praxis core CNCF-based policy
- align the security policy with the supported `v0.1.x` release line
- improve issue, pull request, and proposal templates
- route discussions to the active Praxis forum and feature proposals to the AI repository

## Validation

- parsed all issue-form YAML with Ruby/Psych
- verified changed Markdown has no missing local links
- `git diff --check origin/main...HEAD`
- `codex review --uncommitted` before commit

## Related issue

None.

## Breaking changes

None.
