### PR TITLE
fix(conversations): honor include projections

### DIFF
--- a/apis/src/openai/conversations/contracts.rs
+++ b/apis/src/openai/conversations/contracts.rs
@@ -89,7 +89,7 @@ impl IncludeField {
     }
 }
 
-/// Allocation-free set of requested optional item fields.
+/// Set of requested optional item fields.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct IncludeFields(u8);
 

--- a/apis/src/openai/conversations/contracts.rs
+++ b/apis/src/openai/conversations/contracts.rs
@@ -18,6 +18,93 @@ use utoipa::{
 /// Maximum number of items accepted by create operations.
 pub(super) const MAX_ITEMS_PER_REQUEST: usize = 20;
 
+/// Optional response fields supported by Conversation item endpoints.
+///
+/// The spellings match OpenAI's `IncludeEnum` exactly. Runtime query parsing
+/// and generated `OpenAPI` both consume this enum.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+pub(super) enum IncludeField {
+    /// Include file search result payloads.
+    #[serde(rename = "file_search_call.results")]
+    #[schema(rename = "file_search_call.results")]
+    FileSearchCallResults,
+    /// Include web search result payloads.
+    #[serde(rename = "web_search_call.results")]
+    #[schema(rename = "web_search_call.results")]
+    WebSearchCallResults,
+    /// Include the sources used by web search actions.
+    #[serde(rename = "web_search_call.action.sources")]
+    #[schema(rename = "web_search_call.action.sources")]
+    WebSearchCallActionSources,
+    /// Include image URLs in message input-image parts.
+    #[serde(rename = "message.input_image.image_url")]
+    #[schema(rename = "message.input_image.image_url")]
+    MessageInputImageImageUrl,
+    /// Include image URLs in computer-call outputs.
+    #[serde(rename = "computer_call_output.output.image_url")]
+    #[schema(rename = "computer_call_output.output.image_url")]
+    ComputerCallOutputImageUrl,
+    /// Include code-interpreter output payloads.
+    #[serde(rename = "code_interpreter_call.outputs")]
+    #[schema(rename = "code_interpreter_call.outputs")]
+    CodeInterpreterCallOutputs,
+    /// Include encrypted reasoning content.
+    #[serde(rename = "reasoning.encrypted_content")]
+    #[schema(rename = "reasoning.encrypted_content")]
+    ReasoningEncryptedContent,
+    /// Include token log probabilities in message output-text parts.
+    #[serde(rename = "message.output_text.logprobs")]
+    #[schema(rename = "message.output_text.logprobs")]
+    MessageOutputTextLogprobs,
+}
+
+impl IncludeField {
+    /// Parse one decoded query value using the official enum spelling.
+    pub(super) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "file_search_call.results" => Some(Self::FileSearchCallResults),
+            "web_search_call.results" => Some(Self::WebSearchCallResults),
+            "web_search_call.action.sources" => Some(Self::WebSearchCallActionSources),
+            "message.input_image.image_url" => Some(Self::MessageInputImageImageUrl),
+            "computer_call_output.output.image_url" => Some(Self::ComputerCallOutputImageUrl),
+            "code_interpreter_call.outputs" => Some(Self::CodeInterpreterCallOutputs),
+            "reasoning.encrypted_content" => Some(Self::ReasoningEncryptedContent),
+            "message.output_text.logprobs" => Some(Self::MessageOutputTextLogprobs),
+            _ => None,
+        }
+    }
+
+    /// Return this field's bit in the compact runtime include set.
+    const fn bit(self) -> u8 {
+        match self {
+            Self::FileSearchCallResults => 1 << 0,
+            Self::WebSearchCallResults => 1 << 1,
+            Self::WebSearchCallActionSources => 1 << 2,
+            Self::MessageInputImageImageUrl => 1 << 3,
+            Self::ComputerCallOutputImageUrl => 1 << 4,
+            Self::CodeInterpreterCallOutputs => 1 << 5,
+            Self::ReasoningEncryptedContent => 1 << 6,
+            Self::MessageOutputTextLogprobs => 1 << 7,
+        }
+    }
+}
+
+/// Allocation-free set of requested optional item fields.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct IncludeFields(u8);
+
+impl IncludeFields {
+    /// Add one requested field.
+    pub(super) fn insert(&mut self, field: IncludeField) {
+        self.0 |= field.bit();
+    }
+
+    /// Return whether a field was requested.
+    pub(super) const fn contains(self, field: IncludeField) -> bool {
+        self.0 & field.bit() != 0
+    }
+}
+
 /// Request body accepted by `POST /conversations`.
 #[derive(Debug, Deserialize, ToSchema)]
 pub(super) struct CreateConversationRequest {

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -17,8 +17,8 @@ use tracing::debug;
 use super::{
     contracts::{
         ConversationItem, ConversationItemList, ConversationResource, CreateConversationItemsRequest,
-        CreateConversationRequest, DeletedConversationResource, ItemOrder, MAX_ITEMS_PER_REQUEST, Metadata,
-        MetadataUpdate, UpdateConversationRequest,
+        CreateConversationRequest, DeletedConversationResource, IncludeField, IncludeFields, ItemOrder,
+        MAX_ITEMS_PER_REQUEST, Metadata, MetadataUpdate, UpdateConversationRequest,
     },
     validate::validate_metadata,
 };
@@ -251,6 +251,10 @@ pub(super) async fn handle_create_items(
         Ok(v) => v,
         Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
     };
+    let includes = match parse_include_fields(ctx.request.uri.query()) {
+        Ok(includes) => includes,
+        Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
+    };
     let existing = match store.get_conversation(tenant_id, conversation_id).await {
         Ok(record) => record,
         Err(e) => return Ok(FilterAction::Reject(store_error_response(&e)?)),
@@ -311,7 +315,7 @@ pub(super) async fn handle_create_items(
         "conversation items created"
     );
 
-    let body = conversation_items_response(item_records, false);
+    let body = conversation_items_response(item_records, false, includes);
     Ok(FilterAction::Reject(json_response(200, &body)?))
 }
 
@@ -323,6 +327,10 @@ pub(super) async fn handle_list_items(
     conversation_id: &str,
 ) -> Result<FilterAction, FilterError> {
     let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
+    let includes = match parse_include_fields(ctx.request.uri.query()) {
+        Ok(includes) => includes,
+        Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
+    };
     match store.get_conversation(tenant_id, conversation_id).await {
         Ok(Some(_)) => {},
         Ok(None) => {
@@ -353,7 +361,7 @@ pub(super) async fn handle_list_items(
     let has_more = rows.len() > take_limit;
     let data: Vec<_> = rows.into_iter().take(take_limit).collect();
 
-    let body = conversation_items_response(data, has_more);
+    let body = conversation_items_response(data, has_more, includes);
     Ok(FilterAction::Reject(json_response(200, &body)?))
 }
 
@@ -365,6 +373,10 @@ pub(super) async fn handle_get_item(
     item_id: &str,
 ) -> Result<FilterAction, FilterError> {
     let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
+    let includes = match parse_include_fields(ctx.request.uri.query()) {
+        Ok(includes) => includes,
+        Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
+    };
     let item_id = match decode_item_id_path_segment(item_id) {
         Ok(id) => id,
         Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
@@ -372,7 +384,9 @@ pub(super) async fn handle_get_item(
     let item_id = item_id.as_ref();
     match store.get_conversation_item(tenant_id, conversation_id, item_id).await {
         Ok(Some(record)) => {
-            let item = ConversationItem::from_value(record.item_data);
+            let mut item_data = record.item_data;
+            project_conversation_item(&mut item_data, includes);
+            let item = ConversationItem::from_value(item_data);
             Ok(FilterAction::Reject(json_response(200, &item)?))
         },
         Ok(None) => {
@@ -602,7 +616,11 @@ fn conversation_response(record: ConversationRecord) -> ConversationResource {
 }
 
 /// Move item records into an `OpenAI` list response without copying item JSON.
-fn conversation_items_response(records: Vec<ConversationItemRecord>, has_more: bool) -> ConversationItemList {
+fn conversation_items_response(
+    records: Vec<ConversationItemRecord>,
+    has_more: bool,
+    includes: IncludeFields,
+) -> ConversationItemList {
     let record_count = records.len();
     let mut first_id = String::new();
     let mut last_id = String::new();
@@ -617,10 +635,163 @@ fn conversation_items_response(records: Vec<ConversationItemRecord>, has_more: b
         } else if index + 1 == record_count {
             last_id = record.item_id;
         }
-        data.push(ConversationItem::from_value(record.item_data));
+        let mut item_data = record.item_data;
+        project_conversation_item(&mut item_data, includes);
+        data.push(ConversationItem::from_value(item_data));
     }
 
     ConversationItemList::new(data, has_more, first_id, last_id)
+}
+
+/// Remove optional fields that were not requested through `include`.
+///
+/// The item is already owned by the response path, so projection mutates it in
+/// place without copying provider payloads or the stored representation.
+fn project_conversation_item(item: &mut Value, includes: IncludeFields) {
+    let Some(object) = item.as_object_mut() else {
+        return;
+    };
+    match projection_kind(object) {
+        ProjectionKind::Reasoning => remove_unless_included(
+            object,
+            "encrypted_content",
+            includes.contains(IncludeField::ReasoningEncryptedContent),
+        ),
+        ProjectionKind::FileSearch => remove_unless_included(
+            object,
+            "results",
+            includes.contains(IncludeField::FileSearchCallResults),
+        ),
+        ProjectionKind::WebSearch => project_web_search_fields(object, includes),
+        ProjectionKind::CodeInterpreter => remove_unless_included(
+            object,
+            "outputs",
+            includes.contains(IncludeField::CodeInterpreterCallOutputs),
+        ),
+        ProjectionKind::ComputerOutput => project_computer_output_fields(object, includes),
+        ProjectionKind::Message => project_message_fields(object, includes),
+        ProjectionKind::Other => {},
+    }
+}
+
+/// Item variants with fields controlled by `include`.
+#[derive(Clone, Copy)]
+enum ProjectionKind {
+    /// Reasoning item with optional encrypted content.
+    Reasoning,
+    /// File-search call with optional results.
+    FileSearch,
+    /// Web-search call with optional results and sources.
+    WebSearch,
+    /// Code-interpreter call with optional outputs.
+    CodeInterpreter,
+    /// Computer-call output with an optional image URL.
+    ComputerOutput,
+    /// Message with optional fields in typed content parts.
+    Message,
+    /// Item without any fields controlled by `include`.
+    Other,
+}
+
+/// Classify an item without retaining a borrow into the mutable object.
+fn projection_kind(object: &Map<String, Value>) -> ProjectionKind {
+    match object.get("type").and_then(Value::as_str) {
+        Some("reasoning") => ProjectionKind::Reasoning,
+        Some("file_search_call") => ProjectionKind::FileSearch,
+        Some("web_search_call") => ProjectionKind::WebSearch,
+        Some("code_interpreter_call") => ProjectionKind::CodeInterpreter,
+        Some("computer_call_output") => ProjectionKind::ComputerOutput,
+        Some("message") => ProjectionKind::Message,
+        _ => ProjectionKind::Other,
+    }
+}
+
+/// Remove one top-level field unless it was explicitly requested.
+fn remove_unless_included(object: &mut Map<String, Value>, field: &str, included: bool) {
+    if !included {
+        object.remove(field);
+    }
+}
+
+/// Project web-search fields controlled by independent include values.
+fn project_web_search_fields(object: &mut Map<String, Value>, includes: IncludeFields) {
+    remove_unless_included(object, "results", includes.contains(IncludeField::WebSearchCallResults));
+    if !includes.contains(IncludeField::WebSearchCallActionSources)
+        && let Some(action) = object.get_mut("action").and_then(Value::as_object_mut)
+    {
+        action.remove("sources");
+    }
+}
+
+/// Project the nested image URL from a computer-call output.
+fn project_computer_output_fields(object: &mut Map<String, Value>, includes: IncludeFields) {
+    if !includes.contains(IncludeField::ComputerCallOutputImageUrl)
+        && let Some(output) = object.get_mut("output").and_then(Value::as_object_mut)
+    {
+        output.remove("image_url");
+    }
+}
+
+/// Project optional fields from typed message content parts.
+fn project_message_fields(object: &mut Map<String, Value>, includes: IncludeFields) {
+    let Some(content) = object.get_mut("content").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for part in content {
+        let Some(part) = part.as_object_mut() else {
+            continue;
+        };
+        if part.get("type").and_then(Value::as_str) == Some("input_image")
+            && !includes.contains(IncludeField::MessageInputImageImageUrl)
+        {
+            part.remove("image_url");
+        } else if part.get("type").and_then(Value::as_str) == Some("output_text")
+            && !includes.contains(IncludeField::MessageOutputTextLogprobs)
+        {
+            part.remove("logprobs");
+        }
+    }
+}
+
+/// Parse both official SDK encodings for the array-valued `include` query:
+/// repeated `include=value` pairs and bracketed `include[]=value` pairs.
+fn parse_include_fields(query: Option<&str>) -> Result<IncludeFields, String> {
+    let Some(query) = query else {
+        return Ok(IncludeFields::default());
+    };
+
+    let mut includes = IncludeFields::default();
+    for pair in query.split('&') {
+        let Some((raw_key, raw_value)) = pair.split_once('=') else {
+            let key = decode_query_component_strict(pair)?;
+            if matches!(key.as_ref(), "include" | "include[]") {
+                return Err("'include' query parameter requires a value".to_owned());
+            }
+            continue;
+        };
+        let key = decode_query_component_strict(raw_key)?;
+        if !matches!(key.as_ref(), "include" | "include[]") {
+            continue;
+        }
+        let value = decode_query_component_strict(raw_value)?;
+        let field = IncludeField::parse(&value).ok_or_else(|| format!("unsupported include value: '{value}'"))?;
+        includes.insert(field);
+    }
+    Ok(includes)
+}
+
+/// Strictly decode one query component, including form-style `+` spaces.
+fn decode_query_component_strict(value: &str) -> Result<Cow<'_, str>, String> {
+    if value.contains('+') {
+        let normalized = value.replace('+', " ");
+        return percent_decode_str(&normalized)
+            .decode_utf8()
+            .map(|decoded| Cow::Owned(decoded.into_owned()))
+            .map_err(|e| format!("query parameter must be valid UTF-8: {e}"));
+    }
+    percent_decode_str(value)
+        .decode_utf8()
+        .map_err(|e| format!("query parameter must be valid UTF-8: {e}"))
 }
 
 /// Parse cursor-based pagination parameters from a query string.
@@ -979,6 +1150,119 @@ mod tests {
             Some("item with space"),
             "percent-encoded and plus-encoded values should decode"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // include parsing and projection
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_include_fields_supports_python_and_node_sdk_encodings() {
+        let includes = parse_include_fields(Some(
+            "include=reasoning.encrypted_content&include%5B%5D=message.output_text.logprobs",
+        ))
+        .unwrap();
+
+        assert!(includes.contains(IncludeField::ReasoningEncryptedContent));
+        assert!(includes.contains(IncludeField::MessageOutputTextLogprobs));
+        assert!(!includes.contains(IncludeField::FileSearchCallResults));
+    }
+
+    #[test]
+    fn parse_include_fields_rejects_unknown_or_malformed_values() {
+        let unknown = parse_include_fields(Some("include=future.secret_field")).unwrap_err();
+        assert!(unknown.contains("unsupported include value"));
+
+        let missing = parse_include_fields(Some("include")).unwrap_err();
+        assert!(missing.contains("requires a value"));
+
+        let invalid_utf8 = parse_include_fields(Some("include=%FF")).unwrap_err();
+        assert!(invalid_utf8.contains("valid UTF-8"));
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "one fixture covers every include projection path")]
+    fn projection_removes_every_unrequested_include_gated_field() {
+        let mut items = vec![
+            serde_json::json!({
+                "type": "reasoning",
+                "encrypted_content": "secret",
+                "summary": []
+            }),
+            serde_json::json!({
+                "type": "file_search_call",
+                "results": [{"file_id": "file_1"}],
+                "status": "completed"
+            }),
+            serde_json::json!({
+                "type": "web_search_call",
+                "results": [{"url": "https://example.com"}],
+                "action": {
+                    "type": "search",
+                    "sources": [{"type": "url", "url": "https://example.com"}]
+                }
+            }),
+            serde_json::json!({
+                "type": "code_interpreter_call",
+                "outputs": [{"type": "logs", "logs": "done"}],
+                "status": "completed"
+            }),
+            serde_json::json!({
+                "type": "computer_call_output",
+                "output": {"type": "computer_screenshot", "image_url": "data:image/png;base64,AA=="}
+            }),
+            serde_json::json!({
+                "type": "message",
+                "content": [
+                    {"type": "input_image", "image_url": "https://example.com/image.png", "detail": "auto"},
+                    {"type": "output_text", "text": "answer", "annotations": [], "logprobs": []},
+                    {"type": "input_text", "text": "keep me"}
+                ]
+            }),
+        ];
+
+        for item in &mut items {
+            project_conversation_item(item, IncludeFields::default());
+        }
+
+        assert!(items[0].get("encrypted_content").is_none());
+        assert!(items[1].get("results").is_none());
+        assert!(items[2].get("results").is_none());
+        assert!(items[2]["action"].get("sources").is_none());
+        assert!(items[3].get("outputs").is_none());
+        assert!(items[4]["output"].get("image_url").is_none());
+        assert!(items[5]["content"][0].get("image_url").is_none());
+        assert!(items[5]["content"][1].get("logprobs").is_none());
+        assert_eq!(items[5]["content"][2]["text"], "keep me");
+    }
+
+    #[test]
+    fn projection_preserves_every_requested_include_gated_field() {
+        let mut includes = IncludeFields::default();
+        for field in [
+            IncludeField::FileSearchCallResults,
+            IncludeField::WebSearchCallResults,
+            IncludeField::WebSearchCallActionSources,
+            IncludeField::MessageInputImageImageUrl,
+            IncludeField::ComputerCallOutputImageUrl,
+            IncludeField::CodeInterpreterCallOutputs,
+            IncludeField::ReasoningEncryptedContent,
+            IncludeField::MessageOutputTextLogprobs,
+        ] {
+            includes.insert(field);
+        }
+        let original = serde_json::json!({
+            "type": "message",
+            "content": [
+                {"type": "input_image", "image_url": "https://example.com/image.png"},
+                {"type": "output_text", "logprobs": [{"token": "x"}]}
+            ]
+        });
+        let mut projected = original.clone();
+
+        project_conversation_item(&mut projected, includes);
+
+        assert_eq!(projected, original);
     }
 
     // -------------------------------------------------------------------------

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -645,8 +645,8 @@ fn conversation_items_response(
 
 /// Remove optional fields that were not requested through `include`.
 ///
-/// The item is already owned by the response path, so projection mutates it in
-/// place without copying provider payloads or the stored representation.
+/// Projection changes only the response-owned value after the complete item
+/// representation has crossed the storage boundary.
 fn project_conversation_item(item: &mut Value, includes: IncludeFields) {
     let Some(object) = item.as_object_mut() else {
         return;
@@ -1163,21 +1163,39 @@ mod tests {
         ))
         .unwrap();
 
-        assert!(includes.contains(IncludeField::ReasoningEncryptedContent));
-        assert!(includes.contains(IncludeField::MessageOutputTextLogprobs));
-        assert!(!includes.contains(IncludeField::FileSearchCallResults));
+        assert!(
+            includes.contains(IncludeField::ReasoningEncryptedContent),
+            "repeated-key encoding should parse reasoning encrypted content"
+        );
+        assert!(
+            includes.contains(IncludeField::MessageOutputTextLogprobs),
+            "bracket encoding should parse output-text log probabilities"
+        );
+        assert!(
+            !includes.contains(IncludeField::FileSearchCallResults),
+            "unrequested include values must remain absent"
+        );
     }
 
     #[test]
     fn parse_include_fields_rejects_unknown_or_malformed_values() {
         let unknown = parse_include_fields(Some("include=future.secret_field")).unwrap_err();
-        assert!(unknown.contains("unsupported include value"));
+        assert!(
+            unknown.contains("unsupported include value"),
+            "unknown values should produce an unsupported-value diagnostic: {unknown}"
+        );
 
         let missing = parse_include_fields(Some("include")).unwrap_err();
-        assert!(missing.contains("requires a value"));
+        assert!(
+            missing.contains("requires a value"),
+            "missing include values should identify the required value: {missing}"
+        );
 
         let invalid_utf8 = parse_include_fields(Some("include=%FF")).unwrap_err();
-        assert!(invalid_utf8.contains("valid UTF-8"));
+        assert!(
+            invalid_utf8.contains("valid UTF-8"),
+            "invalid encoding should identify the UTF-8 requirement: {invalid_utf8}"
+        );
     }
 
     #[test]
@@ -1225,14 +1243,38 @@ mod tests {
             project_conversation_item(item, IncludeFields::default());
         }
 
-        assert!(items[0].get("encrypted_content").is_none());
-        assert!(items[1].get("results").is_none());
-        assert!(items[2].get("results").is_none());
-        assert!(items[2]["action"].get("sources").is_none());
-        assert!(items[3].get("outputs").is_none());
-        assert!(items[4]["output"].get("image_url").is_none());
-        assert!(items[5]["content"][0].get("image_url").is_none());
-        assert!(items[5]["content"][1].get("logprobs").is_none());
+        assert!(
+            items[0].get("encrypted_content").is_none(),
+            "reasoning encrypted content should be omitted"
+        );
+        assert!(
+            items[1].get("results").is_none(),
+            "file-search results should be omitted"
+        );
+        assert!(
+            items[2].get("results").is_none(),
+            "web-search results should be omitted"
+        );
+        assert!(
+            items[2]["action"].get("sources").is_none(),
+            "web-search action sources should be omitted"
+        );
+        assert!(
+            items[3].get("outputs").is_none(),
+            "code-interpreter outputs should be omitted"
+        );
+        assert!(
+            items[4]["output"].get("image_url").is_none(),
+            "computer-output image URLs should be omitted"
+        );
+        assert!(
+            items[5]["content"][0].get("image_url").is_none(),
+            "message input-image URLs should be omitted"
+        );
+        assert!(
+            items[5]["content"][1].get("logprobs").is_none(),
+            "message output-text log probabilities should be omitted"
+        );
         assert_eq!(items[5]["content"][2]["text"], "keep me");
     }
 

--- a/apis/src/openai/conversations/openapi.rs
+++ b/apis/src/openai/conversations/openapi.rs
@@ -114,6 +114,45 @@ mod tests {
         );
     }
 
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "checks all three operations and eight enum values")]
+    fn generated_item_operations_share_the_official_include_enum() {
+        let document = serde_json::to_value(implementation_openapi()).unwrap();
+        let expected = [
+            "file_search_call.results",
+            "web_search_call.results",
+            "web_search_call.action.sources",
+            "message.input_image.image_url",
+            "computer_call_output.output.image_url",
+            "code_interpreter_call.outputs",
+            "reasoning.encrypted_content",
+            "message.output_text.logprobs",
+        ]
+        .map(Value::from)
+        .to_vec();
+        for pointer in [
+            "/paths/~1conversations~1{conversation_id}~1items/post/parameters",
+            "/paths/~1conversations~1{conversation_id}~1items/get/parameters",
+            "/paths/~1conversations~1{conversation_id}~1items~1{item_id}/get/parameters",
+        ] {
+            let parameters = document.pointer(pointer).and_then(Value::as_array).unwrap();
+            let include = parameters
+                .iter()
+                .find(|parameter| parameter.get("name") == Some(&Value::String("include".to_owned())))
+                .unwrap();
+            assert_eq!(include["in"], "query");
+            assert_eq!(include["required"], false);
+            assert_eq!(
+                include.pointer("/schema/type"),
+                Some(&Value::String("array".to_owned()))
+            );
+            assert_eq!(
+                include.pointer("/schema/items/enum"),
+                Some(&Value::Array(expected.clone()))
+            );
+        }
+    }
+
     fn collect_component_references<'a>(value: &'a Value, references: &mut Vec<&'a str>) {
         match value {
             Value::Object(object) => {

--- a/apis/src/openai/conversations/routes.rs
+++ b/apis/src/openai/conversations/routes.rs
@@ -9,7 +9,7 @@ use utoipa::PartialSchema;
 
 use super::contracts::{
     ConversationItem, ConversationItemList, ConversationResource, CreateConversationItemsRequest,
-    CreateConversationRequest, DeletedConversationResource, ItemOrder, UpdateConversationRequest,
+    CreateConversationRequest, DeletedConversationResource, IncludeField, ItemOrder, UpdateConversationRequest,
 };
 use crate::openai::operation::{
     MediaTypeSpec, OpenAiHandlingMode, OpenAiHttpMethod, OpenAiOperationSpec, OwnedOperationContract,
@@ -204,10 +204,17 @@ conversation_operations! {
         path: "/conversations/{conversation_id}/items",
         mode: Local,
         contract: owned {
-            parameters: [path_parameter!(
-                "conversation_id",
-                "The ID of the conversation to add the items to."
-            )],
+            parameters: [
+                path_parameter!(
+                    "conversation_id",
+                    "The ID of the conversation to add the items to."
+                ),
+                query_parameter!(
+                    "include",
+                    Vec<IncludeField>,
+                    "Additional fields to include in the response."
+                ),
+            ],
             request: CreateConversationItemsRequest,
             response: ConversationItemList,
         },
@@ -226,6 +233,11 @@ conversation_operations! {
                 query_parameter!("limit", u32, "Maximum number of items to return."),
                 query_parameter!("order", ItemOrder, "Sort order for returned items."),
                 query_parameter!("after", String, "Item ID to list after."),
+                query_parameter!(
+                    "include",
+                    Vec<IncludeField>,
+                    "Additional fields to include in the response."
+                ),
             ],
             request: none,
             response: ConversationItemList,
@@ -243,6 +255,11 @@ conversation_operations! {
                     "The ID of the conversation that contains the item."
                 ),
                 path_parameter!("item_id", "The ID of the item to retrieve."),
+                query_parameter!(
+                    "include",
+                    Vec<IncludeField>,
+                    "Additional fields to include in the response."
+                ),
             ],
             request: none,
             response: ConversationItem,

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1539,6 +1539,118 @@ async fn create_and_delete_item_endpoints_are_local() {
 }
 
 #[tokio::test]
+async fn item_endpoints_apply_include_projection_without_changing_stored_items() {
+    let filter = build_test_filter();
+    let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({})).await;
+
+    let req = make_request(Method::POST, &format!("/v1/conversations/{conv_id}/items"));
+    let mut ctx = make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+    let body_json = serde_json::json!({
+        "items": [{
+            "id": "reasoning_1",
+            "type": "reasoning",
+            "summary": [],
+            "encrypted_content": "stored-secret"
+        }]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject from create items");
+    };
+    assert_eq!(rejection.status, 200);
+    let response = rejection_body(&rejection);
+    assert!(
+        response["data"][0].get("encrypted_content").is_none(),
+        "create response must omit unrequested encrypted reasoning"
+    );
+
+    let req = make_request(
+        Method::GET,
+        &format!("/v1/conversations/{conv_id}/items/reasoning_1?include%5B%5D=reasoning.encrypted_content"),
+    );
+    let mut ctx = make_filter_context(&req);
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject from get item");
+    };
+    assert_eq!(rejection.status, 200);
+    let response = rejection_body(&rejection);
+    assert_eq!(
+        response["encrypted_content"], "stored-secret",
+        "Node SDK bracket encoding should reveal the requested stored field"
+    );
+
+    let req = make_request(Method::GET, &format!("/v1/conversations/{conv_id}/items"));
+    let mut ctx = make_filter_context(&req);
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject from list items");
+    };
+    let response = rejection_body(&rejection);
+    assert!(response["data"][0].get("encrypted_content").is_none());
+
+    let req = make_request(
+        Method::GET,
+        &format!("/v1/conversations/{conv_id}/items?include=reasoning.encrypted_content"),
+    );
+    let mut ctx = make_filter_context(&req);
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject from list items with include");
+    };
+    let response = rejection_body(&rejection);
+    assert_eq!(
+        response["data"][0]["encrypted_content"], "stored-secret",
+        "Python SDK repeated-key encoding should reveal the requested stored field"
+    );
+}
+
+#[tokio::test]
+async fn item_endpoints_reject_unknown_include_values() {
+    let filter = build_test_filter();
+    let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({})).await;
+
+    let req = make_request(
+        Method::POST,
+        &format!("/v1/conversations/{conv_id}/items?include=future.secret_field"),
+    );
+    let mut ctx = make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+    let mut body = Some(Bytes::from_static(
+        br#"{"items":[{"id":"reasoning_2","type":"reasoning","summary":[]}]}"#,
+    ));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject from create items with unknown include");
+    };
+    assert_eq!(rejection.status, 400);
+    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
+
+    for path in [
+        format!("/v1/conversations/{conv_id}/items?include=future.secret_field"),
+        format!("/v1/conversations/{conv_id}/items/missing?include=future.secret_field"),
+    ] {
+        let req = make_request(Method::GET, &path);
+        let mut ctx = make_filter_context(&req);
+        let action = filter.on_request(&mut ctx).await.unwrap();
+        let FilterAction::Reject(rejection) = action else {
+            panic!("expected Reject from {path}");
+        };
+        assert_eq!(rejection.status, 400);
+        let response = rejection_body(&rejection);
+        assert_eq!(response["error"]["type"], "invalid_request_error");
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("unsupported include")
+        );
+    }
+}
+
+#[tokio::test]
 async fn item_subresource_routes_do_not_fall_through_upstream() {
     let filter = build_test_filter();
     let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({})).await;

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1589,7 +1589,10 @@ async fn item_endpoints_apply_include_projection_without_changing_stored_items()
         panic!("expected Reject from list items");
     };
     let response = rejection_body(&rejection);
-    assert!(response["data"][0].get("encrypted_content").is_none());
+    assert!(
+        response["data"][0].get("encrypted_content").is_none(),
+        "list response must omit unrequested encrypted reasoning"
+    );
 
     let req = make_request(
         Method::GET,
@@ -1645,7 +1648,8 @@ async fn item_endpoints_reject_unknown_include_values() {
             response["error"]["message"]
                 .as_str()
                 .unwrap()
-                .contains("unsupported include")
+                .contains("unsupported include"),
+            "unknown include response should explain the unsupported value"
         );
     }
 }

--- a/docs/conformance/openai-conformance-report.json
+++ b/docs/conformance/openai-conformance-report.json
@@ -255,7 +255,7 @@
           "exact": 1,
           "missing": 0,
           "drifted": 7,
-          "request_drifted": 5,
+          "request_drifted": 4,
           "response_drifted": 7,
           "other_drifted": 0,
           "exact_percent": 12.5,
@@ -305,7 +305,6 @@
               "has_response_drift": true,
               "has_other_drift": false,
               "request_details": [
-                "parameters.deleted.query",
                 "parameters.query.limit.schema.format.from",
                 "parameters.query.limit.schema.format.to",
                 "parameters.query.limit.schema.default.from",
@@ -326,12 +325,10 @@
                 "path": "/conversations/{conversation_id}/items/{item_id}",
                 "operation": "GET /conversations/{conversation_id}/items/{item_id}"
               },
-              "has_request_drift": true,
+              "has_request_drift": false,
               "has_response_drift": true,
               "has_other_drift": false,
-              "request_details": [
-                "parameters.deleted.query"
-              ],
+              "request_details": [],
               "response_details": [
                 "responses.200.content.application/json.schema.oneOf.deleted",
                 "responses.200.content.application/json.schema.type.added",
@@ -400,7 +397,6 @@
               "has_response_drift": true,
               "has_other_drift": false,
               "request_details": [
-                "parameters.deleted.query",
                 "requestBody.content.application/json.schema.type.added",
                 "requestBody.content.application/json.schema.properties.items.items.oneOf.deleted",
                 "requestBody.content.application/json.schema.properties.items.items.type.added",
@@ -430,7 +426,7 @@
       "exact": 1,
       "missing": 0,
       "drifted": 7,
-      "request_drifted": 5,
+      "request_drifted": 4,
       "response_drifted": 7,
       "other_drifted": 0,
       "exact_percent": 12.5,
@@ -441,7 +437,7 @@
           "conformant": 1,
           "missing": 0,
           "drifted": 7,
-          "request_drifted": 5,
+          "request_drifted": 4,
           "response_drifted": 7,
           "other_drifted": 0,
           "conformance_percent": 12.5
@@ -464,7 +460,7 @@
         "operations_to_fix": 7,
         "area_contracts_to_fix": 1,
         "missing_operations": 0,
-        "request_drift_operations": 5,
+        "request_drift_operations": 4,
         "response_drift_operations": 7,
         "other_drift_operations": 0
       },
@@ -519,7 +515,6 @@
               "kind": "request_parameters",
               "summary": "Add or align OpenAI request parameters in the implementation spec and handler behavior.",
               "detail_paths": [
-                "parameters.deleted.query",
                 "parameters.query.limit.schema.format.from",
                 "parameters.query.limit.schema.format.to",
                 "parameters.query.limit.schema.default.from",
@@ -547,14 +542,6 @@
             "operation": "GET /conversations/{conversation_id}/items/{item_id}"
           },
           "fixes": [
-            {
-              "area": "request",
-              "kind": "request_parameters",
-              "summary": "Add or align OpenAI request parameters in the implementation spec and handler behavior.",
-              "detail_paths": [
-                "parameters.deleted.query"
-              ]
-            },
             {
               "area": "response",
               "kind": "response_schema",
@@ -641,14 +628,6 @@
             "operation": "POST /conversations/{conversation_id}/items"
           },
           "fixes": [
-            {
-              "area": "request",
-              "kind": "request_parameters",
-              "summary": "Add or align OpenAI request parameters in the implementation spec and handler behavior.",
-              "detail_paths": [
-                "parameters.deleted.query"
-              ]
-            },
             {
               "area": "request",
               "kind": "request_body_schema",


### PR DESCRIPTION
## Summary

- parse and validate the official Conversations `include` values on create, list, and retrieve item endpoints
- omit include-gated fields unless explicitly requested while leaving stored item data unchanged
- publish the shared `include` enum in the generated OpenAPI contract and update the conformance report

## Validation

- `cargo test -p praxis-ai-apis conversations --locked` (188 passed, 1 ignored)
- `cargo clippy -p praxis-ai-apis --all-targets --all-features --locked -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #414