### PR TITLE
refactor(apis): replace CalloutClient with Pingora-native SubRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "cpex-pdp-cel",
  "cpex-plugin-audit-logger",
  "cpex-plugin-delegator-oauth",
+ "cpex-plugin-elicitation-ciba",
  "cpex-plugin-identity-jwt",
  "cpex-plugin-pii-scanner",
  "cpex-session-valkey",
@@ -963,6 +964,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da8c0ce5ae33679beaeb582b6348b9f3ad4762a33dc503a7f872f269bf4804c7"
 dependencies = [
  "async-trait",
+ "chrono",
+ "cpex-core",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "cpex-plugin-elicitation-ciba"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0d6fbd8a25ede8544c528184d317691a543b52df1962a6d92d79ba58c172d"
+dependencies = [
+ "async-trait",
+ "base64",
  "chrono",
  "cpex-core",
  "reqwest 0.12.28",
@@ -2906,6 +2924,8 @@ dependencies = [
  "percent-encoding",
  "praxis-proxy-core",
  "praxis-proxy-filter",
+ "quixotic-plecostomus-core",
+ "quixotic-plecostomus-http",
  "reqwest 0.13.4",
  "rmcp",
  "schemars 1.2.1",
@@ -2965,9 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130643048a6f3a94b1b48c361479a8f2833bf9d3a926cff9a9071bdcaa352552"
+checksum = "34121bbb48d49496e6d61c11c6362037b691663051791bad543d118e06e82222"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -2986,17 +3006,17 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-core"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a30c54be1367e63135c5b3b05f7365ab7d8940c3d5fdac9d97a316c04568c9"
+checksum = "58aeccce4246f7b3d83508bfd71880d1b9261cf7aca1a1cf67e8ff38e5ba655f"
 dependencies = [
+ "bytes",
  "dashmap 6.2.1",
  "http",
  "praxis-proxy-tls",
  "quixotic-plecostomus-core",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.4",
  "serde",
  "thiserror 2.0.19",
  "tokio",
@@ -3007,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-filter"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b775e4c9673c53e967cce25e8e8959a9ff01cf18a17a90448f6601c77e8f050"
+checksum = "2af983f07e1ba5cfcdbf08437b481038a438f708cf760b3563c2388ad2dd437c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3020,6 +3040,8 @@ dependencies = [
  "percent-encoding",
  "praxis-proxy-core",
  "praxis-proxy-tls",
+ "quixotic-plecostomus-core",
+ "quixotic-plecostomus-http",
  "rand 0.10.2",
  "regex",
  "secrecy",
@@ -3035,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-protocol"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3919b20d58ab7cf5af8ba6dc380641f217430061436511fb7b83e21646d3adb9"
+checksum = "763b0190ee99a5d4962ba717c7d8d9edf095336ece5769bc7f66d693d005d3d0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3060,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-tls"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcb6f2aad1284d40edf3ec7eb41f010ce48244c2caa74abd12b55f94edcad5"
+checksum = "fb39ec61f84dd83eb3131743f13a75a9f7c250160adbdf935e73bffa5d0f495b"
 dependencies = [
  "arc-swap",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,11 @@ wiremock = "0.6.5"
 zeroize = "1.9.0"
 
 # Praxis core dependencies
-praxis-core = { version = "0.4.1", package = "praxis-proxy-core", features = ["callout"] }
-praxis-filter = { version = "0.4.1", package = "praxis-proxy-filter" }
-praxis-protocol = { version = "0.4.1", package = "praxis-proxy-protocol" }
-praxis-tls = { version = "0.4.1", package = "praxis-proxy-tls" }
-praxis = { version = "0.4.1", package = "praxis-proxy" }
+praxis-core = { version = "0.5.0", package = "praxis-proxy-core" }
+praxis-filter = { version = "0.5.0", package = "praxis-proxy-filter" }
+praxis-protocol = { version = "0.5.0", package = "praxis-proxy-protocol" }
+praxis-tls = { version = "0.5.0", package = "praxis-proxy-tls" }
+praxis = { version = "0.5.0", package = "praxis-proxy" }
 praxis-test-utils = { path = "tests/utils" }
 
 # Praxis AI workspace dependencies

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -27,7 +27,9 @@ bytes = { workspace = true }
 dashmap = { workspace = true, optional = true }
 http = { workspace = true }
 percent-encoding = { workspace = true }
-praxis-core = { workspace = true, features = ["callout"] }
+pingora-core = { workspace = true }
+pingora-http = { workspace = true }
+praxis-core = { workspace = true }
 praxis-filter = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true }

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod mcp_client;
 pub mod openai;
 #[cfg(feature = "store")]
 pub mod store;
+pub(crate) mod subrequest;
 
 /// Whether a `Content-Type` header value indicates `text/event-stream`,
 /// ignoring parameters (e.g. `; charset=utf-8`) and ASCII case.
@@ -60,6 +61,7 @@ pub(crate) mod test_utils {
     )]
     pub(crate) fn make_filter_context(req: &Request) -> HttpFilterContext<'_> {
         HttpFilterContext {
+            buffered_request_body: None,
             body_done_indices: Vec::new(),
             branch_iterations: std::collections::HashMap::new(),
             client_addr: None,
@@ -88,6 +90,7 @@ pub(crate) mod test_utils {
             response_body_mode: praxis_filter::BodyMode::Stream,
             response_header: None,
             response_headers_modified: false,
+            subrequest_connector: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,

--- a/apis/src/openai/api_client/mod.rs
+++ b/apis/src/openai/api_client/mod.rs
@@ -8,32 +8,27 @@
 //! JSON and byte reads, and normalized error mapping. Used by
 //! [`FilesApiClient`] and vector-store search.
 //!
-//! JSON requests route through `praxis_core::callout::CalloutClient`
-//! for circuit breaking, callout-depth protection, and timeout.
-//! Content downloads use a direct `reqwest::Client` with
-//! chunk-by-chunk bounded reads so oversized responses are rejected
-//! during collection. Unifying both paths behind `CalloutClient`
-//! is tracked in [#454].
+//! All requests route through the Pingora-native
+//! [`SubRequestConnector`] for connection pooling and TLS.
 //!
-//! Each consuming filter retains its own [`ApiClient`] instance so
-//! circuit-breaker state is isolated per filter.
-//!
-//! [#454]: https://github.com/praxis-proxy/ai/issues/454
+//! Each consuming filter retains its own [`ApiClient`] instance.
 //!
 //! [`FilesApiClient`]: super::responses::file_resolve
+//! [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
 
 pub(crate) mod error;
 pub(crate) mod url;
 
 use std::time::Duration;
 
-use praxis_core::callout::{CalloutClient, CalloutConfig, CalloutRequest, CalloutResult};
-use reqwest::redirect;
+use bytes::Bytes;
+use http::HeaderMap;
 
 pub(crate) use self::{
     error::ApiClientError,
     url::{resource_url, validate_base_url, validate_forward_headers},
 };
+use crate::subrequest::{self, SubRequest, SubRequestConnector, SubRequestError, SubResponse};
 
 /// Configuration for constructing an [`ApiClient`].
 ///
@@ -42,75 +37,77 @@ pub(crate) use self::{
 pub(crate) struct ApiClientConfig {
     /// Base URL of the API endpoint (trailing slash stripped).
     pub api_base_url: String,
-    /// Transport configuration for the underlying
-    /// [`CalloutClient`].
-    pub callout_config: CalloutConfig,
+    /// Pingora-native HTTP connector.
+    pub connector: SubRequestConnector,
+    /// Per-request timeout.
+    pub timeout: Duration,
+    /// Maximum response body bytes.
+    pub max_response_bytes: usize,
     /// Header names to forward from the original request.
     pub forward_header_names: Vec<http::HeaderName>,
 }
 
 /// Shared HTTP client for OpenAI-compatible API callouts.
 ///
-/// JSON requests (`get_json`) route through [`CalloutClient`]
-/// for circuit breaking and callout-depth protection. Content
-/// downloads (`get_bytes`) use a direct
-/// `reqwest::Client` with chunk-by-chunk bounded reads so
-/// oversized responses are rejected during collection without
-/// unbounded memory consumption. Unifying both paths behind
-/// `CalloutClient` is tracked in [#454] and requires
-/// `CalloutConfig::max_response_bytes` (praxis-core post-0.4.0).
+/// All requests route through the Pingora-native
+/// [`SubRequestConnector`] for connection pooling and TLS.
 ///
-/// [#454]: https://github.com/praxis-proxy/ai/issues/454
+/// [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
 pub(crate) struct ApiClient {
     /// Base URL of the API endpoint (trailing slash stripped).
     api_base_url: String,
-    /// Callout client for JSON metadata requests.
-    client: CalloutClient,
-    /// Direct HTTP client for bounded content downloads.
-    content_client: reqwest::Client,
+    /// Pingora-native HTTP connector.
+    connector: SubRequestConnector,
+    /// Per-request timeout.
+    timeout: Duration,
+    /// Maximum response body bytes for JSON requests.
+    max_response_bytes: usize,
     /// Header names to forward from the original downstream
     /// request.
     forward_header_names: Vec<http::HeaderName>,
-    /// Per-request timeout (from the callout config).
-    timeout: Duration,
+}
+
+/// Map a [`SubRequestError`] to an [`ApiClientError`], preserving
+/// the `ResponseTooLarge` variant for 2xx responses so callers can
+/// distinguish genuine size violations from backend failures.
+///
+/// Non-2xx oversized responses map to `CalloutFailed` — the
+/// backend error takes precedence over the size limit.
+fn map_subrequest_error(err: SubRequestError) -> ApiClientError {
+    match err {
+        SubRequestError::ResponseTooLarge { status, .. } if !(200..300).contains(&(status as usize)) => {
+            ApiClientError::CalloutFailed {
+                detail: format!("callout rejected with status {status} (response body exceeded limit)"),
+            }
+        },
+        SubRequestError::ResponseTooLarge { limit, .. } => ApiClientError::ResponseTooLarge { limit },
+        other => ApiClientError::CalloutFailed {
+            detail: other.to_string(),
+        },
+    }
 }
 
 impl ApiClient {
     /// Build a new client from validated configuration.
     ///
     /// The base URL should already be validated with
-    /// [`validate_base_url`]. This constructor strips trailing
-    /// slashes and builds the transport client.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the callout client cannot be
-    /// constructed.
-    pub(crate) fn new(config: ApiClientConfig) -> Result<Self, String> {
+    /// [`validate_base_url`].
+    pub(crate) fn new(config: ApiClientConfig) -> Self {
         let ApiClientConfig {
             api_base_url,
-            callout_config,
+            connector,
+            timeout,
+            max_response_bytes,
             forward_header_names,
         } = config;
 
-        let timeout = Duration::from_millis(callout_config.timeout_ms);
-
-        let client = CalloutClient::new(callout_config).map_err(|e| format!("failed to build callout client: {e}"))?;
-
-        let content_client = reqwest::Client::builder()
-            .no_proxy()
-            .redirect(redirect::Policy::none())
-            .timeout(timeout)
-            .build()
-            .map_err(|e| format!("failed to build content client: {e}"))?;
-
-        Ok(Self {
+        Self {
             api_base_url: api_base_url.trim_end_matches('/').to_owned(),
-            client,
-            content_client,
-            forward_header_names,
+            connector,
             timeout,
-        })
+            max_response_bytes,
+            forward_header_names,
+        }
     }
 
     /// Return the validated base URL.
@@ -136,35 +133,26 @@ impl ApiClient {
         resource_url(&self.api_base_url, path_prefix, resource_id, suffix)
     }
 
-    /// Send a GET request via the callout client and parse the
-    /// response body as JSON.
+    /// Send a GET request and parse the response body as JSON.
     pub(crate) async fn get_json(
         &self,
         url: String,
-        request_headers: &http::HeaderMap,
+        request_headers: &HeaderMap,
     ) -> Result<serde_json::Value, ApiClientError> {
-        let headers = self.forward_headers(request_headers);
-        let request = CalloutRequest {
-            body: None,
-            depth: 0,
-            headers,
-            method: http::Method::GET,
-            url,
-        };
-
-        let response = execute_callout(&self.client, request).await?;
+        let headers = self.build_header_map(request_headers);
+        let response = self.execute_url(&url, http::Method::GET, headers, Bytes::new()).await?;
         serde_json::from_slice(&response.body).map_err(|e| ApiClientError::DecodeFailed {
             detail: format!("JSON decode failed: {e}"),
         })
     }
 
-    /// Send a POST request with a JSON body via the callout client
-    /// and parse the response body as JSON.
+    /// Send a POST request with a JSON body and parse the response
+    /// body as JSON.
     pub(crate) async fn post_json(
         &self,
         url: String,
         body: &serde_json::Value,
-        request_headers: &http::HeaderMap,
+        request_headers: &HeaderMap,
     ) -> Result<serde_json::Value, ApiClientError> {
         let serialized = serde_json::to_vec(body).map_err(|e| ApiClientError::DecodeFailed {
             detail: format!("request body serialization failed: {e}"),
@@ -177,80 +165,68 @@ impl ApiClient {
         })
     }
 
-    /// Send a pre-serialized JSON body and return the bounded raw response.
-    ///
-    /// This supports consumers that enforce domain-specific serialization and
-    /// decode limits while retaining the shared transport, header, timeout,
-    /// circuit-breaker, and status handling.
+    /// Send a pre-serialized JSON body and return the bounded raw
+    /// response.
     pub(crate) async fn post_json_bytes(
         &self,
         url: String,
         body: Vec<u8>,
-        request_headers: &http::HeaderMap,
-    ) -> Result<Vec<u8>, ApiClientError> {
-        let mut headers = self.forward_headers(request_headers);
-        headers.retain(|(name, _)| name != http::header::CONTENT_TYPE);
-        headers.push((
+        request_headers: &HeaderMap,
+    ) -> Result<Bytes, ApiClientError> {
+        let mut headers = self.build_header_map(request_headers);
+        headers.remove(http::header::CONTENT_TYPE);
+        headers.insert(
             http::header::CONTENT_TYPE,
             http::HeaderValue::from_static("application/json"),
-        ));
+        );
 
-        let request = CalloutRequest {
-            body: Some(body),
-            depth: 0,
-            headers,
-            method: http::Method::POST,
-            url,
-        };
-
-        let response = execute_callout(&self.client, request).await?;
+        let response = self
+            .execute_url(&url, http::Method::POST, headers, Bytes::from(body))
+            .await?;
         Ok(response.body)
     }
 
     /// Send a GET request and return the response body with
-    /// chunk-by-chunk bounded reads.
+    /// bounded reads.
     ///
-    /// Uses a direct `reqwest::Client` so the `max_bytes` limit
-    /// is enforced during collection — oversized responses are
-    /// rejected without unbounded memory consumption. Redirects
-    /// are rejected, and the configured timeout spans the full
-    /// request including body transfer.
-    ///
-    /// This path does not share the [`CalloutClient`]'s circuit
-    /// breaker or callout-depth accounting. Unifying both behind
-    /// `CalloutClient` is tracked in [#454].
-    ///
-    /// [#454]: https://github.com/praxis-proxy/ai/issues/454
+    /// The Pingora connector does not follow redirects (it
+    /// connects to a specific peer), matching the redirect-
+    /// rejection behavior of the previous `reqwest` path.
     pub(crate) async fn get_bytes(
         &self,
         url: &str,
-        request_headers: &http::HeaderMap,
+        request_headers: &HeaderMap,
         max_bytes: usize,
-    ) -> Result<Vec<u8>, ApiClientError> {
-        let mut builder = self.content_client.get(url);
-        for (name, value) in self.forward_headers(request_headers) {
-            builder = builder.header(name, value);
-        }
+    ) -> Result<Bytes, ApiClientError> {
+        let headers = self.build_header_map(request_headers);
 
-        let response = builder.send().await.map_err(|e| ApiClientError::CalloutFailed {
+        let (target, uri) = subrequest::parse_url(url).map_err(|e| ApiClientError::CalloutFailed {
             detail: format!("content download failed: {e}"),
         })?;
 
-        if !response.status().is_success() {
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri,
+            headers,
+            body: Bytes::new(),
+        };
+
+        let response = subrequest::execute(&self.connector, &target, &request, max_bytes, self.timeout)
+            .await
+            .map_err(map_subrequest_error)?;
+
+        if response.status < 200 || response.status >= 300 {
             return Err(ApiClientError::CalloutFailed {
-                detail: format!("content download failed: {}", response.status()),
+                detail: format!("content download failed: {}", response.status),
             });
         }
 
-        read_bounded_body(response, max_bytes).await
+        Ok(response.body)
     }
 
     /// Copy configured headers from the original downstream
-    /// request for forwarding to the external API.
-    pub(crate) fn forward_headers(
-        &self,
-        request_headers: &http::HeaderMap,
-    ) -> Vec<(http::HeaderName, http::HeaderValue)> {
+    /// request into a [`HeaderMap`] for forwarding.
+    pub(crate) fn forward_headers(&self, request_headers: &HeaderMap) -> Vec<(http::HeaderName, http::HeaderValue)> {
         let mut headers = Vec::new();
         for name in &self.forward_header_names {
             if let Some(value) = request_headers.get(name) {
@@ -259,43 +235,54 @@ impl ApiClient {
         }
         headers
     }
-}
 
-/// Read a response body chunk-by-chunk, rejecting it as soon as
-/// accumulated bytes exceed `max_bytes`.
-async fn read_bounded_body(mut response: reqwest::Response, max_bytes: usize) -> Result<Vec<u8>, ApiClientError> {
-    if let Some(len) = response.content_length()
-        && len > max_bytes as u64
-    {
-        return Err(ApiClientError::ResponseTooLarge { limit: max_bytes });
-    }
-
-    let mut body = Vec::new();
-    while let Some(chunk) = response.chunk().await.map_err(|e| ApiClientError::CalloutFailed {
-        detail: format!("content download failed: {e}"),
-    })? {
-        if body.len() + chunk.len() > max_bytes {
-            return Err(ApiClientError::ResponseTooLarge { limit: max_bytes });
+    /// Build a [`HeaderMap`] from forwarded headers.
+    fn build_header_map(&self, request_headers: &HeaderMap) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for name in &self.forward_header_names {
+            if let Some(value) = request_headers.get(name) {
+                map.insert(name.clone(), value.clone());
+            }
         }
-        body.extend_from_slice(&chunk);
+        map
     }
-    Ok(body)
-}
 
-/// Execute a callout and map non-success outcomes to
-/// [`ApiClientError`].
-async fn execute_callout(
-    client: &CalloutClient,
-    request: CalloutRequest,
-) -> Result<praxis_core::callout::CalloutResponse, ApiClientError> {
-    match client.execute(request).await {
-        CalloutResult::Success(r) => Ok(r),
-        CalloutResult::Failed => Err(ApiClientError::CalloutFailed {
-            detail: "callout failed (fail-open)".to_owned(),
-        }),
-        CalloutResult::Rejected(rejection) => Err(ApiClientError::CalloutFailed {
-            detail: format!("callout rejected with status {}", rejection.status),
-        }),
+    /// Parse the URL, build a [`SubRequest`], execute via the
+    /// connector, and check for non-2xx status.
+    async fn execute_url(
+        &self,
+        url: &str,
+        method: http::Method,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<SubResponse, ApiClientError> {
+        let (target, uri) =
+            subrequest::parse_url(url).map_err(|e| ApiClientError::CalloutFailed { detail: e.to_string() })?;
+
+        let request = SubRequest {
+            method,
+            uri,
+            headers,
+            body,
+        };
+
+        let response = subrequest::execute(
+            &self.connector,
+            &target,
+            &request,
+            self.max_response_bytes,
+            self.timeout,
+        )
+        .await
+        .map_err(map_subrequest_error)?;
+
+        if response.status < 200 || response.status >= 300 {
+            return Err(ApiClientError::CalloutFailed {
+                detail: format!("callout rejected with status {}", response.status),
+            });
+        }
+
+        Ok(response)
     }
 }
 
@@ -314,8 +301,6 @@ mod tests {
         net::{SocketAddr, TcpListener, TcpStream},
         thread::JoinHandle,
     };
-
-    use praxis_core::callout::{CalloutConfig, FailureMode};
 
     use super::*;
 
@@ -371,14 +356,11 @@ mod tests {
     fn test_client(base_url: &str) -> ApiClient {
         ApiClient::new(ApiClientConfig {
             api_base_url: base_url.to_owned(),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                timeout_ms: 1_000,
-                ..CalloutConfig::default()
-            },
+            connector: SubRequestConnector::new(4, None),
+            timeout: Duration::from_millis(1_000),
+            max_response_bytes: 1_048_576,
             forward_header_names: Vec::new(),
         })
-        .unwrap()
     }
 
     #[test]
@@ -391,18 +373,16 @@ mod tests {
     fn forward_headers_copies_configured_headers() {
         let client = ApiClient::new(ApiClientConfig {
             api_base_url: "http://ogx:8321".to_owned(),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                ..CalloutConfig::default()
-            },
+            connector: SubRequestConnector::new(4, None),
+            timeout: Duration::from_millis(1_000),
+            max_response_bytes: 1_048_576,
             forward_header_names: vec![
                 http::header::AUTHORIZATION,
                 http::HeaderName::from_static("x-tenant-id"),
             ],
-        })
-        .unwrap();
+        });
 
-        let mut request_headers = http::HeaderMap::new();
+        let mut request_headers = HeaderMap::new();
         request_headers.insert(http::header::AUTHORIZATION, "Bearer token".parse().unwrap());
         request_headers.insert("x-tenant-id", "tenant-1".parse().unwrap());
         request_headers.insert("x-unrelated", "ignored".parse().unwrap());
@@ -448,7 +428,7 @@ mod tests {
         let err = client
             .get_bytes(
                 &format!("http://{address}/v1/files/test/content"),
-                &http::HeaderMap::new(),
+                &HeaderMap::new(),
                 1024,
             )
             .await
@@ -473,7 +453,7 @@ mod tests {
         let err = client
             .get_bytes(
                 &format!("http://{address}/v1/files/test/content"),
-                &http::HeaderMap::new(),
+                &HeaderMap::new(),
                 1024,
             )
             .await
@@ -500,17 +480,42 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let err = client
-            .get_bytes(
-                &format!("http://{address}/v1/files/test/content"),
-                &http::HeaderMap::new(),
-                8,
-            )
+            .get_bytes(&format!("http://{address}/v1/files/test/content"), &HeaderMap::new(), 8)
             .await
             .unwrap_err();
 
         assert!(
             matches!(err, ApiClientError::ResponseTooLarge { .. }),
-            "responses exceeding per-request max_bytes should be rejected"
+            "responses exceeding per-request max_bytes should be rejected as ResponseTooLarge: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_bytes_oversized_non_2xx_is_callout_failed_not_too_large() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _read = stream.read(&mut request).unwrap();
+            let body = vec![b'x'; 64];
+            let response = format!(
+                "HTTP/1.1 404 Not Found\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.write_all(&body).unwrap();
+        });
+        let client = test_client(&format!("http://{address}"));
+
+        let err = client
+            .get_bytes(&format!("http://{address}/v1/files/test/content"), &HeaderMap::new(), 8)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ApiClientError::CalloutFailed { .. }),
+            "non-2xx oversized response should be CalloutFailed, not ResponseTooLarge: {err:?}"
         );
     }
 
@@ -532,7 +537,7 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let json = client
-            .get_json(format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
+            .get_json(format!("http://{address}/v1/files/file-abc"), &HeaderMap::new())
             .await
             .unwrap();
 
@@ -555,7 +560,7 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let err = client
-            .get_json(format!("http://{address}/v1/files/file-abc"), &http::HeaderMap::new())
+            .get_json(format!("http://{address}/v1/files/file-abc"), &HeaderMap::new())
             .await
             .unwrap_err();
 
@@ -576,7 +581,7 @@ mod tests {
             .post_json(
                 format!("http://{address}/v1/vector_stores/vs-123/search"),
                 &request_body,
-                &http::HeaderMap::new(),
+                &HeaderMap::new(),
             )
             .await
             .unwrap();
@@ -584,9 +589,10 @@ mod tests {
         assert!(json["results"].as_array().unwrap().is_empty());
 
         let request = captured.join().unwrap();
+        let request_lower = request.to_lowercase();
         assert!(request.starts_with("POST"), "should be a POST request");
         assert!(
-            request.contains("content-type: application/json"),
+            request_lower.contains("content-type: application/json"),
             "should have JSON content-type: {request}"
         );
         let (_, body) = request.split_once("\r\n\r\n").unwrap();
@@ -603,7 +609,7 @@ mod tests {
             .post_json(
                 format!("http://{address}/v1/vector_stores/vs-123/search"),
                 &serde_json::json!({"query": "test"}),
-                &http::HeaderMap::new(),
+                &HeaderMap::new(),
             )
             .await
             .unwrap_err();
@@ -622,16 +628,13 @@ mod tests {
 
         let client = ApiClient::new(ApiClientConfig {
             api_base_url: format!("http://{address}"),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                timeout_ms: 1_000,
-                ..CalloutConfig::default()
-            },
+            connector: SubRequestConnector::new(4, None),
+            timeout: Duration::from_millis(1_000),
+            max_response_bytes: 1_048_576,
             forward_header_names: vec![http::header::CONTENT_TYPE],
-        })
-        .unwrap();
+        });
 
-        let mut headers = http::HeaderMap::new();
+        let mut headers = HeaderMap::new();
         headers.insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
 
         client
@@ -640,11 +643,12 @@ mod tests {
             .unwrap();
 
         let req = captured.join().unwrap();
-        let ct_count = req.matches("content-type:").count();
+        let req_lower = req.to_lowercase();
+        let ct_count = req_lower.matches("content-type:").count();
         assert_eq!(ct_count, 1, "exactly one content-type header, got {ct_count}");
         assert!(
-            req.contains("content-type: application/json"),
-            "should be application/json"
+            req_lower.contains("content-type: application/json"),
+            "should be application/json: {req}"
         );
     }
 
@@ -666,7 +670,7 @@ mod tests {
         let client = test_client(&format!("http://{address}"));
 
         let err = client
-            .get_json(format!("http://{address}/v1/files/missing"), &http::HeaderMap::new())
+            .get_json(format!("http://{address}/v1/files/missing"), &HeaderMap::new())
             .await
             .unwrap_err();
 
@@ -693,7 +697,7 @@ mod tests {
         let err = client
             .get_bytes(
                 &format!("http://{address}/v1/files/test/content"),
-                &http::HeaderMap::new(),
+                &HeaderMap::new(),
                 1024,
             )
             .await
@@ -755,7 +759,7 @@ mod tests {
         let bytes = client
             .get_bytes(
                 &format!("http://{address}/v1/files/big/content"),
-                &http::HeaderMap::new(),
+                &HeaderMap::new(),
                 2_000_000,
             )
             .await
@@ -785,21 +789,14 @@ mod tests {
 
         let client = ApiClient::new(ApiClientConfig {
             api_base_url: format!("http://{addr}"),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                timeout_ms: 50,
-                ..CalloutConfig::default()
-            },
+            connector: SubRequestConnector::new(4, None),
+            timeout: Duration::from_millis(50),
+            max_response_bytes: 1_048_576,
             forward_header_names: Vec::new(),
-        })
-        .unwrap();
+        });
 
         let err = client
-            .get_bytes(
-                &format!("http://{addr}/v1/files/slow/content"),
-                &http::HeaderMap::new(),
-                1024,
-            )
+            .get_bytes(&format!("http://{addr}/v1/files/slow/content"), &HeaderMap::new(), 1024)
             .await
             .unwrap_err();
 

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -240,6 +240,7 @@ pub(super) async fn handle_delete_conversation(
 
 /// Handle `POST /v1/conversations/{id}/items` — create items.
 #[expect(clippy::too_many_lines, reason = "sequential guard-clause pipeline")]
+#[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
 pub(super) async fn handle_create_items(
     ctx: &HttpFilterContext<'_>,
     store: &dyn ConversationItemStore,

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -64,7 +64,6 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use praxis_core::callout::{CalloutConfig, FailureMode};
 use praxis_filter::{
     BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, Rejection, parse_filter_config,
 };
@@ -81,6 +80,7 @@ use super::{openai_responses_proxy::serialized_outbound_body_len, state::Respons
 use crate::{
     classifier::is_responses_create,
     openai::api_client::{ApiClient, ApiClientConfig},
+    subrequest::SubRequestConnector,
 };
 
 /// Resolves `file_id` and `file_url` references in Responses API input
@@ -157,15 +157,11 @@ impl FileResolveFilter {
 
         let api_client = ApiClient::new(ApiClientConfig {
             api_base_url: validated.files_api_url.clone(),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                timeout_ms: validated.timeout_ms,
-                status_on_error: 502,
-                ..CalloutConfig::default()
-            },
+            connector: SubRequestConnector::new(4, None),
+            timeout: std::time::Duration::from_millis(validated.timeout_ms),
+            max_response_bytes: 1_048_576,
             forward_header_names,
-        })
-        .map_err(|e| -> FilterError { format!("openai_file_resolve: {e}").into() })?;
+        });
 
         let client = FilesApiClient::new(
             api_client,

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -388,7 +388,7 @@ impl FilesApiClient {
         request_headers: &http::HeaderMap,
         max_content_bytes: usize,
         max_resolved_bytes: usize,
-    ) -> Result<Vec<u8>, ResolveError> {
+    ) -> Result<bytes::Bytes, ResolveError> {
         let url = self
             .client
             .resource_url(FILES_PATH_PREFIX, file_id, Some("content"))
@@ -834,10 +834,11 @@ mod tests {
         net::TcpListener,
     };
 
-    use praxis_core::callout::{CalloutConfig, FailureMode};
-
     use super::*;
-    use crate::openai::api_client::{ApiClient, ApiClientConfig};
+    use crate::{
+        openai::api_client::{ApiClient, ApiClientConfig},
+        subrequest::SubRequestConnector,
+    };
 
     #[test]
     fn infer_mime_pdf() {
@@ -970,14 +971,11 @@ mod tests {
     fn test_api_client(api_base_url: &str, timeout_ms: u64) -> ApiClient {
         ApiClient::new(ApiClientConfig {
             api_base_url: api_base_url.to_owned(),
-            callout_config: CalloutConfig {
-                failure_mode: FailureMode::Closed,
-                timeout_ms,
-                ..CalloutConfig::default()
-            },
+            connector: SubRequestConnector::new(4, None),
+            timeout: std::time::Duration::from_millis(timeout_ms),
+            max_response_bytes: 1_048_576,
             forward_header_names: Vec::new(),
         })
-        .unwrap()
     }
 
     fn test_client(api_base_url: &str) -> FilesApiClient {

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -13,9 +13,12 @@ use bytes::Bytes;
 use serde_json::json;
 
 use super::*;
-use crate::openai::{
-    api_client::{ApiClient, ApiClientConfig},
-    responses::state::ResponsesState,
+use crate::{
+    openai::{
+        api_client::{ApiClient, ApiClientConfig},
+        responses::state::ResponsesState,
+    },
+    subrequest::SubRequestConnector,
 };
 
 // -----------------------------------------------------------------------------
@@ -783,10 +786,11 @@ fn make_client() -> FilesApiClient {
 fn make_client_for_url_with_max(files_api_url: &str, max_resolved_bytes: usize) -> FilesApiClient {
     let api = ApiClient::new(ApiClientConfig {
         api_base_url: files_api_url.to_owned(),
-        callout_config: CalloutConfig::default(),
+        connector: SubRequestConnector::new(4, None),
+        timeout: Duration::from_secs(5),
+        max_response_bytes: 1_048_576,
         forward_header_names: vec![],
-    })
-    .unwrap();
+    });
     FilesApiClient::new(
         api,
         FilesApiClientOptions {

--- a/apis/src/openai/responses/web_search/provider.rs
+++ b/apis/src/openai/responses/web_search/provider.rs
@@ -3,18 +3,26 @@
 
 //! Search provider abstraction and implementations.
 //!
-//! Uses [`CalloutClient`] from praxis-core for HTTP callouts with
-//! circuit breaking, timeout, and loop prevention.
+//! Uses Pingora-native [`SubRequestConnector`] for HTTP callouts
+//! with connection pooling, HTTP/2, and TLS.
+//!
+//! [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
 
-use praxis_core::callout::{
-    CalloutClient, CalloutConfig, CalloutRequest, CalloutResult, CircuitBreakerConfig, FailureMode as CoreFailureMode,
-};
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::HeaderMap;
 use praxis_filter::FilterError;
 use secrecy::{ExposeSecret as _, SecretString};
 use serde_json::Value;
 use tracing::{debug, warn};
 
 use super::config::{FailureMode, SearchContextSize, SearchProvider, ValidatedConfig};
+use crate::subrequest::{self, SubRequest, SubRequestConnector, SubResponse};
+
+/// Response body cap for search callouts (1 MiB). Distinct from
+/// `max_body_bytes` which governs inbound request buffering.
+const MAX_SEARCH_RESPONSE_BYTES: usize = 1_048_576;
 
 // -----------------------------------------------------------------------------
 // SearchResult
@@ -53,17 +61,21 @@ pub(crate) enum SearchOutcome {
 // SearchClient
 // -----------------------------------------------------------------------------
 
-/// HTTP search client wrapping a [`CalloutClient`].
+/// HTTP search client using Pingora-native [`SubRequestConnector`].
+///
+/// [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
 pub(crate) struct SearchClient {
-    /// The underlying HTTP callout client.
-    client: CalloutClient,
+    /// Shared HTTP connector for search callouts.
+    connector: SubRequestConnector,
+    /// Per-request timeout.
+    timeout: Duration,
     /// Search backend provider.
     provider: SearchProvider,
     /// API key for the search provider.
     api_key: SecretString,
     /// Default search context size.
     default_context_size: SearchContextSize,
-    /// Failure mode governing what happens on parse errors.
+    /// Failure mode governing what happens on errors.
     failure_mode: FailureMode,
     /// HTTP status to return on rejection.
     status_on_error: u16,
@@ -72,7 +84,8 @@ pub(crate) struct SearchClient {
 impl std::fmt::Debug for SearchClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SearchClient")
-            .field("client", &self.client)
+            .field("connector", &self.connector)
+            .field("timeout", &self.timeout)
             .field("provider", &self.provider)
             .field("api_key", &"[REDACTED]")
             .field("default_context_size", &self.default_context_size)
@@ -82,36 +95,19 @@ impl std::fmt::Debug for SearchClient {
     }
 }
 
-/// Build a [`CalloutConfig`] from validated filter config.
-fn build_callout_config(config: &ValidatedConfig) -> CalloutConfig {
-    let failure_mode = match config.failure_mode {
-        FailureMode::Closed => CoreFailureMode::Closed,
-        FailureMode::Open => CoreFailureMode::Open,
-    };
-    CalloutConfig {
-        circuit_breaker: Some(CircuitBreakerConfig {
-            consecutive_failures: 5,
-            recovery_window_ms: 30_000,
-        }),
-        failure_mode,
-        status_on_error: config.status_on_error,
-        timeout_ms: config.timeout_ms,
-        ..CalloutConfig::default()
-    }
-}
-
 impl SearchClient {
     /// Build a search client from validated filter config.
     ///
     /// # Errors
     ///
-    /// Returns [`FilterError`] if the underlying [`CalloutClient`]
-    /// cannot be constructed.
+    /// Returns [`FilterError`] if the API key header value is
+    /// not valid ASCII.
     pub(crate) fn from_config(config: &ValidatedConfig) -> Result<Self, FilterError> {
-        let callout_config = build_callout_config(config);
-        let client = CalloutClient::new(callout_config).map_err(|e| FilterError::from(e.to_string()))?;
+        http::HeaderValue::from_str(config.api_key.expose_secret())
+            .map_err(|e| FilterError::from(format!("invalid API key header value: {e}")))?;
         Ok(Self {
-            client,
+            connector: SubRequestConnector::new(4, None),
+            timeout: Duration::from_millis(config.timeout_ms),
             provider: config.provider,
             api_key: config.api_key.clone(),
             default_context_size: config.default_context_size,
@@ -125,58 +121,95 @@ impl SearchClient {
         let size = context_size.unwrap_or(self.default_context_size);
         let count = size.result_count();
         debug!(provider = self.provider.as_str(), query, count, "executing web search");
-        let request = match self.provider {
+        let (url, request) = match self.provider {
             SearchProvider::Brave => self.build_brave_request(query, count),
             SearchProvider::Tavily => self.build_tavily_request(query, size),
             SearchProvider::You => self.build_you_request(query, count),
         };
-        self.handle_callout_result(self.client.execute(request).await)
+        self.execute_search(&url, request).await
     }
 
-    /// Map a [`CalloutResult`] to a [`SearchOutcome`].
-    fn handle_callout_result(&self, result: CalloutResult) -> SearchOutcome {
-        match result {
-            CalloutResult::Success(response) => self.parse_response(&response.body),
-            CalloutResult::Failed => {
-                warn!(provider = self.provider.as_str(), "search callout failed (open mode)");
-                SearchOutcome::Skipped
+    /// Execute a search request and map the result to a
+    /// [`SearchOutcome`].
+    async fn execute_search(&self, url: &str, mut request: SubRequest) -> SearchOutcome {
+        let (target, uri) = match subrequest::parse_url(url) {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(provider = self.provider.as_str(), error = %e, "search URL parse failed");
+                return self.transport_failure_outcome();
             },
-            CalloutResult::Rejected(rejection) => {
+        };
+
+        request.uri = uri;
+
+        let result = subrequest::execute(
+            &self.connector,
+            &target,
+            &request,
+            MAX_SEARCH_RESPONSE_BYTES,
+            self.timeout,
+        )
+        .await;
+        self.map_search_result(result)
+    }
+
+    /// Map a sub-request result to a [`SearchOutcome`].
+    fn map_search_result(&self, result: Result<SubResponse, subrequest::SubRequestError>) -> SearchOutcome {
+        match result {
+            Ok(response) if (200..300).contains(&(response.status as usize)) => self.parse_response(&response.body),
+            Ok(response) => {
                 warn!(
                     provider = self.provider.as_str(),
-                    status = rejection.status,
-                    "search callout rejected"
+                    status = response.status,
+                    "search callout returned non-2xx"
                 );
-                SearchOutcome::Rejected {
-                    status: rejection.status,
-                }
+                self.transport_failure_outcome()
             },
+            Err(e) => {
+                warn!(provider = self.provider.as_str(), error = %e, "search callout failed");
+                self.transport_failure_outcome()
+            },
+        }
+    }
+
+    /// Outcome for a transport or non-2xx failure. Under closed
+    /// mode this is a rejection; under open mode search is silently
+    /// skipped.
+    fn transport_failure_outcome(&self) -> SearchOutcome {
+        match self.failure_mode {
+            FailureMode::Closed => SearchOutcome::Rejected {
+                status: self.status_on_error,
+            },
+            FailureMode::Open => SearchOutcome::Skipped,
         }
     }
 
     /// Build a Brave Search API request.
-    fn build_brave_request(&self, query: &str, count: u32) -> CalloutRequest {
+    fn build_brave_request(&self, query: &str, count: u32) -> (String, SubRequest) {
         let encoded_query = percent_encoding::utf8_percent_encode(query, percent_encoding::NON_ALPHANUMERIC);
         let url = format!("https://api.search.brave.com/res/v1/web/search?q={encoded_query}&count={count}");
 
-        CalloutRequest {
-            method: http::Method::GET,
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::ACCEPT, http::HeaderValue::from_static("application/json"));
+        headers.insert(
+            http::HeaderName::from_static("x-subscription-token"),
+            http::HeaderValue::from_str(self.api_key.expose_secret())
+                .unwrap_or_else(|_| http::HeaderValue::from_static("")),
+        );
+
+        (
             url,
-            headers: vec![
-                (http::header::ACCEPT, http::HeaderValue::from_static("application/json")),
-                (
-                    http::HeaderName::from_static("x-subscription-token"),
-                    http::HeaderValue::from_str(self.api_key.expose_secret())
-                        .unwrap_or_else(|_| http::HeaderValue::from_static("")),
-                ),
-            ],
-            body: None,
-            depth: 0,
-        }
+            SubRequest {
+                method: http::Method::GET,
+                uri: "/".parse().unwrap_or_default(),
+                headers,
+                body: Bytes::new(),
+            },
+        )
     }
 
     /// Build a Tavily Search API request.
-    fn build_tavily_request(&self, query: &str, context_size: SearchContextSize) -> CalloutRequest {
+    fn build_tavily_request(&self, query: &str, context_size: SearchContextSize) -> (String, SubRequest) {
         let search_depth = match context_size {
             SearchContextSize::Low | SearchContextSize::Medium => "basic",
             SearchContextSize::High => "advanced",
@@ -190,46 +223,54 @@ impl SearchClient {
             "max_results": max_results,
         });
 
-        CalloutRequest {
-            method: http::Method::POST,
-            url: "https://api.tavily.com/search".to_owned(),
-            headers: vec![
-                (
-                    http::header::CONTENT_TYPE,
-                    http::HeaderValue::from_static("application/json"),
-                ),
-                (http::header::ACCEPT, http::HeaderValue::from_static("application/json")),
-            ],
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-            depth: 0,
-        }
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(http::header::ACCEPT, http::HeaderValue::from_static("application/json"));
+
+        let url = "https://api.tavily.com/search".to_owned();
+        (
+            url,
+            SubRequest {
+                method: http::Method::POST,
+                uri: "/".parse().unwrap_or_default(),
+                headers,
+                body: Bytes::from(serde_json::to_vec(&body).unwrap_or_default()),
+            },
+        )
     }
 
     /// Build a You.com Search API request.
-    fn build_you_request(&self, query: &str, count: u32) -> CalloutRequest {
+    fn build_you_request(&self, query: &str, count: u32) -> (String, SubRequest) {
         let body = serde_json::json!({
             "query": query,
             "count": count,
         });
 
-        CalloutRequest {
-            method: http::Method::POST,
-            url: "https://api.you.com/v1/search".to_owned(),
-            headers: vec![
-                (
-                    http::header::CONTENT_TYPE,
-                    http::HeaderValue::from_static("application/json"),
-                ),
-                (http::header::ACCEPT, http::HeaderValue::from_static("application/json")),
-                (
-                    http::HeaderName::from_static("x-api-key"),
-                    http::HeaderValue::from_str(self.api_key.expose_secret())
-                        .unwrap_or_else(|_| http::HeaderValue::from_static("")),
-                ),
-            ],
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-            depth: 0,
-        }
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(http::header::ACCEPT, http::HeaderValue::from_static("application/json"));
+        headers.insert(
+            http::HeaderName::from_static("x-api-key"),
+            http::HeaderValue::from_str(self.api_key.expose_secret())
+                .unwrap_or_else(|_| http::HeaderValue::from_static("")),
+        );
+
+        let url = "https://api.you.com/v1/search".to_owned();
+        (
+            url,
+            SubRequest {
+                method: http::Method::POST,
+                uri: "/".parse().unwrap_or_default(),
+                headers,
+                body: Bytes::from(serde_json::to_vec(&body).unwrap_or_default()),
+            },
+        )
     }
 
     /// Parse search results from the provider's JSON response.
@@ -357,6 +398,11 @@ fn parse_you_results(json: &Value) -> Vec<SearchResult> {
     reason = "tests"
 )]
 mod tests {
+    use std::{
+        io::{Read as _, Write as _},
+        net::TcpListener,
+    };
+
     use secrecy::SecretString;
     use serde_json::json;
 
@@ -446,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn build_you_request_uses_callout_client_contract() {
+    fn build_you_request_sends_api_key_and_body() {
         let config = ValidatedConfig {
             provider: SearchProvider::You,
             api_key: SecretString::from("test-key".to_owned()),
@@ -458,19 +504,16 @@ mod tests {
         };
         let client = SearchClient::from_config(&config).unwrap();
 
-        let request = client.build_you_request("Praxis proxy", 5);
+        let (url, request) = client.build_you_request("Praxis proxy", 5);
 
+        assert_eq!(url, "https://api.you.com/v1/search");
         assert_eq!(request.method, http::Method::POST);
-        assert_eq!(request.url, "https://api.you.com/v1/search");
         assert!(
-            request
-                .headers
-                .iter()
-                .any(|(name, value)| name == "x-api-key" && value == "test-key"),
-            "You.com requests must send X-API-Key through the Praxis callout"
+            request.headers.get("x-api-key").is_some_and(|v| v == "test-key"),
+            "You.com requests must send X-API-Key"
         );
         assert_eq!(
-            serde_json::from_slice::<Value>(request.body.as_deref().unwrap()).unwrap(),
+            serde_json::from_slice::<Value>(&request.body).unwrap(),
             json!({"query": "Praxis proxy", "count": 5})
         );
     }
@@ -552,6 +595,190 @@ mod tests {
         assert!(
             matches!(outcome, SearchOutcome::Skipped),
             "open mode should skip on parse failure"
+        );
+    }
+
+    fn test_search_client(failure_mode: FailureMode) -> SearchClient {
+        let config = ValidatedConfig {
+            provider: SearchProvider::Brave,
+            api_key: SecretString::from("test-key".to_owned()),
+            default_context_size: SearchContextSize::Medium,
+            timeout_ms: 1000,
+            max_body_bytes: 64 * 1024 * 1024,
+            failure_mode,
+            status_on_error: 502,
+        };
+        SearchClient::from_config(&config).unwrap()
+    }
+
+    fn spawn_http_server(listener: TcpListener, status: u16, body: &str) {
+        let body = body.to_owned();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let _n = stream.read(&mut buf).unwrap();
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+    }
+
+    #[tokio::test]
+    async fn search_2xx_with_valid_json_returns_results() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        spawn_http_server(
+            listener,
+            200,
+            &json!({
+                "web": {"results": [{"title": "Hit", "url": "https://hit.example", "description": "found"}]}
+            })
+            .to_string(),
+        );
+
+        let client = test_search_client(FailureMode::Closed);
+        let url = format!("http://{addr}/res/v1/web/search?q=test&count=5");
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let outcome = client.execute_search(&url, request).await;
+        assert!(
+            matches!(&outcome, SearchOutcome::Results(r) if r.len() == 1),
+            "2xx with valid JSON should return results: {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_non_2xx_closed_rejects() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        spawn_http_server(listener, 500, "internal error");
+
+        let client = test_search_client(FailureMode::Closed);
+        let url = format!("http://{addr}/search");
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let outcome = client.execute_search(&url, request).await;
+        assert!(
+            matches!(outcome, SearchOutcome::Rejected { status: 502 }),
+            "non-2xx under closed mode should reject: {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_non_2xx_open_skips() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        spawn_http_server(listener, 429, "rate limited");
+
+        let client = test_search_client(FailureMode::Open);
+        let url = format!("http://{addr}/search");
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let outcome = client.execute_search(&url, request).await;
+        assert!(
+            matches!(outcome, SearchOutcome::Skipped),
+            "non-2xx under open mode should skip: {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_connection_failure_closed_rejects() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            drop(stream);
+        });
+
+        let client = test_search_client(FailureMode::Closed);
+        let url = format!("http://{addr}/search");
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let outcome = client.execute_search(&url, request).await;
+        assert!(
+            matches!(outcome, SearchOutcome::Rejected { status: 502 }),
+            "connection failure under closed mode should reject: {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_timeout_open_skips() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+
+        let mut client = test_search_client(FailureMode::Open);
+        client.timeout = Duration::from_millis(50);
+        let url = format!("http://{addr}/search");
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let outcome = client.execute_search(&url, request).await;
+        assert!(
+            matches!(outcome, SearchOutcome::Skipped),
+            "timeout under open mode should skip: {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_oversized_response_closed_rejects() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let _n = stream.read(&mut buf).unwrap();
+            let body = vec![b'x'; MAX_SEARCH_RESPONSE_BYTES + 1];
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.write_all(&body).unwrap();
+        });
+
+        let client = test_search_client(FailureMode::Closed);
+        let url = format!("http://{addr}/search");
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let outcome = client.execute_search(&url, request).await;
+        assert!(
+            matches!(outcome, SearchOutcome::Rejected { status: 502 }),
+            "oversized response under closed mode should reject: {outcome:?}"
         );
     }
 }

--- a/apis/src/subrequest.rs
+++ b/apis/src/subrequest.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Sub-request execution through Pingora's native connector.
+//! **Temporary** sub-request execution — to be replaced by
+//! [praxis-core#826](https://github.com/praxis-proxy/praxis/issues/826).
 //!
 //! Provides URL-to-peer parsing and an HTTP execution function
 //! that replaces `praxis_core::callout::CalloutClient` with
 //! Pingora-native transport — getting connection pooling and TLS
 //! without a separate HTTP stack.
+//!
+//! Once praxis-core exposes the executor and typed errors through
+//! `SubRequestConnector`, this module should shrink to URL
+//! validation, `TargetPeer` construction, and domain error
+//! mapping.
 //!
 //! Types ([`SubRequestConnector`], [`SubRequest`], [`SubResponse`])
 //! are re-exported from [`praxis_core::subrequest`].

--- a/apis/src/subrequest.rs
+++ b/apis/src/subrequest.rs
@@ -1,0 +1,700 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Sub-request execution through Pingora's native connector.
+//!
+//! Provides URL-to-peer parsing and an HTTP execution function
+//! that replaces `praxis_core::callout::CalloutClient` with
+//! Pingora-native transport — getting connection pooling and TLS
+//! without a separate HTTP stack.
+//!
+//! Types ([`SubRequestConnector`], [`SubRequest`], [`SubResponse`])
+//! are re-exported from [`praxis_core::subrequest`].
+//!
+//! [`Connector`]: pingora_core::connectors::http::Connector
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::HeaderMap;
+use pingora_core::{protocols::http::client::HttpSession, upstreams::peer::HttpPeer};
+pub(crate) use praxis_core::subrequest::{SubRequest, SubRequestConnector, SubResponse};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+// -----------------------------------------------------------------------------
+// Error
+// -----------------------------------------------------------------------------
+
+/// Errors from sub-request execution.
+#[derive(Debug, Error)]
+pub(crate) enum SubRequestError {
+    /// Failed to connect to the upstream.
+    #[error("sub-request connect error: {0}")]
+    Connect(String),
+
+    /// Failed to write the request or read the response.
+    #[error("sub-request I/O error: {0}")]
+    Io(String),
+
+    /// Response body exceeded the size limit.
+    #[error(
+        "sub-request response body exceeded limit \
+         ({actual} > {limit} bytes, status {status})"
+    )]
+    ResponseTooLarge {
+        /// Actual bytes received before truncation.
+        actual: usize,
+        /// Configured limit.
+        limit: usize,
+        /// HTTP status code at the time of truncation.
+        status: u16,
+    },
+
+    /// The overall deadline expired.
+    #[error("sub-request deadline exceeded")]
+    DeadlineExceeded,
+
+    /// The URL could not be parsed into a valid peer address.
+    #[error("invalid sub-request URL: {0}")]
+    InvalidUrl(String),
+}
+
+// -----------------------------------------------------------------------------
+// TargetPeer
+// -----------------------------------------------------------------------------
+
+/// Parsed target for sub-request execution.
+///
+/// Holds URL components needed to create an [`HttpPeer`] and set
+/// the Host header. DNS resolution is deferred to execution time
+/// so it is both async and fallible.
+#[derive(Debug, Clone)]
+pub(crate) struct TargetPeer {
+    /// Hostname or IP to connect to.
+    pub(crate) host: String,
+    /// TCP port.
+    pub(crate) port: u16,
+    /// Whether TLS is enabled.
+    pub(crate) tls: bool,
+    /// TLS SNI hostname.
+    sni: String,
+    /// Original URL authority for the HTTP Host header.
+    authority: String,
+}
+
+// -----------------------------------------------------------------------------
+// URL → (TargetPeer, Uri)
+// -----------------------------------------------------------------------------
+
+/// Parse a full URL into a [`TargetPeer`] and a path-only
+/// [`http::Uri`].
+///
+/// Extracts scheme (→ TLS), host, port (defaults 443/80), and
+/// SNI from the URL. The returned URI contains only the path and
+/// query components. Only `http` and `https` schemes are accepted.
+///
+/// DNS resolution is NOT performed here — it happens inside
+/// [`execute`] so it can be async and fallible.
+#[expect(clippy::too_many_lines, reason = "sequential URL component extraction")]
+pub(crate) fn parse_url(url: &str) -> Result<(TargetPeer, http::Uri), SubRequestError> {
+    let parsed: http::Uri = url
+        .parse()
+        .map_err(|e| SubRequestError::InvalidUrl(format!("{e}: {url}")))?;
+
+    let scheme = parsed.scheme_str().unwrap_or("http");
+
+    let tls = match scheme {
+        "https" => true,
+        "http" => false,
+        other => {
+            return Err(SubRequestError::InvalidUrl(format!(
+                "unsupported scheme '{other}': {url}"
+            )));
+        },
+    };
+
+    let authority = parsed
+        .authority()
+        .ok_or_else(|| SubRequestError::InvalidUrl(format!("missing host: {url}")))?;
+
+    let host = authority.host().trim_start_matches('[').trim_end_matches(']');
+    let default_port = if tls { 443 } else { 80 };
+    let port = authority.port_u16().unwrap_or(default_port);
+
+    let sni = if tls { host.to_owned() } else { String::new() };
+
+    let target = TargetPeer {
+        host: host.to_owned(),
+        port,
+        tls,
+        sni,
+        authority: authority.to_string(),
+    };
+
+    let path_and_query = parsed.path_and_query().map_or("/", |pq| pq.as_str());
+    let uri: http::Uri = path_and_query
+        .parse()
+        .map_err(|e| SubRequestError::InvalidUrl(format!("bad path: {e}")))?;
+
+    Ok((target, uri))
+}
+
+// -----------------------------------------------------------------------------
+// Execute
+// -----------------------------------------------------------------------------
+
+/// Execute a sub-request using Pingora's [`Connector`].
+///
+/// Resolves DNS asynchronously, connects to the target, sends
+/// `request`, reads the full response (bounded by
+/// `max_response_bytes`), and returns a [`SubResponse`].  The
+/// overall operation — including DNS — is bounded by `timeout`.
+///
+/// [`Connector`]: pingora_core::connectors::http::Connector
+pub(crate) async fn execute(
+    connector: &SubRequestConnector,
+    target: &TargetPeer,
+    request: &SubRequest,
+    max_response_bytes: usize,
+    timeout: Duration,
+) -> Result<SubResponse, SubRequestError> {
+    tokio::time::timeout(
+        timeout,
+        Box::pin(execute_inner(connector, target, request, max_response_bytes, timeout)),
+    )
+    .await
+    .map_err(|_elapsed| SubRequestError::DeadlineExceeded)?
+}
+
+/// Resolve DNS and perform the HTTP exchange under the deadline
+/// enforced by [`execute`].
+#[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
+#[expect(clippy::too_many_lines, reason = "sequential HTTP exchange steps")]
+#[expect(clippy::cognitive_complexity, reason = "mirrors praxis-filter execute_inner")]
+async fn execute_inner(
+    connector: &SubRequestConnector,
+    target: &TargetPeer,
+    request: &SubRequest,
+    max_response_bytes: usize,
+    timeout: Duration,
+) -> Result<SubResponse, SubRequestError> {
+    let _permit = connector.acquire_permit().await;
+    let addrs = resolve_addrs(target).await?;
+    let (mut session, reused, peer) = connect_to_first_reachable(connector, target, &addrs, timeout).await?;
+
+    debug!(
+        authority = target.authority,
+        reused,
+        method = %request.method,
+        uri = %request.uri,
+        "sub-request: connected"
+    );
+
+    session.set_read_timeout(Some(min_timeout(peer.options.read_timeout, timeout)));
+    session.set_write_timeout(Some(min_timeout(peer.options.write_timeout, timeout)));
+
+    let path = request
+        .uri
+        .path_and_query()
+        .map_or(b"/".as_slice(), |pq| pq.as_str().as_bytes());
+    let mut req_header = pingora_http::RequestHeader::build(request.method.clone(), path, None)
+        .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+    for (name, value) in &request.headers {
+        let _append = req_header.append_header(name.clone(), value.clone());
+    }
+
+    ensure_host_header(&mut req_header, &target.authority)?;
+
+    if !request.body.is_empty() || empty_body_needs_framing(&request.method) {
+        let _cl = req_header.insert_header("Content-Length", request.body.len().to_string());
+    }
+
+    session
+        .write_request_header(Box::new(req_header))
+        .await
+        .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+    if !request.body.is_empty() {
+        session
+            .write_request_body(request.body.clone(), true)
+            .await
+            .map_err(|e| SubRequestError::Io(e.to_string()))?;
+    }
+
+    session
+        .finish_request_body()
+        .await
+        .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+    session
+        .read_response_header()
+        .await
+        .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+    let resp_header = session
+        .response_header()
+        .ok_or_else(|| SubRequestError::Io("no response header received".to_owned()))?;
+
+    let status = resp_header.status.as_u16();
+    if !(100..=599).contains(&status) {
+        session.shutdown().await;
+        return Err(SubRequestError::Io(format!(
+            "upstream returned unsupported HTTP status {status}"
+        )));
+    }
+    let mut resp_headers = HeaderMap::new();
+    for (name, value) in &resp_header.headers {
+        if let Ok(v) = http::header::HeaderValue::from_bytes(value.as_bytes()) {
+            resp_headers.append(name.clone(), v);
+        }
+    }
+
+    let mut body_buf = Vec::new();
+    while !session.response_done() {
+        match session.read_response_body().await {
+            Ok(Some(chunk)) => {
+                if body_buf.len() + chunk.len() > max_response_bytes {
+                    warn!(
+                        current = body_buf.len(),
+                        chunk = chunk.len(),
+                        limit = max_response_bytes,
+                        status,
+                        "sub-request response body exceeded limit"
+                    );
+                    session.shutdown().await;
+                    return Err(SubRequestError::ResponseTooLarge {
+                        actual: body_buf.len() + chunk.len(),
+                        limit: max_response_bytes,
+                        status,
+                    });
+                }
+                body_buf.extend_from_slice(&chunk);
+            },
+            Ok(None) => break,
+            Err(e) => {
+                session.shutdown().await;
+                return Err(SubRequestError::Io(e.to_string()));
+            },
+        }
+    }
+
+    debug!(status, body_bytes = body_buf.len(), "sub-request: response received");
+
+    connector.connector().release_http_session(session, &peer, None).await;
+
+    Ok(SubResponse {
+        status,
+        headers: resp_headers,
+        body: Bytes::from(body_buf),
+    })
+}
+
+/// Methods whose empty payload is commonly rejected without
+/// explicit framing.
+fn empty_body_needs_framing(method: &http::Method) -> bool {
+    matches!(*method, http::Method::POST | http::Method::PUT | http::Method::PATCH)
+}
+
+/// Resolve all addresses for a [`TargetPeer`].
+///
+/// Uses `tokio::net::lookup_host` for async, fallible resolution.
+/// Returns every address so callers can fall back on dual-stack
+/// hosts where the first address family is unreachable.
+async fn resolve_addrs(target: &TargetPeer) -> Result<Vec<std::net::SocketAddr>, SubRequestError> {
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((target.host.as_str(), target.port))
+        .await
+        .map_err(|e| SubRequestError::Connect(format!("DNS resolution failed for {}: {e}", target.host)))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(SubRequestError::Connect(format!(
+            "no addresses resolved for {}",
+            target.host
+        )));
+    }
+
+    Ok(addrs)
+}
+
+/// Try each resolved address in order and return the first
+/// successful connection.
+///
+/// On dual-stack hosts this allows falling back from an
+/// unreachable IPv6 address to a working IPv4 address — a
+/// property the previous `reqwest`-based client provided via
+/// Happy Eyeballs.
+#[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
+async fn connect_to_first_reachable(
+    connector: &SubRequestConnector,
+    target: &TargetPeer,
+    addrs: &[std::net::SocketAddr],
+    timeout: Duration,
+) -> Result<(HttpSession, bool, HttpPeer), SubRequestError> {
+    let mut last_error = None;
+
+    for addr in addrs {
+        let mut peer = HttpPeer::new(addr.to_string(), target.tls, target.sni.clone());
+        clamp_peer_timeouts(&mut peer, timeout);
+
+        match Box::pin(connector.connector().get_http_session(&peer)).await {
+            Ok((session, reused)) => return Ok((session, reused, peer)),
+            Err(e) => {
+                debug!(
+                    address = %addr,
+                    error = %e,
+                    "sub-request: connect failed, trying next address"
+                );
+                last_error = Some(e);
+            },
+        }
+    }
+
+    Err(SubRequestError::Connect(last_error.map_or_else(
+        || format!("no addresses resolved for {}", target.host),
+        |e| format!("all resolved addresses for {} failed: {e}", target.host),
+    )))
+}
+
+/// Ensure HTTP/1.1 virtual hosting and HTTP/2 `:authority` are
+/// valid — using the original URL authority, not the resolved IP.
+fn ensure_host_header(request: &mut pingora_http::RequestHeader, authority: &str) -> Result<(), SubRequestError> {
+    if !request.headers.contains_key(http::header::HOST) {
+        request
+            .insert_header(http::header::HOST, authority)
+            .map_err(|error| SubRequestError::Io(error.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Clamp connect timeouts to the remaining overall deadline.
+fn clamp_peer_timeouts(peer: &mut HttpPeer, deadline: Duration) {
+    peer.options.connection_timeout = Some(min_timeout(peer.options.connection_timeout, deadline));
+    peer.options.total_connection_timeout = Some(min_timeout(peer.options.total_connection_timeout, deadline));
+}
+
+/// Keep an operator-configured timeout when it is stricter than
+/// the deadline.
+fn min_timeout(configured: Option<Duration>, deadline: Duration) -> Duration {
+    configured.map_or(deadline, |configured| configured.min(deadline))
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use std::io::{Read as _, Write as _};
+
+    use super::*;
+
+    #[test]
+    fn parse_url_https() {
+        let (target, uri) = parse_url("https://127.0.0.1:8443/v1/search?q=test").unwrap();
+        assert!(target.tls, "HTTPS should enable TLS");
+        assert_eq!(uri.path(), "/v1/search");
+        assert_eq!(uri.query(), Some("q=test"));
+    }
+
+    #[test]
+    fn parse_url_http_with_port() {
+        let (target, uri) = parse_url("http://127.0.0.1:8080/health").unwrap();
+        assert!(!target.tls, "HTTP should disable TLS");
+        assert_eq!(uri.path(), "/health");
+    }
+
+    #[test]
+    fn parse_url_default_ports() {
+        let (https_target, _) = parse_url("https://127.0.0.1/path").unwrap();
+        assert_eq!(https_target.host, "127.0.0.1");
+        assert_eq!(https_target.port, 443);
+
+        let (http_target, _) = parse_url("http://127.0.0.1/path").unwrap();
+        assert_eq!(http_target.host, "127.0.0.1");
+        assert_eq!(http_target.port, 80);
+    }
+
+    #[test]
+    fn parse_url_preserves_hostname_authority() {
+        let (target, _) = parse_url("https://api.example.com/v1/search").unwrap();
+        assert_eq!(target.authority, "api.example.com");
+        assert_eq!(target.host, "api.example.com");
+        assert_eq!(target.port, 443);
+    }
+
+    #[test]
+    fn parse_url_preserves_hostname_authority_with_port() {
+        let (target, _) = parse_url("https://api.example.com:8443/path").unwrap();
+        assert_eq!(target.authority, "api.example.com:8443");
+        assert_eq!(target.host, "api.example.com");
+        assert_eq!(target.port, 8443);
+    }
+
+    #[test]
+    fn parse_url_ipv6_loopback() {
+        let (target, uri) = parse_url("http://[::1]:9090/metrics").unwrap();
+        assert_eq!(target.host, "::1");
+        assert_eq!(target.port, 9090);
+        assert_eq!(target.authority, "[::1]:9090");
+        assert_eq!(uri.path(), "/metrics");
+    }
+
+    #[test]
+    fn parse_url_ipv6_default_port() {
+        let (target, _) = parse_url("https://[::1]/path").unwrap();
+        assert_eq!(target.host, "::1");
+        assert_eq!(target.port, 443);
+        assert!(target.tls);
+    }
+
+    #[tokio::test]
+    async fn resolve_addrs_handles_ipv6() {
+        let target = TargetPeer {
+            host: "::1".to_owned(),
+            port: 8080,
+            tls: false,
+            sni: String::new(),
+            authority: "[::1]:8080".to_owned(),
+        };
+        let addrs = resolve_addrs(&target).await.unwrap();
+        assert!(!addrs.is_empty(), "should resolve at least one address");
+        assert!(
+            addrs.iter().any(|a| a.to_string().contains("::1")),
+            "resolved addresses should contain IPv6 loopback: {addrs:?}"
+        );
+    }
+
+    #[test]
+    fn parse_url_missing_host_returns_error() {
+        assert!(parse_url("/relative/path").is_err());
+    }
+
+    #[test]
+    fn parse_url_invalid_returns_error() {
+        assert!(parse_url("://bad").is_err());
+    }
+
+    #[test]
+    fn parse_url_root_path() {
+        let (_, uri) = parse_url("https://127.0.0.1").unwrap();
+        assert_eq!(uri.path(), "/");
+    }
+
+    #[test]
+    fn parse_url_rejects_ftp_scheme() {
+        let err = parse_url("ftp://127.0.0.1/data.csv").unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported scheme"),
+            "ftp should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_url_rejects_file_scheme() {
+        let err = parse_url("file:///etc/passwd").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid sub-request URL"),
+            "file:// should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn connector_clone_shares_pool() {
+        let a = SubRequestConnector::new(16, None);
+        let b = a.clone();
+        assert!(
+            std::ptr::eq(a.connector(), b.connector()),
+            "cloned connectors should share the same pool"
+        );
+    }
+
+    #[test]
+    fn connector_debug_does_not_panic() {
+        let connector = SubRequestConnector::new(8, None);
+        let debug = format!("{connector:?}");
+        assert!(
+            debug.contains("SubRequestConnector"),
+            "debug output should contain type name"
+        );
+    }
+
+    #[test]
+    fn empty_body_framing_for_entity_methods() {
+        assert!(empty_body_needs_framing(&http::Method::POST));
+        assert!(empty_body_needs_framing(&http::Method::PUT));
+        assert!(empty_body_needs_framing(&http::Method::PATCH));
+        assert!(!empty_body_needs_framing(&http::Method::GET));
+        assert!(!empty_body_needs_framing(&http::Method::HEAD));
+    }
+
+    #[test]
+    fn min_timeout_preserves_stricter_limit() {
+        assert_eq!(
+            min_timeout(Some(Duration::from_secs(1)), Duration::from_secs(10)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            min_timeout(Some(Duration::from_secs(20)), Duration::from_secs(10)),
+            Duration::from_secs(10)
+        );
+        assert_eq!(min_timeout(None, Duration::from_secs(10)), Duration::from_secs(10));
+    }
+
+    #[tokio::test]
+    async fn deadline_bounds_the_complete_exchange() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let backend = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+        let connector = SubRequestConnector::new(1, None);
+        let (target, uri) = parse_url(&format!("http://{address}/")).unwrap();
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri,
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let started = std::time::Instant::now();
+        let result = Box::pin(execute(&connector, &target, &request, 1024, Duration::from_millis(10))).await;
+        let elapsed = started.elapsed();
+        backend.abort();
+
+        assert!(result.is_err(), "a backend that never responds must time out");
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "exchange exceeded its deadline: {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unresolvable_host_returns_connect_error() {
+        let connector = SubRequestConnector::new(1, None);
+        let (target, uri) = parse_url("https://this-host-does-not-exist.invalid/path").unwrap();
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri,
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let result = Box::pin(execute(&connector, &target, &request, 1024, Duration::from_secs(5))).await;
+
+        assert!(
+            matches!(result, Err(SubRequestError::Connect(_))),
+            "unresolvable host should return Connect error, not panic: {result:?}"
+        );
+    }
+
+    fn capture_raw_request(listener: std::net::TcpListener) -> std::thread::JoinHandle<String> {
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let n = stream.read(&mut buf).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .unwrap();
+            String::from_utf8_lossy(&buf[..n]).into_owned()
+        })
+    }
+
+    #[tokio::test]
+    async fn execute_sends_authority_as_host_header() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let captured = capture_raw_request(listener);
+
+        let connector = SubRequestConnector::new(1, None);
+        let target = TargetPeer {
+            host: "127.0.0.1".to_owned(),
+            port: addr.port(),
+            tls: false,
+            sni: String::new(),
+            authority: format!("my-virtual-host.example.com:{}", addr.port()),
+        };
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/test".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+
+        let _response = Box::pin(execute(&connector, &target, &request, 1024, Duration::from_secs(5)))
+            .await
+            .unwrap();
+
+        let wire = captured.join().unwrap().to_lowercase();
+        let expected = format!("host: my-virtual-host.example.com:{}", addr.port());
+        assert!(
+            wire.contains(&expected),
+            "Host header should use original authority, not resolved IP: {wire}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_falls_back_when_first_address_refuses() {
+        let bad_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let bad_addr = bad_listener.local_addr().unwrap();
+        drop(bad_listener);
+
+        let good_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let good_addr = good_listener.local_addr().unwrap();
+
+        let connector = SubRequestConnector::new(1, None);
+        let target = TargetPeer {
+            host: "127.0.0.1".to_owned(),
+            port: good_addr.port(),
+            tls: false,
+            sni: String::new(),
+            authority: format!("127.0.0.1:{}", good_addr.port()),
+        };
+
+        let addrs = vec![bad_addr, good_addr];
+        let result = connect_to_first_reachable(&connector, &target, &addrs, Duration::from_secs(5)).await;
+
+        drop(good_listener);
+        assert!(result.is_ok(), "should connect via fallback to second address");
+    }
+
+    #[tokio::test]
+    async fn connect_fails_when_all_addresses_refuse() {
+        let l1 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let a1 = l1.local_addr().unwrap();
+        drop(l1);
+        let l2 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let a2 = l2.local_addr().unwrap();
+        drop(l2);
+
+        let connector = SubRequestConnector::new(1, None);
+        let target = TargetPeer {
+            host: "127.0.0.1".to_owned(),
+            port: a1.port(),
+            tls: false,
+            sni: String::new(),
+            authority: format!("127.0.0.1:{}", a1.port()),
+        };
+
+        let result = connect_to_first_reachable(&connector, &target, &[a1, a2], Duration::from_secs(2)).await;
+
+        let Err(err) = result else {
+            panic!("should fail when all addresses refuse connections");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("all resolved"),
+            "should report all addresses failed: {msg}"
+        );
+    }
+}

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) mod test_utils {
     )]
     pub(crate) fn make_filter_context(req: &Request) -> HttpFilterContext<'_> {
         HttpFilterContext {
+            buffered_request_body: None,
             body_done_indices: Vec::new(),
             branch_iterations: std::collections::HashMap::new(),
             client_addr: None,
@@ -82,6 +83,7 @@ pub(crate) mod test_utils {
             response_body_mode: praxis_filter::BodyMode::Stream,
             response_header: None,
             response_headers_modified: false,
+            subrequest_connector: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,


### PR DESCRIPTION
## Summary

Replace the `reqwest`-based `CalloutClient` with Pingora-native `SubRequestConnector` from praxis-core, routing all sub-request HTTP traffic through Pingora's connection pooling and TLS.

**Key changes:**
- New `apis/src/subrequest.rs`: URL-to-`TargetPeer` parsing, async DNS resolution with multi-address fallback (dual-stack safe), admission-permit-bounded execution, bounded response body reads
- `ApiClient`: rewritten to use `SubRequest`/`SubResponse`, returns `Bytes` directly (avoids double-copy), maps oversized non-2xx responses to `CalloutFailed` instead of `ResponseTooLarge`
- `SearchClient`: rewritten to use `SubRequest`, consumes request by value to eliminate clone, drops circuit-breaker (no config surface)
- Praxis deps upgraded to crates.io 0.5.0

**Dropped features** (not used or re-addable later):
- Circuit breaking (only `SearchClient` used it with hardcoded values; no config surface)
- Callout depth tracking (always set to 0 in all call sites)

## Validation

```
make lint   # clippy, nightly rustfmt, deps, docs, examples — clean
make test   # 1985 tests passed, 25 ignored, 0 failed
```

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None — internal refactor only. No API, config, or endpoint changes.