### PR TITLE
deps: pin praxis core to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,11 @@ wiremock = "0.6.5"
 zeroize = "1.9.0"
 
 # Praxis core dependencies
-praxis-core = { version = "0.4.1", package = "praxis-proxy-core", features = ["callout"] }
-praxis-filter = { version = "0.4.1", package = "praxis-proxy-filter" }
-praxis-protocol = { version = "0.4.1", package = "praxis-proxy-protocol" }
-praxis-tls = { version = "0.4.1", package = "praxis-proxy-tls" }
-praxis = { version = "0.4.1", package = "praxis-proxy" }
+praxis-core = { version = "0.5.0", package = "praxis-proxy-core", features = ["callout"] }
+praxis-filter = { version = "0.5.0", package = "praxis-proxy-filter" }
+praxis-protocol = { version = "0.5.0", package = "praxis-proxy-protocol" }
+praxis-tls = { version = "0.5.0", package = "praxis-proxy-tls" }
+praxis = { version = "0.5.0", package = "praxis-proxy" }
 praxis-test-utils = { path = "tests/utils" }
 
 # Praxis AI workspace dependencies


### PR DESCRIPTION
## Summary

Bump all five praxis-proxy workspace dependencies from 0.4.1 to 0.5.0
(praxis-proxy-core, praxis-proxy-filter, praxis-proxy-protocol,
praxis-proxy-tls, praxis-proxy). Prepares the AI crate for the upcoming
praxis core 0.5.0 release.

## Related issue

N/A

## Validation

Version strings updated in workspace `[workspace.dependencies]`. Full
build and test validation will follow once praxis-proxy 0.5.0 is
published on crates.io.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. This is a dependency version bump only.