### PR TITLE
fix(conformance): define Conversations authentication ownership

### DIFF
--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -72,6 +72,19 @@ Every operation has one proxy-boundary mode:
 Only `transform` and `local` operations enter owned-contract OpenAPI
 comparison. All eight current Conversations operations are `local`.
 
+### Authentication ownership
+
+The `openai_conversations` filter terminates matching requests but does not
+authenticate clients. Authentication and authorization are deployment-owned:
+operators must place the required security filter or trusted ingress boundary
+before Conversations. The generated implementation document therefore does
+not claim OpenAI bearer authentication.
+
+Area projections exclude only inherited global security when an area declares
+it deployment-owned. Operation-specific security remains in scope. The report
+records this choice as `inherited_security: "deployment"`, so the comparison
+boundary is explicit without hiding operation contracts.
+
 ## Tooling
 
 The report requires exactly `oasdiff` 1.23.0. Install the pinned release with:

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -131,15 +131,20 @@ byte-compare it with the complete vendored document:
 cargo xtask openai-conformance-reference --check
 ```
 
-Area projection keeps selected path items, inherited security, path-level
-parameters, referenced security schemes, and the recursive closure of local
-component references. Remote and non-component `$ref` values are rejected.
+Area projection keeps selected path items, path-level parameters, and the
+recursive closure of local component references. Inherited global security
+and referenced security schemes are included by default but excluded when
+an area declares authentication as deployment-owned via
+`without_inherited_security()`. Remote and non-component `$ref` values are
+rejected.
 
 ## Reading the Report
 
 Report schema version 3 records the complete reference once, gives every area
-its own projection digest and implementation source, and keeps three
-independent dimensions:
+its own projection digest, implementation source, and `inherited_security`
+ownership (`"owned"` when the area includes global security in its contract,
+`"deployment"` when authentication is declared as deployment-owned and
+excluded from comparison), and keeps three independent dimensions:
 
 1. `capability_coverage` groups selected operations by handling mode and shows
    missing or stale support claims.

--- a/docs/conformance/openai-conformance-report.json
+++ b/docs/conformance/openai-conformance-report.json
@@ -21,8 +21,9 @@
     {
       "area_id": "conversations",
       "area": "Conversations",
-      "projection_sha256": "8c613541c92f2df0fd2f3a424fd067adceb737d5d0dfe1916ed19dc52ff61421",
-      "operations": 8
+      "projection_sha256": "b5b8af413e9cc84597d300f41789b6fb988f328baa531a61df8877fe321dc856",
+      "operations": 8,
+      "inherited_security": "deployment"
     }
   ],
   "capability_coverage": {
@@ -370,11 +371,8 @@
           ]
         },
         "inherited_contract": {
-          "exact": false,
-          "details": [
-            "security.deleted",
-            "components.securitySchemes.deleted"
-          ]
+          "exact": true,
+          "details": []
         },
         "upstream_spec_exceptions": [
           {
@@ -539,18 +537,15 @@
     "area_contracts": [
       {
         "area": "Conversations",
-        "exact": false,
-        "details": [
-          "security.deleted",
-          "components.securitySchemes.deleted"
-        ]
+        "exact": true,
+        "details": []
       }
     ],
     "all_exact": false,
     "fixes_required": {
       "summary": {
         "operations_to_fix": 5,
-        "area_contracts_to_fix": 1,
+        "area_contracts_to_fix": 0,
         "missing_operations": 0,
         "request_drift_operations": 4,
         "response_drift_operations": 3,
@@ -686,22 +681,7 @@
           ]
         }
       ],
-      "by_area": [
-        {
-          "area": "Conversations",
-          "fixes": [
-            {
-              "area": "area",
-              "kind": "inherited_contract",
-              "summary": "Align global or inherited OpenAPI contract fields with the OpenAI spec.",
-              "detail_paths": [
-                "security.deleted",
-                "components.securitySchemes.deleted"
-              ]
-            }
-          ]
-        }
-      ]
+      "by_area": []
     }
   },
   "runtime_verification": {

--- a/xtask/src/openai_conformance/area.rs
+++ b/xtask/src/openai_conformance/area.rs
@@ -10,7 +10,7 @@ pub(super) const OPENAI_REFERENCE_MANIFEST: &str = "docs/conformance/specs/opena
 
 /// Conversations operations selected from the full OpenAI reference.
 pub(super) const CONVERSATIONS_SCOPE: OperationScope =
-    OperationScope::new("conversations", "Conversations", &["/conversations"]);
+    OperationScope::new("conversations", "Conversations", &["/conversations"]).without_inherited_security();
 
 /// Runtime checks executed while generating the conformance report.
 const CONVERSATIONS_RUNTIME_CHECKS: &[RuntimeVerificationCheck] = &[

--- a/xtask/src/openai_conformance/json_report.rs
+++ b/xtask/src/openai_conformance/json_report.rs
@@ -104,6 +104,7 @@ fn spec_source_json(source: &SpecSourceReport) -> Value {
         "area": source.area,
         "projection_sha256": source.projection_sha256.as_str(),
         "operations": source.operations,
+        "inherited_security": if source.include_inherited_security { "owned" } else { "deployment" },
     })
 }
 

--- a/xtask/src/openai_conformance/model.rs
+++ b/xtask/src/openai_conformance/model.rs
@@ -144,6 +144,9 @@ pub(super) struct SpecSourceReport {
 
     /// SHA-256 of the deterministic area projection.
     pub(super) projection_sha256: String,
+
+    /// Whether inherited global security is part of the area contract.
+    pub(super) include_inherited_security: bool,
 }
 
 /// Complete OpenAI source used by every area in one report.
@@ -554,6 +557,9 @@ pub(super) struct OperationScope {
 
     /// Segment-aware path prefixes belonging to the area.
     pub(super) path_prefixes: &'static [&'static str],
+
+    /// Whether global security belongs to this area's owned contract.
+    pub(super) include_inherited_security: bool,
 }
 
 impl OperationScope {
@@ -563,7 +569,14 @@ impl OperationScope {
             id,
             label,
             path_prefixes,
+            include_inherited_security: true,
         }
+    }
+
+    /// Exclude deployment-owned global security from this area's projection.
+    pub(super) const fn without_inherited_security(mut self) -> Self {
+        self.include_inherited_security = false;
+        self
     }
 
     /// Return whether the operation path is in this scope.

--- a/xtask/src/openai_conformance/reference.rs
+++ b/xtask/src/openai_conformance/reference.rs
@@ -183,7 +183,9 @@ impl ReferenceDocument {
         copy_root_field(root, &mut bundle, "openapi");
         copy_root_field(root, &mut bundle, "jsonSchemaDialect");
         copy_root_field(root, &mut bundle, "info");
-        copy_root_field(root, &mut bundle, "security");
+        if scope.include_inherited_security {
+            copy_root_field(root, &mut bundle, "security");
+        }
 
         let source_paths = root
             .get(&YamlValue::String("paths".to_owned()))

--- a/xtask/src/openai_conformance/spec.rs
+++ b/xtask/src/openai_conformance/spec.rs
@@ -76,6 +76,7 @@ pub(super) fn project_reference(reference: &ReferenceSource, scope: OperationSco
         area: scope.label,
         operations: operations.len(),
         projection_sha256: sha256_hex(content.as_bytes()),
+        include_inherited_security: scope.include_inherited_security,
     };
     Ok(AreaReference {
         report,

--- a/xtask/src/openai_conformance/tests.rs
+++ b/xtask/src/openai_conformance/tests.rs
@@ -738,6 +738,8 @@ paths:
     parameters:
       - {in: path, name: conversation_id, required: true, schema: {type: string}}
     get:
+      security:
+        - OperationAuth: []
       responses:
         '200':
           description: OK
@@ -750,6 +752,7 @@ paths:
 components:
   securitySchemes:
     ApiKeyAuth: {type: http, scheme: bearer}
+    OperationAuth: {type: apiKey, name: x-op-key, in: header}
   schemas:
     Conversation:
       type: object
@@ -769,6 +772,10 @@ components:
     assert!(
         bundle.pointer("/components/securitySchemes/ApiKeyAuth").is_some(),
         "owned inherited security schemes should remain in the projection"
+    );
+    assert!(
+        bundle.pointer("/components/securitySchemes/OperationAuth").is_some(),
+        "operation-level security schemes should remain in the owned projection"
     );
     assert!(
         bundle.pointer("/components/schemas/Conversation").is_some(),
@@ -804,6 +811,23 @@ components:
             .pointer("/components/securitySchemes/ApiKeyAuth")
             .is_none(),
         "security schemes referenced only by deployment-owned security should be excluded"
+    );
+    assert!(
+        conversations
+            .pointer("/components/securitySchemes/OperationAuth")
+            .is_some(),
+        "operation-level security schemes should survive deployment-owned exclusion"
+    );
+    let get_op = conversations
+        .pointer("/paths/~1conversations~1{conversation_id}/get/security")
+        .expect("operation-level security block should remain in the projection");
+    assert!(
+        get_op
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|req| req.get("OperationAuth").is_some()),
+        "operation-level OperationAuth should remain in the operation security block"
     );
     assert!(
         conversations.pointer("/components/schemas/Conversation").is_some(),

--- a/xtask/src/openai_conformance/tests.rs
+++ b/xtask/src/openai_conformance/tests.rs
@@ -80,6 +80,7 @@ fn test_sources() -> Vec<SpecSourceReport> {
         area: "Conversations",
         operations: 5,
         projection_sha256: "test-projection-sha256".to_owned(),
+        include_inherited_security: false,
     }]
 }
 
@@ -482,6 +483,12 @@ fn json_report_includes_oasdiff_missing_and_response_drift() {
     let value = report_json(&report, &test_args());
 
     assert_eq!(value.pointer("/schema_version").and_then(Value::as_u64), Some(3));
+    assert_eq!(
+        value
+            .pointer("/area_projections/0/inherited_security")
+            .and_then(Value::as_str),
+        Some("deployment")
+    );
     assert!(value.get("overall_conformance").is_none());
     assert_eq!(
         value
@@ -752,18 +759,55 @@ components:
     Unused: {type: string}
 ";
 
-    let bundle = build_reference_projection(source, CONVERSATIONS_SCOPE).unwrap();
+    let inherited_scope = super::model::OperationScope::new("inherited", "Inherited", &["/conversations"]);
+    let bundle = build_reference_projection(source, inherited_scope).unwrap();
     let bundle: Value = serde_yaml::from_str(&bundle).unwrap();
-    assert!(bundle.pointer("/security/0/ApiKeyAuth").is_some());
-    assert!(bundle.pointer("/components/securitySchemes/ApiKeyAuth").is_some());
-    assert!(bundle.pointer("/components/schemas/Conversation").is_some());
-    assert!(bundle.pointer("/components/schemas/Metadata").is_some());
-    assert!(bundle.pointer("/components/schemas/Unused").is_none());
-    assert!(bundle.pointer("/paths/~1models").is_none());
+    assert!(
+        bundle.pointer("/security/0/ApiKeyAuth").is_some(),
+        "owned inherited security should remain in the projection"
+    );
+    assert!(
+        bundle.pointer("/components/securitySchemes/ApiKeyAuth").is_some(),
+        "owned inherited security schemes should remain in the projection"
+    );
+    assert!(
+        bundle.pointer("/components/schemas/Conversation").is_some(),
+        "referenced schemas should remain in the projection"
+    );
+    assert!(
+        bundle.pointer("/components/schemas/Metadata").is_some(),
+        "transitively referenced schemas should remain in the projection"
+    );
+    assert!(
+        bundle.pointer("/components/schemas/Unused").is_none(),
+        "unreferenced schemas should be excluded"
+    );
+    assert!(
+        bundle.pointer("/paths/~1models").is_none(),
+        "paths outside the scope should be excluded"
+    );
     assert!(
         bundle
             .pointer("/paths/~1conversations~1{conversation_id}/parameters")
-            .is_some()
+            .is_some(),
+        "path-level parameters should remain in the projection"
+    );
+
+    let conversations = build_reference_projection(source, CONVERSATIONS_SCOPE).unwrap();
+    let conversations: Value = serde_yaml::from_str(&conversations).unwrap();
+    assert!(
+        conversations.pointer("/security").is_none(),
+        "deployment-owned global security should be excluded"
+    );
+    assert!(
+        conversations
+            .pointer("/components/securitySchemes/ApiKeyAuth")
+            .is_none(),
+        "security schemes referenced only by deployment-owned security should be excluded"
+    );
+    assert!(
+        conversations.pointer("/components/schemas/Conversation").is_some(),
+        "contract schemas should remain after excluding inherited security"
     );
 }
 


### PR DESCRIPTION
## Problem

The Conversations conformance report flagged missing `security` and `components.securitySchemes` as schema drift. This misrepresented the situation — Conversations authentication is deployment-owned (handled by upstream reverse proxies or ingress), not something the Conversations filter itself enforces.

## Changes

- classify authentication as deployment-owned in the conformance area contract
- explicitly report inherited security drift as an ownership boundary, not a missing implementation
- regenerate the conformance report: inherited area contracts now exact (`true`)
- add conformance tooling support for ownership-boundary declarations

## Validation

- `make lint` (clippy, fmt, deps, docs, examples all clean)
- `cargo test -p praxis-ai-apis -- conversations` (188 passed, 1 ignored)
- `cargo xtask openai-conformance --area conversations` (3/8 exact, inherited contracts exact, 12 exceptions applied)
- `git diff --check origin/main...HEAD`

Closes #569