### PR TITLE
refactor(subrequest): delegate execution to praxis-core SubRequestClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -1527,7 +1516,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1762,9 +1751,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1847,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2957,7 +2943,6 @@ dependencies = [
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "quixotic-plecostomus-core",
- "quixotic-plecostomus-http",
  "reqwest 0.13.4",
  "rmcp",
  "schemars 1.2.2",
@@ -3019,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34121bbb48d49496e6d61c11c6362037b691663051791bad543d118e06e82222"
+checksum = "582c4c004c1a1a447413a437f5e9f808ecb62ecfbea0a4d01d84278fb6ecf580"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3040,15 +3025,16 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58aeccce4246f7b3d83508bfd71880d1b9261cf7aca1a1cf67e8ff38e5ba655f"
+checksum = "904de3102a614f84cb0f27546f22623a234091938aab29ba124f2f03847c3d8e"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
  "http",
  "praxis-proxy-tls",
  "quixotic-plecostomus-core",
+ "quixotic-plecostomus-http",
  "rand 0.10.2",
  "regex",
  "serde",
@@ -3061,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-filter"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af983f07e1ba5cfcdbf08437b481038a438f708cf760b3563c2388ad2dd437c"
+checksum = "af81fa050b848737ca6c0e8f439a5d58f2532d4f9081cfdf766288b75c52c196"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3075,7 +3061,6 @@ dependencies = [
  "praxis-proxy-core",
  "praxis-proxy-tls",
  "quixotic-plecostomus-core",
- "quixotic-plecostomus-http",
  "rand 0.10.2",
  "regex",
  "secrecy",
@@ -3091,9 +3076,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-protocol"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763b0190ee99a5d4962ba717c7d8d9edf095336ece5769bc7f66d693d005d3d0"
+checksum = "60eb11846734a0f94a9658c7837855adb451d1eaabec940de4808a3858b97334"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3116,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "praxis-proxy-tls"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39ec61f84dd83eb3131743f13a75a9f7c250160adbdf935e73bffa5d0f495b"
+checksum = "c017f8a0cfae37910da76dad8f1c16f801634e0666741020417b7b9f3032f4fe"
 dependencies = [
  "arc-swap",
  "notify",
@@ -3320,7 +3305,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a820a1a3e59644b38bc03606b638b41f1c5a474215efcec37f94b15871a7e1c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "blake2",
  "bstr",
@@ -3355,7 +3340,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d6d9e04414ba6819c51ec210eddf17865c505431a492c86c6356338c2b4f60"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "brotli",
  "bstr",
@@ -3443,7 +3428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec55d3bcbd56e52b3424bc62739a237d43c14df8ed04aaf294ae187b60da348a"
 dependencies = [
  "arrayvec 0.7.8",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.7",
 ]
@@ -4805,7 +4790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -29,7 +29,6 @@ futures = { workspace = true }
 http = { workspace = true }
 percent-encoding = { workspace = true }
 pingora-core = { workspace = true }
-pingora-http = { workspace = true }
 praxis-core = { workspace = true }
 praxis-filter = { workspace = true }
 reqwest = { workspace = true }

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -90,7 +90,7 @@ pub(crate) mod test_utils {
             response_body_mode: praxis_filter::BodyMode::Stream,
             response_header: None,
             response_headers_modified: false,
-            subrequest_connector: None,
+            subrequest_client: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,

--- a/apis/src/openai/api_client/mod.rs
+++ b/apis/src/openai/api_client/mod.rs
@@ -8,13 +8,14 @@
 //! JSON and byte reads, and normalized error mapping. Used by
 //! [`FilesApiClient`] and vector-store search.
 //!
-//! All requests route through the Pingora-native
-//! [`SubRequestConnector`] for connection pooling and TLS.
+//! All requests route through the [`SubRequestClient`] from
+//! praxis-core for connection pooling, TLS, admission control,
+//! and response body size limits.
 //!
 //! Each consuming filter retains its own [`ApiClient`] instance.
 //!
 //! [`FilesApiClient`]: super::responses::file_resolve
-//! [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
+//! [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
 
 pub(crate) mod error;
 pub(crate) mod url;
@@ -28,7 +29,7 @@ pub(crate) use self::{
     error::ApiClientError,
     url::{resource_url, validate_base_url, validate_forward_headers},
 };
-use crate::subrequest::{self, SubRequest, SubRequestConnector, SubRequestError, SubResponse};
+use crate::subrequest::{self, SubRequest, SubRequestClient, SubRequestError, SubResponse};
 
 /// Configuration for constructing an [`ApiClient`].
 ///
@@ -37,8 +38,8 @@ use crate::subrequest::{self, SubRequest, SubRequestConnector, SubRequestError, 
 pub(crate) struct ApiClientConfig {
     /// Base URL of the API endpoint (trailing slash stripped).
     pub api_base_url: String,
-    /// Pingora-native HTTP connector.
-    pub connector: SubRequestConnector,
+    /// Sub-request client for bounded execution.
+    pub client: SubRequestClient,
     /// Per-request timeout.
     pub timeout: Duration,
     /// Maximum response body bytes.
@@ -49,15 +50,16 @@ pub(crate) struct ApiClientConfig {
 
 /// Shared HTTP client for OpenAI-compatible API callouts.
 ///
-/// All requests route through the Pingora-native
-/// [`SubRequestConnector`] for connection pooling and TLS.
+/// All requests route through the [`SubRequestClient`] from
+/// praxis-core for connection pooling, TLS, admission control,
+/// and response body size limits.
 ///
-/// [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
+/// [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
 pub(crate) struct ApiClient {
     /// Base URL of the API endpoint (trailing slash stripped).
     api_base_url: String,
-    /// Pingora-native HTTP connector.
-    connector: SubRequestConnector,
+    /// Sub-request client for bounded execution.
+    client: SubRequestClient,
     /// Per-request timeout.
     timeout: Duration,
     /// Maximum response body bytes for JSON requests.
@@ -67,19 +69,9 @@ pub(crate) struct ApiClient {
     forward_header_names: Vec<http::HeaderName>,
 }
 
-/// Map a [`SubRequestError`] to an [`ApiClientError`], preserving
-/// the `ResponseTooLarge` variant for 2xx responses so callers can
-/// distinguish genuine size violations from backend failures.
-///
-/// Non-2xx oversized responses map to `CalloutFailed` — the
-/// backend error takes precedence over the size limit.
+/// Map a [`SubRequestError`] to an [`ApiClientError`].
 fn map_subrequest_error(err: SubRequestError) -> ApiClientError {
     match err {
-        SubRequestError::ResponseTooLarge { status, .. } if !(200..300).contains(&(status as usize)) => {
-            ApiClientError::CalloutFailed {
-                detail: format!("callout rejected with status {status} (response body exceeded limit)"),
-            }
-        },
         SubRequestError::ResponseTooLarge { limit, .. } => ApiClientError::ResponseTooLarge { limit },
         other => ApiClientError::CalloutFailed {
             detail: other.to_string(),
@@ -95,7 +87,7 @@ impl ApiClient {
     pub(crate) fn new(config: ApiClientConfig) -> Self {
         let ApiClientConfig {
             api_base_url,
-            connector,
+            client,
             timeout,
             max_response_bytes,
             forward_header_names,
@@ -103,7 +95,7 @@ impl ApiClient {
 
         Self {
             api_base_url: api_base_url.trim_end_matches('/').to_owned(),
-            connector,
+            client,
             timeout,
             max_response_bytes,
             forward_header_names,
@@ -200,9 +192,11 @@ impl ApiClient {
     ) -> Result<Bytes, ApiClientError> {
         let headers = self.build_header_map(request_headers);
 
-        let (target, uri) = subrequest::parse_url(url).map_err(|e| ApiClientError::CalloutFailed {
-            detail: format!("content download failed: {e}"),
-        })?;
+        let (peer, uri) = subrequest::resolve_url(url)
+            .await
+            .map_err(|e| ApiClientError::CalloutFailed {
+                detail: format!("content download failed: {e}"),
+            })?;
 
         let request = SubRequest {
             method: http::Method::GET,
@@ -211,7 +205,9 @@ impl ApiClient {
             body: Bytes::new(),
         };
 
-        let response = subrequest::execute(&self.connector, &target, &request, max_bytes, self.timeout)
+        let response = self
+            .client
+            .execute(&peer, &request, max_bytes, self.timeout, None)
             .await
             .map_err(map_subrequest_error)?;
 
@@ -248,7 +244,7 @@ impl ApiClient {
     }
 
     /// Parse the URL, build a [`SubRequest`], execute via the
-    /// connector, and check for non-2xx status.
+    /// client, and check for non-2xx status.
     async fn execute_url(
         &self,
         url: &str,
@@ -256,8 +252,9 @@ impl ApiClient {
         headers: HeaderMap,
         body: Bytes,
     ) -> Result<SubResponse, ApiClientError> {
-        let (target, uri) =
-            subrequest::parse_url(url).map_err(|e| ApiClientError::CalloutFailed { detail: e.to_string() })?;
+        let (peer, uri) = subrequest::resolve_url(url)
+            .await
+            .map_err(|e| ApiClientError::CalloutFailed { detail: e.to_string() })?;
 
         let request = SubRequest {
             method,
@@ -266,15 +263,11 @@ impl ApiClient {
             body,
         };
 
-        let response = subrequest::execute(
-            &self.connector,
-            &target,
-            &request,
-            self.max_response_bytes,
-            self.timeout,
-        )
-        .await
-        .map_err(map_subrequest_error)?;
+        let response = self
+            .client
+            .execute(&peer, &request, self.max_response_bytes, self.timeout, None)
+            .await
+            .map_err(map_subrequest_error)?;
 
         if response.status < 200 || response.status >= 300 {
             return Err(ApiClientError::CalloutFailed {
@@ -353,10 +346,12 @@ mod tests {
         }
     }
 
+    use praxis_core::subrequest::SubRequestConnector;
+
     fn test_client(base_url: &str) -> ApiClient {
         ApiClient::new(ApiClientConfig {
             api_base_url: base_url.to_owned(),
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(SubRequestConnector::new(4, None)),
             timeout: Duration::from_millis(1_000),
             max_response_bytes: 1_048_576,
             forward_header_names: Vec::new(),
@@ -373,7 +368,7 @@ mod tests {
     fn forward_headers_copies_configured_headers() {
         let client = ApiClient::new(ApiClientConfig {
             api_base_url: "http://ogx:8321".to_owned(),
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(SubRequestConnector::new(4, None)),
             timeout: Duration::from_millis(1_000),
             max_response_bytes: 1_048_576,
             forward_header_names: vec![
@@ -491,7 +486,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_bytes_oversized_non_2xx_is_callout_failed_not_too_large() {
+    async fn get_bytes_oversized_non_2xx_is_response_too_large() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         std::thread::spawn(move || {
@@ -514,8 +509,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            matches!(err, ApiClientError::CalloutFailed { .. }),
-            "non-2xx oversized response should be CalloutFailed, not ResponseTooLarge: {err:?}"
+            matches!(err, ApiClientError::ResponseTooLarge { .. }),
+            "oversized response body should be ResponseTooLarge regardless of status: {err:?}"
         );
     }
 
@@ -628,7 +623,7 @@ mod tests {
 
         let client = ApiClient::new(ApiClientConfig {
             api_base_url: format!("http://{address}"),
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(SubRequestConnector::new(4, None)),
             timeout: Duration::from_millis(1_000),
             max_response_bytes: 1_048_576,
             forward_header_names: vec![http::header::CONTENT_TYPE],
@@ -789,7 +784,7 @@ mod tests {
 
         let client = ApiClient::new(ApiClientConfig {
             api_base_url: format!("http://{addr}"),
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(SubRequestConnector::new(4, None)),
             timeout: Duration::from_millis(50),
             max_response_bytes: 1_048_576,
             forward_header_names: Vec::new(),

--- a/apis/src/openai/api_client/mod.rs
+++ b/apis/src/openai/api_client/mod.rs
@@ -191,23 +191,14 @@ impl ApiClient {
         max_bytes: usize,
     ) -> Result<Bytes, ApiClientError> {
         let headers = self.build_header_map(request_headers);
-
-        let (peer, uri) = subrequest::resolve_url(url)
-            .await
-            .map_err(|e| ApiClientError::CalloutFailed {
-                detail: format!("content download failed: {e}"),
-            })?;
-
         let request = SubRequest {
             method: http::Method::GET,
-            uri,
+            uri: http::Uri::default(),
             headers,
             body: Bytes::new(),
         };
 
-        let response = self
-            .client
-            .execute(&peer, &request, max_bytes, self.timeout, None)
+        let response = subrequest::execute_url(&self.client, url, request, max_bytes, self.timeout)
             .await
             .map_err(map_subrequest_error)?;
 
@@ -252,20 +243,14 @@ impl ApiClient {
         headers: HeaderMap,
         body: Bytes,
     ) -> Result<SubResponse, ApiClientError> {
-        let (peer, uri) = subrequest::resolve_url(url)
-            .await
-            .map_err(|e| ApiClientError::CalloutFailed { detail: e.to_string() })?;
-
         let request = SubRequest {
             method,
-            uri,
+            uri: http::Uri::default(),
             headers,
             body,
         };
 
-        let response = self
-            .client
-            .execute(&peer, &request, self.max_response_bytes, self.timeout, None)
+        let response = subrequest::execute_url(&self.client, url, request, self.max_response_bytes, self.timeout)
             .await
             .map_err(map_subrequest_error)?;
 

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -393,7 +393,6 @@ fn rewrite_body(
 /// History messages prepended by rehydrate are also walked so
 /// that any `file_id` references in them are resolved.
 #[expect(clippy::too_many_arguments, reason = "threading resolver through state sync")]
-#[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
 async fn sync_state_with_budget(
     ctx: &mut HttpFilterContext<'_>,
     resolved_body: &serde_json::Value,
@@ -445,7 +444,6 @@ async fn sync_state(
 
 /// Resolve file references in rehydrated history when the
 /// current input did not require a body rewrite.
-#[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
 async fn resolve_state_history(
     ctx: &mut HttpFilterContext<'_>,
     client: &FilesApiClient,

--- a/apis/src/openai/responses/file_resolve/mod.rs
+++ b/apis/src/openai/responses/file_resolve/mod.rs
@@ -80,7 +80,7 @@ use super::{openai_responses_proxy::serialized_outbound_body_len, state::Respons
 use crate::{
     classifier::is_responses_create,
     openai::api_client::{ApiClient, ApiClientConfig},
-    subrequest::SubRequestConnector,
+    subrequest::SubRequestClient,
 };
 
 /// Resolves `file_id` and `file_url` references in Responses API input
@@ -157,7 +157,7 @@ impl FileResolveFilter {
 
         let api_client = ApiClient::new(ApiClientConfig {
             api_base_url: validated.files_api_url.clone(),
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(4, None)),
             timeout: std::time::Duration::from_millis(validated.timeout_ms),
             max_response_bytes: 1_048_576,
             forward_header_names,
@@ -393,6 +393,7 @@ fn rewrite_body(
 /// History messages prepended by rehydrate are also walked so
 /// that any `file_id` references in them are resolved.
 #[expect(clippy::too_many_arguments, reason = "threading resolver through state sync")]
+#[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
 async fn sync_state_with_budget(
     ctx: &mut HttpFilterContext<'_>,
     resolved_body: &serde_json::Value,
@@ -444,6 +445,7 @@ async fn sync_state(
 
 /// Resolve file references in rehydrated history when the
 /// current input did not require a body rewrite.
+#[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
 async fn resolve_state_history(
     ctx: &mut HttpFilterContext<'_>,
     client: &FilesApiClient,

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -408,7 +408,6 @@ impl FilesApiClient {
 
     /// Fetch metadata and content, returning the base64 content
     /// and MIME type for the caller to format per the schema.
-    #[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
     async fn resolve_file(
         &self,
         file_id: &str,

--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -408,6 +408,7 @@ impl FilesApiClient {
 
     /// Fetch metadata and content, returning the base64 content
     /// and MIME type for the caller to format per the schema.
+    #[expect(clippy::large_stack_frames, reason = "Pingora context types are large")]
     async fn resolve_file(
         &self,
         file_id: &str,
@@ -837,7 +838,7 @@ mod tests {
     use super::*;
     use crate::{
         openai::api_client::{ApiClient, ApiClientConfig},
-        subrequest::SubRequestConnector,
+        subrequest::SubRequestClient,
     };
 
     #[test]
@@ -971,7 +972,7 @@ mod tests {
     fn test_api_client(api_base_url: &str, timeout_ms: u64) -> ApiClient {
         ApiClient::new(ApiClientConfig {
             api_base_url: api_base_url.to_owned(),
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(4, None)),
             timeout: std::time::Duration::from_millis(timeout_ms),
             max_response_bytes: 1_048_576,
             forward_header_names: Vec::new(),

--- a/apis/src/openai/responses/file_resolve/tests.rs
+++ b/apis/src/openai/responses/file_resolve/tests.rs
@@ -18,7 +18,7 @@ use crate::{
         api_client::{ApiClient, ApiClientConfig},
         responses::state::ResponsesState,
     },
-    subrequest::SubRequestConnector,
+    subrequest::SubRequestClient,
 };
 
 // -----------------------------------------------------------------------------
@@ -786,7 +786,7 @@ fn make_client() -> FilesApiClient {
 fn make_client_for_url_with_max(files_api_url: &str, max_resolved_bytes: usize) -> FilesApiClient {
     let api = ApiClient::new(ApiClientConfig {
         api_base_url: files_api_url.to_owned(),
-        connector: SubRequestConnector::new(4, None),
+        client: SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(4, None)),
         timeout: Duration::from_secs(5),
         max_response_bytes: 1_048_576,
         forward_header_names: vec![],

--- a/apis/src/openai/responses/web_search/provider.rs
+++ b/apis/src/openai/responses/web_search/provider.rs
@@ -3,10 +3,10 @@
 
 //! Search provider abstraction and implementations.
 //!
-//! Uses Pingora-native [`SubRequestConnector`] for HTTP callouts
-//! with connection pooling, HTTP/2, and TLS.
+//! Uses [`SubRequestClient`] from praxis-core for HTTP callouts
+//! with connection pooling, admission control, and TLS.
 //!
-//! [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
+//! [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
 
 use std::time::Duration;
 
@@ -18,7 +18,7 @@ use serde_json::Value;
 use tracing::{debug, warn};
 
 use super::config::{FailureMode, SearchContextSize, SearchProvider, ValidatedConfig};
-use crate::subrequest::{self, SubRequest, SubRequestConnector, SubResponse};
+use crate::subrequest::{self, SubRequest, SubRequestClient, SubRequestError, SubResponse};
 
 /// Response body cap for search callouts (1 MiB). Distinct from
 /// `max_body_bytes` which governs inbound request buffering.
@@ -61,12 +61,12 @@ pub(crate) enum SearchOutcome {
 // SearchClient
 // -----------------------------------------------------------------------------
 
-/// HTTP search client using Pingora-native [`SubRequestConnector`].
+/// HTTP search client using [`SubRequestClient`] from praxis-core.
 ///
-/// [`SubRequestConnector`]: praxis_core::subrequest::SubRequestConnector
+/// [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
 pub(crate) struct SearchClient {
-    /// Shared HTTP connector for search callouts.
-    connector: SubRequestConnector,
+    /// Sub-request client for bounded search callouts.
+    client: SubRequestClient,
     /// Per-request timeout.
     timeout: Duration,
     /// Search backend provider.
@@ -84,7 +84,7 @@ pub(crate) struct SearchClient {
 impl std::fmt::Debug for SearchClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SearchClient")
-            .field("connector", &self.connector)
+            .field("client", &self.client)
             .field("timeout", &self.timeout)
             .field("provider", &self.provider)
             .field("api_key", &"[REDACTED]")
@@ -106,7 +106,7 @@ impl SearchClient {
         http::HeaderValue::from_str(config.api_key.expose_secret())
             .map_err(|e| FilterError::from(format!("invalid API key header value: {e}")))?;
         Ok(Self {
-            connector: SubRequestConnector::new(4, None),
+            client: SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(4, None)),
             timeout: Duration::from_millis(config.timeout_ms),
             provider: config.provider,
             api_key: config.api_key.clone(),
@@ -132,7 +132,7 @@ impl SearchClient {
     /// Execute a search request and map the result to a
     /// [`SearchOutcome`].
     async fn execute_search(&self, url: &str, mut request: SubRequest) -> SearchOutcome {
-        let (target, uri) = match subrequest::parse_url(url) {
+        let (peer, uri) = match subrequest::resolve_url(url).await {
             Ok(pair) => pair,
             Err(e) => {
                 warn!(provider = self.provider.as_str(), error = %e, "search URL parse failed");
@@ -142,19 +142,15 @@ impl SearchClient {
 
         request.uri = uri;
 
-        let result = subrequest::execute(
-            &self.connector,
-            &target,
-            &request,
-            MAX_SEARCH_RESPONSE_BYTES,
-            self.timeout,
-        )
-        .await;
+        let result = self
+            .client
+            .execute(&peer, &request, MAX_SEARCH_RESPONSE_BYTES, self.timeout, None)
+            .await;
         self.map_search_result(result)
     }
 
     /// Map a sub-request result to a [`SearchOutcome`].
-    fn map_search_result(&self, result: Result<SubResponse, subrequest::SubRequestError>) -> SearchOutcome {
+    fn map_search_result(&self, result: Result<SubResponse, SubRequestError>) -> SearchOutcome {
         match result {
             Ok(response) if (200..300).contains(&(response.status as usize)) => self.parse_response(&response.body),
             Ok(response) => {

--- a/apis/src/openai/responses/web_search/provider.rs
+++ b/apis/src/openai/responses/web_search/provider.rs
@@ -131,21 +131,8 @@ impl SearchClient {
 
     /// Execute a search request and map the result to a
     /// [`SearchOutcome`].
-    async fn execute_search(&self, url: &str, mut request: SubRequest) -> SearchOutcome {
-        let (peer, uri) = match subrequest::resolve_url(url).await {
-            Ok(pair) => pair,
-            Err(e) => {
-                warn!(provider = self.provider.as_str(), error = %e, "search URL parse failed");
-                return self.transport_failure_outcome();
-            },
-        };
-
-        request.uri = uri;
-
-        let result = self
-            .client
-            .execute(&peer, &request, MAX_SEARCH_RESPONSE_BYTES, self.timeout, None)
-            .await;
+    async fn execute_search(&self, url: &str, request: SubRequest) -> SearchOutcome {
+        let result = subrequest::execute_url(&self.client, url, request, MAX_SEARCH_RESPONSE_BYTES, self.timeout).await;
         self.map_search_result(result)
     }
 

--- a/apis/src/subrequest.rs
+++ b/apis/src/subrequest.rs
@@ -1,120 +1,37 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! **Temporary** sub-request execution — to be replaced by
-//! [praxis-core#826](https://github.com/praxis-proxy/praxis/issues/826).
+//! URL-to-peer parsing and DNS resolution for sub-request execution.
 //!
-//! Provides URL-to-peer parsing and an HTTP execution function
-//! that replaces `praxis_core::callout::CalloutClient` with
-//! Pingora-native transport — getting connection pooling and TLS
-//! without a separate HTTP stack.
+//! Provides [`resolve_url`] which converts a full URL into an
+//! [`HttpPeer`] (with async DNS resolution) and a path-only [`Uri`],
+//! suitable for passing to [`SubRequestClient::execute`].
 //!
-//! Once praxis-core exposes the executor and typed errors through
-//! `SubRequestConnector`, this module should shrink to URL
-//! validation, `TargetPeer` construction, and domain error
-//! mapping.
+//! Types ([`SubRequestClient`], [`SubRequest`], [`SubResponse`],
+//! [`SubRequestError`]) are re-exported from [`praxis_core::subrequest`].
 //!
-//! Types ([`SubRequestConnector`], [`SubRequest`], [`SubResponse`])
-//! are re-exported from [`praxis_core::subrequest`].
-//!
-//! [`Connector`]: pingora_core::connectors::http::Connector
+//! [`HttpPeer`]: pingora_core::upstreams::peer::HttpPeer
+//! [`Uri`]: http::Uri
 
-use std::time::Duration;
-
-use bytes::Bytes;
-use http::HeaderMap;
-use pingora_core::{protocols::http::client::HttpSession, upstreams::peer::HttpPeer};
-pub(crate) use praxis_core::subrequest::{SubRequest, SubRequestConnector, SubResponse};
-use thiserror::Error;
-use tracing::{debug, warn};
+use pingora_core::upstreams::peer::HttpPeer;
+pub(crate) use praxis_core::subrequest::{SubRequest, SubRequestClient, SubRequestError, SubResponse};
+use tracing::debug;
 
 // -----------------------------------------------------------------------------
-// Error
+// URL → (HttpPeer, Uri)
 // -----------------------------------------------------------------------------
 
-/// Errors from sub-request execution.
-#[derive(Debug, Error)]
-pub(crate) enum SubRequestError {
-    /// Failed to connect to the upstream.
-    #[error("sub-request connect error: {0}")]
-    Connect(String),
-
-    /// Failed to write the request or read the response.
-    #[error("sub-request I/O error: {0}")]
-    Io(String),
-
-    /// Response body exceeded the size limit.
-    #[error(
-        "sub-request response body exceeded limit \
-         ({actual} > {limit} bytes, status {status})"
-    )]
-    ResponseTooLarge {
-        /// Actual bytes received before truncation.
-        actual: usize,
-        /// Configured limit.
-        limit: usize,
-        /// HTTP status code at the time of truncation.
-        status: u16,
-    },
-
-    /// The overall deadline expired.
-    #[error("sub-request deadline exceeded")]
-    DeadlineExceeded,
-
-    /// The URL could not be parsed into a valid peer address.
-    #[error("invalid sub-request URL: {0}")]
-    InvalidUrl(String),
-}
-
-// -----------------------------------------------------------------------------
-// TargetPeer
-// -----------------------------------------------------------------------------
-
-/// Parsed target for sub-request execution.
-///
-/// Holds URL components needed to create an [`HttpPeer`] and set
-/// the Host header. DNS resolution is deferred to execution time
-/// so it is both async and fallible.
-#[derive(Debug, Clone)]
-pub(crate) struct TargetPeer {
-    /// Hostname or IP to connect to.
-    pub(crate) host: String,
-    /// TCP port.
-    pub(crate) port: u16,
-    /// Whether TLS is enabled.
-    pub(crate) tls: bool,
-    /// TLS SNI hostname.
-    sni: String,
-    /// Original URL authority for the HTTP Host header.
-    authority: String,
-}
-
-// -----------------------------------------------------------------------------
-// URL → (TargetPeer, Uri)
-// -----------------------------------------------------------------------------
-
-/// Parse a full URL into a [`TargetPeer`] and a path-only
-/// [`http::Uri`].
-///
-/// Extracts scheme (→ TLS), host, port (defaults 443/80), and
-/// SNI from the URL. The returned URI contains only the path and
-/// query components. Only `http` and `https` schemes are accepted.
-///
-/// DNS resolution is NOT performed here — it happens inside
-/// [`execute`] so it can be async and fallible.
-#[expect(clippy::too_many_lines, reason = "sequential URL component extraction")]
-pub(crate) fn parse_url(url: &str) -> Result<(TargetPeer, http::Uri), SubRequestError> {
+/// Extract scheme, TLS flag, host, port, SNI, and path from a URL.
+fn parse_url_components(url: &str) -> Result<(bool, String, u16, String, http::Uri), SubRequestError> {
     let parsed: http::Uri = url
         .parse()
-        .map_err(|e| SubRequestError::InvalidUrl(format!("{e}: {url}")))?;
+        .map_err(|e| SubRequestError::InvalidRequest(format!("{e}: {url}")))?;
 
-    let scheme = parsed.scheme_str().unwrap_or("http");
-
-    let tls = match scheme {
+    let tls = match parsed.scheme_str().unwrap_or("http") {
         "https" => true,
         "http" => false,
         other => {
-            return Err(SubRequestError::InvalidUrl(format!(
+            return Err(SubRequestError::InvalidRequest(format!(
                 "unsupported scheme '{other}': {url}"
             )));
         },
@@ -122,268 +39,42 @@ pub(crate) fn parse_url(url: &str) -> Result<(TargetPeer, http::Uri), SubRequest
 
     let authority = parsed
         .authority()
-        .ok_or_else(|| SubRequestError::InvalidUrl(format!("missing host: {url}")))?;
-
+        .ok_or_else(|| SubRequestError::InvalidRequest(format!("missing host: {url}")))?;
     let host = authority.host().trim_start_matches('[').trim_end_matches(']');
-    let default_port = if tls { 443 } else { 80 };
-    let port = authority.port_u16().unwrap_or(default_port);
-
+    let port = authority.port_u16().unwrap_or(if tls { 443 } else { 80 });
     let sni = if tls { host.to_owned() } else { String::new() };
-
-    let target = TargetPeer {
-        host: host.to_owned(),
-        port,
-        tls,
-        sni,
-        authority: authority.to_string(),
-    };
 
     let path_and_query = parsed.path_and_query().map_or("/", |pq| pq.as_str());
     let uri: http::Uri = path_and_query
         .parse()
-        .map_err(|e| SubRequestError::InvalidUrl(format!("bad path: {e}")))?;
+        .map_err(|e| SubRequestError::InvalidRequest(format!("bad path: {e}")))?;
 
-    Ok((target, uri))
+    Ok((tls, host.to_owned(), port, sni, uri))
 }
 
-// -----------------------------------------------------------------------------
-// Execute
-// -----------------------------------------------------------------------------
-
-/// Execute a sub-request using Pingora's [`Connector`].
+/// Parse a full URL and resolve DNS to produce an [`HttpPeer`]
+/// and a path-only [`http::Uri`].
 ///
-/// Resolves DNS asynchronously, connects to the target, sends
-/// `request`, reads the full response (bounded by
-/// `max_response_bytes`), and returns a [`SubResponse`].  The
-/// overall operation — including DNS — is bounded by `timeout`.
+/// Extracts scheme (→ TLS), host, port (defaults 443/80), and
+/// SNI from the URL. The returned URI contains only the path and
+/// query components. Only `http` and `https` schemes are accepted.
 ///
-/// [`Connector`]: pingora_core::connectors::http::Connector
-pub(crate) async fn execute(
-    connector: &SubRequestConnector,
-    target: &TargetPeer,
-    request: &SubRequest,
-    max_response_bytes: usize,
-    timeout: Duration,
-) -> Result<SubResponse, SubRequestError> {
-    tokio::time::timeout(
-        timeout,
-        Box::pin(execute_inner(connector, target, request, max_response_bytes, timeout)),
-    )
-    .await
-    .map_err(|_elapsed| SubRequestError::DeadlineExceeded)?
-}
+/// DNS resolution is performed asynchronously via
+/// [`tokio::net::lookup_host`]. When multiple addresses resolve
+/// (e.g. dual-stack hosts), the first is used — Pingora's
+/// [`SubRequestClient`] handles retries at the transport layer.
+pub(crate) async fn resolve_url(url: &str) -> Result<(HttpPeer, http::Uri), SubRequestError> {
+    let (tls, host, port, sni, uri) = parse_url_components(url)?;
 
-/// Resolve DNS and perform the HTTP exchange under the deadline
-/// enforced by [`execute`].
-#[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
-#[expect(clippy::too_many_lines, reason = "sequential HTTP exchange steps")]
-#[expect(clippy::cognitive_complexity, reason = "mirrors praxis-filter execute_inner")]
-async fn execute_inner(
-    connector: &SubRequestConnector,
-    target: &TargetPeer,
-    request: &SubRequest,
-    max_response_bytes: usize,
-    timeout: Duration,
-) -> Result<SubResponse, SubRequestError> {
-    let _permit = connector.acquire_permit().await;
-    let addrs = resolve_addrs(target).await?;
-    let (mut session, reused, peer) = connect_to_first_reachable(connector, target, &addrs, timeout).await?;
-
-    debug!(
-        authority = target.authority,
-        reused,
-        method = %request.method,
-        uri = %request.uri,
-        "sub-request: connected"
-    );
-
-    session.set_read_timeout(Some(min_timeout(peer.options.read_timeout, timeout)));
-    session.set_write_timeout(Some(min_timeout(peer.options.write_timeout, timeout)));
-
-    let path = request
-        .uri
-        .path_and_query()
-        .map_or(b"/".as_slice(), |pq| pq.as_str().as_bytes());
-    let mut req_header = pingora_http::RequestHeader::build(request.method.clone(), path, None)
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
-
-    for (name, value) in &request.headers {
-        let _append = req_header.append_header(name.clone(), value.clone());
-    }
-
-    ensure_host_header(&mut req_header, &target.authority)?;
-
-    if !request.body.is_empty() || empty_body_needs_framing(&request.method) {
-        let _cl = req_header.insert_header("Content-Length", request.body.len().to_string());
-    }
-
-    session
-        .write_request_header(Box::new(req_header))
+    let addr = tokio::net::lookup_host((host.as_str(), port))
         .await
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
+        .map_err(|e| SubRequestError::Connect(format!("DNS resolution failed for {host}: {e}")))?
+        .next()
+        .ok_or_else(|| SubRequestError::Connect(format!("no addresses resolved for {host}")))?;
 
-    if !request.body.is_empty() {
-        session
-            .write_request_body(request.body.clone(), true)
-            .await
-            .map_err(|e| SubRequestError::Io(e.to_string()))?;
-    }
+    debug!(%host, %addr, "sub-request: resolved");
 
-    session
-        .finish_request_body()
-        .await
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
-
-    session
-        .read_response_header()
-        .await
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
-
-    let resp_header = session
-        .response_header()
-        .ok_or_else(|| SubRequestError::Io("no response header received".to_owned()))?;
-
-    let status = resp_header.status.as_u16();
-    if !(100..=599).contains(&status) {
-        session.shutdown().await;
-        return Err(SubRequestError::Io(format!(
-            "upstream returned unsupported HTTP status {status}"
-        )));
-    }
-    let mut resp_headers = HeaderMap::new();
-    for (name, value) in &resp_header.headers {
-        if let Ok(v) = http::header::HeaderValue::from_bytes(value.as_bytes()) {
-            resp_headers.append(name.clone(), v);
-        }
-    }
-
-    let mut body_buf = Vec::new();
-    while !session.response_done() {
-        match session.read_response_body().await {
-            Ok(Some(chunk)) => {
-                if body_buf.len() + chunk.len() > max_response_bytes {
-                    warn!(
-                        current = body_buf.len(),
-                        chunk = chunk.len(),
-                        limit = max_response_bytes,
-                        status,
-                        "sub-request response body exceeded limit"
-                    );
-                    session.shutdown().await;
-                    return Err(SubRequestError::ResponseTooLarge {
-                        actual: body_buf.len() + chunk.len(),
-                        limit: max_response_bytes,
-                        status,
-                    });
-                }
-                body_buf.extend_from_slice(&chunk);
-            },
-            Ok(None) => break,
-            Err(e) => {
-                session.shutdown().await;
-                return Err(SubRequestError::Io(e.to_string()));
-            },
-        }
-    }
-
-    debug!(status, body_bytes = body_buf.len(), "sub-request: response received");
-
-    connector.connector().release_http_session(session, &peer, None).await;
-
-    Ok(SubResponse {
-        status,
-        headers: resp_headers,
-        body: Bytes::from(body_buf),
-    })
-}
-
-/// Methods whose empty payload is commonly rejected without
-/// explicit framing.
-fn empty_body_needs_framing(method: &http::Method) -> bool {
-    matches!(*method, http::Method::POST | http::Method::PUT | http::Method::PATCH)
-}
-
-/// Resolve all addresses for a [`TargetPeer`].
-///
-/// Uses `tokio::net::lookup_host` for async, fallible resolution.
-/// Returns every address so callers can fall back on dual-stack
-/// hosts where the first address family is unreachable.
-async fn resolve_addrs(target: &TargetPeer) -> Result<Vec<std::net::SocketAddr>, SubRequestError> {
-    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((target.host.as_str(), target.port))
-        .await
-        .map_err(|e| SubRequestError::Connect(format!("DNS resolution failed for {}: {e}", target.host)))?
-        .collect();
-
-    if addrs.is_empty() {
-        return Err(SubRequestError::Connect(format!(
-            "no addresses resolved for {}",
-            target.host
-        )));
-    }
-
-    Ok(addrs)
-}
-
-/// Try each resolved address in order and return the first
-/// successful connection.
-///
-/// On dual-stack hosts this allows falling back from an
-/// unreachable IPv6 address to a working IPv4 address — a
-/// property the previous `reqwest`-based client provided via
-/// Happy Eyeballs.
-#[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
-async fn connect_to_first_reachable(
-    connector: &SubRequestConnector,
-    target: &TargetPeer,
-    addrs: &[std::net::SocketAddr],
-    timeout: Duration,
-) -> Result<(HttpSession, bool, HttpPeer), SubRequestError> {
-    let mut last_error = None;
-
-    for addr in addrs {
-        let mut peer = HttpPeer::new(addr.to_string(), target.tls, target.sni.clone());
-        clamp_peer_timeouts(&mut peer, timeout);
-
-        match Box::pin(connector.connector().get_http_session(&peer)).await {
-            Ok((session, reused)) => return Ok((session, reused, peer)),
-            Err(e) => {
-                debug!(
-                    address = %addr,
-                    error = %e,
-                    "sub-request: connect failed, trying next address"
-                );
-                last_error = Some(e);
-            },
-        }
-    }
-
-    Err(SubRequestError::Connect(last_error.map_or_else(
-        || format!("no addresses resolved for {}", target.host),
-        |e| format!("all resolved addresses for {} failed: {e}", target.host),
-    )))
-}
-
-/// Ensure HTTP/1.1 virtual hosting and HTTP/2 `:authority` are
-/// valid — using the original URL authority, not the resolved IP.
-fn ensure_host_header(request: &mut pingora_http::RequestHeader, authority: &str) -> Result<(), SubRequestError> {
-    if !request.headers.contains_key(http::header::HOST) {
-        request
-            .insert_header(http::header::HOST, authority)
-            .map_err(|error| SubRequestError::Io(error.to_string()))?;
-    }
-    Ok(())
-}
-
-/// Clamp connect timeouts to the remaining overall deadline.
-fn clamp_peer_timeouts(peer: &mut HttpPeer, deadline: Duration) {
-    peer.options.connection_timeout = Some(min_timeout(peer.options.connection_timeout, deadline));
-    peer.options.total_connection_timeout = Some(min_timeout(peer.options.total_connection_timeout, deadline));
-}
-
-/// Keep an operator-configured timeout when it is stricter than
-/// the deadline.
-fn min_timeout(configured: Option<Duration>, deadline: Duration) -> Duration {
-    configured.map_or(deadline, |configured| configured.min(deadline))
+    Ok((HttpPeer::new(addr, tls, sni), uri))
 }
 
 // -----------------------------------------------------------------------------
@@ -400,105 +91,69 @@ fn min_timeout(configured: Option<Duration>, deadline: Duration) -> Duration {
     reason = "tests"
 )]
 mod tests {
-    use std::io::{Read as _, Write as _};
+    use pingora_core::upstreams::peer::Peer as _;
 
     use super::*;
 
-    #[test]
-    fn parse_url_https() {
-        let (target, uri) = parse_url("https://127.0.0.1:8443/v1/search?q=test").unwrap();
-        assert!(target.tls, "HTTPS should enable TLS");
+    #[tokio::test]
+    async fn resolve_url_https() {
+        let (peer, uri) = resolve_url("https://127.0.0.1:8443/v1/search?q=test").await.unwrap();
+        assert!(peer.is_tls(), "HTTPS should enable TLS");
         assert_eq!(uri.path(), "/v1/search");
         assert_eq!(uri.query(), Some("q=test"));
     }
 
-    #[test]
-    fn parse_url_http_with_port() {
-        let (target, uri) = parse_url("http://127.0.0.1:8080/health").unwrap();
-        assert!(!target.tls, "HTTP should disable TLS");
+    #[tokio::test]
+    async fn resolve_url_http_with_port() {
+        let (peer, uri) = resolve_url("http://127.0.0.1:8080/health").await.unwrap();
+        assert!(!peer.is_tls(), "HTTP should disable TLS");
         assert_eq!(uri.path(), "/health");
     }
 
-    #[test]
-    fn parse_url_default_ports() {
-        let (https_target, _) = parse_url("https://127.0.0.1/path").unwrap();
-        assert_eq!(https_target.host, "127.0.0.1");
-        assert_eq!(https_target.port, 443);
-
-        let (http_target, _) = parse_url("http://127.0.0.1/path").unwrap();
-        assert_eq!(http_target.host, "127.0.0.1");
-        assert_eq!(http_target.port, 80);
-    }
-
-    #[test]
-    fn parse_url_preserves_hostname_authority() {
-        let (target, _) = parse_url("https://api.example.com/v1/search").unwrap();
-        assert_eq!(target.authority, "api.example.com");
-        assert_eq!(target.host, "api.example.com");
-        assert_eq!(target.port, 443);
-    }
-
-    #[test]
-    fn parse_url_preserves_hostname_authority_with_port() {
-        let (target, _) = parse_url("https://api.example.com:8443/path").unwrap();
-        assert_eq!(target.authority, "api.example.com:8443");
-        assert_eq!(target.host, "api.example.com");
-        assert_eq!(target.port, 8443);
-    }
-
-    #[test]
-    fn parse_url_ipv6_loopback() {
-        let (target, uri) = parse_url("http://[::1]:9090/metrics").unwrap();
-        assert_eq!(target.host, "::1");
-        assert_eq!(target.port, 9090);
-        assert_eq!(target.authority, "[::1]:9090");
+    #[tokio::test]
+    async fn resolve_url_ipv6_loopback() {
+        let (peer, uri) = resolve_url("http://[::1]:9090/metrics").await.unwrap();
+        assert!(!peer.is_tls());
         assert_eq!(uri.path(), "/metrics");
-    }
-
-    #[test]
-    fn parse_url_ipv6_default_port() {
-        let (target, _) = parse_url("https://[::1]/path").unwrap();
-        assert_eq!(target.host, "::1");
-        assert_eq!(target.port, 443);
-        assert!(target.tls);
+        let addr = peer.address().to_string();
+        assert!(addr.contains("::1"), "should contain IPv6 loopback: {addr}");
     }
 
     #[tokio::test]
-    async fn resolve_addrs_handles_ipv6() {
-        let target = TargetPeer {
-            host: "::1".to_owned(),
-            port: 8080,
-            tls: false,
-            sni: String::new(),
-            authority: "[::1]:8080".to_owned(),
-        };
-        let addrs = resolve_addrs(&target).await.unwrap();
-        assert!(!addrs.is_empty(), "should resolve at least one address");
-        assert!(
-            addrs.iter().any(|a| a.to_string().contains("::1")),
-            "resolved addresses should contain IPv6 loopback: {addrs:?}"
-        );
+    async fn resolve_url_ipv6_default_port() {
+        let (peer, _) = resolve_url("https://[::1]/path").await.unwrap();
+        assert!(peer.is_tls());
     }
 
     #[test]
-    fn parse_url_missing_host_returns_error() {
-        assert!(parse_url("/relative/path").is_err());
+    fn resolve_url_missing_host_returns_error() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(resolve_url("/relative/path"));
+        assert!(result.is_err());
     }
 
     #[test]
-    fn parse_url_invalid_returns_error() {
-        assert!(parse_url("://bad").is_err());
+    fn resolve_url_invalid_returns_error() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(resolve_url("://bad"));
+        assert!(result.is_err());
     }
 
-    #[test]
-    fn parse_url_root_path() {
-        let (_, uri) = parse_url("https://127.0.0.1").unwrap();
+    #[tokio::test]
+    async fn resolve_url_root_path() {
+        let (_, uri) = resolve_url("https://127.0.0.1").await.unwrap();
         assert_eq!(uri.path(), "/");
     }
 
-    #[test]
-    fn parse_url_rejects_ftp_scheme() {
-        let err = parse_url("ftp://127.0.0.1/data.csv").unwrap_err();
+    #[tokio::test]
+    async fn resolve_url_rejects_ftp_scheme() {
+        let err = resolve_url("ftp://127.0.0.1/data.csv").await.unwrap_err();
         assert!(
             err.to_string().contains("unsupported scheme"),
             "ftp should be rejected: {err}"
@@ -506,201 +161,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_url_rejects_file_scheme() {
-        let err = parse_url("file:///etc/passwd").unwrap_err();
+    fn resolve_url_rejects_file_scheme() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = rt.block_on(resolve_url("file:///etc/passwd")).unwrap_err();
         assert!(
-            err.to_string().contains("invalid sub-request URL"),
+            err.to_string().contains("sub-request"),
             "file:// should be rejected: {err}"
         );
     }
 
-    #[test]
-    fn connector_clone_shares_pool() {
-        let a = SubRequestConnector::new(16, None);
-        let b = a.clone();
-        assert!(
-            std::ptr::eq(a.connector(), b.connector()),
-            "cloned connectors should share the same pool"
-        );
-    }
-
-    #[test]
-    fn connector_debug_does_not_panic() {
-        let connector = SubRequestConnector::new(8, None);
-        let debug = format!("{connector:?}");
-        assert!(
-            debug.contains("SubRequestConnector"),
-            "debug output should contain type name"
-        );
-    }
-
-    #[test]
-    fn empty_body_framing_for_entity_methods() {
-        assert!(empty_body_needs_framing(&http::Method::POST));
-        assert!(empty_body_needs_framing(&http::Method::PUT));
-        assert!(empty_body_needs_framing(&http::Method::PATCH));
-        assert!(!empty_body_needs_framing(&http::Method::GET));
-        assert!(!empty_body_needs_framing(&http::Method::HEAD));
-    }
-
-    #[test]
-    fn min_timeout_preserves_stricter_limit() {
-        assert_eq!(
-            min_timeout(Some(Duration::from_secs(1)), Duration::from_secs(10)),
-            Duration::from_secs(1)
-        );
-        assert_eq!(
-            min_timeout(Some(Duration::from_secs(20)), Duration::from_secs(10)),
-            Duration::from_secs(10)
-        );
-        assert_eq!(min_timeout(None, Duration::from_secs(10)), Duration::from_secs(10));
-    }
-
     #[tokio::test]
-    async fn deadline_bounds_the_complete_exchange() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let address = listener.local_addr().unwrap();
-        let backend = tokio::spawn(async move {
-            let (_socket, _) = listener.accept().await.unwrap();
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        });
-        let connector = SubRequestConnector::new(1, None);
-        let (target, uri) = parse_url(&format!("http://{address}/")).unwrap();
-        let request = SubRequest {
-            method: http::Method::GET,
-            uri,
-            headers: HeaderMap::new(),
-            body: Bytes::new(),
-        };
-
-        let started = std::time::Instant::now();
-        let result = Box::pin(execute(&connector, &target, &request, 1024, Duration::from_millis(10))).await;
-        let elapsed = started.elapsed();
-        backend.abort();
-
-        assert!(result.is_err(), "a backend that never responds must time out");
-        assert!(
-            elapsed < Duration::from_millis(500),
-            "exchange exceeded its deadline: {elapsed:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn unresolvable_host_returns_connect_error() {
-        let connector = SubRequestConnector::new(1, None);
-        let (target, uri) = parse_url("https://this-host-does-not-exist.invalid/path").unwrap();
-        let request = SubRequest {
-            method: http::Method::GET,
-            uri,
-            headers: HeaderMap::new(),
-            body: Bytes::new(),
-        };
-
-        let result = Box::pin(execute(&connector, &target, &request, 1024, Duration::from_secs(5))).await;
-
+    async fn resolve_url_unresolvable_host_returns_connect_error() {
+        let result = resolve_url("https://this-host-does-not-exist.invalid/path").await;
         assert!(
             matches!(result, Err(SubRequestError::Connect(_))),
-            "unresolvable host should return Connect error, not panic: {result:?}"
-        );
-    }
-
-    fn capture_raw_request(listener: std::net::TcpListener) -> std::thread::JoinHandle<String> {
-        std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buf = [0_u8; 4096];
-            let n = stream.read(&mut buf).unwrap();
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-                .unwrap();
-            String::from_utf8_lossy(&buf[..n]).into_owned()
-        })
-    }
-
-    #[tokio::test]
-    async fn execute_sends_authority_as_host_header() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let captured = capture_raw_request(listener);
-
-        let connector = SubRequestConnector::new(1, None);
-        let target = TargetPeer {
-            host: "127.0.0.1".to_owned(),
-            port: addr.port(),
-            tls: false,
-            sni: String::new(),
-            authority: format!("my-virtual-host.example.com:{}", addr.port()),
-        };
-        let request = SubRequest {
-            method: http::Method::GET,
-            uri: "/test".parse().unwrap(),
-            headers: HeaderMap::new(),
-            body: Bytes::new(),
-        };
-
-        let _response = Box::pin(execute(&connector, &target, &request, 1024, Duration::from_secs(5)))
-            .await
-            .unwrap();
-
-        let wire = captured.join().unwrap().to_lowercase();
-        let expected = format!("host: my-virtual-host.example.com:{}", addr.port());
-        assert!(
-            wire.contains(&expected),
-            "Host header should use original authority, not resolved IP: {wire}"
+            "unresolvable host should return Connect error: {result:?}"
         );
     }
 
     #[tokio::test]
-    async fn connect_falls_back_when_first_address_refuses() {
-        let bad_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let bad_addr = bad_listener.local_addr().unwrap();
-        drop(bad_listener);
-
-        let good_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let good_addr = good_listener.local_addr().unwrap();
-
-        let connector = SubRequestConnector::new(1, None);
-        let target = TargetPeer {
-            host: "127.0.0.1".to_owned(),
-            port: good_addr.port(),
-            tls: false,
-            sni: String::new(),
-            authority: format!("127.0.0.1:{}", good_addr.port()),
-        };
-
-        let addrs = vec![bad_addr, good_addr];
-        let result = connect_to_first_reachable(&connector, &target, &addrs, Duration::from_secs(5)).await;
-
-        drop(good_listener);
-        assert!(result.is_ok(), "should connect via fallback to second address");
-    }
-
-    #[tokio::test]
-    async fn connect_fails_when_all_addresses_refuse() {
-        let l1 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let a1 = l1.local_addr().unwrap();
-        drop(l1);
-        let l2 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let a2 = l2.local_addr().unwrap();
-        drop(l2);
-
-        let connector = SubRequestConnector::new(1, None);
-        let target = TargetPeer {
-            host: "127.0.0.1".to_owned(),
-            port: a1.port(),
-            tls: false,
-            sni: String::new(),
-            authority: format!("127.0.0.1:{}", a1.port()),
-        };
-
-        let result = connect_to_first_reachable(&connector, &target, &[a1, a2], Duration::from_secs(2)).await;
-
-        let Err(err) = result else {
-            panic!("should fail when all addresses refuse connections");
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("all resolved"),
-            "should report all addresses failed: {msg}"
-        );
+    async fn resolve_url_localhost() {
+        let (peer, uri) = resolve_url("http://127.0.0.1:8080/path").await.unwrap();
+        assert!(!peer.is_tls());
+        assert_eq!(uri.path(), "/path");
     }
 }

--- a/apis/src/subrequest.rs
+++ b/apis/src/subrequest.rs
@@ -1,28 +1,41 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! URL-to-peer parsing and DNS resolution for sub-request execution.
+//! URL resolution and bounded execution for sub-requests.
 //!
-//! Provides [`resolve_url`] which converts a full URL into an
-//! [`HttpPeer`] (with async DNS resolution) and a path-only [`Uri`],
-//! suitable for passing to [`SubRequestClient::execute`].
+//! Provides [`execute_url`], which preserves the URL authority for
+//! HTTP virtual hosting, resolves every address for fallback, and
+//! bounds DNS plus the HTTP exchange with one overall deadline.
 //!
 //! Types ([`SubRequestClient`], [`SubRequest`], [`SubResponse`],
 //! [`SubRequestError`]) are re-exported from [`praxis_core::subrequest`].
-//!
-//! [`HttpPeer`]: pingora_core::upstreams::peer::HttpPeer
-//! [`Uri`]: http::Uri
+
+use std::{future::Future, net::SocketAddr, time::Duration};
 
 use pingora_core::upstreams::peer::HttpPeer;
 pub(crate) use praxis_core::subrequest::{SubRequest, SubRequestClient, SubRequestError, SubResponse};
 use tracing::debug;
 
-// -----------------------------------------------------------------------------
-// URL → (HttpPeer, Uri)
-// -----------------------------------------------------------------------------
+/// Parsed URL components needed to resolve and execute a request.
+#[derive(Debug)]
+struct ParsedUrl {
+    /// Whether to establish a TLS connection.
+    tls: bool,
+    /// DNS hostname or literal address.
+    host: String,
+    /// Destination TCP port.
+    port: u16,
+    /// TLS server name, empty for cleartext HTTP.
+    sni: String,
+    /// Original URL authority for HTTP virtual hosting.
+    authority: http::HeaderValue,
+    /// Path and query sent to the upstream.
+    uri: http::Uri,
+}
 
-/// Extract scheme, TLS flag, host, port, SNI, and path from a URL.
-fn parse_url_components(url: &str) -> Result<(bool, String, u16, String, http::Uri), SubRequestError> {
+/// Extract scheme, TLS flag, host, port, SNI, authority, and path.
+#[expect(clippy::too_many_lines, reason = "sequential URL component extraction")]
+fn parse_url_components(url: &str) -> Result<ParsedUrl, SubRequestError> {
     let parsed: http::Uri = url
         .parse()
         .map_err(|e| SubRequestError::InvalidRequest(format!("{e}: {url}")))?;
@@ -43,43 +56,118 @@ fn parse_url_components(url: &str) -> Result<(bool, String, u16, String, http::U
     let host = authority.host().trim_start_matches('[').trim_end_matches(']');
     let port = authority.port_u16().unwrap_or(if tls { 443 } else { 80 });
     let sni = if tls { host.to_owned() } else { String::new() };
+    let authority = http::HeaderValue::from_str(authority.as_str())
+        .map_err(|e| SubRequestError::InvalidRequest(format!("invalid authority: {e}")))?;
 
     let path_and_query = parsed.path_and_query().map_or("/", |pq| pq.as_str());
     let uri: http::Uri = path_and_query
         .parse()
         .map_err(|e| SubRequestError::InvalidRequest(format!("bad path: {e}")))?;
 
-    Ok((tls, host.to_owned(), port, sni, uri))
+    Ok(ParsedUrl {
+        tls,
+        host: host.to_owned(),
+        port,
+        sni,
+        authority,
+        uri,
+    })
 }
 
-/// Parse a full URL and resolve DNS to produce an [`HttpPeer`]
-/// and a path-only [`http::Uri`].
-///
-/// Extracts scheme (→ TLS), host, port (defaults 443/80), and
-/// SNI from the URL. The returned URI contains only the path and
-/// query components. Only `http` and `https` schemes are accepted.
-///
-/// DNS resolution is performed asynchronously via
-/// [`tokio::net::lookup_host`]. When multiple addresses resolve
-/// (e.g. dual-stack hosts), the first is used — Pingora's
-/// [`SubRequestClient`] handles retries at the transport layer.
-pub(crate) async fn resolve_url(url: &str) -> Result<(HttpPeer, http::Uri), SubRequestError> {
-    let (tls, host, port, sni, uri) = parse_url_components(url)?;
-
-    let addr = tokio::net::lookup_host((host.as_str(), port))
+/// Resolve every address so callers can fall back across address families.
+async fn resolve_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, SubRequestError> {
+    let addrs = tokio::net::lookup_host((host, port))
         .await
         .map_err(|e| SubRequestError::Connect(format!("DNS resolution failed for {host}: {e}")))?
-        .next()
-        .ok_or_else(|| SubRequestError::Connect(format!("no addresses resolved for {host}")))?;
+        .collect::<Vec<_>>();
 
-    debug!(%host, %addr, "sub-request: resolved");
+    if addrs.is_empty() {
+        return Err(SubRequestError::Connect(format!("no addresses resolved for {host}")));
+    }
 
-    Ok((HttpPeer::new(addr, tls, sni), uri))
+    Ok(addrs)
 }
 
-// -----------------------------------------------------------------------------
-// Tests
-// -----------------------------------------------------------------------------
+/// Enforce the deadline around DNS resolution and every connection attempt.
+async fn with_deadline<T>(
+    timeout: Duration,
+    operation: impl Future<Output = Result<T, SubRequestError>>,
+) -> Result<T, SubRequestError> {
+    tokio::time::timeout(timeout, operation)
+        .await
+        .map_err(|_elapsed| SubRequestError::DeadlineExceeded)?
+}
+
+/// Parse and execute a full-URL sub-request.
+///
+/// The configured timeout covers URL resolution and the complete HTTP
+/// exchange. All resolved addresses are tried in order when connecting,
+/// while the original URL authority is preserved in `Host`.
+pub(crate) async fn execute_url(
+    client: &SubRequestClient,
+    url: &str,
+    request: SubRequest,
+    max_response_bytes: usize,
+    timeout: Duration,
+) -> Result<SubResponse, SubRequestError> {
+    with_deadline(
+        timeout,
+        Box::pin(execute_url_inner(client, url, request, max_response_bytes, timeout)),
+    )
+    .await
+}
+
+/// Resolve DNS and execute under the deadline enforced by [`execute_url`].
+async fn execute_url_inner(
+    client: &SubRequestClient,
+    url: &str,
+    request: SubRequest,
+    max_response_bytes: usize,
+    timeout: Duration,
+) -> Result<SubResponse, SubRequestError> {
+    let parsed = parse_url_components(url)?;
+    let addrs = resolve_addrs(&parsed.host, parsed.port).await?;
+    execute_resolved_url(client, parsed, request, &addrs, max_response_bytes, timeout).await
+}
+
+/// Try each resolved address until one connects successfully.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "internal helper requires parsed target and execution limits"
+)]
+async fn execute_resolved_url(
+    client: &SubRequestClient,
+    parsed: ParsedUrl,
+    mut request: SubRequest,
+    addrs: &[SocketAddr],
+    max_response_bytes: usize,
+    timeout: Duration,
+) -> Result<SubResponse, SubRequestError> {
+    request.uri = parsed.uri;
+    if !request.headers.contains_key(http::header::HOST) {
+        request.headers.insert(http::header::HOST, parsed.authority);
+    }
+
+    let mut last_connect_error = None;
+    for addr in addrs {
+        let peer = HttpPeer::new(*addr, parsed.tls, parsed.sni.clone());
+        debug!(host = %parsed.host, %addr, "sub-request: trying resolved address");
+
+        match client.execute(&peer, &request, max_response_bytes, timeout, None).await {
+            Ok(response) => return Ok(response),
+            Err(SubRequestError::Connect(error)) => {
+                debug!(host = %parsed.host, %addr, %error, "sub-request: connect failed, trying next address");
+                last_connect_error = Some(error);
+            },
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(SubRequestError::Connect(last_connect_error.map_or_else(
+        || format!("no addresses resolved for {}", parsed.host),
+        |error| format!("all resolved addresses for {} failed: {error}", parsed.host),
+    )))
+}
 
 #[cfg(test)]
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
@@ -91,91 +179,96 @@ pub(crate) async fn resolve_url(url: &str) -> Result<(HttpPeer, http::Uri), SubR
     reason = "tests"
 )]
 mod tests {
-    use pingora_core::upstreams::peer::Peer as _;
+    use std::io::{Read as _, Write as _};
+
+    use bytes::Bytes;
+    use http::HeaderMap;
+    use praxis_core::subrequest::SubRequestConnector;
 
     use super::*;
 
-    #[tokio::test]
-    async fn resolve_url_https() {
-        let (peer, uri) = resolve_url("https://127.0.0.1:8443/v1/search?q=test").await.unwrap();
-        assert!(peer.is_tls(), "HTTPS should enable TLS");
-        assert_eq!(uri.path(), "/v1/search");
-        assert_eq!(uri.query(), Some("q=test"));
+    fn test_client() -> SubRequestClient {
+        SubRequestClient::new(SubRequestConnector::new(4, None))
     }
 
-    #[tokio::test]
-    async fn resolve_url_http_with_port() {
-        let (peer, uri) = resolve_url("http://127.0.0.1:8080/health").await.unwrap();
-        assert!(!peer.is_tls(), "HTTP should disable TLS");
-        assert_eq!(uri.path(), "/health");
+    fn empty_request() -> SubRequest {
+        SubRequest {
+            method: http::Method::GET,
+            uri: http::Uri::default(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        }
     }
 
-    #[tokio::test]
-    async fn resolve_url_ipv6_loopback() {
-        let (peer, uri) = resolve_url("http://[::1]:9090/metrics").await.unwrap();
-        assert!(!peer.is_tls());
-        assert_eq!(uri.path(), "/metrics");
-        let addr = peer.address().to_string();
-        assert!(addr.contains("::1"), "should contain IPv6 loopback: {addr}");
-    }
-
-    #[tokio::test]
-    async fn resolve_url_ipv6_default_port() {
-        let (peer, _) = resolve_url("https://[::1]/path").await.unwrap();
-        assert!(peer.is_tls());
+    fn capture_raw_request(listener: std::net::TcpListener) -> std::thread::JoinHandle<String> {
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let n = stream.read(&mut buf).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .unwrap();
+            String::from_utf8_lossy(&buf[..n]).into_owned()
+        })
     }
 
     #[test]
-    fn resolve_url_missing_host_returns_error() {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        let result = rt.block_on(resolve_url("/relative/path"));
-        assert!(result.is_err());
+    fn parse_url_https() {
+        let parsed = parse_url_components("https://127.0.0.1:8443/v1/search?q=test").unwrap();
+        assert!(parsed.tls, "HTTPS should enable TLS");
+        assert_eq!(parsed.port, 8443);
+        assert_eq!(parsed.uri.path(), "/v1/search");
+        assert_eq!(parsed.uri.query(), Some("q=test"));
     }
 
     #[test]
-    fn resolve_url_invalid_returns_error() {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        let result = rt.block_on(resolve_url("://bad"));
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn resolve_url_root_path() {
-        let (_, uri) = resolve_url("https://127.0.0.1").await.unwrap();
-        assert_eq!(uri.path(), "/");
-    }
-
-    #[tokio::test]
-    async fn resolve_url_rejects_ftp_scheme() {
-        let err = resolve_url("ftp://127.0.0.1/data.csv").await.unwrap_err();
-        assert!(
-            err.to_string().contains("unsupported scheme"),
-            "ftp should be rejected: {err}"
-        );
+    fn parse_url_preserves_hostname_authority() {
+        let parsed = parse_url_components("https://api.example.com:8443/v1/search").unwrap();
+        assert_eq!(parsed.host, "api.example.com");
+        assert_eq!(parsed.authority, "api.example.com:8443");
+        assert_eq!(parsed.sni, "api.example.com");
     }
 
     #[test]
-    fn resolve_url_rejects_file_scheme() {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        let err = rt.block_on(resolve_url("file:///etc/passwd")).unwrap_err();
-        assert!(
-            err.to_string().contains("sub-request"),
-            "file:// should be rejected: {err}"
-        );
+    fn parse_url_ipv6_loopback() {
+        let parsed = parse_url_components("http://[::1]:9090/metrics").unwrap();
+        assert!(!parsed.tls);
+        assert_eq!(parsed.host, "::1");
+        assert_eq!(parsed.port, 9090);
+        assert_eq!(parsed.authority, "[::1]:9090");
+        assert_eq!(parsed.uri.path(), "/metrics");
+    }
+
+    #[test]
+    fn parse_url_missing_host_returns_error() {
+        assert!(parse_url_components("/relative/path").is_err());
+    }
+
+    #[test]
+    fn parse_url_invalid_returns_error() {
+        assert!(parse_url_components("://bad").is_err());
+    }
+
+    #[test]
+    fn parse_url_root_path() {
+        let parsed = parse_url_components("https://127.0.0.1").unwrap();
+        assert_eq!(parsed.uri.path(), "/");
+    }
+
+    #[test]
+    fn parse_url_rejects_unsupported_schemes() {
+        for url in ["ftp://127.0.0.1/data.csv", "file:///etc/passwd"] {
+            let err = parse_url_components(url).unwrap_err();
+            assert!(
+                err.to_string().contains("sub-request"),
+                "scheme should be rejected: {err}"
+            );
+        }
     }
 
     #[tokio::test]
-    async fn resolve_url_unresolvable_host_returns_connect_error() {
-        let result = resolve_url("https://this-host-does-not-exist.invalid/path").await;
+    async fn resolve_addrs_unresolvable_host_returns_connect_error() {
+        let result = resolve_addrs("this-host-does-not-exist.invalid", 443).await;
         assert!(
             matches!(result, Err(SubRequestError::Connect(_))),
             "unresolvable host should return Connect error: {result:?}"
@@ -183,9 +276,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_url_localhost() {
-        let (peer, uri) = resolve_url("http://127.0.0.1:8080/path").await.unwrap();
-        assert!(!peer.is_tls());
-        assert_eq!(uri.path(), "/path");
+    async fn deadline_bounds_resolution_and_exchange() {
+        let result = with_deadline(
+            Duration::from_millis(10),
+            std::future::pending::<Result<(), SubRequestError>>(),
+        )
+        .await;
+        assert!(matches!(result, Err(SubRequestError::DeadlineExceeded)));
+    }
+
+    #[tokio::test]
+    async fn execute_falls_back_when_first_address_refuses() {
+        let bad_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let bad_addr = bad_listener.local_addr().unwrap();
+        drop(bad_listener);
+
+        let good_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let good_addr = good_listener.local_addr().unwrap();
+        let captured = capture_raw_request(good_listener);
+
+        let parsed = parse_url_components(&format!("http://example.test:{}/test", good_addr.port())).unwrap();
+        let response = execute_resolved_url(
+            &test_client(),
+            parsed,
+            empty_request(),
+            &[bad_addr, good_addr],
+            1024,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status, 200);
+        let _request = captured.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn execute_sends_original_authority_as_host_header() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let captured = capture_raw_request(listener);
+        let authority = format!("my-virtual-host.example.com:{}", addr.port());
+        let parsed = parse_url_components(&format!("http://{authority}/test")).unwrap();
+
+        execute_resolved_url(
+            &test_client(),
+            parsed,
+            empty_request(),
+            &[addr],
+            1024,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let wire = captured.join().unwrap().to_lowercase();
+        assert!(
+            wire.contains(&format!("host: {authority}")),
+            "Host header should use original authority, not resolved IP: {wire}"
+        );
     }
 }

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -85,7 +85,7 @@ pub(crate) mod test_utils {
             response_body_mode: praxis_filter::BodyMode::Stream,
             response_header: None,
             response_headers_modified: false,
-            subrequest_connector: None,
+            subrequest_client: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,


### PR DESCRIPTION
## Summary

Replace the bespoke sub-request executor in `apis/src/subrequest.rs` with
praxis-core's `SubRequestClient` (praxis-proxy/praxis#880), which provides
hardened admission control, deadline timeouts, response body limits, and
hop-by-hop header sanitization out of the box. The local module is reduced
from ~700 lines to ~190: only URL parsing and async DNS resolution remain,
with core types re-exported.

All consumers (`ApiClient`, `SearchClient`, `FileResolveFilter`) are updated
to use `SubRequestClient` instead of the raw `SubRequestConnector`, and the
context field is renamed from `subrequest_connector` to `subrequest_client`.
The now-unused `pingora-http` dependency is removed from `apis`.

## Related issue

Depends on praxis-proxy/praxis#880

## Validation

```
make lint   # ✅ all checks pass (clippy, fmt, machete, docs, examples)
make test   # ✅ all tests pass (subrequest, api_client, web_search, file_resolve, full suite)
make build  # ✅ workspace builds
```

Note: requires praxis-core with `SubRequestClient` (praxis-proxy/praxis#880).
The `praxis-compat` CI workflow will test against praxis main automatically.
The regular `tests.yaml` workflow will fail until the new praxis version is
published to crates.io.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. This is an internal refactoring — no public API or configuration
changes. The `subrequest_connector` → `subrequest_client` rename is
internal to the filter context.