### PR TITLE
fix(conversations): align create and update request contracts

### DIFF
--- a/apis/src/openai/conversations/contracts.rs
+++ b/apis/src/openai/conversations/contracts.rs
@@ -11,8 +11,8 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use utoipa::{
-    ToSchema,
-    openapi::schema::{Object, ObjectBuilder, Type},
+    PartialSchema, ToSchema,
+    openapi::schema::{AnyOfBuilder, ArrayBuilder, Object, ObjectBuilder, Schema, Type},
 };
 
 /// Maximum number of items accepted by create operations.
@@ -106,24 +106,23 @@ impl IncludeFields {
 }
 
 /// Request body accepted by `POST /conversations`.
-#[derive(Debug, Deserialize, ToSchema)]
+#[derive(Debug, Default, Deserialize, ToSchema)]
 pub(super) struct CreateConversationRequest {
     /// Optional metadata map. Missing and null both produce empty metadata.
+    #[schema(schema_with = nullable_metadata_schema)]
     pub(super) metadata: Option<Metadata>,
 
-    /// Optional initial items to add to the conversation.
-    #[serde(default)]
-    #[schema(max_items = 20)]
-    pub(super) items: Vec<ConversationItem>,
+    /// Optional nullable initial items to add to the conversation.
+    #[schema(schema_with = nullable_initial_items_schema)]
+    pub(super) items: Option<Vec<ConversationItem>>,
 }
 
 /// Request body accepted by `POST /conversations/{conversation_id}`.
 #[derive(Debug, Deserialize, ToSchema)]
 pub(super) struct UpdateConversationRequest {
-    /// Optional metadata replacement. Null clears existing metadata.
-    #[serde(default)]
-    #[schema(value_type = Option<Metadata>)]
-    pub(super) metadata: MetadataUpdate,
+    /// Required metadata replacement.
+    #[serde(deserialize_with = "deserialize_metadata_object")]
+    pub(super) metadata: Metadata,
 }
 
 /// Request body accepted by `POST /conversations/{conversation_id}/items`.
@@ -161,28 +160,49 @@ impl Metadata {
     }
 }
 
-/// Metadata update semantics for the update operation.
-#[derive(Debug, Default)]
-pub(super) enum MetadataUpdate {
-    /// The metadata field was absent; preserve the stored value.
-    #[default]
-    Missing,
-    /// The metadata field was null; clear the stored value.
-    Clear,
-    /// Replace the stored metadata with this value.
-    Replace(Metadata),
+/// Preserve both nullable layers emitted for create metadata upstream.
+fn nullable_metadata_schema() -> Schema {
+    let metadata = AnyOfBuilder::new()
+        .item(Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(Type::Object)
+                .additional_properties(Some(ObjectBuilder::new().schema_type(Type::String)))
+                .build(),
+        ))
+        .item(Schema::Object(ObjectBuilder::new().schema_type(Type::Null).build()))
+        .build();
+    Schema::AnyOf(
+        AnyOfBuilder::new()
+            .item(Schema::AnyOf(metadata))
+            .item(Schema::Object(ObjectBuilder::new().schema_type(Type::Null).build()))
+            .build(),
+    )
 }
 
-impl<'de> Deserialize<'de> for MetadataUpdate {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Option::<Metadata>::deserialize(deserializer).map(|metadata| match metadata {
-            Some(metadata) => Self::Replace(metadata),
-            None => Self::Clear,
-        })
+/// Generate the official nullable, bounded initial-items composition.
+fn nullable_initial_items_schema() -> Schema {
+    Schema::AnyOf(
+        AnyOfBuilder::new()
+            .item(
+                ArrayBuilder::new()
+                    .items(<ConversationItem as PartialSchema>::schema())
+                    .max_items(Some(MAX_ITEMS_PER_REQUEST)),
+            )
+            .item(Schema::Object(ObjectBuilder::new().schema_type(Type::Null).build()))
+            .build(),
+    )
+}
+
+/// Deserialize update metadata only from a JSON object.
+fn deserialize_metadata_object<'de, D>(deserializer: D) -> Result<Metadata, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    if !value.is_object() {
+        return Err(serde::de::Error::custom("metadata must be an object"));
     }
+    Ok(Metadata(value))
 }
 
 /// Polymorphic conversation item stored and returned as an opaque JSON object.
@@ -365,23 +385,23 @@ mod tests {
     #[test]
     fn create_request_distinguishes_missing_and_null_items() {
         let missing: CreateConversationRequest = serde_json::from_value(json!({})).unwrap();
-        assert!(missing.items.is_empty());
+        assert!(missing.items.is_none(), "missing items should use the default");
 
-        let null = serde_json::from_value::<CreateConversationRequest>(json!({"items": null}));
-        assert!(null.is_err(), "explicit null items must remain invalid");
+        let null: CreateConversationRequest = serde_json::from_value(json!({"items": null})).unwrap();
+        assert!(null.items.is_none(), "null items should use the default");
     }
 
     #[test]
-    fn update_request_preserves_metadata_field_state() {
-        let missing: UpdateConversationRequest = serde_json::from_value(json!({})).unwrap();
-        assert!(matches!(missing.metadata, MetadataUpdate::Missing));
+    fn update_request_requires_non_null_metadata() {
+        let missing = serde_json::from_value::<UpdateConversationRequest>(json!({}));
+        assert!(missing.is_err(), "metadata must be present on update");
 
-        let null: UpdateConversationRequest = serde_json::from_value(json!({"metadata": null})).unwrap();
-        assert!(matches!(null.metadata, MetadataUpdate::Clear));
+        let null = serde_json::from_value::<UpdateConversationRequest>(json!({"metadata": null}));
+        assert!(null.is_err(), "metadata must be an object on update");
 
         let replacement: UpdateConversationRequest =
             serde_json::from_value(json!({"metadata": {"project": "praxis"}})).unwrap();
-        assert!(matches!(replacement.metadata, MetadataUpdate::Replace(_)));
+        assert_eq!(replacement.metadata.as_value(), &json!({"project": "praxis"}));
     }
 
     #[test]

--- a/apis/src/openai/conversations/contracts.rs
+++ b/apis/src/openai/conversations/contracts.rs
@@ -399,6 +399,9 @@ mod tests {
         let null = serde_json::from_value::<UpdateConversationRequest>(json!({"metadata": null}));
         assert!(null.is_err(), "metadata must be an object on update");
 
+        let array = serde_json::from_value::<UpdateConversationRequest>(json!({"metadata": ["a", "b"]}));
+        assert!(array.is_err(), "metadata must reject arrays");
+
         let replacement: UpdateConversationRequest =
             serde_json::from_value(json!({"metadata": {"project": "praxis"}})).unwrap();
         assert_eq!(replacement.metadata.as_value(), &json!({"project": "praxis"}));

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -20,7 +20,7 @@ use super::{
         CreateConversationRequest, DeletedConversationResource, IncludeField, IncludeFields, ItemOrder,
         MAX_ITEMS_PER_REQUEST, Metadata, UpdateConversationRequest,
     },
-    validate::validate_metadata,
+    validate::{MetadataError, validate_metadata},
 };
 use crate::{
     openai::responses::{
@@ -80,8 +80,8 @@ pub(super) async fn handle_create_conversation(
     };
     let metadata = match input.metadata {
         Some(metadata) => {
-            if let Err(msg) = validate_metadata(metadata.as_value()) {
-                return Ok(FilterAction::Reject(invalid_input_response(&msg)?));
+            if let Err(e) = validate_metadata(metadata.as_value()) {
+                return Ok(FilterAction::Reject(invalid_input_response(&e.to_string())?));
             }
             metadata.into_value()
         },
@@ -161,21 +161,26 @@ pub(super) async fn handle_update_conversation(
     body: &[u8],
 ) -> Result<FilterAction, FilterError> {
     let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
+    if body.is_empty() {
+        return Ok(FilterAction::Reject(invalid_input_response_with(
+            "Missing required parameter: 'metadata'.",
+            Some("missing_required_parameter"),
+            Some("metadata"),
+        )?));
+    }
     let input: UpdateConversationRequest = match parse_json_body(body) {
         Ok(v) => v,
         Err(msg) => {
             return Ok(FilterAction::Reject(classify_update_error(&msg)?));
         },
     };
-    if let Err(msg) = validate_metadata(input.metadata.as_value()) {
-        if msg.contains("must be") {
-            return Ok(FilterAction::Reject(invalid_input_response_with(
-                &msg,
-                Some("invalid_type"),
-                Some("metadata"),
-            )?));
-        }
-        return Ok(FilterAction::Reject(invalid_input_response(&msg)?));
+    if let Err(e) = validate_metadata(input.metadata.as_value()) {
+        return Ok(FilterAction::Reject(match e {
+            MetadataError::InvalidType(_) => {
+                invalid_input_response_with(&e.to_string(), Some("invalid_type"), Some("metadata"))?
+            },
+            MetadataError::ConstraintViolation(_) => invalid_input_response(&e.to_string())?,
+        }));
     }
 
     let existing = match store.get_conversation(tenant_id, conversation_id).await {

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -18,7 +18,7 @@ use super::{
     contracts::{
         ConversationItem, ConversationItemList, ConversationResource, CreateConversationItemsRequest,
         CreateConversationRequest, DeletedConversationResource, IncludeField, IncludeFields, ItemOrder,
-        MAX_ITEMS_PER_REQUEST, Metadata, MetadataUpdate, UpdateConversationRequest,
+        MAX_ITEMS_PER_REQUEST, Metadata, UpdateConversationRequest,
     },
     validate::validate_metadata,
 };
@@ -70,9 +70,13 @@ pub(super) async fn handle_create_conversation(
     body: &[u8],
 ) -> Result<FilterAction, FilterError> {
     let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
-    let input: CreateConversationRequest = match parse_json_body(body) {
-        Ok(v) => v,
-        Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
+    let input = if body.is_empty() {
+        CreateConversationRequest::default()
+    } else {
+        match parse_json_body(body) {
+            Ok(v) => v,
+            Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
+        }
     };
     let metadata = match input.metadata {
         Some(metadata) => {
@@ -87,10 +91,11 @@ pub(super) async fn handle_create_conversation(
     let raw_id = ctx.id_generator.generate(ctx.time_source);
     let conversation_id = format!("conv_{raw_id}");
     let created_at = current_timestamp(ctx);
-    if let Err(msg) = validate_item_count(input.items.len()) {
+    let items = input.items.unwrap_or_default();
+    if let Err(msg) = validate_item_count(items.len()) {
         return Ok(FilterAction::Reject(invalid_input_response(&msg)?));
     }
-    let item_values = input.items.into_iter().map(ConversationItem::into_value);
+    let item_values = items.into_iter().map(ConversationItem::into_value);
     let item_records = match build_item_records(ctx, tenant_id, &conversation_id, created_at, 1, item_values) {
         Ok(records) => records,
         Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
@@ -160,9 +165,7 @@ pub(super) async fn handle_update_conversation(
         Ok(v) => v,
         Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
     };
-    if let MetadataUpdate::Replace(metadata) = &input.metadata
-        && let Err(msg) = validate_metadata(metadata.as_value())
-    {
+    if let Err(msg) = validate_metadata(input.metadata.as_value()) {
         return Ok(FilterAction::Reject(invalid_input_response(&msg)?));
     }
 
@@ -177,11 +180,7 @@ pub(super) async fn handle_update_conversation(
         ))?));
     };
 
-    let metadata = match input.metadata {
-        MetadataUpdate::Missing => existing.metadata,
-        MetadataUpdate::Clear => Value::Object(Map::new()),
-        MetadataUpdate::Replace(metadata) => metadata.into_value(),
-    };
+    let metadata = input.metadata.into_value();
 
     let record = ConversationRecord {
         conversation_id: conversation_id.to_owned(),

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -163,10 +163,16 @@ pub(super) async fn handle_update_conversation(
     let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
     let input: UpdateConversationRequest = match parse_json_body(body) {
         Ok(v) => v,
-        Err(msg) => return Ok(FilterAction::Reject(invalid_input_response(&msg)?)),
+        Err(msg) => {
+            return Ok(FilterAction::Reject(classify_update_error(&msg)?));
+        },
     };
     if let Err(msg) = validate_metadata(input.metadata.as_value()) {
-        return Ok(FilterAction::Reject(invalid_input_response(&msg)?));
+        return Ok(FilterAction::Reject(invalid_input_response_with(
+            &msg,
+            Some("invalid_type"),
+            Some("metadata"),
+        )?));
     }
 
     let existing = match store.get_conversation(tenant_id, conversation_id).await {
@@ -897,15 +903,45 @@ fn json_response<T: Serialize + ?Sized>(status: u16, body: &T) -> Result<Rejecti
 
 /// Build a 400 JSON response for invalid input.
 fn invalid_input_response(message: &str) -> Result<Rejection, FilterError> {
+    invalid_input_response_with(message, None, None)
+}
+
+/// Build a 400 JSON response with optional OpenAI error code and parameter.
+fn invalid_input_response_with(
+    message: &str,
+    code: Option<&str>,
+    param: Option<&str>,
+) -> Result<Rejection, FilterError> {
     json_response(
         400,
         &serde_json::json!({
             "error": {
                 "message": message,
                 "type": "invalid_request_error",
+                "code": code,
+                "param": param,
             }
         }),
     )
+}
+
+/// Map update deserialization errors to OpenAI-style error codes.
+fn classify_update_error(msg: &str) -> Result<Rejection, FilterError> {
+    if msg.contains("missing field") && msg.contains("metadata") {
+        return invalid_input_response_with(
+            "Missing required parameter: 'metadata'.",
+            Some("missing_required_parameter"),
+            Some("metadata"),
+        );
+    }
+    if msg.contains("metadata must be an object") {
+        return invalid_input_response_with(
+            "Invalid type for 'metadata': expected an object, but got null.",
+            Some("invalid_type"),
+            Some("metadata"),
+        );
+    }
+    invalid_input_response(msg)
 }
 
 /// Build a 404 JSON response.

--- a/apis/src/openai/conversations/handlers.rs
+++ b/apis/src/openai/conversations/handlers.rs
@@ -168,11 +168,14 @@ pub(super) async fn handle_update_conversation(
         },
     };
     if let Err(msg) = validate_metadata(input.metadata.as_value()) {
-        return Ok(FilterAction::Reject(invalid_input_response_with(
-            &msg,
-            Some("invalid_type"),
-            Some("metadata"),
-        )?));
+        if msg.contains("must be") {
+            return Ok(FilterAction::Reject(invalid_input_response_with(
+                &msg,
+                Some("invalid_type"),
+                Some("metadata"),
+            )?));
+        }
+        return Ok(FilterAction::Reject(invalid_input_response(&msg)?));
     }
 
     let existing = match store.get_conversation(tenant_id, conversation_id).await {
@@ -903,7 +906,15 @@ fn json_response<T: Serialize + ?Sized>(status: u16, body: &T) -> Result<Rejecti
 
 /// Build a 400 JSON response for invalid input.
 fn invalid_input_response(message: &str) -> Result<Rejection, FilterError> {
-    invalid_input_response_with(message, None, None)
+    json_response(
+        400,
+        &serde_json::json!({
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+            }
+        }),
+    )
 }
 
 /// Build a 400 JSON response with optional OpenAI error code and parameter.
@@ -936,7 +947,7 @@ fn classify_update_error(msg: &str) -> Result<Rejection, FilterError> {
     }
     if msg.contains("metadata must be an object") {
         return invalid_input_response_with(
-            "Invalid type for 'metadata': expected an object, but got null.",
+            "Invalid type for 'metadata': expected an object.",
             Some("invalid_type"),
             Some("metadata"),
         );

--- a/apis/src/openai/conversations/openapi.rs
+++ b/apis/src/openai/conversations/openapi.rs
@@ -87,10 +87,6 @@ mod tests {
         let document = serde_json::to_value(implementation_openapi()).unwrap();
 
         assert_eq!(
-            document.pointer("/components/schemas/CreateConversationRequest/properties/items/type"),
-            Some(&Value::String("array".to_owned()))
-        );
-        assert_eq!(
             document.pointer("/components/schemas/CreateConversationItemsRequest/properties/items/type"),
             Some(&Value::String("array".to_owned()))
         );
@@ -151,6 +147,49 @@ mod tests {
                 Some(&Value::Array(expected.clone()))
             );
         }
+    }
+
+    #[test]
+    fn generated_create_request_contract_matches_runtime() {
+        let document = serde_json::to_value(implementation_openapi()).unwrap();
+
+        assert_eq!(
+            document.pointer("/components/schemas/CreateConversationRequest/properties/items/anyOf/0/type"),
+            Some(&Value::String("array".to_owned()))
+        );
+        assert_eq!(
+            document.pointer("/components/schemas/CreateConversationRequest/properties/items/anyOf/1/type"),
+            Some(&Value::String("null".to_owned()))
+        );
+        assert_eq!(
+            document.pointer("/components/schemas/CreateConversationRequest/properties/metadata/anyOf/1/type"),
+            Some(&Value::String("null".to_owned()))
+        );
+        assert!(
+            document
+                .pointer("/paths/~1conversations/post/requestBody/required")
+                .is_none_or(|required| required == &Value::Bool(false)),
+            "create request body should be optional"
+        );
+    }
+
+    #[test]
+    fn generated_update_request_contract_matches_runtime() {
+        let document = serde_json::to_value(implementation_openapi()).unwrap();
+
+        assert_eq!(
+            document.pointer("/components/schemas/UpdateConversationRequest/required/0"),
+            Some(&Value::String("metadata".to_owned()))
+        );
+        assert_eq!(
+            document.pointer("/components/schemas/UpdateConversationRequest/properties/metadata/$ref"),
+            Some(&Value::String("#/components/schemas/Metadata".to_owned()))
+        );
+        assert_eq!(
+            document.pointer("/paths/~1conversations~1{conversation_id}/post/requestBody/required"),
+            Some(&Value::Bool(true)),
+            "live OpenAI behavior requires an update request body"
+        );
     }
 
     fn collect_component_references<'a>(value: &'a Value, references: &mut Vec<&'a str>) {

--- a/apis/src/openai/conversations/openapi.rs
+++ b/apis/src/openai/conversations/openapi.rs
@@ -161,6 +161,11 @@ mod tests {
             document.pointer("/components/schemas/CreateConversationRequest/properties/items/anyOf/1/type"),
             Some(&Value::String("null".to_owned()))
         );
+        assert_eq!(
+            document.pointer("/components/schemas/CreateConversationRequest/properties/items/anyOf/0/maxItems"),
+            Some(&Value::Number(serde_json::Number::from(20_u64))),
+            "items array should preserve the 20-item bound"
+        );
         assert!(
             document
                 .pointer("/paths/~1conversations/post/requestBody/required")

--- a/apis/src/openai/conversations/openapi.rs
+++ b/apis/src/openai/conversations/openapi.rs
@@ -161,15 +161,37 @@ mod tests {
             document.pointer("/components/schemas/CreateConversationRequest/properties/items/anyOf/1/type"),
             Some(&Value::String("null".to_owned()))
         );
-        assert_eq!(
-            document.pointer("/components/schemas/CreateConversationRequest/properties/metadata/anyOf/1/type"),
-            Some(&Value::String("null".to_owned()))
-        );
         assert!(
             document
                 .pointer("/paths/~1conversations/post/requestBody/required")
                 .is_none_or(|required| required == &Value::Bool(false)),
             "create request body should be optional"
+        );
+    }
+
+    #[test]
+    fn generated_create_metadata_has_two_layer_nullable_anyof() {
+        let document = serde_json::to_value(implementation_openapi()).unwrap();
+        let base = "/components/schemas/CreateConversationRequest/properties/metadata";
+
+        assert_eq!(
+            document.pointer(&format!("{base}/anyOf/1/type")),
+            Some(&Value::String("null".to_owned()))
+        );
+        assert_eq!(
+            document.pointer(&format!("{base}/anyOf/0/anyOf/0/type")),
+            Some(&Value::String("object".to_owned())),
+            "inner anyOf should contain the string-map object type"
+        );
+        assert_eq!(
+            document.pointer(&format!("{base}/anyOf/0/anyOf/0/additionalProperties/type")),
+            Some(&Value::String("string".to_owned())),
+            "metadata values should be strings"
+        );
+        assert_eq!(
+            document.pointer(&format!("{base}/anyOf/0/anyOf/1/type")),
+            Some(&Value::String("null".to_owned())),
+            "inner anyOf should include null"
         );
     }
 

--- a/apis/src/openai/conversations/routes.rs
+++ b/apis/src/openai/conversations/routes.rs
@@ -38,12 +38,18 @@ impl Deref for ConversationOperationSpec {
 
 /// Convert a registry request declaration into an optional schema binding.
 macro_rules! request_binding {
-    (none) => {
+    ([none]) => {
         None
     };
-    ($schema:ty) => {
+    ([required $schema:ty]) => {
         Some(RequestBodySpec {
             required: true,
+            content: &[MediaTypeSpec::new(JSON_CONTENT_TYPE, schema_binding!($schema))],
+        })
+    };
+    ([optional $schema:ty]) => {
+        Some(RequestBodySpec {
+            required: false,
             content: &[MediaTypeSpec::new(JSON_CONTENT_TYPE, schema_binding!($schema))],
         })
     };
@@ -152,7 +158,7 @@ conversation_operations! {
         mode: Local,
         contract: owned {
             parameters: [],
-            request: CreateConversationRequest,
+            request: [optional CreateConversationRequest],
             response: ConversationResource,
         },
     },
@@ -166,7 +172,7 @@ conversation_operations! {
                 "conversation_id",
                 "The ID of the conversation to retrieve."
             )],
-            request: none,
+            request: [none],
             response: ConversationResource,
         },
     },
@@ -180,7 +186,7 @@ conversation_operations! {
                 "conversation_id",
                 "The ID of the conversation to update."
             )],
-            request: UpdateConversationRequest,
+            request: [required UpdateConversationRequest],
             response: ConversationResource,
         },
     },
@@ -194,7 +200,7 @@ conversation_operations! {
                 "conversation_id",
                 "The ID of the conversation to delete."
             )],
-            request: none,
+            request: [none],
             response: DeletedConversationResource,
         },
     },
@@ -215,7 +221,7 @@ conversation_operations! {
                     "Additional fields to include in the response."
                 ),
             ],
-            request: CreateConversationItemsRequest,
+            request: [required CreateConversationItemsRequest],
             response: ConversationItemList,
         },
     },
@@ -239,7 +245,7 @@ conversation_operations! {
                     "Additional fields to include in the response."
                 ),
             ],
-            request: none,
+            request: [none],
             response: ConversationItemList,
         },
     },
@@ -261,7 +267,7 @@ conversation_operations! {
                     "Additional fields to include in the response."
                 ),
             ],
-            request: none,
+            request: [none],
             response: ConversationItem,
         },
     },
@@ -278,7 +284,7 @@ conversation_operations! {
                 ),
                 path_parameter!("item_id", "The ID of the item to delete."),
             ],
-            request: none,
+            request: [none],
             response: ConversationResource,
         },
     },

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1226,7 +1226,10 @@ async fn update_conversation_body_requires_metadata() {
         panic!("expected Reject, got {action:?}");
     };
     assert_eq!(rejection.status, 400);
-    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
+    let error = &rejection_body(&rejection)["error"];
+    assert_eq!(error["type"], "invalid_request_error");
+    assert_eq!(error["code"], "missing_required_parameter");
+    assert_eq!(error["param"], "metadata");
 
     let req = make_request(Method::GET, &format!("/v1/conversations/{conv_id}"));
     let mut ctx = make_filter_context(&req);
@@ -2739,6 +2742,10 @@ async fn update_conversation_with_invalid_metadata_returns_400() {
         panic!("expected Reject, got {action:?}");
     };
     assert_eq!(rejection.status, 400, "invalid metadata should return 400");
+    let error = &rejection_body(&rejection)["error"];
+    assert_eq!(error["type"], "invalid_request_error");
+    assert_eq!(error["code"], "invalid_type");
+    assert_eq!(error["param"], "metadata");
 }
 
 #[tokio::test]
@@ -2758,7 +2765,10 @@ async fn update_conversation_with_null_metadata_returns_400() {
         panic!("expected Reject, got {action:?}");
     };
     assert_eq!(rejection.status, 400);
-    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
+    let error = &rejection_body(&rejection)["error"];
+    assert_eq!(error["type"], "invalid_request_error");
+    assert_eq!(error["code"], "invalid_type");
+    assert_eq!(error["param"], "metadata");
 }
 
 #[tokio::test]

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1211,7 +1211,7 @@ async fn update_conversation() {
 }
 
 #[tokio::test]
-async fn update_conversation_without_metadata_preserves_existing_metadata() {
+async fn update_conversation_body_requires_metadata() {
     let filter = build_test_filter();
     let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({"v": "1"})).await;
 
@@ -1225,12 +1225,8 @@ async fn update_conversation_without_metadata_preserves_existing_metadata() {
     let FilterAction::Reject(rejection) = action else {
         panic!("expected Reject, got {action:?}");
     };
-    assert_eq!(rejection.status, 200);
-    let resp = rejection_body(&rejection);
-    assert_eq!(
-        resp["metadata"]["v"], "1",
-        "missing metadata should preserve existing value"
-    );
+    assert_eq!(rejection.status, 400);
+    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
 
     let req = make_request(Method::GET, &format!("/v1/conversations/{conv_id}"));
     let mut ctx = make_filter_context(&req);
@@ -1239,7 +1235,26 @@ async fn update_conversation_without_metadata_preserves_existing_metadata() {
         panic!("expected Reject from get after update");
     };
     let resp = rejection_body(&rejection);
-    assert_eq!(resp["metadata"]["v"], "1", "preserved metadata should be persisted");
+    assert_eq!(resp["metadata"]["v"], "1", "invalid update must not change metadata");
+}
+
+#[tokio::test]
+async fn update_conversation_without_body_returns_400() {
+    let filter = build_test_filter();
+    let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({"v": "1"})).await;
+
+    let req = make_request(Method::POST, &format!("/v1/conversations/{conv_id}"));
+    let mut ctx = make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = None;
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject, got {action:?}");
+    };
+    assert_eq!(rejection.status, 400);
+    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
 }
 
 #[tokio::test]
@@ -2600,7 +2615,7 @@ async fn create_conversation_with_non_array_items_returns_400() {
 }
 
 #[tokio::test]
-async fn create_conversation_with_null_items_returns_400() {
+async fn create_conversation_with_null_items_defaults_to_empty() {
     let filter = build_test_filter();
 
     let req = make_request(Method::POST, "/v1/conversations");
@@ -2611,9 +2626,10 @@ async fn create_conversation_with_null_items_returns_400() {
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
     let FilterAction::Reject(rejection) = action else {
-        panic!("expected Reject for null items, got {action:?}");
+        panic!("expected Reject response for null items, got {action:?}");
     };
-    assert_eq!(rejection.status, 400, "null items should return 400");
+    assert_eq!(rejection.status, 200, "null items should behave like omitted items");
+    assert_eq!(rejection_body(&rejection)["metadata"], serde_json::json!({}));
 }
 
 #[tokio::test]
@@ -2662,7 +2678,7 @@ async fn create_conversation_with_null_metadata_defaults_to_empty() {
 }
 
 #[tokio::test]
-async fn create_conversation_without_body_metadata_defaults_to_empty() {
+async fn create_conversation_with_empty_object_defaults_to_empty() {
     let filter = build_test_filter();
 
     let req = make_request(Method::POST, "/v1/conversations");
@@ -2682,6 +2698,24 @@ async fn create_conversation_without_body_metadata_defaults_to_empty() {
         serde_json::json!({}),
         "missing metadata should default to empty object"
     );
+}
+
+#[tokio::test]
+async fn create_conversation_without_body_defaults_to_empty() {
+    let filter = build_test_filter();
+
+    let req = make_request(Method::POST, "/v1/conversations");
+    let mut ctx = make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = None;
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected Reject, got {action:?}");
+    };
+    assert_eq!(rejection.status, 200);
+    assert_eq!(rejection_body(&rejection)["metadata"], serde_json::json!({}));
 }
 
 // -----------------------------------------------------------------------------
@@ -2708,7 +2742,7 @@ async fn update_conversation_with_invalid_metadata_returns_400() {
 }
 
 #[tokio::test]
-async fn update_conversation_with_null_metadata_clears_metadata() {
+async fn update_conversation_with_null_metadata_returns_400() {
     let filter = build_test_filter();
     let conv_id = create_test_conversation(filter.as_ref(), serde_json::json!({"v": "1"})).await;
 
@@ -2723,13 +2757,8 @@ async fn update_conversation_with_null_metadata_clears_metadata() {
     let FilterAction::Reject(rejection) = action else {
         panic!("expected Reject, got {action:?}");
     };
-    assert_eq!(rejection.status, 200);
-    let resp = rejection_body(&rejection);
-    assert_eq!(
-        resp["metadata"],
-        serde_json::json!({}),
-        "null metadata should clear to empty object"
-    );
+    assert_eq!(rejection.status, 400);
+    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
 }
 
 #[tokio::test]

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -1073,7 +1073,7 @@ fn null_metadata_is_valid() {
 fn reject_non_object_metadata() {
     let metadata = serde_json::json!("string");
     let err = validate_metadata(&metadata).unwrap_err();
-    assert!(err.contains("must be a JSON object"), "got: {err}");
+    assert!(err.to_string().contains("must be a JSON object"), "got: {err}");
 }
 
 #[test]
@@ -1083,7 +1083,7 @@ fn reject_too_many_keys() {
         map.insert(format!("key{i}"), Value::String("val".to_owned()));
     }
     let err = validate_metadata(&Value::Object(map)).unwrap_err();
-    assert!(err.contains("at most 16 keys"), "got: {err}");
+    assert!(err.to_string().contains("at most 16 keys"), "got: {err}");
 }
 
 #[test]
@@ -1091,7 +1091,7 @@ fn reject_long_key() {
     let long_key = "k".repeat(65);
     let metadata = serde_json::json!({long_key: "value"});
     let err = validate_metadata(&metadata).unwrap_err();
-    assert!(err.contains("exceeds 64 bytes"), "got: {err}");
+    assert!(err.to_string().contains("exceeds 64 bytes"), "got: {err}");
 }
 
 #[test]
@@ -1099,14 +1099,14 @@ fn reject_long_value() {
     let long_value = "v".repeat(513);
     let metadata = serde_json::json!({"key": long_value});
     let err = validate_metadata(&metadata).unwrap_err();
-    assert!(err.contains("exceeds 512 bytes"), "got: {err}");
+    assert!(err.to_string().contains("exceeds 512 bytes"), "got: {err}");
 }
 
 #[test]
 fn reject_non_string_value() {
     let metadata = serde_json::json!({"key": 42});
     let err = validate_metadata(&metadata).unwrap_err();
-    assert!(err.contains("must be a string"), "got: {err}");
+    assert!(err.to_string().contains("must be a string"), "got: {err}");
 }
 
 // -----------------------------------------------------------------------------
@@ -1257,7 +1257,10 @@ async fn update_conversation_without_body_returns_400() {
         panic!("expected Reject, got {action:?}");
     };
     assert_eq!(rejection.status, 400);
-    assert_eq!(rejection_body(&rejection)["error"]["type"], "invalid_request_error");
+    let error = &rejection_body(&rejection)["error"];
+    assert_eq!(error["type"], "invalid_request_error");
+    assert_eq!(error["code"], "missing_required_parameter");
+    assert_eq!(error["param"], "metadata");
 }
 
 #[tokio::test]

--- a/apis/src/openai/conversations/validate.rs
+++ b/apis/src/openai/conversations/validate.rs
@@ -3,6 +3,8 @@
 
 //! Metadata validation for conversation objects.
 
+use std::fmt;
+
 use serde_json::Value;
 
 /// Maximum number of metadata keys.
@@ -14,6 +16,23 @@ const MAX_KEY_BYTES: usize = 64;
 /// Maximum length of a metadata string value in bytes.
 const MAX_VALUE_BYTES: usize = 512;
 
+/// Metadata validation failure.
+#[derive(Debug)]
+pub(crate) enum MetadataError {
+    /// Value is not a JSON object (type mismatch).
+    InvalidType(String),
+    /// Constraint violation (key count, key/value length).
+    ConstraintViolation(String),
+}
+
+impl fmt::Display for MetadataError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidType(msg) | Self::ConstraintViolation(msg) => f.write_str(msg),
+        }
+    }
+}
+
 /// Validate conversation metadata.
 ///
 /// Rules:
@@ -21,33 +40,40 @@ const MAX_VALUE_BYTES: usize = 512;
 /// - At most 16 keys
 /// - Each key ≤ 64 bytes
 /// - Each value must be a string ≤ 512 bytes
-pub(crate) fn validate_metadata(metadata: &Value) -> Result<(), String> {
+#[expect(clippy::too_many_lines, reason = "sequential validation pipeline")]
+pub(crate) fn validate_metadata(metadata: &Value) -> Result<(), MetadataError> {
     let obj = match metadata {
         Value::Object(map) => map,
         Value::Null => return Ok(()),
-        _ => return Err("metadata must be a JSON object".to_owned()),
+        _ => return Err(MetadataError::InvalidType("metadata must be a JSON object".to_owned())),
     };
 
     if obj.len() > MAX_METADATA_KEYS {
-        return Err(format!(
+        return Err(MetadataError::ConstraintViolation(format!(
             "metadata must have at most {MAX_METADATA_KEYS} keys, got {}",
             obj.len()
-        ));
+        )));
     }
 
     for (key, value) in obj {
         if key.len() > MAX_KEY_BYTES {
-            return Err(format!("metadata key exceeds {MAX_KEY_BYTES} bytes: '{key}'"));
+            return Err(MetadataError::ConstraintViolation(format!(
+                "metadata key exceeds {MAX_KEY_BYTES} bytes: '{key}'"
+            )));
         }
         match value {
             Value::String(s) => {
                 if s.len() > MAX_VALUE_BYTES {
-                    return Err(format!(
+                    return Err(MetadataError::ConstraintViolation(format!(
                         "metadata value for key '{key}' exceeds {MAX_VALUE_BYTES} bytes"
-                    ));
+                    )));
                 }
             },
-            _ => return Err(format!("metadata value for key '{key}' must be a string")),
+            _ => {
+                return Err(MetadataError::InvalidType(format!(
+                    "metadata value for key '{key}' must be a string"
+                )));
+            },
         }
     }
 

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -35,6 +35,25 @@ and its shared contract types are the authority for what Praxis claims and
 implements. Conformance is the reproducible comparison between those two
 sources, backed by tests of the real runtime path.
 
+### Verified Conversations request behavior
+
+The Conversations create and update request-body edge cases were checked
+against `api.openai.com` on 2026-07-27. Temporary conversations were deleted
+after the probe.
+
+| Request | Result |
+| --- | --- |
+| Create with no body or `{}` | `200` |
+| Create with null `metadata` and `items` | `200` |
+| Update with no body or `{}` | `400 missing_required_parameter` for `metadata` |
+| Update with null `metadata` | `400 invalid_type` for `metadata` |
+| Update with object `metadata` | `200` |
+
+The pinned and current upstream OpenAPI documents omit `requestBody.required`
+for update even though the live endpoint requires the body. The implementation
+document follows the verified runtime contract, so that upstream discrepancy
+remains visible instead of declaring behavior Praxis does not implement.
+
 ## Code Map
 
 - `apis/src/openai/conversations/routes.rs` declares each operation once and

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -38,8 +38,7 @@ sources, backed by tests of the real runtime path.
 ### Verified Conversations request behavior
 
 The Conversations create and update request-body edge cases were checked
-against `api.openai.com` on 2026-07-27. Temporary conversations were deleted
-after the probe.
+against `api.openai.com` on 2026-07-27.
 
 | Request | Result |
 | --- | --- |

--- a/docs/conformance/openai-conformance-report.json
+++ b/docs/conformance/openai-conformance-report.json
@@ -313,16 +313,7 @@
               "has_response_drift": false,
               "has_other_drift": false,
               "request_details": [
-                "requestBody.required.from",
-                "requestBody.required.to",
-                "requestBody.content.application/json.schema.properties.items.anyOf.deleted",
-                "requestBody.content.application/json.schema.properties.items.type.added",
-                "requestBody.content.application/json.schema.properties.items.maxItems.from",
-                "requestBody.content.application/json.schema.properties.items.maxItems.to",
-                "requestBody.content.application/json.schema.properties.items.items.schemaAdded",
-                "requestBody.content.application/json.schema.properties.items.listOfTypes.deleted",
-                "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
-                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
+                "requestBody.content.application/json.schema.properties.items.anyOf.modified"
               ],
               "response_details": [],
               "other_details": []
@@ -339,9 +330,11 @@
               "request_details": [
                 "requestBody.required.from",
                 "requestBody.required.to",
-                "requestBody.content.application/json.schema.required.deleted",
-                "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
-                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
+                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted",
+                "requestBody.content.application/json.schema.properties.metadata.type.added",
+                "requestBody.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+                "requestBody.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+                "requestBody.content.application/json.schema.properties.metadata.listOfTypes.deleted"
               ],
               "response_details": [],
               "other_details": []
@@ -615,16 +608,7 @@
               "kind": "request_body_schema",
               "summary": "Align the request body schema with the OpenAI spec.",
               "detail_paths": [
-                "requestBody.required.from",
-                "requestBody.required.to",
-                "requestBody.content.application/json.schema.properties.items.anyOf.deleted",
-                "requestBody.content.application/json.schema.properties.items.type.added",
-                "requestBody.content.application/json.schema.properties.items.maxItems.from",
-                "requestBody.content.application/json.schema.properties.items.maxItems.to",
-                "requestBody.content.application/json.schema.properties.items.items.schemaAdded",
-                "requestBody.content.application/json.schema.properties.items.listOfTypes.deleted",
-                "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
-                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
+                "requestBody.content.application/json.schema.properties.items.anyOf.modified"
               ]
             }
           ]
@@ -643,9 +627,11 @@
               "detail_paths": [
                 "requestBody.required.from",
                 "requestBody.required.to",
-                "requestBody.content.application/json.schema.required.deleted",
-                "requestBody.content.application/json.schema.properties.metadata.oneOf.added",
-                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"
+                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted",
+                "requestBody.content.application/json.schema.properties.metadata.type.added",
+                "requestBody.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+                "requestBody.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+                "requestBody.content.application/json.schema.properties.metadata.listOfTypes.deleted"
               ]
             }
           ]

--- a/tests/integration/tests/suite/examples/openai_conversations.rs
+++ b/tests/integration/tests/suite/examples/openai_conversations.rs
@@ -71,7 +71,7 @@ async fn update_conversation_metadata() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn update_conversation_without_metadata_preserves_existing_metadata() {
+async fn update_conversation_without_metadata_returns_400() {
     let proxy = start_test_proxy();
     let conv_id = create_conversation(&proxy, r#"{"metadata":{"v":"1"}}"#);
 
@@ -79,17 +79,11 @@ async fn update_conversation_without_metadata_preserves_existing_metadata() {
         proxy.addr(),
         &json_post(&format!("/v1/conversations/{conv_id}"), r#"{}"#),
     );
-    assert_eq!(parse_status(&raw), 200, "update should return 200");
-    let body: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
-    assert_eq!(body["metadata"]["v"], "1");
-
-    let raw = http_send(
-        proxy.addr(),
-        &format!("GET /v1/conversations/{conv_id} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "update without metadata should return 400 per OpenAI contract"
     );
-    assert_eq!(parse_status(&raw), 200, "GET after update should return 200");
-    let body: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
-    assert_eq!(body["metadata"]["v"], "1");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Problem

The Conversations create and update request contracts diverged from verified
OpenAI live behavior: create treated `items` as a required `Vec` instead of
a nullable optional array, and update accepted absent or null `metadata` via
a three-variant `MetadataUpdate` enum instead of requiring a metadata object.

## Changes

- make `CreateConversationRequest.items` an `Option<Vec<ConversationItem>>`
  with a nullable bounded-array OpenAPI schema matching upstream
- replace `MetadataUpdate` enum with a required `Metadata` field using a
  custom deserializer that rejects null, matching verified `400` behavior
- add `nullable_metadata_schema` and `nullable_initial_items_schema` for
  precise OpenAPI generation
- document verified create/update edge cases in conformance README
- regenerate the conformance report (request drift reduced on create and
  update operations)

## Validation

- `make lint` (clippy, fmt, deps, docs, examples all clean)
- `cargo test -p praxis-ai-apis -- conversations`
- `cargo xtask openai-conformance --area conversations` (3/8 exact, 12 exceptions)
- `git diff --check origin/main...HEAD`

Closes #566