### PR TITLE
fix(filter): reject unknown fields in no-config filters

### DIFF
--- a/apis/src/openai/responses/validate/mod.rs
+++ b/apis/src/openai/responses/validate/mod.rs
@@ -25,8 +25,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
-    FilterAction, FilterError, HttpFilter, HttpFilterContext,
+    EmptyFilterConfig, FilterAction, FilterError, HttpFilter, HttpFilterContext,
     body::{BodyAccess, BodyMode, MAX_JSON_BODY_BYTES},
+    parse_filter_config,
 };
 use tracing::{debug, trace};
 
@@ -59,17 +60,13 @@ pub struct OpenaiResponsesValidateFilter;
 impl OpenaiResponsesValidateFilter {
     /// Create a filter from YAML config.
     ///
-    /// This filter has no configuration fields. The config parameter
-    /// is accepted but ignored.
-    ///
     /// # Errors
     ///
-    /// This function does not return errors; the `Result` return type
-    /// is required by the [`FilterFactory`] signature.
+    /// Returns [`FilterError`] if the YAML config contains unknown fields.
     ///
-    /// [`FilterFactory`]: praxis_filter::FilterFactory
-    #[expect(clippy::unnecessary_wraps, reason = "signature required by FilterFactory")]
-    pub fn from_config(_config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+    /// [`FilterError`]: praxis_filter::FilterError
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let _: EmptyFilterConfig = parse_filter_config("openai_responses_validate", config)?;
         Ok(Box::new(Self))
     }
 }
@@ -571,6 +568,13 @@ mod tests {
             "openai_responses_validate",
             "filter name should be openai_responses_validate"
         );
+    }
+
+    #[test]
+    fn from_config_rejects_unknown_fields() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str("bogus: true").unwrap();
+        let result = OpenaiResponsesValidateFilter::from_config(&yaml);
+        assert!(result.is_err(), "unknown fields should be rejected");
     }
 
     #[test]

--- a/filters/src/token_usage/headers.rs
+++ b/filters/src/token_usage/headers.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use http::header::{HeaderName, HeaderValue};
-use praxis_filter::{FilterAction, FilterError, HttpFilter, HttpFilterContext};
+use praxis_filter::{EmptyFilterConfig, FilterAction, FilterError, HttpFilter, HttpFilterContext, parse_filter_config};
 use tracing::trace;
 
 use super::{META_TOKEN_INPUT, META_TOKEN_OUTPUT, META_TOKEN_TOTAL};
@@ -61,9 +61,9 @@ impl TokenUsageHeadersFilter {
     ///
     /// # Errors
     ///
-    /// Returns [`FilterError`] if the YAML config is malformed.
-    #[expect(clippy::unnecessary_wraps, reason = "signature required by registry")]
-    pub fn from_config(_config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+    /// Returns [`FilterError`] if the YAML config contains unknown fields.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let _: EmptyFilterConfig = parse_filter_config("token_usage_headers", config)?;
         Ok(Box::new(Self))
     }
 }
@@ -288,5 +288,18 @@ mod tests {
         let config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
         let filter = TokenUsageHeadersFilter::from_config(&config).unwrap();
         assert_eq!(filter.name(), "token_usage_headers", "filter name should match");
+    }
+
+    #[test]
+    fn from_config_succeeds_with_null() {
+        let filter = TokenUsageHeadersFilter::from_config(&serde_yaml::Value::Null).unwrap();
+        assert_eq!(filter.name(), "token_usage_headers", "filter name should match");
+    }
+
+    #[test]
+    fn from_config_rejects_unknown_fields() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str("bogus: true").unwrap();
+        let result = TokenUsageHeadersFilter::from_config(&yaml);
+        assert!(result.is_err(), "unknown fields should be rejected");
     }
 }


### PR DESCRIPTION
## Summary

- `openai_responses_validate` and `token_usage_headers` now validate their config through `EmptyFilterConfig` with `deny_unknown_fields`, catching typos at startup instead of silently ignoring them
- Adds `from_config` rejection test coverage for both filters

Closes #423

## Test plan

- [x] `openai_responses_validate::from_config` succeeds with null config: existing test
- [x] `openai_responses_validate::from_config` rejects unknown fields: new test
- [x] `token_usage_headers::from_config` succeeds with empty config: existing test
- [x] `token_usage_headers::from_config` succeeds with null config: new test
- [x] `token_usage_headers::from_config` rejects unknown fields: new test
- [x] No other filters in the repo ignore their config (`grep` for `_config: &serde_yaml::Value` returns zero results)
- [x] Full test suite passes locally