### PR TITLE
fix(filters): remove redundant Content-Length updates from body-mutating filters

### DIFF
--- a/apis/src/openai/responses/doc_extract/mod.rs
+++ b/apis/src/openai/responses/doc_extract/mod.rs
@@ -50,8 +50,6 @@ mod extract;
 )]
 mod tests;
 
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
@@ -196,7 +194,7 @@ fn extract_and_rewrite(
     }
 
     debug!(count, "extracted input_file parts");
-    if let Some(rejection) = rewrite_body(body, parsed, ctx, filter.config.max_body_bytes)? {
+    if let Some(rejection) = rewrite_body(body, parsed, filter.config.max_body_bytes)? {
         return Ok(rejection);
     }
     if let Err(e) = sync_state_after_rewrite(ctx, parsed, &mut budget) {
@@ -248,7 +246,6 @@ fn extract_item_parts(item: &mut serde_json::Value, budget: &mut ExtractionBudge
 fn rewrite_body(
     body: &mut Option<Bytes>,
     parsed: &serde_json::Value,
-    ctx: &mut HttpFilterContext<'_>,
     max_body_bytes: usize,
 ) -> Result<Option<FilterAction>, FilterError> {
     let rewritten = serde_json::to_vec(parsed)
@@ -258,8 +255,6 @@ fn rewrite_body(
         return Ok(Some(reject_rewritten_body_too_large(len, max_body_bytes)));
     }
     *body = Some(Bytes::from(rewritten));
-    ctx.extra_request_headers
-        .push((Cow::Borrowed("content-length"), len.to_string()));
     Ok(None)
 }
 

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -60,8 +60,6 @@ pub(crate) mod resolve_url;
 )]
 mod tests;
 
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
@@ -287,7 +285,7 @@ async fn resolve_and_rewrite(
     }
 
     debug!(count, "resolved file_id references");
-    if let Some(rejection) = rewrite_body(body, parsed, ctx, filter.config.max_body_bytes)? {
+    if let Some(rejection) = rewrite_body(body, parsed, filter.config.max_body_bytes)? {
         return Ok(rejection);
     }
     if let Err(e) = update_state(filter, ctx, Some(parsed), &mut budget).await {
@@ -369,7 +367,6 @@ async fn update_state(
 fn rewrite_body(
     body: &mut Option<Bytes>,
     parsed: &serde_json::Value,
-    ctx: &mut HttpFilterContext<'_>,
     max_body_bytes: usize,
 ) -> Result<Option<FilterAction>, FilterError> {
     let rewritten = serde_json::to_vec(parsed)
@@ -379,8 +376,6 @@ fn rewrite_body(
         return Ok(Some(reject_rewritten_body_too_large(len, max_body_bytes)));
     }
     *body = Some(Bytes::from(rewritten));
-    ctx.extra_request_headers
-        .push((Cow::Borrowed("content-length"), len.to_string()));
     Ok(None)
 }
 

--- a/apis/src/openai/responses/model_rewrite/mod.rs
+++ b/apis/src/openai/responses/model_rewrite/mod.rs
@@ -355,9 +355,9 @@ fn noop_result() -> RewriteResult {
     }
 }
 
-/// Serialize the mutated body, update content-length, and log.
+/// Serialize the mutated body and log.
 fn serialize_and_update(
-    ctx: &mut HttpFilterContext<'_>,
+    _ctx: &mut HttpFilterContext<'_>,
     body: &mut Option<Bytes>,
     value: &serde_json::Value,
     result: &RewriteResult,
@@ -366,11 +366,7 @@ fn serialize_and_update(
         format!("openai_responses_model_rewrite: failed to re-serialize rewritten request body: {e}").into()
     })?;
 
-    let len = serialized.len();
     *body = Some(Bytes::from(serialized));
-
-    ctx.extra_request_headers
-        .push((Cow::Borrowed("content-length"), len.to_string()));
 
     debug!(
         original = ?result.original_model,

--- a/apis/src/openai/responses/model_rewrite/mod.rs
+++ b/apis/src/openai/responses/model_rewrite/mod.rs
@@ -157,7 +157,7 @@ impl ModelRewriteFilter {
             return Ok(FilterAction::Continue);
         }
 
-        serialize_and_update(ctx, body, &value, &result)
+        serialize_and_update(body, &value, &result)
     }
 }
 
@@ -357,7 +357,6 @@ fn noop_result() -> RewriteResult {
 
 /// Serialize the mutated body and log.
 fn serialize_and_update(
-    _ctx: &mut HttpFilterContext<'_>,
     body: &mut Option<Bytes>,
     value: &serde_json::Value,
     result: &RewriteResult,

--- a/apis/src/openai/responses/model_rewrite/tests.rs
+++ b/apis/src/openai/responses/model_rewrite/tests.rs
@@ -788,25 +788,18 @@ async fn preserves_function_call_output_items() {
 }
 
 // -----------------------------------------------------------------------------
-// Content-Length Behavior
+// Content-Length Behavior — filter must NOT set it (core handles framing)
 // -----------------------------------------------------------------------------
 
 #[tokio::test]
-async fn updates_content_length_when_mutated() {
-    let (ctx, body) = run_filter_with_body(ALIAS_CONFIG, r#"{"model":"codex-mini-latest","input":"test"}"#).await;
+async fn does_not_set_content_length_when_mutated() {
+    let (ctx, _body) = run_filter_with_body(ALIAS_CONFIG, r#"{"model":"codex-mini-latest","input":"test"}"#).await;
 
-    let cl_header = ctx
-        .extra_request_headers
-        .iter()
-        .find(|(k, _)| k.as_ref() == "content-length")
-        .map(|(_, v)| v.as_str());
-
-    assert!(cl_header.is_some(), "content-length should be set after mutation");
-    let cl_value: usize = cl_header.unwrap().parse().unwrap();
-    assert_eq!(
-        cl_value,
-        body.len(),
-        "content-length should match serialized body length"
+    assert!(
+        ctx.extra_request_headers
+            .iter()
+            .all(|(k, _)| k.as_ref() != "content-length"),
+        "filter must not set content-length (core handles framing)"
     );
 }
 

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -41,7 +41,6 @@ mod config;
 mod tests;
 
 use std::{
-    borrow::Cow,
     collections::{HashMap, HashSet},
     time::Duration,
 };
@@ -490,7 +489,7 @@ async fn fetch_tools(
 /// or `connector_id` only) are left unchanged for upstream to
 /// handle.
 fn rewrite_request_body(
-    ctx: &mut HttpFilterContext<'_>,
+    _ctx: &mut HttpFilterContext<'_>,
     body: &mut Option<Bytes>,
     original_bytes: &[u8],
     per_entry: Vec<Vec<serde_json::Value>>,
@@ -525,10 +524,7 @@ fn rewrite_request_body(
         ResolveError::Serialization(e)
     })?;
 
-    let len = serialized.len();
     *body = Some(Bytes::from(serialized));
-    ctx.extra_request_headers
-        .push((Cow::Borrowed("content-length"), len.to_string()));
 
     debug!(tool_count = rewritten_count, "rewrote MCP tools to function tools");
     Ok(())

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -157,7 +157,7 @@ impl McpToolResolveFilter {
         debug!(tool_count = resolution.tool_map.len(), "mcp_tool_map built");
 
         let Resolution { per_entry, tool_map } = resolution;
-        rewrite_request_body(ctx, body, &original_bytes, per_entry, &tool_map)?;
+        rewrite_request_body(body, &original_bytes, per_entry, &tool_map)?;
 
         let body_for_state = body.as_ref().map_or_else(|| original_bytes.as_ref(), |b| b.as_ref());
         write_state(ctx, body_for_state, tool_map);
@@ -489,7 +489,6 @@ async fn fetch_tools(
 /// or `connector_id` only) are left unchanged for upstream to
 /// handle.
 fn rewrite_request_body(
-    _ctx: &mut HttpFilterContext<'_>,
     body: &mut Option<Bytes>,
     original_bytes: &[u8],
     per_entry: Vec<Vec<serde_json::Value>>,

--- a/apis/src/openai/responses/openai_responses_proxy/mod.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/mod.rs
@@ -31,8 +31,6 @@ mod config;
 )]
 mod tests;
 
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
@@ -188,10 +186,7 @@ impl HttpFilter for ResponsesProxyFilter {
             Err(action) => return Ok(action),
         };
 
-        let len = serialized.len();
         *body = Some(Bytes::from(serialized));
-        ctx.extra_request_headers
-            .push((Cow::Borrowed("content-length"), len.to_string()));
 
         Ok(FilterAction::Continue)
     }
@@ -203,7 +198,7 @@ impl HttpFilter for ResponsesProxyFilter {
 
 /// Defensively strip `conversation` from a passthrough body so it never
 /// leaks to the backend even when no [`ResponsesState`] was produced.
-fn strip_conversation_field(ctx: &mut HttpFilterContext<'_>, body: &mut Option<Bytes>) {
+fn strip_conversation_field(_ctx: &mut HttpFilterContext<'_>, body: &mut Option<Bytes>) {
     let Some(bytes) = body.as_ref() else {
         return;
     };
@@ -216,10 +211,7 @@ fn strip_conversation_field(ctx: &mut HttpFilterContext<'_>, body: &mut Option<B
     {
         debug!("stripped conversation from passthrough body");
         if let Ok(serialized) = serde_json::to_vec(&parsed) {
-            let len = serialized.len();
             *body = Some(Bytes::from(serialized));
-            ctx.extra_request_headers
-                .push((Cow::Borrowed("content-length"), len.to_string()));
         }
     }
 }

--- a/apis/src/openai/responses/openai_responses_proxy/mod.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/mod.rs
@@ -166,13 +166,13 @@ impl HttpFilter for ResponsesProxyFilter {
         }
 
         let Some(state) = ctx.extensions.get::<ResponsesState>() else {
-            strip_conversation_field(ctx, body);
+            strip_conversation_field(body);
             debug!("no ResponsesState in extensions, passthrough");
             return Ok(FilterAction::Continue);
         };
 
         if !request_needs_rebuild(state) {
-            strip_conversation_field(ctx, body);
+            strip_conversation_field(body);
             debug!("ResponsesState does not require an outbound rewrite, passthrough");
             return Ok(FilterAction::Continue);
         }
@@ -198,7 +198,7 @@ impl HttpFilter for ResponsesProxyFilter {
 
 /// Defensively strip `conversation` from a passthrough body so it never
 /// leaks to the backend even when no [`ResponsesState`] was produced.
-fn strip_conversation_field(_ctx: &mut HttpFilterContext<'_>, body: &mut Option<Bytes>) {
+fn strip_conversation_field(body: &mut Option<Bytes>) {
     let Some(bytes) = body.as_ref() else {
         return;
     };

--- a/apis/src/openai/responses/openai_responses_proxy/tests.rs
+++ b/apis/src/openai/responses/openai_responses_proxy/tests.rs
@@ -222,7 +222,7 @@ async fn rebuilds_body_with_conversation_history() {
 }
 
 #[tokio::test]
-async fn updates_content_length_header() {
+async fn does_not_set_content_length_header() {
     let filter = make_filter();
     let req = make_request(Method::POST, "/v1/responses");
     let mut ctx = make_filter_context(&req);
@@ -244,25 +244,11 @@ async fn updates_content_length_header() {
     ));
     let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
-    let has_content_length = ctx
-        .extra_request_headers
-        .iter()
-        .any(|(k, _)| k.as_ref() == "content-length");
     assert!(
-        has_content_length,
-        "content-length header should be set after body rebuild"
-    );
-
-    let cl_value: usize = ctx
-        .extra_request_headers
-        .iter()
-        .find(|(k, _)| k.as_ref() == "content-length")
-        .map(|(_, v)| v.parse().unwrap())
-        .unwrap();
-    assert_eq!(
-        cl_value,
-        body.as_ref().unwrap().len(),
-        "content-length should match rebuilt body size"
+        ctx.extra_request_headers
+            .iter()
+            .all(|(k, _)| k.as_ref() != "content-length"),
+        "filter must not set content-length (core handles framing)"
     );
 }
 
@@ -404,12 +390,11 @@ async fn passthrough_strips_conversation_from_body() {
         "conversation should be stripped even without ResponsesState"
     );
     assert_eq!(parsed["model"], "gpt-4.1", "other fields should be preserved");
-    assert_eq!(
+    assert!(
         ctx.extra_request_headers
             .iter()
-            .find(|(name, _value)| name.as_ref() == "content-length")
-            .map(|(_name, value)| value.parse::<usize>().unwrap()),
-        body.as_ref().map(Bytes::len)
+            .all(|(k, _)| k.as_ref() != "content-length"),
+        "filter must not set content-length (core handles framing)"
     );
 }
 

--- a/filters/src/prompt_enrich/mod.rs
+++ b/filters/src/prompt_enrich/mod.rs
@@ -17,8 +17,6 @@ mod config;
 )]
 mod tests;
 
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
@@ -148,7 +146,7 @@ impl HttpFilter for PromptEnrichFilter {
 
     async fn on_request_body(
         &self,
-        ctx: &mut HttpFilterContext<'_>,
+        _ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
         end_of_stream: bool,
     ) -> Result<FilterAction, FilterError> {
@@ -178,11 +176,7 @@ impl HttpFilter for PromptEnrichFilter {
         let serialized =
             serde_json::to_vec(&value).map_err(|e| -> FilterError { format!("prompt_enrich: {e}").into() })?;
 
-        let len = serialized.len();
         *body = Some(Bytes::from(serialized));
-
-        ctx.extra_request_headers
-            .push((Cow::Borrowed("content-length"), len.to_string()));
 
         Ok(FilterAction::Continue)
     }

--- a/filters/src/prompt_enrich/tests.rs
+++ b/filters/src/prompt_enrich/tests.rs
@@ -434,18 +434,15 @@ async fn body_none_returns_continue() {
 }
 
 #[tokio::test]
-async fn updates_content_length_header() {
+async fn does_not_set_content_length_header() {
     let filter = make_filter(Some(&[("system", "Injected system prompt.")]), None);
-    let (body, ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
+    let (_body, ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
 
-    let serialized = serde_json::to_vec(&body).unwrap();
-    assert_eq!(ctx.extra_request_headers.len(), 1, "should set content-length header");
-    let (name, value) = &ctx.extra_request_headers[0];
-    assert_eq!(name, "content-length", "header name should be content-length");
-    assert_eq!(
-        value,
-        &serialized.len().to_string(),
-        "content-length should match serialized body size"
+    assert!(
+        ctx.extra_request_headers
+            .iter()
+            .all(|(k, _)| k.as_ref() != "content-length"),
+        "filter must not set content-length (core handles framing)"
     );
 }
 


### PR DESCRIPTION
## Summary

Praxis core already recomputes `Content-Length` from the mutated body via
`mutated_request_body_len` → `apply_mutated_content_length` in the
`upstream_request_filter` hook, making filter-level `Content-Length` pushes
redundant. This removes the manual `Content-Length` header updates from all
six body-mutating filters: `model_rewrite`, `prompt_enrich`,
`responses_proxy`, `file_resolve`, `doc_extract`, and `mcp_tool_resolve`.

Unit tests are updated to assert that filters do **not** set
`Content-Length`, enforcing protocol-layer ownership. Existing integration
tests (`prompt_enrichment_updates_content_length`,
`content_length_matches_mutated_body`) continue to pass unchanged,
confirming the backend still receives exactly one correct `Content-Length`.

## Validation

```console
cargo test -p praxis-ai-apis model_rewrite           # 82 passed
cargo test -p praxis-ai-apis openai_responses_proxy   # 21 passed
cargo test -p praxis-ai-filters prompt_enrich         # 47 passed
cargo test -p praxis-tests-integration prompt_enrichment_updates_content_length  # 1 passed
cargo test -p praxis-tests-integration openai_responses_model_rewrite           # 16 passed
make fmt   # clean
make lint  # clean
rg 'Cow::Borrowed\("content-length"\)' apis/src filters/src  # 0 matches
```

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None — this is a purely internal cleanup with no user-facing behavioral change.