### PR TITLE
feat(server): wire SubRequestClient into pipeline resolution

### DIFF
--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -35,7 +35,14 @@ pub(crate) fn validate_config_for_startup(config: &Config) -> Result<(), Box<dyn
     let registry = praxis_ai::build_full_registry();
     let health_registry = praxis_core::health::build_health_registry(&config.clusters);
     let kv_stores = praxis_core::kv::KvStoreRegistry::new();
-    praxis_ai::resolve_pipelines(config, &registry, &health_registry, &kv_stores)?;
+    let pool_size = config
+        .runtime
+        .subrequest_pool_size
+        .unwrap_or(praxis_core::config::DEFAULT_SUBREQUEST_POOL_SIZE);
+    let subrequest_client = praxis_core::subrequest::SubRequestClient::new(
+        praxis_core::subrequest::SubRequestConnector::new(pool_size, config.runtime.subrequest_max_connections),
+    );
+    praxis_ai::resolve_pipelines(config, &registry, &health_registry, &kv_stores, &subrequest_client)?;
     Ok(())
 }
 

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -27,6 +27,7 @@ pub fn resolve_pipelines(
     registry: &FilterRegistry,
     health_registry: &praxis_core::health::HealthRegistry,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
+    subrequest_client: &praxis_core::subrequest::SubRequestClient,
 ) -> Result<ListenerPipelines, Box<dyn std::error::Error + Send + Sync>> {
     let chains: HashMap<&str, &[_]> = config
         .filter_chains
@@ -47,7 +48,7 @@ pub fn resolve_pipelines(
         }
 
         let mut pipeline = FilterPipeline::build_with_chains(&mut entries, registry, &chains)?;
-        configure_pipeline(&mut pipeline, config, health_registry, kv_stores)?;
+        configure_pipeline(&mut pipeline, config, health_registry, kv_stores, subrequest_client)?;
 
         validate_pipeline(&pipeline, &entries, &listener.name, &config.insecure_options)?;
 
@@ -64,6 +65,7 @@ fn configure_pipeline(
     config: &Config,
     health_registry: &praxis_core::health::HealthRegistry,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
+    subrequest_client: &praxis_core::subrequest::SubRequestClient,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     pipeline.apply_body_limits(
         config.body_limits.max_request_bytes,
@@ -77,6 +79,7 @@ fn configure_pipeline(
         pipeline.set_kv_stores(kv_stores.clone());
     }
     pipeline.add_pipeline_extension(Box::new(praxis_ai_apis::store::ResponseStoreRegistry::new()));
+    pipeline.set_subrequest_client(subrequest_client.clone());
     pipeline.apply_insecure_options(&config.insecure_options);
     Ok(())
 }
@@ -145,7 +148,14 @@ mod tests {
     fn resolve_pipelines_builds_for_each_listener() {
         let config = valid_config();
         let registry = FilterRegistry::with_builtins();
-        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores()).unwrap();
+        let pipelines = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        )
+        .unwrap();
         assert!(
             pipelines.get("web").is_some(),
             "pipeline should exist for 'web' listener"
@@ -188,7 +198,14 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores()).unwrap();
+        let pipelines = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        )
+        .unwrap();
         let pipeline = pipelines.get("web").unwrap().load();
         assert!(
             pipeline.is_empty(),
@@ -222,7 +239,14 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores()).unwrap();
+        let pipelines = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        )
+        .unwrap();
         let pipeline = pipelines.get("web").unwrap().load();
         assert_eq!(pipeline.len(), 3, "two chains should produce 3 filters total");
     }
@@ -253,7 +277,14 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores()).unwrap();
+        let pipelines = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        )
+        .unwrap();
         let pipeline = pipelines.get("web").unwrap().load();
         let caps = pipeline.body_capabilities();
         assert!(caps.needs_request_body, "body limits should enable request body access");
@@ -292,7 +323,13 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let result = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores());
+        let result = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        );
         assert!(result.is_ok(), "router without LB should be a warning, not an error");
     }
 
@@ -317,7 +354,13 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let result = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores());
+        let result = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        );
         assert!(result.is_ok(), "skip_pipeline_validation should allow startup");
     }
 
@@ -344,7 +387,13 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let result = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores());
+        let result = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        );
         assert!(result.is_err(), "misaligned clusters should fail validation");
         let err = result.err().unwrap().to_string();
         assert!(
@@ -379,7 +428,13 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let result = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores());
+        let result = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        );
         assert!(result.is_err(), "open security filter should fail validation");
         let err = result.err().unwrap().to_string();
         assert!(
@@ -416,7 +471,13 @@ filter_chains:
         )
         .unwrap();
         let registry = FilterRegistry::with_builtins();
-        let result = resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores());
+        let result = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &test_client(),
+        );
         assert!(result.is_ok(), "allow_open_security_filters should permit open ip_acl");
     }
 
@@ -425,7 +486,7 @@ filter_chains:
         let config = valid_config();
         let registry = FilterRegistry::with_builtins();
         let kv = make_kv_registry();
-        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &kv).unwrap();
+        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &kv, &test_client()).unwrap();
         let pipeline = pipelines.get("web").unwrap().load();
         assert!(pipeline.kv_stores().is_some(), "pipeline should have kv_stores set");
     }
@@ -435,7 +496,7 @@ filter_chains:
         let config = valid_config();
         let registry = FilterRegistry::with_builtins();
         let kv = empty_kv_stores();
-        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &kv).unwrap();
+        let pipelines = resolve_pipelines(&config, &registry, &empty_health_registry(), &kv, &test_client()).unwrap();
         let pipeline = pipelines.get("web").unwrap().load();
         assert!(
             pipeline.kv_stores().is_none(),
@@ -455,6 +516,11 @@ filter_chains:
     /// Empty KV store registry for tests without KV stores.
     fn empty_kv_stores() -> praxis_core::kv::KvStoreRegistry {
         praxis_core::kv::KvStoreRegistry::new()
+    }
+
+    /// Minimal sub-request client for tests.
+    fn test_client() -> praxis_core::subrequest::SubRequestClient {
+        praxis_core::subrequest::SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(8, None))
     }
 
     /// KV store registry with one test store.

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -509,9 +509,14 @@ filter_chains:
         let config = valid_config();
         let registry = FilterRegistry::with_builtins();
         let client = test_client();
-        let pipelines =
-            resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores(), &client)
-                .unwrap();
+        let pipelines = resolve_pipelines(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &client,
+        )
+        .unwrap();
         let pipeline = pipelines.get("web").unwrap().load();
         assert!(
             pipeline.subrequest_client().is_some(),

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -504,6 +504,21 @@ filter_chains:
         );
     }
 
+    #[test]
+    fn resolve_pipelines_threads_subrequest_client() {
+        let config = valid_config();
+        let registry = FilterRegistry::with_builtins();
+        let client = test_client();
+        let pipelines =
+            resolve_pipelines(&config, &registry, &empty_health_registry(), &empty_kv_stores(), &client)
+                .unwrap();
+        let pipeline = pipelines.get("web").unwrap().load();
+        assert!(
+            pipeline.subrequest_client().is_some(),
+            "pipeline should have subrequest_client set after resolve_pipelines",
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------

--- a/server/src/reload.rs
+++ b/server/src/reload.rs
@@ -44,6 +44,7 @@ pub(crate) fn reload_pipelines(
     live: &ListenerPipelines,
     health_shutdown: &Arc<Mutex<CancellationToken>>,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
+    subrequest_client: &praxis_core::subrequest::SubRequestClient,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("building new pipelines from reloaded config");
 
@@ -54,7 +55,7 @@ pub(crate) fn reload_pipelines(
 
     let health_registry = build_health_registry(&new_config.clusters);
 
-    let new_pipelines = match resolve_pipelines(new_config, registry, &health_registry, kv_stores) {
+    let new_pipelines = match resolve_pipelines(new_config, registry, &health_registry, kv_stores, subrequest_client) {
         Ok(p) => p,
         Err(e) => {
             error!(error = %e, "config reload failed: pipeline build error");
@@ -142,6 +143,7 @@ fn log_restart_required_changes(old: &Config, new: &Config) {
     detect_protocol_changes(old, new);
     detect_compression_additions(old, new);
     detect_tls_toggles(old, new);
+    detect_subrequest_connector_changes(old, new);
 }
 
 /// Detect listener additions, removals, and address rebinds.
@@ -253,6 +255,24 @@ fn detect_tls_toggles(old: &Config, new: &Config) {
     }
 }
 
+/// Detect changes to sub-request connector parameters.
+fn detect_subrequest_connector_changes(old: &Config, new: &Config) {
+    if old.runtime.subrequest_pool_size != new.runtime.subrequest_pool_size {
+        warn!(
+            old_pool_size = ?old.runtime.subrequest_pool_size,
+            new_pool_size = ?new.runtime.subrequest_pool_size,
+            "subrequest pool size changed; requires restart"
+        );
+    }
+    if old.runtime.subrequest_max_connections != new.runtime.subrequest_max_connections {
+        warn!(
+            old_max = ?old.runtime.subrequest_max_connections,
+            new_max = ?new.runtime.subrequest_max_connections,
+            "subrequest max connections changed; requires restart"
+        );
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Stateful Filter Warnings
 // -----------------------------------------------------------------------------
@@ -312,6 +332,7 @@ mod tests {
             &live,
             &shutdown,
             &empty_kv_stores(),
+            &test_client(),
         );
 
         assert!(result.is_ok(), "valid reload should succeed");
@@ -345,6 +366,7 @@ filter_chains:
             &live,
             &shutdown,
             &empty_kv_stores(),
+            &test_client(),
         );
         assert!(result.is_err(), "invalid filter should return Err");
 
@@ -365,6 +387,7 @@ filter_chains:
             &live,
             &shutdown,
             &empty_kv_stores(),
+            &test_client(),
         )
         .unwrap();
 
@@ -387,6 +410,7 @@ filter_chains:
             &live,
             &shutdown,
             &empty_kv_stores(),
+            &test_client(),
         )
         .unwrap();
 
@@ -424,6 +448,7 @@ filter_chains:
             &live,
             &shutdown,
             &empty_kv_stores(),
+            &test_client(),
         );
         assert!(
             !old_token.is_cancelled(),
@@ -460,6 +485,7 @@ filter_chains:
             &live,
             &shutdown,
             &empty_kv_stores(),
+            &test_client(),
         );
         assert!(result.is_ok(), "reload with new listener should succeed");
         assert!(
@@ -591,6 +617,16 @@ filter_chains:
         log_restart_required_changes(&old, &new);
     }
 
+    #[test]
+    fn subrequest_connector_change_detected() {
+        let old = valid_config();
+        let mut new = valid_config();
+        new.runtime.subrequest_pool_size = Some(32);
+        new.runtime.subrequest_max_connections = Some(256);
+
+        log_restart_required_changes(&old, &new);
+    }
+
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
@@ -618,7 +654,8 @@ filter_chains:
         let config = valid_config();
         let registry = FilterRegistry::with_builtins();
         let health_registry: HealthRegistry = Arc::new(HashMap::new());
-        let pipelines = resolve_pipelines(&config, &registry, &health_registry, &empty_kv_stores()).unwrap();
+        let pipelines =
+            resolve_pipelines(&config, &registry, &health_registry, &empty_kv_stores(), &test_client()).unwrap();
         let shutdown = Arc::new(Mutex::new(CancellationToken::new()));
         (pipelines, config, registry, shutdown)
     }
@@ -626,5 +663,10 @@ filter_chains:
     /// Empty KV store registry for tests without KV stores.
     fn empty_kv_stores() -> praxis_core::kv::KvStoreRegistry {
         praxis_core::kv::KvStoreRegistry::new()
+    }
+
+    /// Minimal sub-request client for tests.
+    fn test_client() -> praxis_core::subrequest::SubRequestClient {
+        praxis_core::subrequest::SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(8, None))
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -104,6 +104,8 @@ struct ServerState {
     pipelines: Arc<ListenerPipelines>,
     /// KV store registry.
     kv_stores: praxis_core::kv::KvStoreRegistry,
+    /// Shared sub-request client for filters and `iterative_request_router` step chains.
+    subrequest_client: praxis_core::subrequest::SubRequestClient,
     /// Health check cancellation token.
     health_shutdown: Arc<Mutex<CancellationToken>>,
 }
@@ -113,7 +115,16 @@ fn build_server_state(config: &Config, registry: &FilterRegistry, health_registr
     info!("building filter pipelines");
     let kv_stores = praxis_core::kv::KvStoreRegistry::new();
 
-    let pipelines = resolve_pipelines(config, registry, health_registry, &kv_stores).unwrap_or_else(|e| fatal(&e));
+    let pool_size = config
+        .runtime
+        .subrequest_pool_size
+        .unwrap_or(praxis_core::config::DEFAULT_SUBREQUEST_POOL_SIZE);
+    let subrequest_client = praxis_core::subrequest::SubRequestClient::new(
+        praxis_core::subrequest::SubRequestConnector::new(pool_size, config.runtime.subrequest_max_connections),
+    );
+
+    let pipelines = resolve_pipelines(config, registry, health_registry, &kv_stores, &subrequest_client)
+        .unwrap_or_else(|e| fatal(&e));
 
     let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
     spawn_health_check_tasks(config, Arc::clone(health_registry), &health_shutdown);
@@ -121,6 +132,7 @@ fn build_server_state(config: &Config, registry: &FilterRegistry, health_registr
     ServerState {
         pipelines: Arc::new(pipelines),
         kv_stores,
+        subrequest_client,
         health_shutdown,
     }
 }
@@ -170,6 +182,7 @@ fn spawn_watcher(
         pipelines: state.pipelines,
         registry: Arc::new(registry),
         shutdown: CancellationToken::new(),
+        subrequest_client: state.subrequest_client,
     });
     Some(handle)
 }

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -61,6 +61,9 @@ pub(crate) struct WatcherParams {
 
     /// Token for clean watcher shutdown.
     pub(crate) shutdown: CancellationToken,
+
+    /// Shared sub-request client, preserved across reloads.
+    pub(crate) subrequest_client: praxis_core::subrequest::SubRequestClient,
 }
 
 // -----------------------------------------------------------------------------
@@ -121,6 +124,7 @@ async fn run_event_loop(rx: &mut mpsc::Receiver<()>, params: &WatcherParams) {
                     &params.pipelines,
                     &params.health_shutdown,
                     &params.kv_stores,
+                    &params.subrequest_client,
                 );
             }
             () = params.shutdown.cancelled() => {
@@ -144,6 +148,7 @@ fn handle_reload(
     pipelines: &ListenerPipelines,
     health_shutdown: &Arc<Mutex<CancellationToken>>,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
+    subrequest_client: &praxis_core::subrequest::SubRequestClient,
 ) {
     let content = match std::fs::read_to_string(config_path) {
         Ok(c) => c,
@@ -176,6 +181,7 @@ fn handle_reload(
         pipelines,
         health_shutdown,
         kv_stores,
+        subrequest_client,
     ) {
         Ok(()) => {
             *current_config = new_config;
@@ -289,8 +295,10 @@ mod tests {
         let registry = Arc::new(FilterRegistry::with_builtins());
         let health_registry = Arc::new(std::collections::HashMap::new());
         let kv_stores = praxis_core::kv::KvStoreRegistry::new();
-        let pipelines =
-            Arc::new(crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores).unwrap());
+        let pipelines = Arc::new(
+            crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores, &test_client())
+                .unwrap(),
+        );
         let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
         let shutdown = CancellationToken::new();
 
@@ -302,6 +310,7 @@ mod tests {
             pipelines,
             registry,
             shutdown: shutdown.clone(),
+            subrequest_client: test_client(),
         });
 
         std::thread::sleep(Duration::from_millis(100));
@@ -320,8 +329,10 @@ mod tests {
         let registry = Arc::new(FilterRegistry::with_builtins());
         let health_registry = Arc::new(std::collections::HashMap::new());
         let kv_stores = praxis_core::kv::KvStoreRegistry::new();
-        let pipelines =
-            Arc::new(crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores).unwrap());
+        let pipelines = Arc::new(
+            crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores, &test_client())
+                .unwrap(),
+        );
         let old_ptr = Arc::as_ptr(&pipelines.get("web").unwrap().load());
         let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
         let shutdown = CancellationToken::new();
@@ -334,6 +345,7 @@ mod tests {
             pipelines: Arc::clone(&pipelines),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
+            subrequest_client: test_client(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));
@@ -360,8 +372,10 @@ mod tests {
         let registry = Arc::new(FilterRegistry::with_builtins());
         let health_registry = Arc::new(std::collections::HashMap::new());
         let kv_stores = praxis_core::kv::KvStoreRegistry::new();
-        let pipelines =
-            Arc::new(crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores).unwrap());
+        let pipelines = Arc::new(
+            crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores, &test_client())
+                .unwrap(),
+        );
         let old_ptr = Arc::as_ptr(&pipelines.get("web").unwrap().load());
         let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
         let shutdown = CancellationToken::new();
@@ -374,6 +388,7 @@ mod tests {
             pipelines: Arc::clone(&pipelines),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
+            subrequest_client: test_client(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));
@@ -430,8 +445,10 @@ mod tests {
         let registry = Arc::new(FilterRegistry::with_builtins());
         let health_registry = Arc::new(std::collections::HashMap::new());
         let kv_stores = praxis_core::kv::KvStoreRegistry::new();
-        let pipelines =
-            Arc::new(crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores).unwrap());
+        let pipelines = Arc::new(
+            crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores, &test_client())
+                .unwrap(),
+        );
         let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
         let shutdown = CancellationToken::new();
 
@@ -443,6 +460,7 @@ mod tests {
             pipelines,
             registry,
             shutdown: shutdown.clone(),
+            subrequest_client: test_client(),
         });
 
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
@@ -491,6 +509,11 @@ mod tests {
         fn drop(&mut self) {
             std::env::set_current_dir(&self.0).expect("failed to restore working directory");
         }
+    }
+
+    /// Minimal sub-request client for tests.
+    fn test_client() -> praxis_core::subrequest::SubRequestClient {
+        praxis_core::subrequest::SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(8, None))
     }
 
     /// Valid YAML config for watcher tests.


### PR DESCRIPTION
## Summary

PR #610 refactored sub-request code to use praxis-core's `SubRequestClient` but only updated the filter-side consumers. This change closes the gap by wiring the producer side: creating a `SubRequestClient` at server startup (from `runtime.subrequest_pool_size` and `runtime.subrequest_max_connections` config), passing it through `resolve_pipelines` → `configure_pipeline` → `pipeline.set_subrequest_client(...)`, and threading it into `reload_pipelines` and the config watcher so it survives hot reloads. A restart-required warning is emitted when sub-request connector parameters change at reload time.

## Related issue

Closes the wiring gap left by #610.

## Validation

```
cargo test -p praxis-ai-proxy -- resolve_pipelines_threads_subrequest_client
test pipelines::tests::resolve_pipelines_threads_subrequest_client ... ok
```

All existing tests in `pipelines`, `reload`, and `watcher` modules updated and passing.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

`resolve_pipelines` now takes an additional `&SubRequestClient` parameter. Callers must provide one.