### PR TITLE
Fix/external filter discovery 478

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,6 +3056,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "praxis-ai-build-support"
+version = "0.2.0"
+dependencies = [
+ "cargo_metadata",
+ "tempfile",
+]
+
+[[package]]
 name = "praxis-ai-filters"
 version = "0.2.0"
 dependencies = [
@@ -3095,6 +3103,7 @@ dependencies = [
  "nix",
  "notify",
  "praxis-ai-apis",
+ "praxis-ai-build-support",
  "praxis-ai-filters",
  "praxis-proxy-core",
  "praxis-proxy-filter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "server",
+    "server/build_support",
     "filters",
     "apis",
     "xtask",
@@ -79,6 +80,7 @@ praxis-test-utils = { path = "tests/utils" }
 praxis-ai-proxy = { version = "0.2.0", path = "server" }
 praxis-ai-filters = { version = "0.2.0", path = "filters" }
 praxis-ai-apis = { version = "0.2.0", path = "apis" }
+praxis-ai-build-support = { version = "0.2.0", path = "server/build_support" }
 
 # Pingora (temporary fork)
 pingora-core = { version = "0.8.2", package = "quixotic-plecostomus-core", features = ["rustls"] }

--- a/Containerfile
+++ b/Containerfile
@@ -29,18 +29,24 @@ COPY server/build_support/Cargo.toml ./server/build_support/Cargo.toml
 
 # The server crate has a build.rs that discovers external filter
 # crates via cargo metadata for build-time auto-registration,
-# backed by the praxis-ai-build-support crate.
+# backed by the praxis-ai-build-support crate. build.rs is a
+# build-dependency of the server crate, not an ordinary crate under
+# test: cargo compiles it (and everything it depends on) up front,
+# so praxis-ai-build-support needs its real source here too, not a
+# stub — a stub would compile but export none of the functions
+# build.rs calls, breaking compilation of the build script itself.
 COPY server/build.rs ./server/build.rs
+COPY server/build_support/src ./server/build_support/src
 
 # Strip workspace members not needed for the binary.
 RUN sed -i '/xtask/d; /tests\//d' Cargo.toml
 
-# Create stub source files for all crates.
-RUN mkdir -p apis/src filters/src server/src server/build_support/src \
+# Create stub source files for the crates whose real source isn't
+# needed until after dependencies are cached.
+RUN mkdir -p apis/src filters/src server/src \
     && echo '//! stub' > apis/src/lib.rs \
     && echo '//! stub' > filters/src/lib.rs \
     && echo '//! stub' > server/src/lib.rs \
-    && echo '//! stub' > server/build_support/src/lib.rs \
     && printf '//! stub\nfn main() {}\n' > server/src/main.rs
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -53,12 +59,13 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # Replace stubs with real source, then rebuild. Only the project
 # crates recompile; all external dependencies are cached.
+# build_support/src was already real (see above), so it is not
+# copied again here.
 COPY apis/src ./apis/src
 COPY filters/src ./filters/src
 COPY server/src ./server/src
-COPY server/build_support/src ./server/build_support/src
 
-RUN find apis/src filters/src server/src server/build_support/src \
+RUN find apis/src filters/src server/src \
     -name '*.rs' -exec touch {} +
 
 # ------------------------------------------------------------------------------

--- a/Containerfile
+++ b/Containerfile
@@ -25,19 +25,22 @@ COPY Cargo.toml Cargo.lock ./
 COPY apis/Cargo.toml ./apis/Cargo.toml
 COPY filters/Cargo.toml ./filters/Cargo.toml
 COPY server/Cargo.toml ./server/Cargo.toml
+COPY server/build_support/Cargo.toml ./server/build_support/Cargo.toml
 
 # The server crate has a build.rs that discovers external filter
-# crates via cargo metadata for build-time auto-registration.
+# crates via cargo metadata for build-time auto-registration,
+# backed by the praxis-ai-build-support crate.
 COPY server/build.rs ./server/build.rs
 
 # Strip workspace members not needed for the binary.
 RUN sed -i '/xtask/d; /tests\//d' Cargo.toml
 
 # Create stub source files for all crates.
-RUN mkdir -p apis/src filters/src server/src \
+RUN mkdir -p apis/src filters/src server/src server/build_support/src \
     && echo '//! stub' > apis/src/lib.rs \
     && echo '//! stub' > filters/src/lib.rs \
     && echo '//! stub' > server/src/lib.rs \
+    && echo '//! stub' > server/build_support/src/lib.rs \
     && printf '//! stub\nfn main() {}\n' > server/src/main.rs
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -53,8 +56,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 COPY apis/src ./apis/src
 COPY filters/src ./filters/src
 COPY server/src ./server/src
+COPY server/build_support/src ./server/build_support/src
 
-RUN find apis/src filters/src server/src \
+RUN find apis/src filters/src server/src server/build_support/src \
     -name '*.rs' -exec touch {} +
 
 # ------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ test-unit:
 	cargo test -p praxis-ai-apis $(_NOCAPTURE)
 	cargo test -p praxis-ai-filters $(_NOCAPTURE)
 	cargo test -p praxis-ai-proxy $(_NOCAPTURE)
+	cargo test -p praxis-ai-build-support $(_NOCAPTURE)
 
 test-schema:
 	cargo test -p praxis-tests-schema $(_NOCAPTURE)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,6 +47,7 @@ tikv-jemallocator = { workspace = true }
 
 [build-dependencies]
 cargo_metadata = { workspace = true }
+praxis-ai-build-support = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/server/build.rs
+++ b/server/build.rs
@@ -6,6 +6,13 @@
 //! Discovers external filter crates via `cargo metadata` and generates
 //! a registration function that calls each crate's `register_filters()`
 //! at startup.
+//!
+//! This file is a thin orchestrator over the build-script environment
+//! (`OUT_DIR`, `CARGO_MANIFEST_DIR`, `CARGO_FEATURE_*`, `TARGET`). The
+//! dependency-graph scanning and marker-matching logic lives in
+//! `praxis-ai-build-support` instead, because build scripts are not
+//! compiled as ordinary `cargo test` targets and cannot carry their
+//! own unit tests.
 
 #![allow(
     clippy::expect_used,
@@ -13,44 +20,20 @@
     reason = "build script: panics are the only error path; println is cargo directives"
 )]
 
-use std::{collections::HashMap, fmt::Write as _};
+use build_support::ActiveFeatures;
+use cargo_metadata::{CargoOpt, Metadata};
 
-use cargo_metadata::{CargoOpt, DependencyKind, Metadata, NodeDep, Package, PackageId, Resolve};
-
-/// Active Cargo feature selection for this build script invocation.
-struct ActiveFeatures {
-    /// Whether Cargo enabled the package's default feature set.
-    default_enabled: bool,
-
-    /// Explicit active non-default feature names.
-    names: Vec<String>,
-}
+/// Manifest path of this package, resolved at compile time so that
+/// `cargo metadata` always targets `praxis-ai-proxy` regardless of the
+/// build script's current working directory.
+const MANIFEST_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
 
 fn main() {
     let metadata = load_metadata();
-    let crates = discover_external_filter_crates(&metadata);
-    let code = generate_registration_code(&crates);
+    let crates = build_support::discover_external_filter_crate_names(&metadata);
+    let code = build_support::generate_registration_code(&crates);
     write_generated_file(&code);
     emit_rerun_directives(&metadata);
-}
-
-/// Scan dependencies for `[package.metadata.praxis-filters]`.
-fn discover_external_filter_crates(metadata: &Metadata) -> Vec<String> {
-    let packages = packages_by_id(&metadata.packages);
-    let resolve = metadata.resolve.as_ref().expect("no resolve graph");
-
-    let mut crates: Vec<String> = collect_server_deps(&metadata.packages, resolve)
-        .into_iter()
-        .filter(|dep| is_runtime_dependency(dep))
-        .filter_map(|dep| packages.get(&dep.pkg).map(|pkg| (dep, *pkg)))
-        .filter(|(_, pkg)| has_praxis_filter_marker(pkg))
-        // NodeDep::name is the Rust import path, including Cargo aliases and custom lib names.
-        .map(|(dep, _)| dep.name.clone())
-        .collect();
-
-    crates.sort();
-    crates.dedup();
-    crates
 }
 
 /// Load cargo metadata, narrowed to dependencies available for the current
@@ -58,6 +41,7 @@ fn discover_external_filter_crates(metadata: &Metadata) -> Vec<String> {
 fn load_metadata() -> Metadata {
     let active_features = active_features();
     let mut command = cargo_metadata::MetadataCommand::new();
+    command.manifest_path(MANIFEST_PATH);
     apply_active_features(&mut command, active_features);
     if let Ok(target) = std::env::var("TARGET") {
         command.other_options(vec!["--filter-platform".to_owned(), target]);
@@ -69,38 +53,17 @@ fn load_metadata() -> Metadata {
 /// Resolve active package features from Cargo's build-script environment.
 fn active_features() -> ActiveFeatures {
     let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(MANIFEST_PATH)
         .no_deps()
         .exec()
         .expect("failed to read package feature metadata");
     let package = metadata
         .packages
         .iter()
-        .find(|pkg| pkg.name == "praxis-ai-proxy")
+        .find(|pkg| pkg.name == env!("CARGO_PKG_NAME"))
         .expect("praxis-ai package not found in metadata");
 
-    let feature_names_by_env: HashMap<String, String> = package
-        .features
-        .keys()
-        .map(|name| (feature_env_name(name), name.clone()))
-        .collect();
-
-    let mut names: Vec<String> = std::env::vars()
-        .filter_map(|(key, _)| key.strip_prefix("CARGO_FEATURE_").map(str::to_owned))
-        .filter(|name| name != "DEFAULT")
-        .filter_map(|name| feature_names_by_env.get(&name).cloned())
-        .collect();
-    names.sort();
-    names.dedup();
-
-    ActiveFeatures {
-        default_enabled: std::env::var_os("CARGO_FEATURE_DEFAULT").is_some(),
-        names,
-    }
-}
-
-/// Convert a Cargo feature name to the corresponding build-script env suffix.
-fn feature_env_name(name: &str) -> String {
-    name.replace('-', "_").to_ascii_uppercase()
+    build_support::resolve_active_features(&package.features, std::env::vars())
 }
 
 /// Apply the current build's active feature set to a `cargo metadata` command.
@@ -111,67 +74,6 @@ fn apply_active_features(command: &mut cargo_metadata::MetadataCommand, active_f
     if !active_features.names.is_empty() {
         command.features(CargoOpt::SomeFeatures(active_features.names));
     }
-}
-
-/// Build a package lookup by package ID.
-fn packages_by_id(packages: &[Package]) -> HashMap<&PackageId, &Package> {
-    packages.iter().map(|pkg| (&pkg.id, pkg)).collect()
-}
-
-/// Collect dependency edges of the server crate.
-fn collect_server_deps<'a>(packages: &'a [Package], resolve: &'a Resolve) -> Vec<&'a NodeDep> {
-    resolve
-        .nodes
-        .iter()
-        .find(|node| packages.iter().any(|p| p.id == node.id && p.name == "praxis-ai-proxy"))
-        .map(|node| node.deps.iter().collect())
-        .unwrap_or_default()
-}
-
-/// Check whether a dependency edge is available to normal runtime code.
-fn is_runtime_dependency(dep: &NodeDep) -> bool {
-    dep.dep_kinds.iter().any(|kind| kind.kind == DependencyKind::Normal)
-}
-
-/// Check whether a package carries `[package.metadata.praxis-filters]`.
-fn has_praxis_filter_marker(pkg: &Package) -> bool {
-    pkg.metadata
-        .as_object()
-        .is_some_and(|obj| obj.contains_key("praxis-filters"))
-}
-
-/// Generate the `register_external_filters` function body.
-fn generate_registration_code(crates: &[String]) -> String {
-    let mut code = String::from(
-        "/// Register all auto-discovered external filter crates.\n\
-         ///\n\
-         /// Generated by `build.rs` from dependencies carrying\n\
-         /// `[package.metadata.praxis-filters]` in their `Cargo.toml`.\n\
-         ///\n\
-         /// # Panics\n\
-         ///\n\
-         /// Panics if any external filter name conflicts with a\n\
-         /// built-in or previously registered filter.\n",
-    );
-
-    if crates.is_empty() {
-        code.push_str(
-            "#[expect(\n    \
-             unused_variables,\n    \
-             clippy::needless_pass_by_ref_mut,\n    \
-             reason = \"generated: no external filters discovered\"\n\
-             )]\n",
-        );
-    }
-
-    code.push_str("fn register_external_filters(registry: &mut praxis_filter::FilterRegistry) {\n");
-
-    for crate_name in crates {
-        writeln!(code, "    {crate_name}::register_filters(registry);").expect("writing to String should not fail");
-    }
-
-    code.push_str("}\n");
-    code
 }
 
 /// Write the generated registration code to `$OUT_DIR/external_filters.rs`.
@@ -188,24 +90,7 @@ fn emit_rerun_directives(metadata: &Metadata) {
     println!("cargo:rerun-if-changed=../Cargo.lock");
     println!("cargo:rerun-if-changed=build.rs");
 
-    for manifest_path in direct_runtime_dependency_manifest_paths(metadata) {
+    for manifest_path in build_support::direct_runtime_dependency_manifest_paths(metadata) {
         println!("cargo:rerun-if-changed={manifest_path}");
     }
-}
-
-/// Return manifest paths for direct runtime dependencies scanned for
-/// auto-discovery.
-fn direct_runtime_dependency_manifest_paths(metadata: &Metadata) -> Vec<String> {
-    let packages = packages_by_id(&metadata.packages);
-    let resolve = metadata.resolve.as_ref().expect("no resolve graph");
-
-    let mut paths: Vec<String> = collect_server_deps(&metadata.packages, resolve)
-        .into_iter()
-        .filter(|dep| is_runtime_dependency(dep))
-        .filter_map(|dep| packages.get(&dep.pkg).map(|pkg| pkg.manifest_path.to_string()))
-        .collect();
-
-    paths.sort();
-    paths.dedup();
-    paths
 }

--- a/server/build_support/Cargo.toml
+++ b/server/build_support/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "praxis-ai-build-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Testable dependency-graph and marker-scanning logic for praxis-ai-proxy's build script"
+license.workspace = true
+repository.workspace = true
+readme = "../../README.md"
+publish = false
+
+[lib]
+name = "build_support"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+cargo_metadata = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/server/build_support/src/lib.rs
+++ b/server/build_support/src/lib.rs
@@ -19,16 +19,9 @@ use std::{
 
 use cargo_metadata::{DependencyKind, Metadata, NodeDep, Package, PackageId, Resolve};
 
-#[cfg(test)]
-#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic,
-    reason = "tests"
-)]
-mod tests;
+// -----------------------------------------------------------------------------
+// Public Types
+// -----------------------------------------------------------------------------
 
 /// Active Cargo feature selection for a build script invocation.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -39,6 +32,10 @@ pub struct ActiveFeatures {
     /// Explicit active non-default feature names.
     pub names: Vec<String>,
 }
+
+// -----------------------------------------------------------------------------
+// Public Functions
+// -----------------------------------------------------------------------------
 
 /// Convert a Cargo feature name to the corresponding build-script env
 /// suffix, e.g. `my-feature` becomes `MY_FEATURE`.
@@ -213,6 +210,10 @@ pub fn generate_registration_code(crates: &[String]) -> String {
     code
 }
 
+// -----------------------------------------------------------------------------
+// Private Helpers
+// -----------------------------------------------------------------------------
+
 /// Build a package lookup by package ID.
 fn packages_by_id(packages: &[Package]) -> HashMap<&PackageId, &Package> {
     packages.iter().map(|pkg| (&pkg.id, pkg)).collect()
@@ -227,3 +228,14 @@ fn resolve_or_panic(metadata: &Metadata) -> &Resolve {
         .as_ref()
         .expect("cargo metadata returned no resolve graph; verify MetadataCommand does not pass --no-deps")
 }
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests;

--- a/server/build_support/src/lib.rs
+++ b/server/build_support/src/lib.rs
@@ -88,8 +88,9 @@ pub fn resolve_active_features(
 ///
 /// # Panics
 ///
-/// Panics if `resolve.root` is `None`; verify `MetadataCommand` has
-/// an explicit `manifest_path` and does not pass `--no-deps`.
+/// Panics if `resolve.root` is `None`, or if no node in
+/// `resolve.nodes` matches it; verify `MetadataCommand` has an
+/// explicit `manifest_path` and does not pass `--no-deps`.
 #[must_use]
 #[expect(clippy::expect_used, reason = "build-time discovery: panics are the only error path")]
 pub fn collect_root_deps(resolve: &Resolve) -> Vec<&NodeDep> {
@@ -101,8 +102,13 @@ pub fn collect_root_deps(resolve: &Resolve) -> Vec<&NodeDep> {
         .nodes
         .iter()
         .find(|node| &node.id == root)
-        .map(|node| node.deps.iter().collect())
-        .unwrap_or_default()
+        .expect(
+            "cargo metadata resolve graph has no node for the root package; verify \
+             MetadataCommand is invoked with an explicit manifest_path and without --no-deps",
+        )
+        .deps
+        .iter()
+        .collect()
 }
 
 /// Check whether a dependency edge is available to normal runtime
@@ -211,7 +217,7 @@ pub fn generate_registration_code(crates: &[String]) -> String {
 }
 
 // -----------------------------------------------------------------------------
-// Private Helpers
+// Private Utility Functions
 // -----------------------------------------------------------------------------
 
 /// Build a package lookup by package ID.

--- a/server/build_support/src/lib.rs
+++ b/server/build_support/src/lib.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Dependency-graph and marker-scanning logic for `praxis-ai-proxy`'s
+//! external-filter auto-discovery build script.
+//!
+//! Isolated from `server/build.rs` because build scripts are never
+//! compiled as `cargo test` targets, so this logic must live in an
+//! ordinary library crate to be unit tested (see `tests.rs`) against
+//! real `cargo metadata` output. `build.rs` stays a thin orchestrator
+//! over the build-script environment.
+
+#![deny(unsafe_code)]
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Write as _,
+};
+
+use cargo_metadata::{DependencyKind, Metadata, NodeDep, Package, PackageId, Resolve};
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests;
+
+/// Active Cargo feature selection for a build script invocation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ActiveFeatures {
+    /// Whether Cargo enabled the package's default feature set.
+    pub default_enabled: bool,
+
+    /// Explicit active non-default feature names.
+    pub names: Vec<String>,
+}
+
+/// Convert a Cargo feature name to the corresponding build-script env
+/// suffix, e.g. `my-feature` becomes `MY_FEATURE`.
+#[must_use]
+pub fn feature_env_name(name: &str) -> String {
+    name.replace('-', "_").to_ascii_uppercase()
+}
+
+/// Resolve active package features from build-script environment
+/// variables.
+///
+/// Pure over its inputs so it can be unit tested without a real
+/// build-script environment: pass `std::env::vars()` in production
+/// and a fixed list in tests.
+#[must_use]
+pub fn resolve_active_features(
+    feature_names: &BTreeMap<String, Vec<String>>,
+    env_vars: impl IntoIterator<Item = (String, String)>,
+) -> ActiveFeatures {
+    let feature_names_by_env: HashMap<String, String> = feature_names
+        .keys()
+        .map(|name| (feature_env_name(name), name.clone()))
+        .collect();
+
+    let mut default_enabled = false;
+    let mut names: Vec<String> = Vec::new();
+    for (key, _value) in env_vars {
+        let Some(suffix) = key.strip_prefix("CARGO_FEATURE_") else {
+            continue;
+        };
+        if suffix == "DEFAULT" {
+            default_enabled = true;
+        } else if let Some(name) = feature_names_by_env.get(suffix) {
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    names.dedup();
+
+    ActiveFeatures { default_enabled, names }
+}
+
+/// Collect the dependency edges of the resolved root package.
+///
+/// Anchored on [`Resolve::root`] rather than a hardcoded package
+/// name: matching packages by the literal name `"praxis-proxy"`
+/// previously collided with the core alias `praxis = { package =
+/// "praxis-proxy" }`, silently scanning the wrong node's edges and
+/// discovering nothing.
+///
+/// # Panics
+///
+/// Panics if `resolve.root` is `None`; verify `MetadataCommand` has
+/// an explicit `manifest_path` and does not pass `--no-deps`.
+#[must_use]
+#[expect(clippy::expect_used, reason = "build-time discovery: panics are the only error path")]
+pub fn collect_root_deps(resolve: &Resolve) -> Vec<&NodeDep> {
+    let root = resolve.root.as_ref().expect(
+        "cargo metadata returned no root package; verify MetadataCommand is invoked with an \
+         explicit manifest_path and without --no-deps",
+    );
+    resolve
+        .nodes
+        .iter()
+        .find(|node| &node.id == root)
+        .map(|node| node.deps.iter().collect())
+        .unwrap_or_default()
+}
+
+/// Check whether a dependency edge is available to normal runtime
+/// code (as opposed to `dev-dependencies` or `build-dependencies`).
+#[must_use]
+pub fn is_runtime_dependency(dep: &NodeDep) -> bool {
+    dep.dep_kinds.iter().any(|kind| kind.kind == DependencyKind::Normal)
+}
+
+/// Check whether a package carries `[package.metadata.praxis-filters]`.
+#[must_use]
+pub fn has_praxis_filter_marker(pkg: &Package) -> bool {
+    pkg.metadata
+        .as_object()
+        .is_some_and(|obj| obj.contains_key("praxis-filters"))
+}
+
+/// Scan the resolved root package's direct runtime dependencies for
+/// `[package.metadata.praxis-filters]` and return their Rust import
+/// names (post Cargo alias/rename).
+///
+/// Only scans [`Resolve::root`]'s direct edges, never the full
+/// `metadata.packages` list — otherwise a marked crate reachable only
+/// transitively, or gated behind a disabled feature, would be
+/// discovered even though it isn't an active dependency.
+///
+/// # Panics
+///
+/// Panics if `metadata.resolve` is `None` (see [`collect_root_deps`]).
+#[must_use]
+pub fn discover_external_filter_crate_names(metadata: &Metadata) -> Vec<String> {
+    let packages = packages_by_id(&metadata.packages);
+    let resolve = resolve_or_panic(metadata);
+
+    let mut crates: Vec<String> = collect_root_deps(resolve)
+        .into_iter()
+        .filter(|dep| is_runtime_dependency(dep))
+        .filter_map(|dep| packages.get(&dep.pkg).map(|pkg| (dep, *pkg)))
+        .filter(|(_, pkg)| has_praxis_filter_marker(pkg))
+        // dep.name is the post-alias import path; the marker lookup above keys on
+        // dep.pkg, so renaming a dependency cannot hide or spoof its marker status.
+        .map(|(dep, _)| dep.name.clone())
+        .collect();
+
+    crates.sort();
+    crates.dedup();
+    crates
+}
+
+/// Return manifest paths for the resolved root package's direct
+/// runtime dependencies, for `cargo:rerun-if-changed` directives.
+///
+/// # Panics
+///
+/// Panics if `metadata.resolve` is `None` (see [`collect_root_deps`]).
+#[must_use]
+pub fn direct_runtime_dependency_manifest_paths(metadata: &Metadata) -> Vec<String> {
+    let packages = packages_by_id(&metadata.packages);
+    let resolve = resolve_or_panic(metadata);
+
+    let mut paths: Vec<String> = collect_root_deps(resolve)
+        .into_iter()
+        .filter(|dep| is_runtime_dependency(dep))
+        .filter_map(|dep| packages.get(&dep.pkg).map(|pkg| pkg.manifest_path.to_string()))
+        .collect();
+
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// Generate the `register_external_filters` function body.
+#[must_use]
+#[expect(clippy::expect_used, reason = "writing to a String cannot fail")]
+pub fn generate_registration_code(crates: &[String]) -> String {
+    let mut code = String::from(
+        "/// Register all auto-discovered external filter crates.\n\
+         ///\n\
+         /// Generated by `build.rs` from dependencies carrying\n\
+         /// `[package.metadata.praxis-filters]` in their `Cargo.toml`.\n\
+         ///\n\
+         /// # Panics\n\
+         ///\n\
+         /// Panics if any external filter name conflicts with a\n\
+         /// built-in or previously registered filter.\n",
+    );
+
+    if crates.is_empty() {
+        code.push_str(
+            "#[expect(\n    \
+             unused_variables,\n    \
+             clippy::needless_pass_by_ref_mut,\n    \
+             reason = \"generated: no external filters discovered\"\n\
+             )]\n",
+        );
+    }
+
+    code.push_str("fn register_external_filters(registry: &mut praxis_filter::FilterRegistry) {\n");
+
+    for crate_name in crates {
+        writeln!(code, "    {crate_name}::register_filters(registry);").expect("writing to String should not fail");
+    }
+
+    code.push_str("}\n");
+    code
+}
+
+/// Build a package lookup by package ID.
+fn packages_by_id(packages: &[Package]) -> HashMap<&PackageId, &Package> {
+    packages.iter().map(|pkg| (&pkg.id, pkg)).collect()
+}
+
+/// Borrow the resolve graph, panicking with an actionable message if
+/// `cargo metadata` did not produce one.
+#[expect(clippy::expect_used, reason = "build-time discovery: panics are the only error path")]
+fn resolve_or_panic(metadata: &Metadata) -> &Resolve {
+    metadata
+        .resolve
+        .as_ref()
+        .expect("cargo metadata returned no resolve graph; verify MetadataCommand does not pass --no-deps")
+}

--- a/server/build_support/src/tests.rs
+++ b/server/build_support/src/tests.rs
@@ -161,6 +161,10 @@ fn direct_runtime_dependency_manifest_paths_excludes_dev_and_disabled_optional_d
     );
 }
 
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
 /// Build a minimal but structurally-valid `cargo_metadata::Metadata`,
 /// substituting a caller-supplied `resolve` field body (or `null`).
 fn minimal_metadata_json(resolve_body: &str) -> Metadata {

--- a/server/build_support/src/tests.rs
+++ b/server/build_support/src/tests.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for build-script dependency discovery.
+//!
+//! The fixture-based tests spawn real `cargo metadata` subprocesses
+//! against small on-disk crates, exercising actual Cargo dependency
+//! resolution (feature gating, renamed dependencies) rather than
+//! hand-built `cargo_metadata` structs.
+
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cargo_metadata::{CargoOpt, Metadata, MetadataCommand};
+use tempfile::TempDir;
+
+use super::{
+    direct_runtime_dependency_manifest_paths, discover_external_filter_crate_names, feature_env_name,
+    generate_registration_code, resolve_active_features,
+};
+
+#[test]
+fn feature_env_name_replaces_hyphens_and_uppercases() {
+    assert_eq!(feature_env_name("my-cool-feature"), "MY_COOL_FEATURE");
+}
+
+#[test]
+fn resolve_active_features_detects_named_features_and_ignores_unmatched() {
+    let mut feature_names = BTreeMap::new();
+    feature_names.insert("my-feature".to_owned(), Vec::new());
+    feature_names.insert("other-feature".to_owned(), Vec::new());
+
+    let env_vars = vec![
+        ("CARGO_FEATURE_DEFAULT".to_owned(), "1".to_owned()),
+        ("CARGO_FEATURE_MY_FEATURE".to_owned(), "1".to_owned()),
+        ("CARGO_FEATURE_SOME_UNKNOWN".to_owned(), "1".to_owned()),
+        ("PATH".to_owned(), "/usr/bin".to_owned()),
+    ];
+
+    let active = resolve_active_features(&feature_names, env_vars);
+
+    assert!(
+        active.default_enabled,
+        "CARGO_FEATURE_DEFAULT should mark default features enabled"
+    );
+    assert_eq!(
+        active.names,
+        vec!["my-feature".to_owned()],
+        "only the matched feature should be reported, and an unmatched env var ignored"
+    );
+}
+
+#[test]
+fn generate_registration_code_emits_calls_and_empty_case_suppression() {
+    let code = generate_registration_code(&["alpha".to_owned(), "beta".to_owned()]);
+    assert!(
+        code.contains("alpha::register_filters(registry);"),
+        "missing call for alpha: {code}"
+    );
+    assert!(
+        code.contains("beta::register_filters(registry);"),
+        "missing call for beta: {code}"
+    );
+    assert!(
+        !code.contains("no external filters discovered"),
+        "suppression should not appear when crates exist: {code}"
+    );
+
+    let empty_code = generate_registration_code(&[]);
+    assert!(
+        empty_code.contains("no external filters discovered"),
+        "empty case must document the unused parameter: {empty_code}"
+    );
+}
+
+#[test]
+#[should_panic(expected = "cargo metadata returned no root package")]
+fn discover_external_filter_crate_names_panics_when_resolve_has_no_root() {
+    let metadata = minimal_metadata_json(r#"{"nodes":[],"root":null}"#);
+    let _unused = discover_external_filter_crate_names(&metadata);
+}
+
+#[test]
+#[should_panic(expected = "cargo metadata returned no resolve graph")]
+fn discover_external_filter_crate_names_panics_when_resolve_is_missing() {
+    let metadata = minimal_metadata_json("null");
+    let _unused = discover_external_filter_crate_names(&metadata);
+}
+
+#[test]
+fn discovers_normal_and_renamed_marked_dependencies_only() {
+    let fixture = Fixture::build();
+    let discovered = discover_external_filter_crate_names(&fixture.metadata(&[]));
+
+    assert_eq!(
+        discovered,
+        vec!["normal_marked".to_owned(), "renamed_marked".to_owned()],
+        "should discover the normal marked dep (hyphenated crate name normalized to its Rust \
+         import form) and the renamed marked dep under its aliased import name — never its \
+         original crate name `renamed-target` — and nothing else, with default features: \
+         {discovered:?}"
+    );
+}
+
+#[test]
+fn optional_dependency_discovery_follows_its_gating_feature() {
+    let fixture = Fixture::build();
+
+    let without_feature = discover_external_filter_crate_names(&fixture.metadata(&[]));
+    assert!(
+        !without_feature.contains(&"optional_marked".to_owned()),
+        "must be absent when its gating feature is disabled: {without_feature:?}"
+    );
+
+    let with_feature = discover_external_filter_crate_names(&fixture.metadata(&["opt-in".to_owned()]));
+    assert!(
+        with_feature.contains(&"optional_marked".to_owned()),
+        "must be discovered once its gating feature is enabled: {with_feature:?}"
+    );
+}
+
+#[test]
+fn unmarked_dev_and_transitive_dependencies_are_excluded() {
+    let fixture = Fixture::build();
+    let discovered = discover_external_filter_crate_names(&fixture.metadata(&["opt-in".to_owned()]));
+
+    assert!(
+        !discovered.contains(&"plain_dep".to_owned()),
+        "a dependency without the praxis-filters marker must never be discovered: {discovered:?}"
+    );
+    assert!(
+        !discovered.contains(&"dev_marked".to_owned()),
+        "a marked dev-dependency must be excluded: only normal runtime deps are discovered: {discovered:?}"
+    );
+    // Regression test for #478: `nested-marked` is only a transitive dependency (via the
+    // unmarked `praxis-proxy` decoy), so it must never surface from `collect_root_deps`'s
+    // direct-edge scan.
+    assert!(
+        !discovered.contains(&"nested_marked".to_owned()),
+        "a marked crate reachable only through a transitive dependency must not be discovered: {discovered:?}"
+    );
+}
+
+#[test]
+fn direct_runtime_dependency_manifest_paths_excludes_dev_and_disabled_optional_deps() {
+    let fixture = Fixture::build();
+    let metadata = fixture.metadata(&[]);
+
+    let paths = direct_runtime_dependency_manifest_paths(&metadata);
+
+    assert!(
+        paths.iter().any(|path| path.contains("normal-marked")),
+        "should include the normal runtime dependency's manifest: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|path| path.contains("dev-marked")),
+        "must exclude dev-dependency manifests: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|path| path.contains("optional-marked")),
+        "must exclude a disabled optional dependency's manifest: {paths:?}"
+    );
+}
+
+/// Build a minimal but structurally-valid `cargo_metadata::Metadata`,
+/// substituting a caller-supplied `resolve` field body (or `null`).
+fn minimal_metadata_json(resolve_body: &str) -> Metadata {
+    let json = format!(
+        r#"{{"packages":[],"workspace_members":[],"resolve":{resolve_body},"workspace_root":"/tmp/fixture","target_directory":"/tmp/fixture/target","build_directory":null,"version":1}}"#
+    );
+    MetadataCommand::parse(json).expect("fixture metadata JSON should deserialize")
+}
+
+/// Fixture workspace covering discovery's dependency shapes: a
+/// normal marked dep, a renamed (`package = "..."`) marked dep, a
+/// feature-gated optional marked dep, an unmarked dep, a marked
+/// dev-dependency, and a `praxis-proxy` decoy whose only marked
+/// dependency is purely transitive.
+struct Fixture {
+    _dir: TempDir,
+    manifest_path: PathBuf,
+}
+
+impl Fixture {
+    /// Write the fixture crates to a fresh temporary directory.
+    fn build() -> Self {
+        let dir = TempDir::new().expect("create fixture temp dir");
+        let root = dir.path();
+
+        Self::write_crate(root, "normal-marked", "", true);
+        Self::write_crate(root, "renamed-target", "", true);
+        Self::write_crate(root, "optional-marked", "", true);
+        Self::write_crate(root, "plain-dep", "", false);
+        Self::write_crate(root, "dev-marked", "", true);
+        Self::write_crate(root, "nested-marked", "", true);
+        Self::write_crate(
+            root,
+            "praxis-proxy",
+            "nested-marked = { path = \"../nested-marked\" }\n",
+            false,
+        );
+        let manifest_path = Self::write_root_manifest(root);
+
+        Self {
+            _dir: dir,
+            manifest_path,
+        }
+    }
+
+    /// Write the fixture root crate and return its manifest path.
+    fn write_root_manifest(root: &std::path::Path) -> PathBuf {
+        let manifest_path = root.join("fixture-server").join("Cargo.toml");
+        fs::create_dir_all(root.join("fixture-server").join("src")).expect("create fixture root crate dir");
+        fs::write(
+            &manifest_path,
+            "[workspace]\n\n[package]\nname = \"fixture-server\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nnormal-marked = { path = \"../normal-marked\" }\nrenamed_marked = { package = \"renamed-target\", path = \"../renamed-target\" }\noptional-marked = { path = \"../optional-marked\", optional = true }\nplain-dep = { path = \"../plain-dep\" }\npraxis-proxy = { path = \"../praxis-proxy\" }\n\n[dev-dependencies]\ndev-marked = { path = \"../dev-marked\" }\n\n[features]\nopt-in = [\"dep:optional-marked\"]\n",
+        )
+        .expect("write fixture root Cargo.toml");
+        fs::write(
+            root.join("fixture-server").join("src").join("lib.rs"),
+            "//! fixture root crate\n",
+        )
+        .expect("write fixture root lib.rs");
+
+        manifest_path
+    }
+
+    /// Run real `cargo metadata` against the fixture with the given
+    /// non-default features enabled.
+    fn metadata(&self, features: &[String]) -> Metadata {
+        let mut command = MetadataCommand::new();
+        command.manifest_path(self.manifest_path.clone());
+        command.features(CargoOpt::NoDefaultFeatures);
+        if !features.is_empty() {
+            command.features(CargoOpt::SomeFeatures(features.to_vec()));
+        }
+        command
+            .exec()
+            .expect("cargo metadata should succeed against the fixture workspace")
+    }
+
+    /// Write one fixture crate under `root/<name>/`.
+    fn write_crate(root: &std::path::Path, name: &str, extra_deps: &str, marked: bool) {
+        let crate_dir = root.join(name);
+        fs::create_dir_all(crate_dir.join("src")).expect("create fixture crate dir");
+
+        let marker = if marked {
+            "\n[package.metadata.praxis-filters]\n"
+        } else {
+            ""
+        };
+        let dependencies = if extra_deps.is_empty() {
+            String::new()
+        } else {
+            format!("\n[dependencies]\n{extra_deps}")
+        };
+        fs::write(
+            crate_dir.join("Cargo.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n{marker}{dependencies}"),
+        )
+        .expect("write fixture crate Cargo.toml");
+        fs::write(crate_dir.join("src").join("lib.rs"), "//! fixture crate\n").expect("write fixture crate lib.rs");
+    }
+}

--- a/server/build_support/src/tests.rs
+++ b/server/build_support/src/tests.rs
@@ -87,6 +87,13 @@ fn discover_external_filter_crate_names_panics_when_resolve_is_missing() {
 }
 
 #[test]
+#[should_panic(expected = "resolve graph has no node for the root package")]
+fn discover_external_filter_crate_names_panics_when_root_has_no_matching_node() {
+    let metadata = minimal_metadata_json(r#"{"nodes":[],"root":"praxis-ai-proxy 0.1.0 (path+file:///tmp/fixture)"}"#);
+    let _unused = discover_external_filter_crate_names(&metadata);
+}
+
+#[test]
 fn discovers_normal_and_renamed_marked_dependencies_only() {
     let fixture = Fixture::build();
     let discovered = discover_external_filter_crate_names(&fixture.metadata(&[]));

--- a/server/tests/external_filter_discovery_e2e.rs
+++ b/server/tests/external_filter_discovery_e2e.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! End-to-end regression test for external-filter auto-discovery
+//! (issue #478).
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stderr,
+    reason = "integration test"
+)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+    };
+
+    use tempfile::TempDir;
+
+    /// Name of the filter exported by the fixture external filter crate.
+    /// Must match the name passed to `export_filters!` in
+    /// [`Fixture::write_filter_crate`].
+    const FIXTURE_FILTER_NAME: &str = "e2e_fixture_filter";
+
+    /// Closes the loop that `praxis-ai-build-support`'s unit tests
+    /// (`server/build_support/src/tests.rs`) cannot reach alone: a
+    /// marked external filter dependency must not just be
+    /// *discovered*, but the generated `register_external_filters`
+    /// function must compile and, at runtime, register the filter
+    /// into a real `praxis_filter::FilterRegistry`.
+    ///
+    /// The fixture crates are generated into a temp dir and built as
+    /// an isolated, non-workspace Cargo project so this stays purely
+    /// a test concern (no trace in the shipped `praxis-ai-proxy`
+    /// manifest or `cargo tree`).
+    ///
+    /// Spawns a `cargo run` subprocess and is comparatively slow;
+    /// skip it locally with `cargo test -p praxis-ai-proxy -- --skip
+    /// external_filter_discovery_e2e`. It also needs the sibling
+    /// `../praxis` checkout for a real `praxis-proxy-filter` path
+    /// dependency and skips itself when that's absent (e.g. the
+    /// standard CI unit-test job).
+    #[test]
+    fn external_filter_dependency_is_discovered_and_registered_at_runtime() {
+        if !Fixture::praxis_filter_dir().join("Cargo.toml").is_file() {
+            eprintln!(
+                "skipping external_filter_discovery_e2e; sibling ../praxis checkout not found \
+                 (clone https://github.com/praxis-proxy/praxis as ../praxis to run this test)"
+            );
+            return;
+        }
+
+        let workspace = Fixture::write();
+
+        let output = Command::new(env!("CARGO"))
+            .arg("run")
+            .current_dir(workspace.fixture_server_dir())
+            .output()
+            .expect("failed to spawn `cargo run` for the fixture server");
+
+        assert!(
+            output.status.success(),
+            "fixture server build/run failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let expected_line = format!("FILTER:{FIXTURE_FILTER_NAME}");
+        assert!(
+            stdout.lines().any(|line| line == expected_line),
+            "expected the auto-discovered external filter to be registered at runtime; got \
+             stdout:\n{stdout}"
+        );
+    }
+
+    /// An isolated, on-disk Cargo workspace: `filter-crate` is an
+    /// external filter crate carrying `[package.metadata.praxis-filters]`;
+    /// `fixture-server` is a `praxis-ai-proxy` stand-in whose `build.rs`
+    /// calls the real `praxis-ai-build-support` discovery functions and
+    /// whose `main` prints every filter registered into a fresh
+    /// `praxis_filter::FilterRegistry`.
+    struct Fixture {
+        dir: TempDir,
+    }
+
+    impl Fixture {
+        /// Write the fixture workspace to a fresh temporary directory.
+        fn write() -> Self {
+            let dir = TempDir::new().expect("create fixture temp dir");
+            let root = dir.path();
+
+            fs::write(
+                root.join("Cargo.toml"),
+                "[workspace]\nmembers = [\"filter-crate\", \"fixture-server\"]\n",
+            )
+            .expect("write fixture workspace Cargo.toml");
+            Self::write_toolchain_pin(root);
+            Self::write_filter_crate(root);
+            Self::write_fixture_server(root);
+
+            Self { dir }
+        }
+
+        /// Directory containing the fixture server crate.
+        fn fixture_server_dir(&self) -> PathBuf {
+            self.dir.path().join("fixture-server")
+        }
+
+        /// Absolute path to the sibling Praxis core repository's filter
+        /// crate, resolved from `CARGO_MANIFEST_DIR` so this test does
+        /// not depend on the current working directory.
+        fn praxis_filter_dir() -> PathBuf {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(Path::parent)
+                .expect("server/ should have a workspace root two levels up")
+                .join("praxis/filter")
+        }
+
+        /// Absolute path to this repo's `praxis-ai-build-support` crate.
+        fn build_support_dir() -> PathBuf {
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("build_support")
+        }
+
+        /// Pin the same toolchain as the enclosing repo: the Praxis core
+        /// crates this fixture depends on require it, and the fixture
+        /// otherwise has no `rust-toolchain.toml` of its own to inherit.
+        fn write_toolchain_pin(root: &Path) {
+            let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("server/ should have a parent directory");
+            let toolchain = fs::read_to_string(workspace_root.join("rust-toolchain.toml"))
+                .expect("read repo's rust-toolchain.toml");
+            fs::write(root.join("rust-toolchain.toml"), toolchain).expect("write fixture rust-toolchain.toml");
+        }
+
+        /// Write the marked external filter crate.
+        fn write_filter_crate(root: &Path) {
+            let crate_dir = root.join("filter-crate");
+            fs::create_dir_all(crate_dir.join("src")).expect("create filter-crate dir");
+
+            fs::write(crate_dir.join("Cargo.toml"), Self::filter_crate_manifest())
+                .expect("write filter-crate Cargo.toml");
+            fs::write(crate_dir.join("src/lib.rs"), Self::filter_crate_lib_rs())
+                .expect("write filter-crate src/lib.rs");
+        }
+
+        /// `Cargo.toml` contents for the fixture external filter crate.
+        fn filter_crate_manifest() -> String {
+            let praxis_filter_dir = Self::praxis_filter_dir();
+            format!(
+                "[package]\nname = \"e2e-fixture-filter\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[package.metadata.praxis-filters]\n\n[dependencies]\nasync-trait = \"0.1\"\npraxis-proxy-filter = {{ path = {praxis_filter_dir:?} }}\nserde_yaml = {{ package = \"yaml_serde\", version = \"0.10.4\" }}\n"
+            )
+        }
+
+        /// `src/lib.rs` contents for the fixture external filter crate:
+        /// a trivial `HttpFilter` exported via `export_filters!`.
+        fn filter_crate_lib_rs() -> String {
+            format!(
+                "use async_trait::async_trait;\nuse praxis_filter::{{FilterAction, FilterError, HttpFilter, HttpFilterContext, export_filters}};\n\nstruct NoopFilter;\n\n#[async_trait]\nimpl HttpFilter for NoopFilter {{\n    fn name(&self) -> &'static str {{\n        \"{FIXTURE_FILTER_NAME}\"\n    }}\n\n    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {{\n        Ok(FilterAction::Continue)\n    }}\n}}\n\nfn from_config(_config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {{\n    Ok(Box::new(NoopFilter))\n}}\n\nexport_filters! {{\n    http \"{FIXTURE_FILTER_NAME}\" => from_config,\n}}\n"
+            )
+        }
+
+        /// Write the `praxis-ai-proxy` stand-in that exercises the real
+        /// discovery build script logic.
+        fn write_fixture_server(root: &Path) {
+            let crate_dir = root.join("fixture-server");
+            fs::create_dir_all(crate_dir.join("src")).expect("create fixture-server dir");
+
+            fs::write(crate_dir.join("Cargo.toml"), Self::fixture_server_manifest())
+                .expect("write fixture-server Cargo.toml");
+            fs::write(crate_dir.join("build.rs"), Self::fixture_server_build_rs())
+                .expect("write fixture-server build.rs");
+            fs::write(crate_dir.join("src/main.rs"), Self::fixture_server_main_rs())
+                .expect("write fixture-server src/main.rs");
+        }
+
+        /// `Cargo.toml` contents for the fixture server crate.
+        fn fixture_server_manifest() -> String {
+            let praxis_filter_dir = Self::praxis_filter_dir();
+            let build_support_dir = Self::build_support_dir();
+            format!(
+                "[package]\nname = \"e2e-fixture-server\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\npraxis-proxy-filter = {{ path = {praxis_filter_dir:?} }}\ne2e-fixture-filter = {{ path = \"../filter-crate\" }}\nserde_yaml = {{ package = \"yaml_serde\", version = \"0.10.4\" }}\n\n[build-dependencies]\ncargo_metadata = \"0.23.1\"\npraxis-ai-build-support = {{ path = {build_support_dir:?} }}\n"
+            )
+        }
+
+        /// `build.rs` contents for the fixture server: a minimal
+        /// version of `server/build.rs` calling the real
+        /// `praxis-ai-build-support` discovery functions.
+        fn fixture_server_build_rs() -> &'static str {
+            "fn main() {\n    let mut command = cargo_metadata::MetadataCommand::new();\n    command.manifest_path(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/Cargo.toml\"));\n    let metadata = command.exec().expect(\"cargo metadata should succeed\");\n\n    let crates = build_support::discover_external_filter_crate_names(&metadata);\n    let code = build_support::generate_registration_code(&crates);\n\n    let out_dir = std::env::var(\"OUT_DIR\").expect(\"OUT_DIR not set\");\n    let dest = std::path::Path::new(&out_dir).join(\"external_filters.rs\");\n    std::fs::write(&dest, code).expect(\"failed to write external_filters.rs\");\n}\n"
+        }
+
+        /// `src/main.rs` contents for the fixture server: builds a
+        /// registry with the auto-discovered filters and prints every
+        /// registered filter name.
+        fn fixture_server_main_rs() -> &'static str {
+            "include!(concat!(env!(\"OUT_DIR\"), \"/external_filters.rs\"));\n\nfn main() {\n    let mut registry = praxis_filter::FilterRegistry::with_builtins();\n    register_external_filters(&mut registry);\n    let mut names = registry.available_filters();\n    names.sort();\n    for name in names {\n        println!(\"FILTER:{name}\");\n    }\n}\n"
+        }
+    }
+}

--- a/server/tests/external_filter_discovery_e2e.rs
+++ b/server/tests/external_filter_discovery_e2e.rs
@@ -27,24 +27,6 @@ mod tests {
     /// [`Fixture::write_filter_crate`].
     const FIXTURE_FILTER_NAME: &str = "e2e_fixture_filter";
 
-    /// Closes the loop that `praxis-ai-build-support`'s unit tests
-    /// (`server/build_support/src/tests.rs`) cannot reach alone: a
-    /// marked external filter dependency must not just be
-    /// *discovered*, but the generated `register_external_filters`
-    /// function must compile and, at runtime, register the filter
-    /// into a real `praxis_filter::FilterRegistry`.
-    ///
-    /// The fixture crates are generated into a temp dir and built as
-    /// an isolated, non-workspace Cargo project so this stays purely
-    /// a test concern (no trace in the shipped `praxis-ai-proxy`
-    /// manifest or `cargo tree`).
-    ///
-    /// Spawns a `cargo run` subprocess and is comparatively slow;
-    /// skip it locally with `cargo test -p praxis-ai-proxy -- --skip
-    /// external_filter_discovery_e2e`. It also needs the sibling
-    /// `../praxis` checkout for a real `praxis-proxy-filter` path
-    /// dependency and skips itself when that's absent (e.g. the
-    /// standard CI unit-test job).
     #[test]
     fn external_filter_dependency_is_discovered_and_registered_at_runtime() {
         if !Fixture::praxis_filter_dir().join("Cargo.toml").is_file() {


### PR DESCRIPTION
## Summary

`praxis-ai-proxy`'s external-filter auto-discovery build script never actually discovered anything: `collect_server_deps` matched packages by the literal name `"praxis-proxy"` to identify the AI server crate, but that string is also the real package name of an unrelated dependency (the workspace alias `praxis = { package = "praxis-proxy" }` for Praxis core). The lookup silently matched the wrong graph node and scanned *its* dependency edges instead of the AI server's, so no external filter dependency — including ones gated behind an optional feature — was ever picked up.

Closes #478

## What changed

- **Root cause fix** — `collect_root_deps` now anchors on `cargo_metadata`'s resolved `Resolve::root` instead of a hardcoded name match, removing the ambiguity entirely. `MetadataCommand` is also given an explicit `manifest_path` rather than relying on the build script's working directory.
- **New `praxis-ai-build-support` crate** (`server/build_support/`) — the dependency-graph and marker-scanning logic moved out of `server/build.rs` into this library crate, since build scripts are never compiled as `cargo test` targets and couldn't carry unit tests. `server/build.rs` is now a thin orchestrator over the build-script environment.
- **Unit tests** (`server/build_support/src/tests.rs`) — exercise discovery against real `cargo metadata` output from on-disk fixture crates, covering normal/renamed marked dependencies, feature-gated optional dependencies, dev-dependency and unmarked dependencies being excluded, and the original collision bug (a marked crate reachable only transitively must not be discovered).
- **End-to-end regression test** (`server/tests/external_filter_discovery_e2e.rs`) — builds an isolated fixture Cargo project exercising the real `praxis-ai-build-support` functions and confirms the generated registration function compiles and registers the filter into a live `praxis_filter::FilterRegistry` at runtime. Skips itself with an explanatory message when the sibling `../praxis` checkout isn't present (e.g. the standard CI unit-test job).
- **Container build fix** — `Containerfile`'s dependency-caching stage now copies `server/build_support`'s manifest and source alongside the other workspace crates.
- `Makefile`'s `test-unit` target now also runs `cargo test -p praxis-ai-build-support`.

## Test plan

- [x] `cargo test -p praxis-ai-build-support`
- [x] `cargo test -p praxis-ai-proxy --test external_filter_discovery_e2e` (passes with `../praxis` present, skips cleanly without it)
- [x] `cargo check --workspace`
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo +nightly fmt --all -- --check`
- [x] `make coverage-check` — 95%+ line coverage
