### PR TITLE
docs(filters): refresh on_invalid type rendering

### DIFF
--- a/docs/filters/a2a.md
+++ b/docs/filters/a2a.md
@@ -23,7 +23,7 @@ When `task_routing.enabled` is true, the filter captures task and context owners
 | `headers.version` | string | no | Header name for A2A version (e.g. `x-praxis-a2a-version`). |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer`. |
 | `method_aliases` | object<string, string> | no | Method aliases for compatibility (slash-delimited → `PascalCase`). |
-| `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
+| `on_invalid` | OnInvalidBehavior | no | Invalid input handling behavior. |
 | `task_routing` | TaskRoutingConfig | no | Task-ownership routing configuration. |
 | `task_routing.enabled` | bool | no | Whether task routing is enabled. |
 | `task_routing.max_response_body_bytes` | integer | no | Maximum response body bytes to buffer for task route capture. |

--- a/docs/filters/anthropic_messages_format.md
+++ b/docs/filters/anthropic_messages_format.md
@@ -9,7 +9,7 @@ Classifies Anthropic Messages API requests and promotes routing facts to headers
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `on_invalid` | `continue` \| `reject` \| `error` | no | Behavior when the body cannot be classified. |
+| `on_invalid` | OnInvalidBehavior | no | Behavior when the body cannot be classified. |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `headers` | AnthropicMessagesFormatHeaders | no | Header names for promoted classification facts. |
 | `headers.format` | string | no | Header name for the detected format. |

--- a/docs/filters/mcp.md
+++ b/docs/filters/mcp.md
@@ -35,7 +35,7 @@ Supports two protocol profiles: `current` (session-based, default) and `stateles
 | `headers.protocol_version` | string | no | Header name for the MCP protocol version (e.g. `x-praxis-mcp-protocol-version`). |
 | `headers.session_present` | string | no | Header name for MCP session presence (e.g. `x-praxis-mcp-session-present`). |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer`. |
-| `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
+| `on_invalid` | OnInvalidBehavior | no | Invalid input handling behavior. |
 | `cache_scope` | `public` \| `private` | no | Cache scope for stateless responses. Requires `protocol_profile: stateless`. |
 | `cache_ttl_ms` | integer | no | Cache TTL in milliseconds for stateless responses. Requires `protocol_profile: stateless`. |
 | `default_version` | string | no | Fallback MCP protocol version. When omitted, derived from the profile. |

--- a/docs/filters/openai_responses_format.md
+++ b/docs/filters/openai_responses_format.md
@@ -19,7 +19,7 @@ Use with branch chains to route stateful and stateless requests to different clu
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `on_invalid` | `continue` \| `reject` \| `error` | no | Behavior when the body cannot be classified. |
+| `on_invalid` | OnInvalidBehavior | no | Behavior when the body cannot be classified. |
 | `max_body_bytes` | integer | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `headers` | ResponsesFormatHeaders | no | Header names for promoted classification facts. |
 | `headers.format` | string | no | Header name for the detected format (e.g. `openai_responses`, `openai_chat_completions`). |


### PR DESCRIPTION
## Summary

Regenerate filter docs so `on_invalid` fields use the `OnInvalidBehavior` type name instead of stale union literals.

## Related issue

N/A

## Validation

- `cargo xtask generate-filter-docs`
- `cargo xtask lint-filter-docs` (up to date)
- `make lint` (green after regenerate)

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Tests are added or updated when behavior changes.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.