### PR TITLE
fix(mcp): align stateless profile with final 2026 spec

### DIFF
--- a/docs/architecture/agentic-protocols.md
+++ b/docs/architecture/agentic-protocols.md
@@ -60,9 +60,10 @@ broker.
 
 From the JSON-RPC envelope, the filter extracts:
 
-- **Method**: 14 known MCP methods
+- **Method**: known MCP methods
   (`initialize`, `tools/list`, `tools/call`,
-  `resources/read`, `prompts/get`, `ping`, etc.)
+  `resources/read`, `prompts/get`, current/legacy
+  `ping`, etc.)
   plus `Other(String)` for extensions
 - **Name**: tool, resource, or prompt name from
   `params` (for methods like `tools/call`)
@@ -91,7 +92,7 @@ Client --> MCP Broker Filter
              |                negotiation
              +-- tools/list:  aggregated catalog
              |                from all servers
-             +-- ping:        local response
+             +-- ping:        local response (current profile only)
              +-- tools/call:  stateless routes by
              |                configured catalog tool
              |                current profile returns -32601

--- a/docs/filters/mcp.md
+++ b/docs/filters/mcp.md
@@ -5,7 +5,7 @@
 
 Extracts MCP protocol metadata from JSON-RPC request bodies and promotes method, tool/resource/prompt name, JSON-RPC kind, protocol version, and session presence to request headers/filter results; stores session ID in durable metadata.
 
-MCP static catalog filter that aggregates tool catalogs from multiple backend MCP servers and handles `initialize`, `tools/list`, `tools/call`, `ping`, and `notifications/initialized` as a static broker.
+MCP static catalog filter that aggregates tool catalogs from multiple backend MCP servers and handles `tools/list`, `tools/call`, and current-profile broker methods (`initialize`, `ping`, and `notifications/initialized`).
 
 ## Configuration Notes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ before sending requests.
 | [credential-injection.yaml](configs/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |
 | [json-rpc-routing.yaml](configs/json-rpc-routing.yaml) | Routes JSON-RPC 2.0 requests to different backends based on the "method" field in the JSON request body |
 | [mcp-classifier-routing.yaml](configs/mcp-classifier-routing.yaml) | Routes MCP requests by body-derived method and tool name |
-| [mcp-stateless-broker.yaml](configs/mcp-stateless-broker.yaml) | Configurable stateless MCP broker using the 2026-07-28 release candidate profile |
+| [mcp-stateless-broker.yaml](configs/mcp-stateless-broker.yaml) | Configurable stateless MCP broker using the final MCP 2026-07-28 stateless profile |
 | [model-to-header-routing.yaml](configs/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
 | [nemo-guardrails.yaml](configs/nemo-guardrails.yaml) | Evaluates all incoming requests against a NeMo Guardrails service before forwarding to the upstream provider |
 | [prompt-enrichment.yaml](configs/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |

--- a/examples/configs/mcp-stateless-broker.yaml
+++ b/examples/configs/mcp-stateless-broker.yaml
@@ -1,7 +1,7 @@
 # MCP Stateless Broker (2026-07-28 Profile)
 #
-# Configurable stateless MCP broker using the 2026-07-28
-# release candidate profile. No protocol sessions,
+# Configurable stateless MCP broker using the final
+# MCP 2026-07-28 stateless profile. No protocol sessions,
 # no initialize handshake. Clients use server/discover
 # for capability discovery and include
 # MCP-Protocol-Version, Mcp-Method, and Mcp-Name

--- a/filters/src/agentic/mcp/broker/mod.rs
+++ b/filters/src/agentic/mcp/broker/mod.rs
@@ -2,8 +2,8 @@
 // Copyright (c) 2026 Praxis Contributors
 
 //! MCP static catalog filter: static tool catalog, prefix management, broker
-//! behavior for `initialize`, `tools/list`, `ping`, `notifications`, and
-//! stateless-profile `tools/call` routing.
+//! behavior for `tools/list`, current-profile `initialize`, `ping`, and
+//! `notifications`, and stateless-profile `tools/call` routing.
 
 pub(crate) mod config;
 
@@ -72,8 +72,8 @@ const BASE64_SENTINEL_SUFFIX: &str = "?=";
 // -----------------------------------------------------------------------------
 
 /// MCP static catalog filter that aggregates tool catalogs from multiple backend
-/// MCP servers and handles `initialize`, `tools/list`, `tools/call`, `ping`,
-/// and `notifications/initialized` as a static broker.
+/// MCP servers and handles `tools/list`, `tools/call`, and current-profile
+/// broker methods (`initialize`, `ping`, and `notifications/initialized`).
 ///
 /// In the stateless profile, `tools/call` routes to the configured backend
 /// cluster by exposed tool name, stripping the public prefix from `params.name`
@@ -244,7 +244,6 @@ impl McpBrokerFilter {
             "server/discover" => self.handle_server_discover(envelope),
             "tools/list" => self.handle_stateless_tools_list(envelope),
             "tools/call" => self.handle_stateless_tools_call(ctx, value, envelope, body),
-            "ping" => handle_ping(envelope),
             "initialize" => json_rpc_error_action_with_status(
                 envelope,
                 404,

--- a/filters/src/agentic/mcp/broker/tests.rs
+++ b/filters/src/agentic/mcp/broker/tests.rs
@@ -1934,11 +1934,11 @@ async fn stateless_delete_returns_405() {
 #[tokio::test]
 async fn stateless_ignores_mcp_session_id_header() {
     let filter = make_stateless_broker_filter();
-    let mut req = make_stateless_mcp_request("ping", None);
+    let mut req = make_stateless_mcp_request("server/discover", None);
     req.headers
         .insert("mcp-session-id", "should-be-ignored".parse().unwrap());
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let mut body = Some(Bytes::from(stateless_body("ping", 1, None)));
+    let mut body = Some(Bytes::from(stateless_body("server/discover", 1, None)));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
@@ -1946,7 +1946,7 @@ async fn stateless_ignores_mcp_session_id_header() {
         FilterAction::Reject(rejection) => {
             assert_eq!(
                 rejection.status, 200,
-                "stateless ping should succeed even with session header"
+                "stateless server/discover should succeed even with session header"
             );
             assert!(
                 !rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
@@ -2244,6 +2244,98 @@ async fn stateless_notifications_initialized_returns_method_not_found() {
 }
 
 #[tokio::test]
+async fn stateless_ping_returns_method_not_found() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("ping", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 404, "stateless ping should return 404");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32601, "should return method not found");
+            assert_eq!(parsed["error"]["message"], "method not found");
+        },
+        _ => panic!("expected Reject with 404"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_ping_invalid_id_wins_before_method_not_found() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("ping", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = r#"{"jsonrpc":"2.0","id":1.5,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 200,
+                "invalid id should return a JSON-RPC error response"
+            );
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["error"]["code"], -32600,
+                "invalid id must win before stateless ping method-not-found"
+            );
+        },
+        _ => panic!("expected Reject with JSON-RPC error"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_logging_set_level_returns_method_not_found() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("logging/setLevel", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(stateless_body("logging/setLevel", 1, None)));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 404, "stateless logging/setLevel should return 404");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32601, "should return method not found");
+        },
+        _ => panic!("expected Reject with 404"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_notifications_roots_list_changed_returns_method_not_found() {
+    let filter = make_stateless_broker_filter();
+    let req = make_stateless_mcp_request("notifications/roots/list_changed", None);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_notification_body("notifications/roots/list_changed");
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(
+                rejection.status, 404,
+                "stateless notifications/roots/list_changed should return 404"
+            );
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(parsed["error"]["code"], -32601, "should return method not found");
+        },
+        _ => panic!("expected Reject with 404"),
+    }
+}
+
+#[tokio::test]
 async fn stateless_notification_missing_mcp_method_rejected() {
     let filter = make_stateless_broker_filter();
     let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
@@ -2321,9 +2413,9 @@ async fn string_json_rpc_id_with_quotes_preserved_in_stateless_error() {
 #[tokio::test]
 async fn stateless_missing_client_info_rejected() {
     let filter = make_stateless_broker_filter();
-    let req = make_stateless_mcp_request("ping", None);
+    let req = make_stateless_mcp_request("tools/list", None);
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
     let mut body = Some(Bytes::from(body_str));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
@@ -2342,9 +2434,9 @@ async fn stateless_missing_client_info_rejected() {
 #[tokio::test]
 async fn stateless_null_client_info_rejected() {
     let filter = make_stateless_broker_filter();
-    let req = make_stateless_mcp_request("ping", None);
+    let req = make_stateless_mcp_request("tools/list", None);
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":null,"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":null,"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
     let mut body = Some(Bytes::from(body_str));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
@@ -2363,9 +2455,9 @@ async fn stateless_null_client_info_rejected() {
 #[tokio::test]
 async fn stateless_string_client_info_rejected() {
     let filter = make_stateless_broker_filter();
-    let req = make_stateless_mcp_request("ping", None);
+    let req = make_stateless_mcp_request("tools/list", None);
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":"not-an-object","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":"not-an-object","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
     let mut body = Some(Bytes::from(body_str));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
@@ -2384,9 +2476,9 @@ async fn stateless_string_client_info_rejected() {
 #[tokio::test]
 async fn stateless_client_info_missing_name_rejected() {
     let filter = make_stateless_broker_filter();
-    let req = make_stateless_mcp_request("ping", None);
+    let req = make_stateless_mcp_request("tools/list", None);
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
     let mut body = Some(Bytes::from(body_str));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
@@ -2405,9 +2497,9 @@ async fn stateless_client_info_missing_name_rejected() {
 #[tokio::test]
 async fn stateless_client_info_missing_version_rejected() {
     let filter = make_stateless_broker_filter();
-    let req = make_stateless_mcp_request("ping", None);
+    let req = make_stateless_mcp_request("tools/list", None);
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
     let mut body = Some(Bytes::from(body_str));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
@@ -2426,9 +2518,9 @@ async fn stateless_client_info_missing_version_rejected() {
 #[tokio::test]
 async fn stateless_array_client_capabilities_rejected() {
     let filter = make_stateless_broker_filter();
-    let req = make_stateless_mcp_request("ping", None);
+    let req = make_stateless_mcp_request("tools/list", None);
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":["not","an","object"]}}}"#;
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":["not","an","object"]}}}"#;
     let mut body = Some(Bytes::from(body_str));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
@@ -2754,6 +2846,31 @@ async fn stateless_header_body_mismatch_still_returns_32020() {
             assert_eq!(
                 parsed["error"]["code"], ERR_HEADER_MISMATCH,
                 "header/body mismatch must return -32020, not -32602"
+            );
+        },
+        _ => panic!("expected Reject with 400"),
+    }
+}
+
+#[tokio::test]
+async fn stateless_tools_call_malformed_params_win_before_header_mismatch() {
+    let filter = make_stateless_broker_filter();
+    let mut req = make_stateless_mcp_request("tools/call", Some("wrong_name"));
+    req.headers.insert("mcp-method", "tools/call".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let body_str = stateless_body_with_params("tools/call", 1, r#""arguments":{}"#);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match &action {
+        FilterAction::Reject(rejection) => {
+            assert_eq!(rejection.status, 400, "malformed params should return 400");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["error"]["code"], ERR_INVALID_PARAMS,
+                "malformed params must win before tools/call header mismatch"
             );
         },
         _ => panic!("expected Reject with 400"),

--- a/filters/src/agentic/mcp/protocol.rs
+++ b/filters/src/agentic/mcp/protocol.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 /// Protocol version implemented by the current broker behavior.
 pub(crate) const PROTOCOL_VERSION_CURRENT: &str = "2025-03-26";
 
-/// Protocol version for the MCP 2026-07-28 stateless profile (release candidate).
+/// Protocol version for the final MCP 2026-07-28 stateless profile.
 pub(crate) const PROTOCOL_VERSION_STATELESS_2026_07_28: &str = "2026-07-28";
 
 /// Protocol versions supported by the current profile.

--- a/tests/integration/tests/suite/mcp_broker.rs
+++ b/tests/integration/tests/suite/mcp_broker.rs
@@ -641,7 +641,7 @@ fn mcp_stateless_missing_mcp_method_rejects_with_400_32020() {
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
-    let body_str = stateless_rpc_body(4, "ping", None);
+    let body_str = stateless_rpc_body(4, "tools/list", None);
     let request = format!(
         "POST /mcp HTTP/1.1\r\n\
          Host: localhost\r\n\
@@ -689,6 +689,29 @@ fn mcp_stateless_notifications_initialized_rejects_with_404_32601() {
 }
 
 #[test]
+fn mcp_stateless_ping_returns_method_not_found() {
+    let backend_guard = start_backend_with_shutdown("not-reachable-backend");
+    let proxy_port = free_port();
+
+    let yaml = stateless_broker_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body_str = stateless_rpc_body(10, "ping", None);
+    let request = stateless_post("/mcp", &body_str, "ping", None);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 404, "stateless ping should return 404");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["error"]["code"], -32601, "should return method not found");
+    assert!(
+        !body.contains("not-reachable-backend"),
+        "stateless ping must not hit backend"
+    );
+}
+
+#[test]
 fn mcp_stateless_unsupported_version_rejects_with_400_32022() {
     let backend_guard = start_backend_with_shutdown("not-reachable-backend");
     let proxy_port = free_port();
@@ -697,14 +720,14 @@ fn mcp_stateless_unsupported_version_rejects_with_400_32022() {
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
-    let body_str = stateless_rpc_body_with_version(5, "ping", "9999-12-31");
+    let body_str = stateless_rpc_body_with_version(5, "tools/list", "9999-12-31");
     let request = format!(
         "POST /mcp HTTP/1.1\r\n\
          Host: localhost\r\n\
          Content-Type: application/json\r\n\
          Content-Length: {}\r\n\
          MCP-Protocol-Version: 9999-12-31\r\n\
-         Mcp-Method: ping\r\n\
+         Mcp-Method: tools/list\r\n\
          Connection: close\r\n\
          \r\n\
          {body_str}",
@@ -738,8 +761,8 @@ fn mcp_stateless_malformed_client_info_rejected() {
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
-    let body_str = r#"{"jsonrpc":"2.0","id":6,"method":"ping","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":"not-an-object","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
-    let request = stateless_post("/mcp", body_str, "ping", None);
+    let body_str = r#"{"jsonrpc":"2.0","id":6,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":"not-an-object","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let request = stateless_post("/mcp", body_str, "tools/list", None);
     let raw = http_send(proxy.addr(), &request);
 
     assert_eq!(parse_status(&raw), 400, "malformed clientInfo should return 400");


### PR DESCRIPTION
## Summary

  Aligns the explicit MCP stateless broker profile with the final MCP `2026-07-28` method set.

  This removes local `ping` handling only from the `stateless` broker path. The `current` compatibility profile and classifier/pass-through recognition are intentionally preserved.

  ## Background

  The earlier stateless-profile work was split to keep PR size manageable: it landed the profile, `server/discover`, stateless validation, and `tools/list` first. The broker already had a local `ping` handler from  existing current-profile behavior, and early stateless tests used `ping`  as a simple valid request while method-set cleanup was deferred.

  Now that stateless `tools/call` routing has merged, this PR closes that deferred conformance gap.

  ## Changes

  - Removes stateless broker success handling for `ping`.
  - Keeps current-profile `ping` behavior unchanged.
  - Keeps current-profile `initialize`, `notifications/initialized`, session header, and `DELETE` behavior unchanged.
  - Preserves `McpMethod::Ping` recognition for classifier/current/legacy observability.
  - Verifies removed stateless methods return method-not-found behavior:
    - `ping`
    - `logging/setLevel`
    - `notifications/roots/list_changed`
  - Replaces generic valid stateless test requests that used `ping` with final-spec methods such as `tools/list` or `server/discover`.
  - Adds validation-precedence regression coverage:
    - invalid request IDs win before stateless `ping` method-not-found
    - malformed `tools/call` params win before header mismatch
  - Updates docs and examples to remove stale release-candidate wording and clarify that `ping` is current-profile behavior only.

  ## Scope

  This is a conformance cleanup PR, not a feature expansion.

  Out of scope:

  - `Mcp-Param-*` / `x-mcp-header`
  - `subscriptions/listen`
  - dynamic catalog discovery
  - resource/prompt routing
  - MRTR / `input_required`
  - Redis/Valkey
  - legacy backend session compatibility
  - A2A changes

  ## Validation

  - `cargo test -p praxis-ai-filters mcp` — 268 passed
  - `cargo test -p praxis-tests-integration --test suite mcp_broker` — 31 passed
  - `cargo test -p praxis-tests-schema` — 90 passed
  - `cargo clippy --workspace --all-targets -- -D warnings` — clean
  - `cargo +nightly fmt --all --check` — clean
  - `cargo xtask lint-filter-docs` — clean
  - `cargo xtask lint-example-tests` — clean
  - `cargo xtask sync-example-readme` — clean
  - `git diff --check` — clean
  - `make lint` — clean

  `make test` ran the full suite but hit one unrelated SQLite concurrency flake:

  `store::tests::concurrent_upserts_do_not_lose_data`

  The failure is `database is locked` in `apis/src/store/tests.rs`, outside
  the MCP broker/filter code touched by this PR. MCP-specific unit and
  integration tests passed.