### PR TITLE
fix(openai_conversations): stream by default, buffer only matched routes

### DIFF
--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -302,15 +302,11 @@ impl HttpFilter for OpenaiConversationsFilter {
     }
 
     fn request_body_mode(&self) -> BodyMode {
-        BodyMode::StreamBuffer {
-            max_bytes: Some(MAX_JSON_BODY_BYTES),
-        }
+        BodyMode::Stream
     }
 
     fn response_body_mode(&self) -> BodyMode {
-        BodyMode::StreamBuffer {
-            max_bytes: Some(MAX_JSON_BODY_BYTES),
-        }
+        BodyMode::Stream
     }
 
     fn needs_request_context(&self) -> bool {
@@ -442,6 +438,9 @@ impl HttpFilter for OpenaiConversationsFilter {
         ctx.insert_filter_state(ConversationResponseState { armed });
 
         if armed {
+            ctx.set_response_body_mode(BodyMode::StreamBuffer {
+                max_bytes: Some(MAX_JSON_BODY_BYTES),
+            });
             drop(self.get_or_init_store().await);
         }
 

--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -302,7 +302,9 @@ impl HttpFilter for OpenaiConversationsFilter {
     }
 
     fn request_body_mode(&self) -> BodyMode {
-        BodyMode::Stream
+        BodyMode::StreamBuffer {
+            max_bytes: Some(MAX_JSON_BODY_BYTES),
+        }
     }
 
     fn response_body_mode(&self) -> BodyMode {

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1256,14 +1256,11 @@ async fn unmatched_path_continues() {
 }
 
 #[tokio::test]
-async fn post_routes_use_stream_buffer_body_mode() {
+async fn post_routes_upgrade_to_stream_buffer_body_mode() {
     let filter = build_test_filter();
     assert!(
-        matches!(
-            filter.request_body_mode(),
-            BodyMode::StreamBuffer { max_bytes: Some(_) }
-        ),
-        "conversation POST routes require buffered bodies for local handling"
+        matches!(filter.request_body_mode(), BodyMode::Stream),
+        "default body mode should be Stream to avoid buffering unrelated requests"
     );
 
     let req = make_request(Method::POST, "/v1/conversations");
@@ -1274,25 +1271,23 @@ async fn post_routes_use_stream_buffer_body_mode() {
     assert!(matches!(action, FilterAction::Continue));
     assert!(
         matches!(ctx.request_body_mode, BodyMode::StreamBuffer { max_bytes: Some(_) }),
-        "matched POST should keep buffering enabled for request-body handling"
+        "matched POST should upgrade to StreamBuffer for request-body handling"
     );
 }
 
 #[tokio::test]
-async fn unmatched_post_path_continues() {
+async fn unmatched_post_path_stays_streaming() {
     let filter = build_test_filter();
 
     let req = make_request(Method::POST, "/v1/chat/completions");
     let mut ctx = make_filter_context(&req);
+    ctx.request_body_mode = filter.request_body_mode();
     let action = filter.on_request(&mut ctx).await.unwrap();
 
     assert!(matches!(action, FilterAction::Continue));
     assert!(
-        matches!(
-            filter.request_body_mode(),
-            BodyMode::StreamBuffer { max_bytes: Some(_) }
-        ),
-        "body mode declaration is static; unmatched path handling remains a local Continue"
+        matches!(ctx.request_body_mode, BodyMode::Stream),
+        "unmatched path should not upgrade body mode"
     );
 }
 

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -3034,6 +3034,7 @@ async fn on_response_armed_for_json_200() {
     let req = make_request(Method::POST, "/v1/responses");
     let mut ctx = make_filter_context(&req);
     ctx.current_filter_id = Some(0);
+    ctx.response_body_mode = filter.response_body_mode();
     set_append_back_metadata(&mut ctx);
 
     let mut resp = make_response();
@@ -3043,6 +3044,26 @@ async fn on_response_armed_for_json_200() {
 
     let action = filter.on_response(&mut ctx).await.unwrap();
     assert!(matches!(action, FilterAction::Continue));
+    assert!(
+        matches!(ctx.response_body_mode, BodyMode::StreamBuffer { max_bytes: Some(_) }),
+        "armed append-back should upgrade response body mode to StreamBuffer"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_response_unarmed_keeps_stream_body_mode() {
+    let filter = build_test_filter();
+    let req = make_request(Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    ctx.current_filter_id = Some(0);
+    ctx.response_body_mode = filter.response_body_mode();
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert!(
+        matches!(ctx.response_body_mode, BodyMode::Stream),
+        "unarmed response should keep default Stream body mode"
+    );
 }
 
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1256,11 +1256,14 @@ async fn unmatched_path_continues() {
 }
 
 #[tokio::test]
-async fn post_routes_upgrade_to_stream_buffer_body_mode() {
+async fn post_routes_use_stream_buffer_request_body_mode() {
     let filter = build_test_filter();
     assert!(
-        matches!(filter.request_body_mode(), BodyMode::Stream),
-        "default body mode should be Stream to avoid buffering unrelated requests"
+        matches!(
+            filter.request_body_mode(),
+            BodyMode::StreamBuffer { max_bytes: Some(_) }
+        ),
+        "request body mode must be StreamBuffer so the pipeline pre-reads the body for local handling"
     );
 
     let req = make_request(Method::POST, "/v1/conversations");
@@ -1271,24 +1274,28 @@ async fn post_routes_upgrade_to_stream_buffer_body_mode() {
     assert!(matches!(action, FilterAction::Continue));
     assert!(
         matches!(ctx.request_body_mode, BodyMode::StreamBuffer { max_bytes: Some(_) }),
-        "matched POST should upgrade to StreamBuffer for request-body handling"
+        "matched POST should keep buffering enabled for request-body handling"
     );
 }
 
 #[tokio::test]
-async fn unmatched_post_path_stays_streaming() {
+async fn response_body_mode_defaults_to_stream() {
+    let filter = build_test_filter();
+    assert!(
+        matches!(filter.response_body_mode(), BodyMode::Stream),
+        "response body mode should default to Stream to avoid buffering unrelated responses"
+    );
+}
+
+#[tokio::test]
+async fn unmatched_post_path_continues() {
     let filter = build_test_filter();
 
     let req = make_request(Method::POST, "/v1/chat/completions");
     let mut ctx = make_filter_context(&req);
-    ctx.request_body_mode = filter.request_body_mode();
     let action = filter.on_request(&mut ctx).await.unwrap();
 
     assert!(matches!(action, FilterAction::Continue));
-    assert!(
-        matches!(ctx.request_body_mode, BodyMode::Stream),
-        "unmatched path should not upgrade body mode"
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

 - Default `response_body_mode` to `BodyMode::Stream` instead of `StreamBuffer`, so unrelated responses pass through without buffering
- Upgrade to bounded `StreamBuffer` in `on_response` only when conversation append-back is armed
- Update tests to assert the new dynamic upgrade behavior

Closes #411

## Test plan

- [x] `cargo check -p praxis-ai-apis` compiles cleanly
- [x] All 147 `conversations::tests` pass
- [ ] CI green