### PR TITLE
docs: make generated filter references authoritative

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,120 +1,66 @@
 # Features
 
-Praxis AI extends the [Praxis proxy framework][praxis]
-with AI-specific filters for inference routing, provider
-APIs, token counting, guardrails, agentic protocols,
-response storage, and prompt enrichment.
+Praxis AI extends the [Praxis proxy framework][praxis] with AI-specific
+filters and provider integrations. This page describes the capability
+areas; the generated [filter reference](filters/reference.md) is the
+authoritative inventory of filter names and configuration documentation.
 
-For base proxy features (TLS, HTTP/2, TCP, WebSocket,
-load balancing, rate limiting, compression, CORS,
-health checks, etc.), see the
-[Praxis core documentation][praxis].
+For base proxy capabilities such as TLS, HTTP/2, TCP, WebSocket, load
+balancing, rate limiting, compression, CORS, health checks, and credential
+injection, see the [Praxis core documentation][praxis].
+
+## Inference routing and transformation
+
+- Classify requests by provider format, model, streaming mode, and tool
+  composition, then promote those facts for policy-driven routing.
+- Rewrite models and enrich prompts without changing application code.
+- Translate Anthropic Messages requests and responses for
+  Chat Completions-compatible inference backends.
+- Normalize provider protocol headers and validate the JSON envelope fields
+  required by the proxy.
+
+## OpenAI Responses and Conversations
+
+- Proxy native Responses API traffic and rebuild enriched request state.
+- Store and rehydrate response history through SQLite or PostgreSQL.
+- Serve the Conversations API locally and maintain conversation items.
+- Resolve file references, extract supported document content, and accumulate
+  streaming response state.
+- Parse tool configuration and dispatch MCP or web-search tool calls in an
+  agentic loop.
+
+See the generated [OpenAI filter inventory](filters/reference.md#openai)
+for the complete list.
+
+## Anthropic Messages
+
+- Classify and validate Anthropic Messages requests.
+- Normalize native Anthropic protocol headers.
+- Translate request, response, and streaming event formats for compatible
+  OpenAI-style backends.
+
+See the generated [Anthropic filter inventory](filters/reference.md#anthropic).
+
+## Agentic protocols
+
+- Classify and route Model Context Protocol (MCP) traffic.
+- Broker configured MCP catalog operations and upstream tool discovery.
+- Classify Agent-to-Agent (A2A) requests and route task or context follow-ups.
+- Build on the JSON-RPC primitives provided by Praxis core.
+
+## Safety and observability
+
+- Evaluate request content through an external guardrail provider.
+- Extract token usage across supported provider response formats.
+- Expose normalized token counts through downstream response headers.
+
+## Extensibility
+
+Custom Rust filters implement the `HttpFilter` trait from `praxis-filter` and
+register through the `register_filters!` macro. External filter crates can
+self-register at build time with `[package.metadata.praxis-filters]`.
+
+Start with the [example configurations](../examples/README.md), then use the
+[filter reference](filters/reference.md) for exact configuration fields.
 
 [praxis]: https://github.com/praxis-proxy/praxis
-
-## AI Inference
-
-- **Model-based routing** (`model_to_header`): extracts
-  the `model` field from JSON request bodies and
-  promotes it to an `X-Model` header, enabling
-  header-based routing to provider-specific clusters.
-  Uses StreamBuffer to inspect the body before upstream
-  selection.
-- **Credential injection** (`credential_injection`):
-  per-cluster API key injection with client credential
-  stripping. Supports inline values and environment
-  variable sources. Pair with a source discriminator
-  (IP ACL, client auth) to control which clients get
-  credential upgrades.
-- **Prompt enrichment** (`prompt_enrich`): inject system
-  or user messages into OpenAI-compatible chat
-  completion request bodies at the proxy layer. Static
-  configured messages are prepended or appended to the
-  `messages` array before forwarding upstream.
-
-## OpenAI Responses API
-
-- **Responses API classification**
-  (`openai_responses_format`): classifies OpenAI
-  Responses API and Chat Completions API requests by
-  inspecting the request body. Promotes format, model,
-  stream, and routing mode (stateless/stateful) to
-  configurable headers, metadata, and filter results
-  for downstream routing via branch chains.
-- **Responses API validation**
-  (`openai_responses_validate`): validates Responses
-  API JSON syntax, extracts conversation IDs, and
-  generates cryptographically random response and
-  conversation IDs with `resp_` and `conv_` prefixes.
-  Provider-owned parameter combinations pass through.
-- **Model rewrite**
-  (`openai_responses_model_rewrite`): rewrites the
-  `model` field in Responses API request bodies.
-- **Response rehydration**
-  (`openai_responses_rehydrate`): validates
-  `previous_response_id` by fetching the stored
-  response, confirming its status is `"completed"`,
-  and populating `ResponsesState` with the full
-  conversation history.
-- **Response store** (`openai_response_store`):
-  persists non-streaming Responses API responses to a
-  configured storage backend (SQLite, PostgreSQL).
-- **Conversation management**
-  (`openai_conversations`): handles all
-  `/v1/conversations` endpoints locally.
-- **Responses proxy** (`openai_responses_proxy`): rebuilds
-  the request body from `ResponsesState` when present.
-
-## Anthropic Messages API
-
-- **Messages classification**
-  (`anthropic_messages_format`): classifies Anthropic
-  Messages API requests and promotes routing facts to
-  headers, metadata, and filter results.
-- **Messages protocol**
-  (`anthropic_messages_protocol`): normalizes Anthropic
-  Messages protocol headers for native backends.
-- **Stream event translation**
-  (`anthropic_stream_events`): transforms streaming SSE
-  responses between OpenAI and Anthropic formats,
-  processing each chunk as it arrives.
-- **API translation** (`anthropic_to_openai`):
-  transforms Anthropic Messages API requests to Chat
-  Completions-compatible request bodies and transforms
-  compatible responses back.
-- **Request validation** (`anthropic_validate`):
-  validates Anthropic Messages request bodies for
-  proxy-owned JSON envelope requirements.
-
-## AI Agentic
-
-- **JSON-RPC 2.0 foundation** (`json_rpc`): request
-  envelope parsing and method/id extraction for HTTP
-  POST bodies, enabling method-based routing for
-  MCP/A2A-style traffic.
-- **MCP proxying** (`mcp`): Model Context Protocol
-  broker with tool discovery and routing via the
-  filter pipeline.
-- **A2A proxying** (`a2a`): Agent-to-Agent protocol
-  support with task routing via the filter pipeline.
-
-## Security and Observability
-
-- **AI guardrails** (`ai_guardrails`): calls an
-  external AI guardrail provider to evaluate request
-  bodies. The provider determines whether content
-  should be passed, blocked, or redacted.
-- **Token usage headers** (`token_usage_headers`):
-  injects `Praxis-Token-Input`, `Praxis-Token-Output`,
-  and `Praxis-Token-Total` headers into downstream
-  responses when token usage data is present in filter
-  metadata.
-
-## Extensions
-
-- **Rust extensions**: compile-time custom filters with
-  zero overhead via the `HttpFilter` trait from
-  `praxis-filter` and `register_filters!` macro.
-- **Auto-discovery**: external filter crates
-  self-register at build time via
-  `[package.metadata.praxis-filters]`.

--- a/docs/filters/README.md
+++ b/docs/filters/README.md
@@ -1,85 +1,57 @@
 # Filters
 
 Praxis AI registers AI-specific filters into the
-[Praxis filter pipeline][praxis-filters]. For the base
-filter system architecture (pipeline execution, filter
-traits, body access, conditional execution, filter
-chains), see the Praxis core filter documentation.
+[Praxis filter pipeline][praxis-filters]. The generated
+[filter reference](reference.md) is the authoritative inventory of filter
+names, descriptions, and configuration documentation.
 
-[praxis-filters]: https://github.com/praxis-proxy/praxis/tree/main/docs/filters
+For pipeline execution, filter traits, body access, conditional execution,
+filter chains, and core filters, see the Praxis core filter documentation.
 
-## AI Filter Categories
+## Organization
 
 AI filters are organized across two crates:
 
 ```text
-apis/src/                 Provider API filters
+apis/src/                 Provider API integrations
   anthropic/              Anthropic Messages API
-  openai/                 OpenAI Responses/Chat API
-  classifier/             Request classification
-  store/                  Response persistence
+  openai/                 OpenAI Responses and Conversations APIs
+  classifier/             Shared request classification
+  store/                  Response and conversation persistence
+  token_usage/            Provider token-usage parsing
 
-filters/src/              Cross-provider filters
-  agentic/                MCP, A2A, JSON-RPC
+filters/src/              Cross-provider behavior
+  agentic/                MCP and A2A
   guardrails/             AI content guardrails
-  inference/              Model routing, credentials
+  inference/              Model routing
   prompt_enrich/          Prompt injection
-  token_usage/            Token counting and token headers
+  token_usage/            Token counting and headers
 ```
 
-### Provider APIs (`praxis-ai-apis`)
-
-| Filter | Description |
-|--------|-------------|
-| `anthropic_messages_format` | Classifies Anthropic Messages API requests |
-| `anthropic_messages_protocol` | Normalizes Anthropic protocol headers |
-| `anthropic_stream_events` | SSE format translation (OpenAI / Anthropic) |
-| `anthropic_to_openai` | Anthropic-to-Chat Completions body translation |
-| `anthropic_validate` | Anthropic request envelope validation |
-| `openai_responses_format` | Classifies Responses/Chat Completions requests |
-| `openai_responses_model_rewrite` | Rewrites `model` field in request bodies |
-| `openai_responses_validate` | Validates and enriches Responses API requests |
-| `openai_responses_rehydrate` | Fetches stored responses for conversation context |
-| `openai_response_store` | Persists responses to storage backend |
-| `openai_conversations` | Handles `/v1/conversations` endpoints |
-| `openai_responses_proxy` | Rebuilds request body from `ResponsesState` |
-
-### Cross-Provider Filters (`praxis-ai-filters`)
-
-| Filter | Description |
-|--------|-------------|
-| `a2a` | A2A protocol metadata extraction |
-| `mcp` | MCP protocol broker and routing |
-| `json_rpc` | JSON-RPC 2.0 envelope parsing |
-| `ai_guardrails` | External guardrail provider integration |
-| `model_to_header` | Promotes `model` body field to header |
-| `prompt_enrich` | Injects messages into chat completions |
-| `token_count` | Extracts token counts from provider responses |
-| `token_usage_headers` | Token count response headers |
+Praxis AI also inherits all base proxy filters from Praxis core through
+`FilterRegistry::with_builtins()`. This includes routing, load balancing,
+headers, credential injection, JSON-RPC parsing, CORS, compression, IP ACLs,
+and other general proxy behavior. Those filters are intentionally documented
+in the [Praxis core filter reference][praxis-filters], not duplicated here.
 
 ## Registration
 
-AI filters are registered at startup in
-`server/src/lib.rs` via the `register_ai_filters`
-function. This adds them to the base `FilterRegistry`
-alongside Praxis core builtins:
+`server/src/lib.rs` builds the registry in three steps:
 
 ```rust
 let mut registry = FilterRegistry::with_builtins();
 register_ai_filters(&mut registry);
+register_external_filters(&mut registry);
 ```
 
-## Base Proxy Filters
+This keeps core filters, in-tree AI filters, and auto-discovered extensions at
+clear ownership boundaries.
 
-Praxis AI inherits all base proxy filters from Praxis
-core (router, load balancer, rate limiter, headers,
-CORS, IP ACL, guardrails, compression, etc.). These are
-included via `FilterRegistry::with_builtins()`. See the
-[Praxis core filter reference][praxis-filters] for their
-configuration.
+## Related documentation
 
-## Related
+- [Generated filter reference](reference.md)
+- [Feature overview](../features.md)
+- [Example configurations](../../examples/README.md)
+- [Writing extensions](extensions.md)
 
-- [Filter Reference](reference.md):
-  configuration for all AI filters
-- [Extensions](extensions.md): writing custom filters
+[praxis-filters]: https://github.com/praxis-proxy/praxis/tree/main/docs/filters


### PR DESCRIPTION
## Summary

Replace stale hand-maintained filter inventories in `docs/features.md`
and `docs/filters/README.md` with capability-level descriptions that
link to the generated `docs/filters/reference.md` for exact filter
names and configuration. This eliminates the maintenance burden of
keeping two sources of truth in sync and ensures readers always find
the current filter set.

## Validation

- `make lint`: passed
- `make build`: passed
- No runtime code changes — documentation only

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None — documentation only.