### PR TITLE
release: align distribution policy and automation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,9 +20,6 @@ jobs:
 
   container:
     runs-on: ubuntu-24.04
-    if: >-
-      github.event_name == 'push' ||
-      github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       packages: write

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Praxis AI handles the AI-specific layer. For listeners, TLS, load balancing,
 rate limiting, health checks, and other core proxy features, visit the
 [Praxis repository](https://github.com/praxis-proxy/praxis).
 
+> [!IMPORTANT]
+> Praxis AI is alpha software. APIs, configuration, and operational
+> behavior may change before `v1.0.0`. See the [security policy]
+> for the supported release line.
+
+Released container images are available from
+[`ghcr.io/praxis-proxy/ai`][container images]. Source builds and local
+development instructions are in the [development guide].
+
+```console
+docker pull ghcr.io/praxis-proxy/ai:0.1
+```
+
+Podman can pull the same OCI image. See the [quickstart] for a source build
+and the [release documentation] for image contents and tagging.
+
 ## Contributing
 
 Contributions are welcome, from bug reports and documentation fixes to new
@@ -95,3 +111,8 @@ For larger changes, start a [discussion] and follow the
 [issues]: https://github.com/praxis-proxy/ai/issues/new
 [pull requests]: https://github.com/praxis-proxy/ai/compare
 [discussion]: https://github.com/praxis-proxy/ai/discussions
+[container images]: https://github.com/praxis-proxy/ai/pkgs/container/ai
+[development guide]: docs/developing/getting-started.md
+[quickstart]: docs/quickstart.md
+[release documentation]: docs/release.md
+[security policy]: SECURITY.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,13 @@
 
 ## Supported Versions
 
-| Version   | Supported   |
-| --------- | ----------- |
-| 0.1.x     | No (Alpha)  |
-| 0.2.x     | No (Alpha)  |
-| 0.3.x     | No (Alpha)  |
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | Yes (Alpha) |
 
-Only the latest patch release of each minor version
-receives security updates.
+Praxis AI is pre-`1.0.0`. Only the latest patch release of the current
+minor line receives security updates. Older pre-release lines become
+unsupported when a new minor line is released.
 
 ## Reporting a Vulnerability
 
@@ -25,8 +24,9 @@ Include:
 
 ## Response Timeline
 
-Prior to `v1.0.0` we will work with researchers individually on
-timelines. After `v1.0.0` we will have a standardized response timeline.
+Prior to `v1.0.0`, we coordinate disclosure and remediation timelines
+with researchers individually. We will publish a standardized response
+timeline before the first stable release.
 
 ## Severity Classification
 

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 description = "AI provider API types and persistence for Praxis"
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [lib]
 name = "praxis_ai_apis"

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,6 +9,12 @@ All workspace crates inherit this version.
 
 [semver]: https://semver.org/
 
+## Distribution
+
+The supported release artifact is the Praxis AI container image on GHCR.
+Workspace crates are implementation packages and are not published to
+crates.io independently.
+
 ## Pre-release Checklist
 
 Before tagging a release:
@@ -21,7 +27,7 @@ Before tagging a release:
 - [ ] Version in root `Cargo.toml` is bumped
 - [ ] `Cargo.lock` is regenerated with the new version
 - [ ] `SECURITY.md` lists the new minor version
-- [ ] GitHub Release changelog is drafted (see below)
+- [ ] Pull request labels produce useful generated release notes
 
 ## Tagging a Release
 
@@ -38,35 +44,34 @@ git push origin v0.1.0
 Container images are published to
 [GitHub Container Registry][ghcr] (GHCR).
 
-After pushing a tag, manually trigger the **Publish**
-workflow via the GitHub Actions UI
-(`workflow_dispatch`). The workflow builds a multi-stage
-Alpine image from the `Containerfile` and pushes it to
-`ghcr.io/praxis-proxy/ai`.
+Pushing a valid release tag triggers the **Release** workflow. It verifies
+that the tag matches `workspace.package.version`, runs the test suite,
+builds the multi-stage Alpine image, pushes it to
+`ghcr.io/praxis-proxy/ai`, and creates the GitHub Release.
+
+Maintainers can manually dispatch the **Publish** workflow when a container
+image is needed without creating a tagged GitHub Release.
 
 [ghcr]: https://ghcr.io/praxis-proxy/ai
 
 ### Image Tags
 
-The publish workflow produces these tags per run:
+The release workflow produces these tags per run:
 
 | Pattern | Example | Description |
 | --------- | --------- | ------------- |
 | `sha-<hash>` | `sha-abc1234` | Git commit SHA |
-| `<branch>` | `main` | Branch name |
 | `<version>` | `0.1.0` | Full semver (from git tag) |
 | `<major>.<minor>` | `0.1` | Major.minor shorthand |
 
-Semver tags are only generated when the workflow runs
-against a semver git tag.
+The workflow also publishes a `sha-<hash>` tag for traceability.
 
 ## Changelog
 
-Praxis AI uses [GitHub Releases][gh-releases] for
-changelogs. Each release is created through the GitHub
-UI after pushing a tag. Use GitHub's "Generate release
-notes" feature to auto-populate from merged PRs, then
-edit for clarity. There is no separate CHANGELOG file.
+Praxis AI uses [GitHub Releases][gh-releases] for changelogs. The release
+workflow creates each release with generated notes. Review pull request
+labels before tagging so entries fall into the categories configured in
+`.github/release.yml`. There is no separate `CHANGELOG.md` file.
 
 [gh-releases]: https://github.com/praxis-proxy/ai/releases
 
@@ -76,9 +81,8 @@ Release branches are optional and created from tags when
 backports are needed. The naming convention is
 `release/v<MAJOR>.<MINOR>.x` (e.g. `release/v0.1.x`).
 
-Fixes are cherry-picked onto the release branch, a new
-patch tag is created from it, and the publish workflow is
-triggered as usual.
+Fixes are cherry-picked onto the release branch and a new patch tag is
+created from it. The tag triggers the release workflow as usual.
 
 ## Container Details
 
@@ -86,10 +90,10 @@ The production image is a minimal Alpine container:
 
 - Static musl build with LTO, single codegen unit,
   and stripped symbols
-- Runs as non-root user (`praxis-ai`)
+- Runs as non-root user (`praxis`)
 - Exposes ports `8080` (proxy) and `9901` (admin)
 - Built-in health check at
   `http://127.0.0.1:9901/healthy`
-- Config directory: `/etc/praxis-ai`
+- Config directory and working directory: `/etc/praxis`
 
 > **Note**: This is subject to change.

--- a/filters/Cargo.toml
+++ b/filters/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 description = "AI filter implementations for Praxis"
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [lib]
 name = "praxis_ai_filters"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,6 +8,7 @@ description = "AI-native proxy server built on Praxis"
 license.workspace = true
 repository.workspace = true
 readme = "../README.md"
+publish = false
 
 [package.metadata.cargo-machete]
 ignored = ["cargo_metadata"]


### PR DESCRIPTION
### What does this PR do?

- establishes GHCR container images as the supported distribution artifact
- prevents accidental crates.io publication of internal runtime crates
- fixes the manually dispatched Publish workflow, whose job condition always skipped
- aligns release, image-tag, container, and pre-1.0 security documentation with the repository automation

### Which issue(s) does this relate to?

N/A — follow-up repository professionalism and release-hygiene work.

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated (not required; no runtime behavior changed)
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

Additional validation:

- `actionlint .github/workflows/publish.yaml .github/workflows/release.yaml`
- verified `ghcr.io/praxis-proxy/ai:0.1` is publicly retrievable
- verified package metadata marks all three runtime crates as non-publishable

### Does this introduce a breaking change?

No.
