### PR TITLE
fix(mcp_dispatch): match tool calls by encoded function name

### DIFF
--- a/apis/src/openai/responses/mcp_dispatch/mod.rs
+++ b/apis/src/openai/responses/mcp_dispatch/mod.rs
@@ -54,7 +54,7 @@ use self::{
     approval::{parse_approval_policy, requires_approval},
     config::{McpDispatchConfig, build_config},
 };
-use super::state::ResponsesState;
+use super::{openai_mcp_tool_resolve::encode_function_name, state::ResponsesState};
 use crate::mcp_client;
 
 // -----------------------------------------------------------------------------
@@ -240,32 +240,36 @@ fn extract_mcp_tool_calls(
         .collect()
 }
 
-/// Check whether a tool call is an MCP tool call.
+/// Check whether a tool call is an MCP tool call by matching the
+/// encoded function name against the tool map.
 fn is_mcp_tool_call(tool_call: &serde_json::Value, tool_map: &HashMap<(String, String), serde_json::Value>) -> bool {
     tool_call
         .get("name")
         .and_then(serde_json::Value::as_str)
-        .is_some_and(|name| find_by_tool_name(tool_map, name).is_some())
+        .is_some_and(|name| find_by_encoded_name(tool_map, name).is_some())
 }
 
-/// Find an entry in the tool map by tool name (second element of
-/// the `(server_label, tool_name)` key). Returns the first match.
+/// Find an entry in the tool map by encoded function name.
 ///
-/// Warns when multiple servers expose the same tool name, since
-/// routing is first-match and may be nondeterministic.
-fn find_by_tool_name<'a>(
+/// Computes `encode_function_name(label, tool_name)` for each key
+/// and returns the first match along with its key. Warns when
+/// multiple entries produce the same encoded name, since routing
+/// is first-match and may be nondeterministic.
+fn find_by_encoded_name<'a>(
     tool_map: &'a HashMap<(String, String), serde_json::Value>,
-    tool_name: &str,
-) -> Option<&'a serde_json::Value> {
-    let mut matches = tool_map.iter().filter(|((_, name), _)| name == tool_name);
+    encoded_name: &str,
+) -> Option<(&'a (String, String), &'a serde_json::Value)> {
+    let mut matches = tool_map
+        .iter()
+        .filter(|((label, name), _)| encode_function_name(label, name) == encoded_name);
     let first = matches.next()?;
     if matches.next().is_some() {
         warn!(
-            tool_name,
-            "multiple servers expose the same tool name; routing to first match"
+            encoded_name,
+            "multiple entries produce the same encoded tool name; routing to first match"
         );
     }
-    Some(first.1)
+    Some((first.0, first.1))
 }
 
 // -----------------------------------------------------------------------------
@@ -299,30 +303,35 @@ fn extract_arguments(tc: &serde_json::Value) -> String {
 /// Check a single tool call for approval requirement.
 ///
 /// Returns `Some` with approval details if approval is required,
-/// or if the tool name is ambiguous across servers.
+/// or if the encoded tool name is ambiguous across servers.
+#[expect(clippy::too_many_lines, reason = "linear validation with clear structure")]
 fn check_single_approval(
     tc: &serde_json::Value,
     tool_map: &HashMap<(String, String), serde_json::Value>,
 ) -> Option<PendingApproval> {
-    let tool_name = tc.get("name").and_then(serde_json::Value::as_str)?;
+    let encoded_name = tc.get("name").and_then(serde_json::Value::as_str)?;
 
-    let match_count = tool_map.keys().filter(|(_, name)| name == tool_name).count();
+    let match_count = tool_map
+        .keys()
+        .filter(|(label, name)| encode_function_name(label, name) == encoded_name)
+        .count();
     if match_count > 1 {
         warn!(
-            tool_name,
+            encoded_name,
             server_count = match_count,
-            "ambiguous tool name in approval check; requiring approval"
+            "ambiguous encoded tool name in approval check; requiring approval"
         );
         return Some(PendingApproval {
             call_id: extract_call_id(tc),
             server_label: "unknown".to_owned(),
-            tool_name: tool_name.to_owned(),
+            tool_name: encoded_name.to_owned(),
             arguments: extract_arguments(tc),
         });
     }
 
-    let entry = find_by_tool_name(tool_map, tool_name)?;
-    if !requires_approval(&parse_approval_policy(entry), tool_name) {
+    let (key, entry) = find_by_encoded_name(tool_map, encoded_name)?;
+    let original_tool_name = &key.1;
+    if !requires_approval(&parse_approval_policy(entry), original_tool_name) {
         return None;
     }
 
@@ -335,7 +344,7 @@ fn check_single_approval(
     Some(PendingApproval {
         call_id: extract_call_id(tc),
         server_label,
-        tool_name: tool_name.to_owned(),
+        tool_name: original_tool_name.to_owned(),
         arguments: extract_arguments(tc),
     })
 }
@@ -428,32 +437,37 @@ async fn execute_sequential(
     results
 }
 
-/// Resolve a tool name to its unique entry, rejecting ambiguity.
+/// Resolve an encoded function name to its unique entry, rejecting
+/// ambiguity.
+#[expect(clippy::type_complexity, reason = "key+value pair needed by callers")]
 fn resolve_tool_entry<'a>(
     tool_map: &'a HashMap<(String, String), serde_json::Value>,
-    tool_name: &str,
+    encoded_name: &str,
     call_id: &str,
-) -> Result<&'a serde_json::Value, Option<Box<McpCallResult>>> {
-    let match_count = tool_map.keys().filter(|(_, name)| name == tool_name).count();
+) -> Result<(&'a (String, String), &'a serde_json::Value), Option<Box<McpCallResult>>> {
+    let match_count = tool_map
+        .keys()
+        .filter(|(label, name)| encode_function_name(label, name) == encoded_name)
+        .count();
     if match_count == 0 {
-        warn!(tool_name, "tool not found in mcp_tool_map, skipping");
+        warn!(encoded_name, "tool not found in mcp_tool_map, skipping");
         return Err(None);
     }
     if match_count > 1 {
         warn!(
-            tool_name,
+            encoded_name,
             server_count = match_count,
-            "ambiguous MCP tool name: multiple servers expose this tool"
+            "ambiguous MCP tool name: multiple entries produce this encoded name"
         );
         return Err(Some(Box::new(build_error_result(
             call_id,
             "unknown",
-            tool_name,
+            encoded_name,
             "",
-            &format!("ambiguous tool name: {match_count} servers expose '{tool_name}'"),
+            &format!("ambiguous tool name: {match_count} servers expose '{encoded_name}'"),
         ))));
     }
-    find_by_tool_name(tool_map, tool_name).ok_or(None)
+    find_by_encoded_name(tool_map, encoded_name).ok_or(None)
 }
 
 /// Parse tool call arguments, handling JSON-string encoding.
@@ -542,17 +556,18 @@ async fn execute_single_call(
     timeout: Duration,
     allow_loopback: bool,
 ) -> Option<McpCallResult> {
-    let tool_name = tool_call.get("name").and_then(serde_json::Value::as_str)?;
+    let encoded_name = tool_call.get("name").and_then(serde_json::Value::as_str)?;
     let call_id = tool_call
         .get("call_id")
         .or_else(|| tool_call.get("id"))
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
 
-    let entry = match resolve_tool_entry(tool_map, tool_name, call_id) {
-        Ok(e) => e,
+    let (key, entry) = match resolve_tool_entry(tool_map, encoded_name, call_id) {
+        Ok(r) => r,
         Err(opt) => return opt.map(|b| *b),
     };
+    let original_tool_name = &key.1;
     let server_url = entry.get("server_url").and_then(serde_json::Value::as_str)?;
     let server_label = entry
         .get("server_label")
@@ -560,18 +575,22 @@ async fn execute_single_call(
         .unwrap_or("unknown");
     let headers = entry.get("headers");
     let authorization = entry.get("authorization").and_then(serde_json::Value::as_str);
-    let (arguments, arguments_string) = match parse_call_arguments(tool_call, call_id, server_label, tool_name) {
+    let (arguments, arguments_string) = match parse_call_arguments(tool_call, call_id, server_label, original_tool_name)
+    {
         Ok(r) => r,
         Err(r) => return Some(*r),
     };
 
-    debug!(tool_name, server_label, call_id, "executing MCP tool call");
+    debug!(
+        tool_name = original_tool_name,
+        server_label, call_id, "executing MCP tool call"
+    );
 
     let result = mcp_client::call_tool(
         server_url,
         headers,
         authorization,
-        tool_name,
+        original_tool_name,
         arguments,
         timeout,
         allow_loopback,
@@ -581,7 +600,7 @@ async fn execute_single_call(
         result,
         call_id,
         server_label,
-        tool_name,
+        original_tool_name,
         &arguments_string,
     ))
 }

--- a/apis/src/openai/responses/mcp_dispatch/tests.rs
+++ b/apis/src/openai/responses/mcp_dispatch/tests.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use super::{
     McpDispatchFilter, build_error_result, build_success_result, content_blocks_to_text, execute_mcp_calls,
     execute_single_call, extract_arguments, extract_call_id, extract_mcp_tool_calls, find_approval_required,
-    is_mcp_tool_call, parse_call_arguments, process_call_result, resolve_tool_entry,
+    find_by_encoded_name, is_mcp_tool_call, parse_call_arguments, process_call_result, resolve_tool_entry,
 };
 use crate::{
     openai::responses::{
@@ -226,11 +226,46 @@ fn sample_tool_map() -> HashMap<(String, String), serde_json::Value> {
     map
 }
 
+fn lossy_collision_tool_map() -> HashMap<(String, String), serde_json::Value> {
+    let mut map = HashMap::new();
+    map.insert(
+        ("my.server".to_owned(), "get".to_owned()),
+        json!({
+            "server_label": "my.server",
+            "server_url": "http://a.example.com/mcp",
+            "headers": null, "authorization": null,
+            "tool_definition": {"name": "get"},
+            "require_approval": "never",
+        }),
+    );
+    map.insert(
+        ("my_server".to_owned(), "get".to_owned()),
+        json!({
+            "server_label": "my_server",
+            "server_url": "http://b.example.com/mcp",
+            "headers": null, "authorization": null,
+            "tool_definition": {"name": "get"},
+            "require_approval": "never",
+        }),
+    );
+    map
+}
+
 #[test]
 fn is_mcp_tool_call_matches_known_tool() {
     let tool_map = sample_tool_map();
-    let tc = json!({"name": "get_weather", "call_id": "call_1"});
+    let tc = json!({"name": "weather__get_weather", "call_id": "call_1"});
     assert!(is_mcp_tool_call(&tc, &tool_map));
+}
+
+#[test]
+fn is_mcp_tool_call_rejects_raw_tool_name() {
+    let tool_map = sample_tool_map();
+    let tc = json!({"name": "get_weather", "call_id": "call_1"});
+    assert!(
+        !is_mcp_tool_call(&tc, &tool_map),
+        "raw tool name should not match; inference returns encoded names"
+    );
 }
 
 #[test]
@@ -251,14 +286,38 @@ fn is_mcp_tool_call_rejects_missing_name() {
 fn extract_mcp_tool_calls_filters_correctly() {
     let tool_map = sample_tool_map();
     let tool_calls = vec![
-        json!({"name": "get_weather", "call_id": "call_1"}),
+        json!({"name": "weather__get_weather", "call_id": "call_1"}),
         json!({"name": "my_function", "call_id": "call_2"}),
-        json!({"name": "search_docs", "call_id": "call_3"}),
+        json!({"name": "docs__search_docs", "call_id": "call_3"}),
     ];
     let mcp_calls = extract_mcp_tool_calls(&tool_calls, &tool_map);
     assert_eq!(mcp_calls.len(), 2, "should extract only MCP tool calls");
-    assert_eq!(mcp_calls[0]["name"], "get_weather");
-    assert_eq!(mcp_calls[1]["name"], "search_docs");
+    assert_eq!(mcp_calls[0]["name"], "weather__get_weather");
+    assert_eq!(mcp_calls[1]["name"], "docs__search_docs");
+}
+
+// =========================================================================
+// find_by_encoded_name
+// =========================================================================
+
+#[test]
+fn find_by_encoded_name_matches_via_encoding() {
+    let map = sample_tool_map();
+    let result = find_by_encoded_name(&map, "weather__get_weather");
+    assert!(result.is_some(), "should find entry by encoded name");
+    let (key, entry) = result.unwrap();
+    assert_eq!(key.0, "weather", "key should have original label");
+    assert_eq!(key.1, "get_weather", "key should have original tool name");
+    assert_eq!(entry["server_label"], "weather");
+}
+
+#[test]
+fn find_by_encoded_name_rejects_raw_name() {
+    let map = sample_tool_map();
+    assert!(
+        find_by_encoded_name(&map, "get_weather").is_none(),
+        "raw tool name should not match; lookup is by encoded name"
+    );
 }
 
 #[test]
@@ -280,8 +339,8 @@ fn find_approval_required_returns_none_when_all_never() {
         entry["require_approval"] = json!("never");
     }
     let calls = vec![
-        json!({"name": "get_weather", "call_id": "call_1"}),
-        json!({"name": "search_docs", "call_id": "call_2"}),
+        json!({"name": "weather__get_weather", "call_id": "call_1"}),
+        json!({"name": "docs__search_docs", "call_id": "call_2"}),
     ];
     assert!(find_approval_required(&calls, &tool_map).is_none());
 }
@@ -290,8 +349,8 @@ fn find_approval_required_returns_none_when_all_never() {
 fn find_approval_required_returns_first_when_absent() {
     let tool_map = sample_tool_map();
     let calls = vec![
-        json!({"name": "get_weather", "call_id": "call_1"}),
-        json!({"name": "search_docs", "call_id": "call_2"}),
+        json!({"name": "weather__get_weather", "call_id": "call_1"}),
+        json!({"name": "docs__search_docs", "call_id": "call_2"}),
     ];
     let pending = find_approval_required(&calls, &tool_map).unwrap();
     assert_eq!(pending.tool_name, "get_weather");
@@ -308,8 +367,8 @@ fn find_approval_required_returns_first_requiring() {
         .unwrap()["require_approval"] = json!("always");
 
     let calls = vec![
-        json!({"name": "get_weather", "call_id": "call_1"}),
-        json!({"name": "search_docs", "call_id": "call_2", "arguments": {"query": "rust"}}),
+        json!({"name": "weather__get_weather", "call_id": "call_1"}),
+        json!({"name": "docs__search_docs", "call_id": "call_2", "arguments": {"query": "rust"}}),
     ];
     let pending = find_approval_required(&calls, &tool_map).unwrap();
     assert_eq!(pending.tool_name, "search_docs");
@@ -320,7 +379,7 @@ fn find_approval_required_returns_first_requiring() {
 #[test]
 fn find_approval_required_defaults_to_approval_when_absent() {
     let tool_map = sample_tool_map();
-    let calls = vec![json!({"name": "get_weather", "call_id": "call_1"})];
+    let calls = vec![json!({"name": "weather__get_weather", "call_id": "call_1"})];
     assert!(
         find_approval_required(&calls, &tool_map).is_some(),
         "absent require_approval should default to requiring approval"
@@ -329,29 +388,15 @@ fn find_approval_required_defaults_to_approval_when_absent() {
 
 #[test]
 fn find_approval_required_ambiguous_tool_requires_approval() {
-    let mut tool_map = sample_tool_map();
-    tool_map.insert(
-        ("other_weather".to_owned(), "get_weather".to_owned()),
-        json!({
-            "server_label": "other_weather",
-            "server_url": "http://other.example.com/mcp",
-            "headers": null,
-            "authorization": null,
-            "tool_definition": {"name": "get_weather"},
-            "require_approval": "never",
-        }),
-    );
-    for entry in tool_map.values_mut() {
-        entry["require_approval"] = json!("never");
-    }
-    let calls = vec![json!({"name": "get_weather", "call_id": "call_1"})];
+    let tool_map = lossy_collision_tool_map();
+    let calls = vec![json!({"name": "my_server__get", "call_id": "call_1"})];
     let pending = find_approval_required(&calls, &tool_map);
     assert!(
         pending.is_some(),
-        "ambiguous tool name should require approval even when all servers say never"
+        "ambiguous encoded name should require approval even when all servers say never"
     );
     let pending = pending.unwrap();
-    assert_eq!(pending.tool_name, "get_weather");
+    assert_eq!(pending.tool_name, "my_server__get");
     assert_eq!(pending.server_label, "unknown");
 }
 
@@ -510,8 +555,9 @@ fn content_blocks_to_text_skips_non_text() {
 #[test]
 fn resolve_tool_entry_returns_entry_for_unique_tool() {
     let map = sample_tool_map();
-    let entry = resolve_tool_entry(&map, "get_weather", "call_1").unwrap();
+    let (key, entry) = resolve_tool_entry(&map, "weather__get_weather", "call_1").unwrap();
     assert_eq!(entry.get("server_label").unwrap(), "weather");
+    assert_eq!(key.1, "get_weather", "key should contain the original tool name");
 }
 
 #[test]
@@ -523,12 +569,8 @@ fn resolve_tool_entry_returns_none_for_unknown_tool() {
 
 #[test]
 fn resolve_tool_entry_returns_error_for_ambiguous_tool() {
-    let mut map = sample_tool_map();
-    map.insert(
-        ("other-server".to_owned(), "get_weather".to_owned()),
-        serde_json::json!({"server_label": "other", "server_url": "http://other/mcp"}),
-    );
-    let result = resolve_tool_entry(&map, "get_weather", "call_1");
+    let map = lossy_collision_tool_map();
+    let result = resolve_tool_entry(&map, "my_server__get", "call_1");
     let err = result.unwrap_err().expect("should return error result for ambiguity");
     assert!(
         err.output_item["error"].as_str().unwrap().contains("ambiguous"),
@@ -692,15 +734,8 @@ async fn execute_single_call_unknown_tool_returns_none() {
 
 #[tokio::test]
 async fn execute_single_call_ambiguous_returns_error() {
-    let mut map = sample_tool_map();
-    map.insert(
-        ("other".to_owned(), "get_weather".to_owned()),
-        json!({
-            "server_label": "other",
-            "server_url": "http://other.example.com/mcp",
-        }),
-    );
-    let tc = json!({"name": "get_weather", "call_id": "c1"});
+    let map = lossy_collision_tool_map();
+    let tc = json!({"name": "my_server__get", "call_id": "c1"});
     let timeout = std::time::Duration::from_millis(100);
     let result = execute_single_call(&tc, &map, timeout, true).await.unwrap();
     assert!(result.output_item["error"].as_str().unwrap().contains("ambiguous"));
@@ -709,7 +744,7 @@ async fn execute_single_call_ambiguous_returns_error() {
 #[tokio::test]
 async fn execute_single_call_malformed_args_returns_error() {
     let map = sample_tool_map();
-    let tc = json!({"name": "get_weather", "call_id": "c1", "arguments": "not-json"});
+    let tc = json!({"name": "weather__get_weather", "call_id": "c1", "arguments": "not-json"});
     let timeout = std::time::Duration::from_millis(100);
     let result = execute_single_call(&tc, &map, timeout, true).await.unwrap();
     assert!(result.output_item["error"].as_str().unwrap().contains("malformed"));
@@ -718,7 +753,7 @@ async fn execute_single_call_malformed_args_returns_error() {
 #[tokio::test]
 async fn execute_single_call_connection_error() {
     let map = sample_tool_map();
-    let tc = json!({"name": "get_weather", "call_id": "c1", "arguments": {"city": "Paris"}});
+    let tc = json!({"name": "weather__get_weather", "call_id": "c1", "arguments": {"city": "Paris"}});
     let timeout = std::time::Duration::from_millis(200);
     let result = execute_single_call(&tc, &map, timeout, true).await.unwrap();
     assert!(
@@ -743,7 +778,7 @@ async fn execute_mcp_calls_empty_input() {
 #[tokio::test]
 async fn execute_mcp_calls_sequential() {
     let map = std::sync::Arc::new(sample_tool_map());
-    let calls = vec![json!({"name": "get_weather", "call_id": "c1", "arguments": {}})];
+    let calls = vec![json!({"name": "weather__get_weather", "call_id": "c1", "arguments": {}})];
     let timeout = std::time::Duration::from_millis(200);
     let results = execute_mcp_calls(&calls, &map, false, timeout, true).await;
     assert_eq!(results.len(), 1);
@@ -753,7 +788,7 @@ async fn execute_mcp_calls_sequential() {
 #[tokio::test]
 async fn execute_mcp_calls_parallel() {
     let map = std::sync::Arc::new(sample_tool_map());
-    let calls = vec![json!({"name": "get_weather", "call_id": "c1", "arguments": {}})];
+    let calls = vec![json!({"name": "weather__get_weather", "call_id": "c1", "arguments": {}})];
     let timeout = std::time::Duration::from_millis(200);
     let results = execute_mcp_calls(&calls, &map, true, timeout, true).await;
     assert_eq!(results.len(), 1);
@@ -853,7 +888,7 @@ fn on_response_body_with_mcp_calls_sets_execute_metadata() {
     }
     let state = ResponsesState {
         mcp_tool_map: tool_map,
-        tool_calls: vec![json!({"name": "get_weather", "call_id": "c1"})],
+        tool_calls: vec![json!({"name": "weather__get_weather", "call_id": "c1"})],
         ..ResponsesState::default()
     };
     ctx.extensions.insert(state);
@@ -873,7 +908,7 @@ fn on_response_body_approval_required_sets_done_metadata() {
     let mut ctx = make_filter_context(&req);
     let state = ResponsesState {
         mcp_tool_map: sample_tool_map(),
-        tool_calls: vec![json!({"name": "get_weather", "call_id": "c1"})],
+        tool_calls: vec![json!({"name": "weather__get_weather", "call_id": "c1"})],
         ..ResponsesState::default()
     };
     ctx.extensions.insert(state);
@@ -916,7 +951,7 @@ async fn on_request_executes_and_appends_results() {
     let mut ctx = make_filter_context(&req);
     let state = ResponsesState {
         mcp_tool_map: sample_tool_map(),
-        tool_calls: vec![json!({"name": "get_weather", "call_id": "c1", "arguments": {}})],
+        tool_calls: vec![json!({"name": "weather__get_weather", "call_id": "c1", "arguments": {}})],
         ..ResponsesState::default()
     };
     ctx.extensions.insert(state);

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -654,7 +654,7 @@ fn mcp_tool_to_function_tool(label: &str, definition: &serde_json::Value) -> ser
 /// within [`MAX_FUNCTION_NAME_LEN`]. Lossy: distinct inputs can
 /// produce the same output. Use [`detect_name_collisions`] after
 /// building the full tools array to catch this.
-fn encode_function_name(label: &str, tool_name: &str) -> String {
+pub(crate) fn encode_function_name(label: &str, tool_name: &str) -> String {
     let raw = format!("{label}__{tool_name}");
     let sanitized: String = raw
         .chars()


### PR DESCRIPTION
### What does this PR do?

The MCP tool resolver encodes function names as `{label}__{tool_name}` for
inference, but the dispatcher compared tool calls from inference against the
raw tool name in the map key — which never matched. This PR changes all
dispatcher lookups to compute `encode_function_name(label, tool_name)` from
each map entry and compare against the encoded name returned by inference.
Lookup functions now return both key and value so callers can extract the
original tool name for MCP server calls, approval policy checks, and result
construction.

### Which issue(s) does this relate to?

Fixes #544

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No.