### PR TITLE
fix(mcp_client): redact credentials from CallTool error messages

### DIFF
--- a/apis/src/mcp_client/mod.rs
+++ b/apis/src/mcp_client/mod.rs
@@ -54,7 +54,7 @@ pub(crate) struct McpDisplayUrl(String);
 
 impl McpDisplayUrl {
     /// Build a safe display URL from an already-parsed URI.
-    fn from_uri(uri: &http::Uri) -> Self {
+    pub(crate) fn from_uri(uri: &http::Uri) -> Self {
         let mut value = String::new();
 
         if let Some(scheme) = uri.scheme_str() {
@@ -120,17 +120,16 @@ pub(crate) enum McpClientError {
     },
 
     /// The `tools/call` request failed.
-    #[error("mcp tools/call failed for {url} tool {tool_name}: {source}")]
+    ///
+    /// The third-party source error is intentionally discarded because it may
+    /// retain and format the original credential-bearing URL.
+    #[error("mcp tools/call failed for {url} tool {tool_name}")]
     CallTool {
         /// URL of the MCP server.
-        url: String,
+        url: McpDisplayUrl,
 
         /// Name of the tool that was called.
         tool_name: String,
-
-        /// Underlying error.
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     /// Timed out waiting for the MCP server.
@@ -277,10 +276,9 @@ pub(crate) async fn call_tool(
             url: display_url.clone(),
             timeout,
         })?
-        .map_err(|e| McpClientError::CallTool {
-            url: server_url.to_owned(),
+        .map_err(|_source| McpClientError::CallTool {
+            url: display_url.clone(),
             tool_name: tool_name.to_owned(),
-            source: Box::new(e),
         })
 }
 

--- a/apis/src/mcp_client/tests.rs
+++ b/apis/src/mcp_client/tests.rs
@@ -258,6 +258,10 @@ fn url_bearing_errors_only_format_sanitized_urls() {
     let errors = [
         McpClientError::Connection { url: url.clone() },
         McpClientError::ListTools { url: url.clone() },
+        McpClientError::CallTool {
+            url: url.clone(),
+            tool_name: "test_tool".to_owned(),
+        },
         McpClientError::Timeout {
             url: url.clone(),
             timeout: Duration::from_secs(5),
@@ -579,14 +583,14 @@ async fn allow_loopback_still_blocks_unspecified() {
 #[test]
 fn call_tool_error_display() {
     let err = McpClientError::CallTool {
-        url: "http://example.com/mcp".to_owned(),
+        url: display_url("http://example.com/mcp?api_key=TOPSECRET"),
         tool_name: "get_weather".to_owned(),
-        source: Box::new(std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused")),
     };
     let msg = err.to_string();
     assert!(msg.contains("tools/call failed"), "should mention tools/call: {msg}");
     assert!(msg.contains("get_weather"), "should mention tool name: {msg}");
     assert!(msg.contains("example.com"), "should mention URL: {msg}");
+    assert!(!msg.contains("TOPSECRET"), "error must redact query credentials: {msg}");
 }
 
 // =========================================================================

--- a/apis/src/openai/responses/mcp_dispatch/tests.rs
+++ b/apis/src/openai/responses/mcp_dispatch/tests.rs
@@ -595,9 +595,8 @@ fn process_call_result_tool_error() {
 #[test]
 fn process_call_result_transport_error() {
     let err = crate::mcp_client::McpClientError::CallTool {
-        url: "http://example.com/mcp".to_owned(),
+        url: crate::mcp_client::McpDisplayUrl::from_uri(&"http://example.com/mcp".parse().unwrap()),
         tool_name: "tool".to_owned(),
-        source: Box::new(std::io::Error::other("transport error")),
     };
     let result = process_call_result(Err(err), "c1", "srv", "tool", "{}");
     assert!(result.message["output"].as_str().unwrap().contains("Error:"));


### PR DESCRIPTION
### What does this PR do?

The `McpClientError::CallTool` variant stored the raw server URL as a `String` and
included the third-party `{source}` error in its `Display` output — both paths could
leak credentials stored in URL query strings (e.g. `?api_key=TOPSECRET`).

This PR switches the `url` field to `McpDisplayUrl` (which strips query, fragment, and
userinfo) and drops the source error from the formatted message, matching the existing
pattern on `Connection` and `ListTools` variants that already carry the same
doc-comment: *"The third-party source error is intentionally discarded because it may
retain and format the original credential-bearing URL."*

### Which issue(s) does this relate to?

Fixes #417

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No.