### PR TITLE
feat(mcp_tool_resolve): resolve MCP servers concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ dependencies = [
  "base64",
  "bytes",
  "dashmap 6.2.1",
+ "futures",
  "http",
  "percent-encoding",
  "praxis-proxy-core",

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true, optional = true }
+futures = { workspace = true }
 http = { workspace = true }
 percent-encoding = { workspace = true }
 pingora-core = { workspace = true }

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -178,11 +178,12 @@ impl McpToolResolveFilter {
         entries: &[serde_json::Value],
         previous_tools: Option<&Vec<serde_json::Value>>,
     ) -> Result<Resolution, ResolveError> {
-        let (entry_to_task, task_entries) = dedup_entries(entries);
+        let (entry_to_task, task_entries, task_allowed_names) = dedup_entries(entries);
 
         let futures: Vec<_> = task_entries
             .iter()
-            .map(|entry| self.resolve_entry(entry, previous_tools))
+            .zip(&task_allowed_names)
+            .map(|(entry, allowed)| self.resolve_entry(entry, previous_tools, allowed.as_deref()))
             .collect();
         let task_results = futures::future::try_join_all(futures).await?;
 
@@ -210,10 +211,16 @@ impl McpToolResolveFilter {
     }
 
     /// Resolve tools for a single MCP entry independently.
+    ///
+    /// `cache_allowed_names` is the union of `allowed_tools` names
+    /// across all entries sharing this resolution task; it is passed
+    /// to [`find_cached_listing`] so the cache is only used when it
+    /// covers every entry in the group.
     async fn resolve_entry(
         &self,
         entry: &serde_json::Value,
         previous_tools: Option<&Vec<serde_json::Value>>,
+        cache_allowed_names: Option<&[String]>,
     ) -> Result<Option<Vec<serde_json::Value>>, ResolveError> {
         let Some(server_url) = resolvable_server_url(entry) else {
             return Ok(None);
@@ -222,9 +229,8 @@ impl McpToolResolveFilter {
         mcp_client::validate_mcp_url(server_url, self.timeout, self.allow_loopback)
             .await
             .map_err(ResolveError::Client)?;
-        let allowed = extract_allowed_tools(entry);
         if !has_entry_credentials(entry)
-            && let Some(cached) = find_cached_listing(previous_tools, label, server_url, allowed.as_names())
+            && let Some(cached) = find_cached_listing(previous_tools, label, server_url, cache_allowed_names)
         {
             debug!(label, tool_count = cached.len(), "reusing cached MCP tool listing");
             return Ok(Some(cached));
@@ -384,38 +390,62 @@ fn check_duplicate_labels(entries: &[serde_json::Value]) -> Result<(), ResolveEr
     Ok(())
 }
 
+/// Return type for [`dedup_entries`]: `(entry_to_task, task_entries, task_allowed_names)`.
+type DedupResult<'a> = (Vec<Option<usize>>, Vec<&'a serde_json::Value>, Vec<Option<Vec<String>>>);
+
 /// Deduplicate MCP entries into resolution tasks. Non-credentialed
 /// entries sharing the same `(label, url)` map to a single task;
 /// credentialed entries always get their own task.
-///
-/// Returns `(entry_to_task, task_entries)` where `entry_to_task[i]`
-/// is the task index for entry `i` (or `None` if non-resolvable),
-/// and `task_entries` holds the representative entry for each task.
-fn dedup_entries(entries: &[serde_json::Value]) -> (Vec<Option<usize>>, Vec<&serde_json::Value>) {
+fn dedup_entries(entries: &[serde_json::Value]) -> DedupResult<'_> {
     let mut entry_to_task: Vec<Option<usize>> = vec![None; entries.len()];
     let mut task_entries: Vec<&serde_json::Value> = Vec::new();
+    let mut task_allowed_names: Vec<Option<Vec<String>>> = Vec::new();
     let mut seen: HashMap<(&str, &str), usize> = HashMap::new();
 
     for (slot, entry) in entry_to_task.iter_mut().zip(entries) {
         let Some(url) = resolvable_server_url(entry) else {
             continue;
         };
-        if has_entry_credentials(entry) {
-            let task_idx = task_entries.len();
-            task_entries.push(entry);
+        let allowed = extract_allowed_tools(entry);
+        let existing = if has_entry_credentials(entry) {
+            None
+        } else {
+            seen.get(&(server_label(entry), url)).copied()
+        };
+        if let Some(task_idx) = existing {
+            if let Some(merged) = task_allowed_names.get_mut(task_idx) {
+                merge_allowed_names(merged, &allowed.names);
+            }
             *slot = Some(task_idx);
         } else {
-            let label = server_label(entry);
-            let task_idx = *seen.entry((label, url)).or_insert_with(|| {
-                let idx = task_entries.len();
-                task_entries.push(entry);
-                idx
-            });
+            let task_idx = task_entries.len();
+            if !has_entry_credentials(entry) {
+                seen.insert((server_label(entry), url), task_idx);
+            }
+            task_entries.push(entry);
+            task_allowed_names.push(allowed.names);
             *slot = Some(task_idx);
         }
     }
 
-    (entry_to_task, task_entries)
+    (entry_to_task, task_entries, task_allowed_names)
+}
+
+/// Merge `new` into `existing` as a union. If either side is
+/// unrestricted (`None`), the result is unrestricted.
+fn merge_allowed_names(existing: &mut Option<Vec<String>>, new: &Option<Vec<String>>) {
+    let Some(new_names) = new else {
+        *existing = None;
+        return;
+    };
+    let Some(existing_names) = existing.as_mut() else {
+        return;
+    };
+    for name in new_names {
+        if !existing_names.contains(name) {
+            existing_names.push(name.clone());
+        }
+    }
 }
 
 /// Count distinct resolvable `(server_label, server_url)` pairs.

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -169,23 +169,28 @@ impl McpToolResolveFilter {
     /// map and pre-built function tools for body rewriting.
     ///
     /// Server resolutions run concurrently via
-    /// [`futures::future::try_join_all`], bounded by the
-    /// `max_servers` cap checked before this method is called.
+    /// [`futures::future::try_join_all`]. Non-credentialed entries
+    /// sharing the same `(server_label, server_url)` are
+    /// deduplicated to a single resolution task; credentialed
+    /// entries always resolve independently.
     async fn resolve_all_entries(
         &self,
         entries: &[serde_json::Value],
         previous_tools: Option<&Vec<serde_json::Value>>,
     ) -> Result<Resolution, ResolveError> {
-        let futures: Vec<_> = entries
+        let (entry_to_task, task_entries) = dedup_entries(entries);
+
+        let futures: Vec<_> = task_entries
             .iter()
             .map(|entry| self.resolve_entry(entry, previous_tools))
             .collect();
-        let resolved = futures::future::try_join_all(futures).await?;
+        let task_results = futures::future::try_join_all(futures).await?;
 
         let mut tool_map = HashMap::new();
         let mut per_entry = Vec::with_capacity(entries.len());
 
-        for (entry, tools_opt) in entries.iter().zip(resolved) {
+        for (entry, task_idx) in entries.iter().zip(&entry_to_task) {
+            let tools_opt = task_idx.and_then(|idx| task_results.get(idx)?.clone());
             let Some(tools) = tools_opt else {
                 per_entry.push(Vec::new());
                 continue;
@@ -377,6 +382,40 @@ fn check_duplicate_labels(entries: &[serde_json::Value]) -> Result<(), ResolveEr
         }
     }
     Ok(())
+}
+
+/// Deduplicate MCP entries into resolution tasks. Non-credentialed
+/// entries sharing the same `(label, url)` map to a single task;
+/// credentialed entries always get their own task.
+///
+/// Returns `(entry_to_task, task_entries)` where `entry_to_task[i]`
+/// is the task index for entry `i` (or `None` if non-resolvable),
+/// and `task_entries` holds the representative entry for each task.
+fn dedup_entries(entries: &[serde_json::Value]) -> (Vec<Option<usize>>, Vec<&serde_json::Value>) {
+    let mut entry_to_task: Vec<Option<usize>> = vec![None; entries.len()];
+    let mut task_entries: Vec<&serde_json::Value> = Vec::new();
+    let mut seen: HashMap<(&str, &str), usize> = HashMap::new();
+
+    for (slot, entry) in entry_to_task.iter_mut().zip(entries) {
+        let Some(url) = resolvable_server_url(entry) else {
+            continue;
+        };
+        if has_entry_credentials(entry) {
+            let task_idx = task_entries.len();
+            task_entries.push(entry);
+            *slot = Some(task_idx);
+        } else {
+            let label = server_label(entry);
+            let task_idx = *seen.entry((label, url)).or_insert_with(|| {
+                let idx = task_entries.len();
+                task_entries.push(entry);
+                idx
+            });
+            *slot = Some(task_idx);
+        }
+    }
+
+    (entry_to_task, task_entries)
 }
 
 /// Count distinct resolvable `(server_label, server_url)` pairs.

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -167,17 +167,26 @@ impl McpToolResolveFilter {
 
     /// Resolve all MCP entries, building both the global dispatch
     /// map and pre-built function tools for body rewriting.
+    ///
+    /// Server resolutions run concurrently via
+    /// [`futures::future::try_join_all`], bounded by the
+    /// `max_servers` cap checked before this method is called.
     async fn resolve_all_entries(
         &self,
         entries: &[serde_json::Value],
         previous_tools: Option<&Vec<serde_json::Value>>,
     ) -> Result<Resolution, ResolveError> {
+        let futures: Vec<_> = entries
+            .iter()
+            .map(|entry| self.resolve_entry(entry, previous_tools))
+            .collect();
+        let resolved = futures::future::try_join_all(futures).await?;
+
         let mut tool_map = HashMap::new();
         let mut per_entry = Vec::with_capacity(entries.len());
-        let mut fetched: HashMap<(&str, &str), Vec<serde_json::Value>> = HashMap::new();
 
-        for entry in entries {
-            let Some(tools) = self.resolve_entry(entry, previous_tools, &mut fetched).await? else {
+        for (entry, tools_opt) in entries.iter().zip(resolved) {
+            let Some(tools) = tools_opt else {
                 per_entry.push(Vec::new());
                 continue;
             };
@@ -195,36 +204,27 @@ impl McpToolResolveFilter {
         Ok(Resolution { per_entry, tool_map })
     }
 
-    /// Resolve tools for a single entry, reusing within-request
-    /// cached results for the same `(label, url)`.
-    async fn resolve_entry<'a>(
+    /// Resolve tools for a single MCP entry independently.
+    async fn resolve_entry(
         &self,
-        entry: &'a serde_json::Value,
+        entry: &serde_json::Value,
         previous_tools: Option<&Vec<serde_json::Value>>,
-        fetched: &mut HashMap<(&'a str, &'a str), Vec<serde_json::Value>>,
     ) -> Result<Option<Vec<serde_json::Value>>, ResolveError> {
         let Some(server_url) = resolvable_server_url(entry) else {
             return Ok(None);
         };
         let label = server_label(entry);
-        let has_credentials = has_entry_credentials(entry);
-        if !has_credentials && let Some(cached) = fetched.get(&(label, server_url)) {
-            return Ok(Some(cached.clone()));
-        }
         mcp_client::validate_mcp_url(server_url, self.timeout, self.allow_loopback)
             .await
             .map_err(ResolveError::Client)?;
         let allowed = extract_allowed_tools(entry);
-        if !has_credentials
+        if !has_entry_credentials(entry)
             && let Some(cached) = find_cached_listing(previous_tools, label, server_url, allowed.as_names())
         {
             debug!(label, tool_count = cached.len(), "reusing cached MCP tool listing");
             return Ok(Some(cached));
         }
         let tools = fetch_tools(entry, server_url, self.timeout, self.max_tools, self.allow_loopback).await?;
-        if !has_credentials {
-            fetched.insert((label, server_url), tools.clone());
-        }
         Ok(Some(tools))
     }
 }

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -828,6 +828,66 @@ async fn connector_id_entry_preserves_body() {
 }
 
 // =========================================================================
+// Entry Deduplication
+// =========================================================================
+
+#[test]
+fn dedup_entries_groups_same_label_url() {
+    let entries = vec![
+        serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp", "allowed_tools": ["x"]}),
+        serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp", "allowed_tools": ["y"]}),
+        serde_json::json!({"server_label": "b", "server_url": "http://10.0.0.2/mcp"}),
+    ];
+    let (mapping, tasks) = dedup_entries(&entries);
+
+    assert_eq!(tasks.len(), 2, "two unique servers → two tasks");
+    assert_eq!(
+        mapping[0], mapping[1],
+        "entries sharing (label, url) should map to the same task"
+    );
+    assert_ne!(
+        mapping[0], mapping[2],
+        "different servers should map to different tasks"
+    );
+}
+
+#[test]
+fn dedup_entries_keeps_credentialed_independent() {
+    let entries = vec![
+        serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp", "authorization": "tok_a"}),
+        serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp", "authorization": "tok_b"}),
+        serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp"}),
+    ];
+    let (mapping, tasks) = dedup_entries(&entries);
+
+    assert_eq!(
+        tasks.len(),
+        3,
+        "each credentialed entry + one non-credentialed = three tasks"
+    );
+    assert_ne!(mapping[0], mapping[1], "different credentials → different tasks");
+    assert_ne!(
+        mapping[0], mapping[2],
+        "credentialed vs non-credentialed → different tasks"
+    );
+}
+
+#[test]
+fn dedup_entries_skips_non_resolvable() {
+    let entries = vec![
+        serde_json::json!({"server_label": "a", "connector_id": "conn_1"}),
+        serde_json::json!({"server_label": "b", "server_url": "http://10.0.0.1/mcp", "defer_loading": true}),
+        serde_json::json!({"server_label": "c", "server_url": "http://10.0.0.2/mcp"}),
+    ];
+    let (mapping, tasks) = dedup_entries(&entries);
+
+    assert_eq!(tasks.len(), 1, "only one resolvable entry");
+    assert!(mapping[0].is_none(), "connector_id entry not resolvable");
+    assert!(mapping[1].is_none(), "deferred entry not resolvable");
+    assert_eq!(mapping[2], Some(0), "resolvable entry maps to task 0");
+}
+
+// =========================================================================
 // Distinct Server Counting
 // =========================================================================
 

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -838,7 +838,7 @@ fn dedup_entries_groups_same_label_url() {
         serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp", "allowed_tools": ["y"]}),
         serde_json::json!({"server_label": "b", "server_url": "http://10.0.0.2/mcp"}),
     ];
-    let (mapping, tasks) = dedup_entries(&entries);
+    let (mapping, tasks, _) = dedup_entries(&entries);
 
     assert_eq!(tasks.len(), 2, "two unique servers → two tasks");
     assert_eq!(
@@ -858,7 +858,7 @@ fn dedup_entries_keeps_credentialed_independent() {
         serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp", "authorization": "tok_b"}),
         serde_json::json!({"server_label": "a", "server_url": "http://10.0.0.1/mcp"}),
     ];
-    let (mapping, tasks) = dedup_entries(&entries);
+    let (mapping, tasks, _) = dedup_entries(&entries);
 
     assert_eq!(
         tasks.len(),
@@ -879,12 +879,109 @@ fn dedup_entries_skips_non_resolvable() {
         serde_json::json!({"server_label": "b", "server_url": "http://10.0.0.1/mcp", "defer_loading": true}),
         serde_json::json!({"server_label": "c", "server_url": "http://10.0.0.2/mcp"}),
     ];
-    let (mapping, tasks) = dedup_entries(&entries);
+    let (mapping, tasks, _) = dedup_entries(&entries);
 
     assert_eq!(tasks.len(), 1, "only one resolvable entry");
     assert!(mapping[0].is_none(), "connector_id entry not resolvable");
     assert!(mapping[1].is_none(), "deferred entry not resolvable");
     assert_eq!(mapping[2], Some(0), "resolvable entry maps to task 0");
+}
+
+// =========================================================================
+// Allowed Names Merging
+// =========================================================================
+
+#[test]
+fn dedup_entries_merges_allowed_names_union() {
+    let entries = vec![
+        serde_json::json!({"server_label": "s", "server_url": "http://10.0.0.1/mcp", "allowed_tools": ["a"]}),
+        serde_json::json!({"server_label": "s", "server_url": "http://10.0.0.1/mcp", "allowed_tools": ["b"]}),
+    ];
+    let (_, _, allowed) = dedup_entries(&entries);
+
+    assert_eq!(allowed.len(), 1, "one task");
+    let names = allowed[0].as_ref().expect("should have merged names");
+    assert!(names.contains(&"a".to_owned()), "union should contain a");
+    assert!(names.contains(&"b".to_owned()), "union should contain b");
+}
+
+#[test]
+fn dedup_entries_unrestricted_entry_forces_unrestricted() {
+    let entries = vec![
+        serde_json::json!({"server_label": "s", "server_url": "http://10.0.0.1/mcp", "allowed_tools": ["a"]}),
+        serde_json::json!({"server_label": "s", "server_url": "http://10.0.0.1/mcp"}),
+    ];
+    let (_, _, allowed) = dedup_entries(&entries);
+
+    assert_eq!(allowed.len(), 1, "one task");
+    assert!(
+        allowed[0].is_none(),
+        "unrestricted entry should force the union to unrestricted"
+    );
+}
+
+#[test]
+fn merge_allowed_names_both_some() {
+    let mut existing = Some(vec!["a".to_owned()]);
+    merge_allowed_names(&mut existing, &Some(vec!["b".to_owned(), "a".to_owned()]));
+    let names = existing.expect("should remain Some");
+    assert_eq!(names.len(), 2, "union without duplicates");
+    assert!(names.contains(&"a".to_owned()));
+    assert!(names.contains(&"b".to_owned()));
+}
+
+#[test]
+fn merge_allowed_names_new_unrestricted() {
+    let mut existing = Some(vec!["a".to_owned()]);
+    merge_allowed_names(&mut existing, &None);
+    assert!(existing.is_none(), "unrestricted new → unrestricted result");
+}
+
+#[test]
+fn merge_allowed_names_existing_unrestricted() {
+    let mut existing: Option<Vec<String>> = None;
+    merge_allowed_names(&mut existing, &Some(vec!["a".to_owned()]));
+    assert!(existing.is_none(), "unrestricted existing stays unrestricted");
+}
+
+// =========================================================================
+// Dedup Cache Interaction
+// =========================================================================
+
+/// When dedup'd entries have different `allowed_tools` and the
+/// `previous_tools` cache only covers one entry's tools, the
+/// merged union must force a cache miss so that `fetch_tools`
+/// retrieves the full listing for all entries in the group.
+#[tokio::test]
+async fn dedup_cache_miss_when_partial_cache_covers_only_representative() {
+    let filter = McpToolResolveFilter::from_config(&serde_yaml::from_str("{}").unwrap()).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let server_url = "http://10.0.0.5/mcp";
+    let body_json = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [
+            {"type": "mcp", "server_label": "srv", "server_url": server_url, "allowed_tools": ["tool_a"]},
+            {"type": "mcp", "server_label": "srv", "server_url": server_url, "allowed_tools": ["tool_b"]}
+        ]
+    });
+    let mut state = ResponsesState::from_request_body(body_json.clone());
+    state.previous_tools = vec![serde_json::json!({
+        "server_label": "srv",
+        "server_url": server_url,
+        "tools": [{"name": "tool_a", "description": "A"}]
+    })];
+    ctx.extensions.insert(state);
+
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "should reject (tools/list call fails against non-listening address)"
+    );
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

- Replace the sequential `for` loop in `resolve_all_entries` with `futures::future::try_join_all` so all MCP server `tools/list` calls run concurrently
- With `max_servers: 10` and a 5 s timeout, worst-case latency drops from 50 s (serial) to ~5 s (parallel)
- Remove the within-request `fetched` HashMap (sequential dedup); cross-request dedup via `previous_tools` cache is preserved

Closes #344

## Test plan

- [x] All 87 `openai_mcp_tool_resolve` unit tests pass
- [x] `make lint` passes (clippy, fmt, dependency checks, filter doc checks, example test coverage)