### PR TITLE
fix(ci): handle stale and duplicate check runs in ci-status poller

### DIFF
--- a/.github/workflows/ci-status.yaml
+++ b/.github/workflows/ci-status.yaml
@@ -61,11 +61,24 @@ jobs:
               });
 
               // Only include GitHub Actions checks, excluding ourselves
-              const relevant = checkRuns.filter(cr => {
+              const filtered = checkRuns.filter(cr => {
                 if (excludedChecks.has(cr.name)) return false;
                 if (!cr.app || cr.app.slug !== 'github-actions') return false;
                 return true;
               });
+
+              // Deduplicate by check name, keeping the most recently started run.
+              // When cancel-in-progress supersedes a run, both the cancelled and
+              // the replacement run appear as separate check_run entries on the
+              // same SHA. Without dedup the cancelled run blocks forever.
+              const latestByName = new Map();
+              for (const cr of filtered) {
+                const prev = latestByName.get(cr.name);
+                if (!prev || new Date(cr.started_at) > new Date(prev.started_at)) {
+                  latestByName.set(cr.name, cr);
+                }
+              }
+              const relevant = [...latestByName.values()];
 
               if (relevant.length === 0) {
                 core.info('No other CI checks found yet, waiting...');
@@ -73,8 +86,12 @@ jobs:
                 continue;
               }
 
-              const pending = relevant.filter(cr => !terminalStatuses.has(cr.status));
-              const completed = relevant.filter(cr => terminalStatuses.has(cr.status));
+              // A check is done when its status is "completed", OR when the API
+              // reports a conclusion despite the status still being "in_progress"
+              // (a known GitHub glitch where status never flips).
+              const isDone = cr => terminalStatuses.has(cr.status) || cr.conclusion != null;
+              const pending = relevant.filter(cr => !isDone(cr));
+              const completed = relevant.filter(cr => isDone(cr));
 
               core.info(`Checks: ${completed.length} completed, ${pending.length} pending out of ${relevant.length} total`);
 


### PR DESCRIPTION
## Summary

- **Dedup check runs by name**: when `cancel-in-progress` supersedes a
  workflow run, both the cancelled and replacement `check_run` entries
  coexist on the same SHA. The poller now keeps only the most recently
  started run per check name, so a cancelled run no longer blocks
  indefinitely.
- **Treat conclusion as terminal**: a GitHub API glitch can leave a
  check run's `status` stuck at `in_progress` even though `conclusion`
  and `completed_at` are set. The poller now considers any check with a
  non-null `conclusion` as done.

Fixes the stuck `ci-status` on #603 and #604.

## Test plan

- [x] Verified #604 has duplicate `conformance` runs (cancelled + success) — dedup resolves it
- [x] Verified #603 has `proposal-check` with `status: in_progress` but `conclusion: success` — isDone resolves it