### PR TITLE
fix(store): fail closed when response store is unavailable

### DIFF
--- a/apis/src/openai/responses/store/filter.rs
+++ b/apis/src/openai/responses/store/filter.rs
@@ -11,8 +11,9 @@
 //! persist?" decision as new information becomes available:
 //!
 //! - **`on_request`**: reads classifier metadata to decide whether the request needs the store (persistable POST or
-//!   `previous_response_id`). Lazily initializes the store backend when needed. Sets `responses.skip_persist` metadata
-//!   on store init failure for requests that would otherwise persist.
+//!   `previous_response_id`). Lazily initializes the store backend when needed. Rejects with a 500 response on store
+//!   init failure for any request that requires the store (persistence or rehydration). `GET` and `DELETE` endpoints
+//!   owned by the store also reject rather than falling through to the upstream.
 //!
 //! - **`on_response`**: re-checks skip conditions, then inspects the response status and content-type. Non-2xx
 //!   responses or responses with a content-type other than JSON or event-stream set `responses.skip_persist` and bail
@@ -66,6 +67,7 @@ use super::{
     list_input_items,
 };
 use crate::{
+    classifier::is_responses_create,
     is_event_stream_content_type,
     store::{
         PostgresResponseStore, ResponseRecord, ResponseStore, ResponseStoreRegistry, SqliteResponseStore, StoreError,
@@ -212,7 +214,7 @@ impl ResponseStoreFilter {
     /// Handle `DELETE /v1/responses/{id}` by deleting from the store.
     async fn handle_delete(&self, tenant_id: &str, id: &str) -> Result<FilterAction, FilterError> {
         let Some(store) = self.ensure_store().await else {
-            return Ok(FilterAction::Continue);
+            return Ok(FilterAction::Reject(reject_store_error()));
         };
 
         let deleted = store
@@ -474,7 +476,10 @@ fn delete_not_found_rejection(id: &str) -> Rejection {
 
 /// Check whether this request should skip persistence entirely.
 fn should_skip(ctx: &HttpFilterContext<'_>) -> bool {
-    is_non_post_request(ctx) || is_non_responses_format(ctx) || is_store_disabled(ctx)
+    is_non_post_request(ctx)
+        || is_non_responses_format(ctx)
+        || is_store_disabled(ctx)
+        || !is_responses_create(&ctx.request.method, ctx.request.uri.path())
 }
 
 /// Check whether this request should initialize the store.
@@ -484,7 +489,9 @@ fn should_init_store_for_request(ctx: &HttpFilterContext<'_>) -> bool {
 
 /// Check whether this request can persist the eventual response.
 fn request_will_persist_response(ctx: &HttpFilterContext<'_>) -> bool {
-    ctx.request.method == http::Method::POST && is_responses_format(ctx) && !is_store_disabled(ctx)
+    is_responses_create(&ctx.request.method, ctx.request.uri.path())
+        && is_responses_format(ctx)
+        && !is_store_disabled(ctx)
 }
 
 /// Check whether rehydrate needs the store before the request phase.
@@ -738,11 +745,9 @@ impl HttpFilter for ResponseStoreFilter {
             return Ok(FilterAction::Continue);
         }
 
-        let will_persist = request_will_persist_response(ctx);
         match &self.get_or_init_store().await {
             Some(store) => register_store_in_context(ctx, store),
-            None if will_persist => ctx.set_metadata("responses.skip_persist", "true"),
-            None => {},
+            None => return Ok(FilterAction::Reject(reject_store_error())),
         }
 
         Ok(FilterAction::Continue)
@@ -766,11 +771,9 @@ impl HttpFilter for ResponseStoreFilter {
             ctx.insert_filter_state(ResponseStoreRequestState { input });
         }
         if should_init_store_for_request(ctx) {
-            let will_persist = request_will_persist_response(ctx);
             match &self.get_or_init_store().await {
                 Some(store) => register_store_in_context(ctx, store),
-                None if will_persist => ctx.set_metadata("responses.skip_persist", "true"),
-                None => {},
+                None => return Ok(FilterAction::Reject(reject_store_error())),
             }
         }
         Ok(FilterAction::Continue)
@@ -786,9 +789,7 @@ impl HttpFilter for ResponseStoreFilter {
         }
 
         if self.get_or_init_store().await.is_none() {
-            trace!("skipping persistence because response store is unavailable");
-            ctx.set_metadata("responses.skip_persist", "true");
-            return Ok(FilterAction::Continue);
+            return Ok(FilterAction::Reject(reject_store_error()));
         }
 
         trace!("response body persistence armed");

--- a/apis/src/openai/responses/store/tests.rs
+++ b/apis/src/openai/responses/store/tests.rs
@@ -623,7 +623,7 @@ async fn on_response_continues_for_event_stream_200() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn on_response_does_not_buffer_when_store_unavailable() {
+async fn on_request_rejects_when_store_unavailable_for_persist() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"
 backend: sqlite
@@ -639,27 +639,12 @@ conversations_table: conversations
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    run_request_phase(&filter, &mut ctx).await;
 
-    let mut resp = crate::test_utils::make_response();
-    resp.headers
-        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
-    ctx.response_header = Some(&mut resp);
-
-    let action = filter.on_response(&mut ctx).await.unwrap();
-    assert!(
-        matches!(action, FilterAction::Continue),
-        "should continue when store init fails"
-    );
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
     assert_eq!(
-        ctx.response_body_mode,
-        BodyMode::Stream,
-        "body mode should remain Stream when store is unavailable"
-    );
-    assert_eq!(
-        ctx.get_metadata("responses.skip_persist"),
-        Some("true"),
-        "should mark persistence skipped when store is unavailable"
+        rejection.status, 500,
+        "should reject with 500 when store is unavailable for a persistable request"
     );
 }
 
@@ -1835,7 +1820,9 @@ conversations_table: conversations
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
 
-    drop(filter.on_request(&mut ctx).await.unwrap());
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 500, "first request should reject with 500");
 
     let store_opt = filter
         .store
@@ -1846,7 +1833,9 @@ conversations_table: conversations
     let mut ctx2 = crate::test_utils::make_filter_context(&req);
     ctx2.set_metadata("openai_responses_format.format", "openai_responses");
 
-    drop(filter.on_request(&mut ctx2).await.unwrap());
+    let action2 = filter.on_request(&mut ctx2).await.unwrap();
+    let rejection2 = expect_reject(action2);
+    assert_eq!(rejection2.status, 500, "second request should also reject with 500");
 
     let store_opt2 = filter.store.get().expect("store OnceCell should still be initialized");
     assert!(
@@ -1884,16 +1873,15 @@ allow_private_database_url: true
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
 
-    drop(filter.on_request(&mut ctx).await.unwrap());
-
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 500,
+        "failed postgres initialization should reject with 500"
+    );
     assert!(
         filter.store.get().is_none(),
         "failed postgres initialization should leave OnceCell unset for retry"
-    );
-    assert_eq!(
-        ctx.get_metadata("responses.skip_persist"),
-        Some("true"),
-        "current request should still skip persistence after failed init"
     );
 }
 
@@ -1961,8 +1949,12 @@ allow_private_database_url: true
     let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_test123");
     let mut ctx = crate::test_utils::make_filter_context(&req);
 
-    drop(filter.on_request(&mut ctx).await.unwrap());
-
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 500,
+        "DELETE with failed postgres init should reject with 500"
+    );
     assert!(
         filter.store.get().is_none(),
         "failed postgres initialization on DELETE should leave OnceCell unset for retry"
@@ -3295,7 +3287,7 @@ async fn delete_uses_tenant_metadata() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn delete_continues_when_store_unavailable() {
+async fn delete_rejects_when_store_unavailable() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"
 backend: sqlite
@@ -3313,9 +3305,121 @@ conversations_table: conversations
     let mut ctx = crate::test_utils::make_filter_context(&req);
 
     let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 500,
+        "DELETE should reject with 500 when store is unavailable"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_continues_when_store_unavailable() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite:///nonexistent/path/that/will/fail.db"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    let filter = ResponseStoreFilter::new(cfg);
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/resp_abc/cancel");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
     assert!(
         matches!(action, FilterAction::Continue),
-        "DELETE should continue when store is unavailable"
+        "POST /cancel should continue on_request when store is unavailable"
+    );
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "POST /cancel should continue on_response when store is unavailable"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn input_tokens_continues_when_store_unavailable() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite:///nonexistent/path/that/will/fail.db"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    let filter = ResponseStoreFilter::new(cfg);
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/input_tokens");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "POST /input_tokens should continue on_request when store is unavailable"
+    );
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "POST /input_tokens should continue on_response when store is unavailable"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compact_continues_when_store_unavailable() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite:///nonexistent/path/that/will/fail.db"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    let filter = ResponseStoreFilter::new(cfg);
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses/compact");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "POST /compact should continue on_request when store is unavailable"
+    );
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "POST /compact should continue on_response when store is unavailable"
     );
 }
 

--- a/docs/architecture/response-store.md
+++ b/docs/architecture/response-store.md
@@ -40,8 +40,11 @@ the persistence decision as new information arrives:
   directly from the store.
 - Handles `DELETE /v1/responses/{id}` locally.
 - Lazily initializes the store backend.
-- Sets `responses.skip_persist` metadata on init
-  failure.
+- Rejects with a 500 response on store init failure
+  for any request that requires the store
+  (persistence, rehydration, GET retrieval, or
+  DELETE). Locally owned endpoints never fall through
+  to the upstream when the backend is unavailable.
 
 ### `on_response`
 


### PR DESCRIPTION
### What does this PR do?

When the configured store backend cannot be initialized, the filter now
rejects with a 500 response instead of silently continuing. This
prevents data loss on create (response never persisted, breaking later
retrieve/rehydrate) and wrong-target deletes (forwarded upstream where
they could delete a different provider-side response). Non-create
subresource POSTs (`/cancel`, `/input_tokens`, `/compact`) are excluded
from the store requirement via `is_responses_create` and continue to the
upstream regardless of store availability.

**Changes:**
- `handle_delete`: returns `Reject(500)` instead of `Continue` when store is unavailable
- `on_request` / `on_request_body`: rejects with 500 when store init fails for any request that requires it
- `on_response`: rejects with 500 instead of setting `skip_persist`
- `should_skip`: adds `is_responses_create` gate so non-create POSTs bypass all persistence phases
- `request_will_persist_response`: uses `is_responses_create` to exclude subresource POSTs
- Updated tests to expect 500 rejections and added outage tests for `/cancel`, `/input_tokens`, `/compact` through both request and response phases
- Updated rustdoc and `response-store.md` to describe fail-closed behavior

### Which issue(s) does this relate to?

Fixes #545

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

Yes. Store outages that previously allowed requests through (fail-open)
now return 500 errors (fail-closed). Operators relying on the old
behavior where requests continued despite store unavailability will see
errors until the store backend is healthy.