### PR TITLE
fix(conformance): document Conversation metadata schema exception

### DIFF
--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -143,6 +143,22 @@ global security mismatch.
 Use `owned_contract_conformance.fixes_required` as the actionable contract
 backlog.
 
+### Upstream specification exceptions
+
+An area may remove an exact drift fingerprint from the actionable backlog only
+when authoritative or live evidence shows the pinned upstream schema is
+incomplete. Every exception records its operation, drift channel, exact detail,
+rationale, and evidence under `upstream_spec_exceptions`. Generation fails when
+a declared fingerprint no longer appears, so an upstream correction cannot be
+masked by a stale exception. Unrelated drift on the same operation remains
+active.
+
+OpenAI Conversations responses were checked against `api.openai.com` on
+2026-07-27. Omitted and explicitly null create metadata returned `{}`, while a
+populated string map round-tripped unchanged. Praxis therefore retains its
+string-map response schema and records the 12 missing upstream metadata
+constraints as explicit exceptions.
+
 ## CI Enforcement
 
 CI always runs strict capability and owned-contract conformance after the

--- a/docs/conformance/openai-conformance-report.json
+++ b/docs/conformance/openai-conformance-report.json
@@ -252,49 +252,15 @@
         "implementation_source": "generated:praxis-ai-apis/openai/conversations",
         "operation_contracts": {
           "total": 8,
-          "exact": 1,
+          "exact": 3,
           "missing": 0,
-          "drifted": 7,
+          "drifted": 5,
           "request_drifted": 4,
-          "response_drifted": 7,
+          "response_drifted": 3,
           "other_drifted": 0,
-          "exact_percent": 12.5,
+          "exact_percent": 37.5,
           "missing_operations": [],
           "drifted_operations": [
-            {
-              "operation": {
-                "method": "DELETE",
-                "path": "/conversations/{conversation_id}/items/{item_id}",
-                "operation": "DELETE /conversations/{conversation_id}/items/{item_id}"
-              },
-              "has_request_drift": false,
-              "has_response_drift": true,
-              "has_other_drift": false,
-              "request_details": [],
-              "response_details": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ],
-              "other_details": []
-            },
-            {
-              "operation": {
-                "method": "GET",
-                "path": "/conversations/{conversation_id}",
-                "operation": "GET /conversations/{conversation_id}"
-              },
-              "has_request_drift": false,
-              "has_response_drift": true,
-              "has_other_drift": false,
-              "request_details": [],
-              "response_details": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ],
-              "other_details": []
-            },
             {
               "operation": {
                 "method": "GET",
@@ -343,7 +309,7 @@
                 "operation": "POST /conversations"
               },
               "has_request_drift": true,
-              "has_response_drift": true,
+              "has_response_drift": false,
               "has_other_drift": false,
               "request_details": [
                 "requestBody.required.from",
@@ -357,11 +323,7 @@
                 "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
                 "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
               ],
-              "response_details": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ],
+              "response_details": [],
               "other_details": []
             },
             {
@@ -371,7 +333,7 @@
                 "operation": "POST /conversations/{conversation_id}"
               },
               "has_request_drift": true,
-              "has_response_drift": true,
+              "has_response_drift": false,
               "has_other_drift": false,
               "request_details": [
                 "requestBody.required.from",
@@ -380,11 +342,7 @@
                 "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
                 "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
               ],
-              "response_details": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ],
+              "response_details": [],
               "other_details": []
             },
             {
@@ -418,29 +376,163 @@
             "components.securitySchemes.deleted"
           ]
         },
+        "upstream_spec_exceptions": [
+          {
+            "kind": "response",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations",
+              "operation": "POST /conversations"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.type.added",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations",
+              "operation": "POST /conversations"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations",
+              "operation": "POST /conversations"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "GET",
+              "path": "/conversations/{conversation_id}",
+              "operation": "GET /conversations/{conversation_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.type.added",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "GET",
+              "path": "/conversations/{conversation_id}",
+              "operation": "GET /conversations/{conversation_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "GET",
+              "path": "/conversations/{conversation_id}",
+              "operation": "GET /conversations/{conversation_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.type.added",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "DELETE",
+              "path": "/conversations/{conversation_id}/items/{item_id}",
+              "operation": "DELETE /conversations/{conversation_id}/items/{item_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.type.added",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "DELETE",
+              "path": "/conversations/{conversation_id}/items/{item_id}",
+              "operation": "DELETE /conversations/{conversation_id}/items/{item_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "response",
+            "operation": {
+              "method": "DELETE",
+              "path": "/conversations/{conversation_id}/items/{item_id}",
+              "operation": "DELETE /conversations/{conversation_id}/items/{item_id}"
+            },
+            "detail": "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+            "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+            "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          }
+        ],
         "all_exact": false
       }
     ],
     "operation_contracts": {
       "total": 8,
-      "exact": 1,
+      "exact": 3,
       "missing": 0,
-      "drifted": 7,
+      "drifted": 5,
       "request_drifted": 4,
-      "response_drifted": 7,
+      "response_drifted": 3,
       "other_drifted": 0,
-      "exact_percent": 12.5,
+      "exact_percent": 37.5,
       "by_area": [
         {
           "area": "Conversations",
           "total": 8,
-          "conformant": 1,
+          "conformant": 3,
           "missing": 0,
-          "drifted": 7,
+          "drifted": 5,
           "request_drifted": 4,
-          "response_drifted": 7,
+          "response_drifted": 3,
           "other_drifted": 0,
-          "conformance_percent": 12.5
+          "conformance_percent": 37.5
         }
       ]
     },
@@ -457,52 +549,14 @@
     "all_exact": false,
     "fixes_required": {
       "summary": {
-        "operations_to_fix": 7,
+        "operations_to_fix": 5,
         "area_contracts_to_fix": 1,
         "missing_operations": 0,
         "request_drift_operations": 4,
-        "response_drift_operations": 7,
+        "response_drift_operations": 3,
         "other_drift_operations": 0
       },
       "by_operation": [
-        {
-          "operation": {
-            "method": "DELETE",
-            "path": "/conversations/{conversation_id}/items/{item_id}",
-            "operation": "DELETE /conversations/{conversation_id}/items/{item_id}"
-          },
-          "fixes": [
-            {
-              "area": "response",
-              "kind": "response_schema",
-              "summary": "Align the response body schema with the OpenAI spec.",
-              "detail_paths": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ]
-            }
-          ]
-        },
-        {
-          "operation": {
-            "method": "GET",
-            "path": "/conversations/{conversation_id}",
-            "operation": "GET /conversations/{conversation_id}"
-          },
-          "fixes": [
-            {
-              "area": "response",
-              "kind": "response_schema",
-              "summary": "Align the response body schema with the OpenAI spec.",
-              "detail_paths": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ]
-            }
-          ]
-        },
         {
           "operation": {
             "method": "GET",
@@ -577,16 +631,6 @@
                 "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
                 "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
               ]
-            },
-            {
-              "area": "response",
-              "kind": "response_schema",
-              "summary": "Align the response body schema with the OpenAI spec.",
-              "detail_paths": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
-              ]
             }
           ]
         },
@@ -607,16 +651,6 @@
                 "requestBody.content.application/json.schema.required.deleted",
                 "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
                 "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
-              ]
-            },
-            {
-              "area": "response",
-              "kind": "response_schema",
-              "summary": "Align the response body schema with the OpenAI spec.",
-              "detail_paths": [
-                "responses.200.content.application/json.schema.properties.metadata.type.added",
-                "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded"
               ]
             }
           ]

--- a/xtask/src/openai_conformance/area.rs
+++ b/xtask/src/openai_conformance/area.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-use super::model::{CoverageMode, OperationScope, RuntimeVerificationCheck, SupportedOperation};
+use super::model::{ContractException, CoverageMode, OperationScope, RuntimeVerificationCheck, SupportedOperation};
 
 /// Vendored OpenAI `OpenAPI` reference used by default.
 pub(super) const OPENAI_REFERENCE_SPEC: &str = "docs/conformance/specs/openai-openapi.yaml";
@@ -31,6 +31,70 @@ const CONVERSATIONS_RUNTIME_CHECKS: &[RuntimeVerificationCheck] = &[
     },
 ];
 
+/// Response metadata discrepancies caused by the incomplete upstream property.
+const CONVERSATIONS_CONTRACT_EXCEPTIONS: &[ContractException] = &[
+    metadata_response_exception(
+        "POST",
+        "/conversations",
+        "responses.200.content.application/json.schema.properties.metadata.type.added",
+    ),
+    metadata_response_exception(
+        "POST",
+        "/conversations",
+        "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+    ),
+    metadata_response_exception(
+        "POST",
+        "/conversations",
+        "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+    ),
+    metadata_response_exception(
+        "GET",
+        "/conversations/{conversation_id}",
+        "responses.200.content.application/json.schema.properties.metadata.type.added",
+    ),
+    metadata_response_exception(
+        "GET",
+        "/conversations/{conversation_id}",
+        "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+    ),
+    metadata_response_exception(
+        "GET",
+        "/conversations/{conversation_id}",
+        "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+    ),
+    metadata_response_exception(
+        "POST",
+        "/conversations/{conversation_id}",
+        "responses.200.content.application/json.schema.properties.metadata.type.added",
+    ),
+    metadata_response_exception(
+        "POST",
+        "/conversations/{conversation_id}",
+        "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+    ),
+    metadata_response_exception(
+        "POST",
+        "/conversations/{conversation_id}",
+        "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+    ),
+    metadata_response_exception(
+        "DELETE",
+        "/conversations/{conversation_id}/items/{item_id}",
+        "responses.200.content.application/json.schema.properties.metadata.type.added",
+    ),
+    metadata_response_exception(
+        "DELETE",
+        "/conversations/{conversation_id}/items/{item_id}",
+        "responses.200.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+    ),
+    metadata_response_exception(
+        "DELETE",
+        "/conversations/{conversation_id}/items/{item_id}",
+        "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+    ),
+];
+
 /// One conformance area checked by `cargo xtask openai-conformance`.
 pub(super) struct ApiArea {
     /// Operation scope loaded from the reference spec.
@@ -53,6 +117,25 @@ pub(super) struct ApiArea {
 
     /// Runtime checks selected by the focused command.
     pub(super) runtime_checks: &'static [RuntimeVerificationCheck],
+
+    /// Evidence-backed differences in the pinned upstream contract.
+    pub(super) contract_exceptions: &'static [ContractException],
+}
+
+/// Declare one live-verified response metadata exception.
+const fn metadata_response_exception(
+    method: &'static str,
+    path: &'static str,
+    detail: &'static str,
+) -> ContractException {
+    ContractException {
+        kind: super::model::ContractDriftKind::Response,
+        method: Some(method),
+        path: Some(path),
+        detail,
+        rationale: "OpenAI returns metadata as a string map, while the upstream response property has no schema",
+        evidence: "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map",
+    }
 }
 
 /// Areas included in the current OpenAI conformance suite.
@@ -72,6 +155,7 @@ pub(super) const CONFORMANCE_AREAS: &[ApiArea] = &[ApiArea {
         "--show-output",
     ],
     runtime_checks: CONVERSATIONS_RUNTIME_CHECKS,
+    contract_exceptions: CONVERSATIONS_CONTRACT_EXCEPTIONS,
 }];
 
 /// Generate the Conversations implementation spec from crate code.

--- a/xtask/src/openai_conformance/json_report.rs
+++ b/xtask/src/openai_conformance/json_report.rs
@@ -11,9 +11,10 @@ use serde_json::{Value, json};
 use super::{
     Args,
     model::{
-        AreaStats, CoverageMode, CoverageReport, CoveredOperation, OasdiffAreaDrift, OasdiffAreaReport,
-        OasdiffAreaStats, OasdiffOperationDrift, OasdiffReport, OperationKey, RuntimeVerificationArea,
-        RuntimeVerificationStatus, SpecOperation, SpecSourceReport, SupportedOperation, percent,
+        AppliedContractException, AreaStats, CoverageMode, CoverageReport, CoveredOperation, OasdiffAreaDrift,
+        OasdiffAreaReport, OasdiffAreaStats, OasdiffOperationDrift, OasdiffReport, OperationKey,
+        RuntimeVerificationArea, RuntimeVerificationStatus, SpecOperation, SpecSourceReport, SupportedOperation,
+        percent,
     },
 };
 
@@ -236,7 +237,19 @@ fn oasdiff_area_report_json(area: &OasdiffAreaReport) -> Value {
             "exact": area.inherited_details.is_empty(),
             "details": &area.inherited_details,
         },
+        "upstream_spec_exceptions": area.exceptions.iter().map(contract_exception_json).collect::<Vec<_>>(),
         "all_exact": area.all_exact(),
+    })
+}
+
+/// Serialize one applied upstream-spec exception.
+fn contract_exception_json(exception: &AppliedContractException) -> Value {
+    json!({
+        "kind": exception.kind.as_str(),
+        "operation": exception.operation.as_ref().map(operation_key_json),
+        "detail": exception.detail,
+        "rationale": exception.rationale,
+        "evidence": exception.evidence,
     })
 }
 

--- a/xtask/src/openai_conformance/model.rs
+++ b/xtask/src/openai_conformance/model.rs
@@ -290,6 +290,79 @@ pub(super) struct OasdiffAreaReport {
 
     /// Global or inherited contract drift for this area.
     pub(super) inherited_details: Vec<String>,
+
+    /// Evidence-backed upstream discrepancies removed from actionable drift.
+    pub(super) exceptions: Vec<AppliedContractException>,
+}
+
+/// Contract-drift channel for one declared upstream exception.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[expect(dead_code, reason = "the exception model supports every oasdiff drift channel")]
+pub(super) enum ContractDriftKind {
+    /// Global or inherited area drift.
+    Inherited,
+
+    /// Other operation-level drift.
+    Other,
+
+    /// Request parameter or body drift.
+    Request,
+
+    /// Response contract drift.
+    Response,
+}
+
+impl ContractDriftKind {
+    /// Stable report label.
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Request => "request",
+            Self::Response => "response",
+            Self::Other => "other",
+            Self::Inherited => "inherited",
+        }
+    }
+}
+
+/// Evidence-backed discrepancy declared by one API area.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ContractException {
+    /// Exact normalized `oasdiff` detail path.
+    pub(super) detail: &'static str,
+
+    /// Authoritative or live evidence for the discrepancy.
+    pub(super) evidence: &'static str,
+
+    /// Drift channel containing the exact detail.
+    pub(super) kind: ContractDriftKind,
+
+    /// Uppercase HTTP method for operation exceptions.
+    pub(super) method: Option<&'static str>,
+
+    /// `OpenAPI` operation path for operation exceptions.
+    pub(super) path: Option<&'static str>,
+
+    /// Why Praxis intentionally preserves the runtime contract.
+    pub(super) rationale: &'static str,
+}
+
+/// Exception that matched the current pinned comparison.
+#[derive(Clone, Debug)]
+pub(super) struct AppliedContractException {
+    /// Exact normalized `oasdiff` detail path.
+    pub(super) detail: &'static str,
+
+    /// Authoritative or live evidence for the discrepancy.
+    pub(super) evidence: &'static str,
+
+    /// Drift channel containing the detail.
+    pub(super) kind: ContractDriftKind,
+
+    /// Operation for operation-level exceptions.
+    pub(super) operation: Option<OperationKey>,
+
+    /// Why Praxis intentionally preserves the runtime contract.
+    pub(super) rationale: &'static str,
 }
 
 impl OasdiffAreaReport {

--- a/xtask/src/openai_conformance/oasdiff.rs
+++ b/xtask/src/openai_conformance/oasdiff.rs
@@ -15,8 +15,8 @@ use tempfile::{Builder as TempFileBuilder, NamedTempFile};
 use super::{
     area::ApiArea,
     model::{
-        OasdiffAreaDrift, OasdiffAreaReport, OasdiffAreaStats, OasdiffOperationDrift, OasdiffReport, OperationKey,
-        OperationScope, SpecOperation,
+        AppliedContractException, ContractDriftKind, ContractException, OasdiffAreaDrift, OasdiffAreaReport,
+        OasdiffAreaStats, OasdiffOperationDrift, OasdiffReport, OperationKey, OperationScope, SpecOperation,
     },
     spec::read_spec,
 };
@@ -61,6 +61,12 @@ pub(super) fn run_scoped_oasdiff(
             &mut area_drifted,
             &mut inherited_details,
         );
+        let exceptions = apply_contract_exceptions(
+            area.scope.label,
+            area.contract_exceptions,
+            &mut area_drifted,
+            &mut inherited_details,
+        )?;
         let area_considered = considered
             .iter()
             .filter(|operation| operation.area == area.scope.label)
@@ -81,6 +87,7 @@ pub(super) fn run_scoped_oasdiff(
             missing: area_missing_vec,
             drifted: area_drifted_vec,
             inherited_details: inherited_details.clone(),
+            exceptions,
         });
         missing.extend(area_missing);
         for drift in area_drifted.into_values() {
@@ -102,6 +109,80 @@ pub(super) fn run_scoped_oasdiff(
         area_drift,
         area_reports,
     ))
+}
+
+/// Remove only declared discrepancies that match the current pinned diff.
+pub(super) fn apply_contract_exceptions(
+    area: &str,
+    declared: &[ContractException],
+    drifted: &mut BTreeMap<OperationKey, OasdiffOperationDrift>,
+    inherited_details: &mut Vec<String>,
+) -> Result<Vec<AppliedContractException>, String> {
+    let mut applied = Vec::with_capacity(declared.len());
+    for exception in declared {
+        let operation = exception_operation(area, exception)?;
+        if !remove_exception_detail(exception, operation.as_ref(), drifted, inherited_details) {
+            return Err(format!(
+                "stale contract exception for {area}: {} {}",
+                operation
+                    .as_ref()
+                    .map_or_else(|| "inherited".to_owned(), ToString::to_string),
+                exception.detail,
+            ));
+        }
+        applied.push(AppliedContractException {
+            kind: exception.kind,
+            operation,
+            detail: exception.detail,
+            rationale: exception.rationale,
+            evidence: exception.evidence,
+        });
+    }
+    drifted.retain(|_key, drift| drift.has_any_drift());
+    Ok(applied)
+}
+
+/// Resolve and validate an exception's optional operation selector.
+fn exception_operation(area: &str, exception: &ContractException) -> Result<Option<OperationKey>, String> {
+    match (exception.method, exception.path) {
+        (Some(method), Some(path)) => Ok(Some(OperationKey::new(method, path))),
+        (None, None) => Ok(None),
+        _ => Err(format!(
+            "invalid contract exception declaration for {area}: {}",
+            exception.detail
+        )),
+    }
+}
+
+/// Remove an exception from its declared drift channel.
+fn remove_exception_detail(
+    exception: &ContractException,
+    operation: Option<&OperationKey>,
+    drifted: &mut BTreeMap<OperationKey, OasdiffOperationDrift>,
+    inherited_details: &mut Vec<String>,
+) -> bool {
+    match (operation, exception.kind) {
+        (Some(key), ContractDriftKind::Request) => drifted
+            .get_mut(key)
+            .is_some_and(|drift| remove_detail(&mut drift.request_details, exception.detail)),
+        (Some(key), ContractDriftKind::Response) => drifted
+            .get_mut(key)
+            .is_some_and(|drift| remove_detail(&mut drift.response_details, exception.detail)),
+        (Some(key), ContractDriftKind::Other) => drifted
+            .get_mut(key)
+            .is_some_and(|drift| remove_detail(&mut drift.other_details, exception.detail)),
+        (None, ContractDriftKind::Inherited) => remove_detail(inherited_details, exception.detail),
+        _ => false,
+    }
+}
+
+/// Remove one exact drift detail and report whether it was present.
+fn remove_detail(details: &mut Vec<String>, expected: &str) -> bool {
+    let Some(index) = details.iter().position(|detail| detail == expected) else {
+        return false;
+    };
+    details.remove(index);
+    true
 }
 
 /// Require a stable `oasdiff` output schema before invoking the tool.

--- a/xtask/src/openai_conformance/print.rs
+++ b/xtask/src/openai_conformance/print.rs
@@ -97,17 +97,24 @@ fn print_oasdiff_summary(report: &OasdiffReport, args: &Args) {
     for area in &report.area_drift {
         println!("    {}: {} drift details", area.area, area.details.len());
     }
+    let exception_count = report
+        .area_reports
+        .iter()
+        .map(|area| area.exceptions.len())
+        .sum::<usize>();
+    println!("  upstream spec exceptions applied: {exception_count}");
 
     println!("oasdiff by area:");
     for area in &report.area_reports {
         println!(
-            "  {}: {}/{} ({:.2}%), missing {}, drifted {}, implementation {}",
+            "  {}: {}/{} ({:.2}%), missing {}, drifted {}, exceptions {}, implementation {}",
             area.area,
             area.conformant,
             area.total,
             area.conformance_percent(),
             area.missing.len(),
             area.drifted.len(),
+            area.exceptions.len(),
             area.implementation_source,
         );
     }

--- a/xtask/src/openai_conformance/tests.rs
+++ b/xtask/src/openai_conformance/tests.rs
@@ -12,12 +12,13 @@ use super::{
     find_missing_sentinels,
     json_report::report_json,
     model::{
-        CoverageMode, OasdiffAreaDrift, OasdiffAreaReport, OasdiffOperationDrift, OperationKey, ReferenceSourceReport,
-        RuntimeVerificationCheck, SpecOperation, SpecSourceReport, SupportedOperation, percent,
+        AppliedContractException, ContractDriftKind, ContractException, CoverageMode, OasdiffAreaDrift,
+        OasdiffAreaReport, OasdiffOperationDrift, OperationKey, ReferenceSourceReport, RuntimeVerificationCheck,
+        SpecOperation, SpecSourceReport, SupportedOperation, percent,
     },
     oasdiff::{
-        OASDIFF_VERSION, build_oasdiff_report, collect_oasdiff_operation_status, operation_drift_from_diff,
-        parse_oasdiff_module_version, parse_oasdiff_version,
+        OASDIFF_VERSION, apply_contract_exceptions, build_oasdiff_report, collect_oasdiff_operation_status,
+        operation_drift_from_diff, parse_oasdiff_module_version, parse_oasdiff_version,
     },
     parse_percent,
     reference::build_reference_projection,
@@ -458,6 +459,13 @@ fn json_report_includes_oasdiff_missing_and_response_drift() {
         missing: missing.iter().cloned().collect(),
         drifted: drifted.values().cloned().collect(),
         inherited_details: vec!["security.deleted.ApiKeyAuth".to_owned()],
+        exceptions: vec![AppliedContractException {
+            kind: ContractDriftKind::Response,
+            operation: Some(OperationKey::new("POST", "/conversations")),
+            detail: "responses.200.content.application/json.schema.properties.metadata.type.added",
+            rationale: "live response is stricter than the incomplete property",
+            evidence: "live probe",
+        }],
     };
     report.oasdiff = Some(build_oasdiff_report(
         OASDIFF_VERSION,
@@ -540,6 +548,12 @@ fn json_report_includes_oasdiff_missing_and_response_drift() {
             .pointer("/owned_contract_conformance/areas/0/implementation_source")
             .and_then(Value::as_str),
         Some("implementation-spec")
+    );
+    assert_eq!(
+        value
+            .pointer("/owned_contract_conformance/areas/0/upstream_spec_exceptions/0/detail")
+            .and_then(Value::as_str),
+        Some("responses.200.content.application/json.schema.properties.metadata.type.added")
     );
     assert_eq!(
         value
@@ -660,6 +674,48 @@ fn reports_global_security_and_path_level_parameter_drift() {
         .get(&OperationKey::new("GET", "/conversations/{conversation_id}"))
         .expect("path-level parameter drift should apply to GET");
     assert!(get.has_request_drift());
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "covers applied, unrelated, and stale exception states"
+)]
+fn contract_exceptions_remove_only_exact_current_fingerprints() {
+    let key = OperationKey::new("POST", "/conversations");
+    let mut drift = OasdiffOperationDrift::new(key.clone());
+    drift.response_details = vec![
+        "responses.200.content.application/json.schema.properties.metadata.type.added".to_owned(),
+        "responses.200.content.application/json.schema.properties.id.type.added".to_owned(),
+    ];
+    let mut drifted = BTreeMap::from([(key, drift)]);
+    let mut inherited = Vec::new();
+    let exception = ContractException {
+        kind: ContractDriftKind::Response,
+        method: Some("POST"),
+        path: Some("/conversations"),
+        detail: "responses.200.content.application/json.schema.properties.metadata.type.added",
+        rationale: "live responses always return an object",
+        evidence: "live probe",
+    };
+
+    let applied = apply_contract_exceptions("Conversations", &[exception], &mut drifted, &mut inherited).unwrap();
+
+    assert_eq!(applied.len(), 1);
+    assert_eq!(
+        drifted
+            .values()
+            .next()
+            .expect("unrelated drift should remain")
+            .response_details,
+        ["responses.200.content.application/json.schema.properties.id.type.added"]
+    );
+
+    let error = apply_contract_exceptions("Conversations", &[exception], &mut drifted, &mut inherited).unwrap_err();
+    assert!(
+        error.contains("stale contract exception"),
+        "a stale exception should fail closed: {error}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The Conversations conformance report flagged metadata response fields (`type`, `additionalProperties`, `propertyNames`) as schema drift on four operations. This overstated actual divergence — Praxis types metadata as a string map matching verified live OpenAI behavior, while the upstream spec simply omits the schema.

## Changes

- add fingerprinted upstream specification exceptions for 12 metadata response-schema diffs across `POST /conversations`, `GET /conversations/{id}`, `POST /conversations/{id}`, and `DELETE /conversations/{id}/items/{item_id}`
- each exception includes rationale and live `api.openai.com` probe evidence (2026-07-27)
- regenerate the conformance report: exact operations improve from 1/8 to 3/8, response drift drops from 7 to 3
- extend the conformance tooling to support exception declarations and staleness detection

## Validation

- `make lint` (clippy, fmt, deps, docs, examples all clean)
- `cargo test -p praxis-ai-apis -- conversations` (188 passed, 1 ignored)
- `cargo xtask openai-conformance --area conversations` (3/8 exact, 12 exceptions applied)
- `git diff --check origin/main...HEAD`

Closes #568