### PR TITLE
feat(store): add schema validation and version tracking at init

### DIFF
--- a/apis/src/store/postgres.rs
+++ b/apis/src/store/postgres.rs
@@ -15,7 +15,10 @@ use tracing::info;
 
 use super::{
     pool::{PoolConfig, apply_pool_config},
-    schemas::{TableNames, generate_ddl, validate_postgres_identifiers},
+    schemas::{
+        ColumnCheck, SCHEMA_VERSION, TableNames, VERSION_COLUMNS, check_column_presence, expected_table_columns,
+        generate_ddl, schema_version_table, validate_postgres_identifiers,
+    },
     trait_def::{ConversationItemStore, ResponseStore},
     types::{ConversationItemRecord, ConversationRecord, ResponseRecord, StoreError},
 };
@@ -139,6 +142,9 @@ impl PostgresResponseStore {
                 .map_err(|e| StoreError::Database(e.to_string()))?;
         }
 
+        validate_schema(&pool, &tables).await?;
+        check_schema_version(&pool, &tables).await?;
+
         info!(
             responses = responses_table,
             conversations = conversations_table,
@@ -241,6 +247,69 @@ fn pg_connect_options(
     Ok(options)
 }
 
+/// Query column metadata for each table and verify expected columns exist.
+async fn validate_schema(pool: &sqlx::PgPool, tables: &TableNames) -> Result<(), StoreError> {
+    let version_table = schema_version_table(&tables.responses);
+    let expected = expected_table_columns(tables);
+    let mut results = Vec::with_capacity(expected.len() + 1);
+
+    for (table_name, expected_cols) in &expected {
+        let actual: Vec<String> = sqlx::query_scalar::<_, String>(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_schema = current_schema() AND table_name = $1",
+        )
+        .bind(*table_name)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        results.push((*table_name, *expected_cols, actual));
+    }
+
+    let actual: Vec<String> = sqlx::query_scalar::<_, String>(
+        "SELECT column_name FROM information_schema.columns \
+         WHERE table_schema = current_schema() AND table_name = $1",
+    )
+    .bind(version_table.as_str())
+    .fetch_all(pool)
+    .await
+    .map_err(|e| StoreError::Database(e.to_string()))?;
+    results.push((version_table.as_str(), VERSION_COLUMNS, actual));
+
+    let refs: Vec<ColumnCheck<'_>> = results
+        .iter()
+        .map(|(name, expected, actual)| (*name, *expected, actual.as_slice()))
+        .collect();
+
+    check_column_presence(&refs)
+}
+
+/// Stamp or validate the schema version.
+async fn check_schema_version(pool: &sqlx::PgPool, tables: &TableNames) -> Result<(), StoreError> {
+    let vt = schema_version_table(&tables.responses);
+    let select = format!("SELECT version FROM {vt}");
+    let row: Option<i64> = sqlx::query_scalar(AssertSqlSafe(select.as_str()))
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+    match row {
+        None => {
+            let insert = format!("INSERT INTO {vt} (version) VALUES ($1) ON CONFLICT (version) DO NOTHING");
+            sqlx::query(AssertSqlSafe(insert.as_str()))
+                .bind(SCHEMA_VERSION)
+                .execute(pool)
+                .await
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        },
+        Some(v) if v == SCHEMA_VERSION => Ok(()),
+        Some(v) => Err(StoreError::Database(format!(
+            "schema version mismatch in '{vt}': stored version {v}, \
+             expected {SCHEMA_VERSION}; database migration required"
+        ))),
+    }
+}
 
 #[async_trait]
 impl ResponseStore for PostgresResponseStore {

--- a/apis/src/store/postgres.rs
+++ b/apis/src/store/postgres.rs
@@ -822,4 +822,10 @@ mod tests {
             "explicit ssl_mode should override URL sslmode"
         );
     }
+
+    #[test]
+    fn connect_options_applies_ssl_root_cert() {
+        pg_connect_options("postgres://user:pass@example.com/db", None, Some("/path/to/ca.pem"))
+            .expect("ssl_root_cert path should be accepted");
+    }
 }

--- a/apis/src/store/schemas.rs
+++ b/apis/src/store/schemas.rs
@@ -672,4 +672,85 @@ mod tests {
             "should reject collision: {err}"
         );
     }
+
+    #[test]
+    fn generate_ddl_includes_items_ddl() {
+        let tables = TableNames {
+            responses: "test_responses".to_owned(),
+            conversations: "test_conversations".to_owned(),
+            items: Some("test_items".to_owned()),
+        };
+        let ddl = generate_ddl(&tables).expect("valid names with items should produce DDL");
+        assert_eq!(
+            ddl.len(),
+            6,
+            "should produce 6 DDL statements (responses, conversations, tenant_id index, items, items index, version)"
+        );
+        assert!(
+            ddl[3].contains("test_items"),
+            "fourth statement should create items table: {}",
+            ddl[3]
+        );
+        assert!(
+            ddl[4].contains("idx_test_items_conversation"),
+            "fifth statement should create items index: {}",
+            ddl[4]
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_items_same_as_responses() {
+        let tables = TableNames {
+            responses: "shared_name".to_owned(),
+            conversations: "test_conversations".to_owned(),
+            items: Some("shared_name".to_owned()),
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("items and response table names must be distinct"),
+            "should reject items == responses: {err}"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_items_same_as_conversations() {
+        let tables = TableNames {
+            responses: "test_responses".to_owned(),
+            conversations: "shared_name".to_owned(),
+            items: Some("shared_name".to_owned()),
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("items and conversation table names must be distinct"),
+            "should reject items == conversations: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_postgres_table_identifiers_accepts_valid() {
+        validate_postgres_table_identifiers("test_responses", "test_conversations")
+            .expect("valid names should pass PostgreSQL validation");
+    }
+
+    #[test]
+    fn validate_postgres_table_set_identifiers_accepts_valid_with_items() {
+        validate_postgres_table_set_identifiers("test_responses", "test_conversations", Some("test_items"))
+            .expect("valid names with items should pass PostgreSQL validation");
+    }
+
+    #[test]
+    fn validate_postgres_table_set_identifiers_rejects_long_items() {
+        let err = validate_postgres_table_set_identifiers(
+            "test_responses",
+            "test_conversations",
+            Some(&"i".repeat(POSTGRES_MAX_ITEMS_TABLE_LEN + 1)),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("PostgreSQL identifier limit"),
+            "should reject items name PostgreSQL would truncate: {err}"
+        );
+    }
 }

--- a/apis/src/store/schemas.rs
+++ b/apis/src/store/schemas.rs
@@ -25,6 +25,22 @@ pub(crate) struct TableNames {
 }
 
 // -----------------------------------------------------------------------------
+// Schema Version
+// -----------------------------------------------------------------------------
+
+/// Current schema version. Bump this when the DDL changes.
+pub(crate) const SCHEMA_VERSION: i64 = 1;
+
+/// Suffix appended to the responses table name to derive the schema
+/// version table name.
+const SCHEMA_VERSION_SUFFIX: &str = "_schema_version";
+
+/// Derive the schema version table name from the responses table name.
+pub(crate) fn schema_version_table(responses: &str) -> String {
+    format!("{responses}{SCHEMA_VERSION_SUFFIX}")
+}
+
+// -----------------------------------------------------------------------------
 // Schema DDL
 // -----------------------------------------------------------------------------
 
@@ -53,6 +69,23 @@ pub(crate) fn generate_ddl(tables: &TableNames) -> Result<Vec<String>, StoreErro
         append_items_ddl(&mut stmts, i);
     }
 
+    let v = schema_version_table(r);
+    if v.eq_ignore_ascii_case(c) {
+        return Err(StoreError::Database(format!(
+            "derived schema version table name collides with conversation table: {v}"
+        )));
+    }
+    if let Some(items) = &tables.items
+        && v.eq_ignore_ascii_case(items)
+    {
+        return Err(StoreError::Database(format!(
+            "derived schema version table name collides with items table: {v}"
+        )));
+    }
+    stmts.push(format!(
+        "CREATE TABLE IF NOT EXISTS {v} (version BIGINT NOT NULL PRIMARY KEY)"
+    ));
+
     Ok(stmts)
 }
 
@@ -69,7 +102,7 @@ pub(crate) fn generate_ddl(tables: &TableNames) -> Result<Vec<String>, StoreErro
 pub(crate) fn validate_postgres_identifiers(tables: &TableNames) -> Result<(), StoreError> {
     let (r, c) = validate_table_names(tables)?;
 
-    validate_postgres_identifier_len("response table name", r, POSTGRES_MAX_IDENTIFIER_LEN)?;
+    validate_postgres_identifier_len("response table name", r, POSTGRES_MAX_RESPONSES_TABLE_LEN)?;
     validate_postgres_identifier_len("conversation table name", c, POSTGRES_MAX_CONVERSATION_TABLE_LEN)?;
 
     if let Some(items) = &tables.items {
@@ -188,6 +221,10 @@ const POSTGRES_MAX_CONVERSATION_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN -
 /// and `_conversation` (13) in the generated index name.
 const POSTGRES_MAX_ITEMS_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN - 17;
 
+/// Maximum responses table name length that leaves room for the
+/// `_schema_version` (15) suffix in the derived version table name.
+const POSTGRES_MAX_RESPONSES_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN - 15;
+
 /// Reject identifiers that could cause SQL injection or invalid DDL.
 pub(crate) fn validate_identifier(name: &str) -> Result<(), StoreError> {
     if name.is_empty() {
@@ -239,6 +276,85 @@ fn validate_postgres_identifier_len(kind: &str, name: &str, max_len: usize) -> R
         )));
     }
     Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Expected Columns
+// -----------------------------------------------------------------------------
+
+/// Expected column names for the responses table.
+pub(crate) const RESPONSES_COLUMNS: &[&str] = &[
+    "tenant_id",
+    "id",
+    "created_at",
+    "model",
+    "response_object",
+    "input",
+    "messages",
+];
+
+/// Expected column names for the conversations table.
+pub(crate) const CONVERSATIONS_COLUMNS: &[&str] =
+    &["conversation_id", "tenant_id", "created_at", "metadata", "messages"];
+
+/// Expected column names for the schema version table.
+pub(crate) const VERSION_COLUMNS: &[&str] = &["version"];
+
+/// Expected column names for the items table.
+pub(crate) const ITEMS_COLUMNS: &[&str] = &[
+    "item_id",
+    "tenant_id",
+    "conversation_id",
+    "item_data",
+    "created_at",
+    "position",
+];
+
+/// Collect `(table_name, expected_columns)` pairs for schema validation.
+pub(crate) fn expected_table_columns(tables: &TableNames) -> Vec<(&str, &'static [&'static str])> {
+    let mut pairs = vec![
+        (tables.responses.as_str(), RESPONSES_COLUMNS),
+        (tables.conversations.as_str(), CONVERSATIONS_COLUMNS),
+    ];
+    if let Some(items) = &tables.items {
+        pairs.push((items.as_str(), ITEMS_COLUMNS));
+    }
+    pairs
+}
+
+/// `(table_name, expected_columns, actual_columns)` triple for schema
+/// validation.
+pub(crate) type ColumnCheck<'a> = (&'a str, &'a [&'static str], &'a [String]);
+
+/// Validate that every expected column exists in the actual column set.
+///
+/// Column name comparison is case-insensitive to handle backends that
+/// fold identifiers.
+///
+/// # Errors
+///
+/// Returns [`StoreError::Database`] listing all tables with missing
+/// columns.
+pub(crate) fn check_column_presence(table_columns: &[ColumnCheck<'_>]) -> Result<(), StoreError> {
+    let mut errors = Vec::new();
+    for &(table, expected, actual) in table_columns {
+        let missing: Vec<&str> = expected
+            .iter()
+            .filter(|col| !actual.iter().any(|a| a.eq_ignore_ascii_case(col)))
+            .copied()
+            .collect();
+        if !missing.is_empty() {
+            errors.push(format!("table '{table}' is missing columns: {}", missing.join(", ")));
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(StoreError::Database(format!(
+            "schema validation failed: {}",
+            errors.join("; ")
+        )))
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -309,7 +425,11 @@ mod tests {
             items: None,
         };
         let ddl = generate_ddl(&tables).expect("valid names should produce DDL");
-        assert_eq!(ddl.len(), 3, "should produce 3 DDL statements");
+        assert_eq!(
+            ddl.len(),
+            4,
+            "should produce 4 DDL statements (responses, conversations, tenant_id index, version)"
+        );
         assert!(
             ddl[0].contains("test_responses"),
             "first statement should reference responses table"
@@ -377,7 +497,7 @@ mod tests {
     #[test]
     fn postgres_identifier_rejects_truncated_table_name() {
         let tables = TableNames {
-            responses: "r".repeat(POSTGRES_MAX_IDENTIFIER_LEN + 1),
+            responses: "r".repeat(POSTGRES_MAX_RESPONSES_TABLE_LEN + 1),
             conversations: "test_conversations".to_owned(),
             items: None,
         };
@@ -401,6 +521,148 @@ mod tests {
         assert!(
             err.to_string().contains("PostgreSQL identifier limit"),
             "should reject generated index names PostgreSQL would truncate: {err}"
+        );
+    }
+
+    #[test]
+    fn check_column_presence_passes_when_all_present() {
+        let actual = vec!["id".to_owned(), "tenant_id".to_owned(), "created_at".to_owned()];
+        let input = [("t", &["id", "tenant_id", "created_at"][..], actual.as_slice())];
+        check_column_presence(&input).expect("all columns present should pass");
+    }
+
+    #[test]
+    fn check_column_presence_detects_missing_columns() {
+        let actual = vec!["id".to_owned(), "tenant_id".to_owned()];
+        let input = [(
+            "my_table",
+            &["id", "tenant_id", "created_at", "model"][..],
+            actual.as_slice(),
+        )];
+        let err = check_column_presence(&input).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("schema validation failed"), "{msg}");
+        assert!(msg.contains("my_table"), "{msg}");
+        assert!(msg.contains("created_at"), "{msg}");
+        assert!(msg.contains("model"), "{msg}");
+    }
+
+    #[test]
+    fn check_column_presence_is_case_insensitive() {
+        let actual = vec!["ID".to_owned(), "TENANT_ID".to_owned()];
+        let input = [("t", &["id", "tenant_id"][..], actual.as_slice())];
+        check_column_presence(&input).expect("case-insensitive match should pass");
+    }
+
+    #[test]
+    fn check_column_presence_aggregates_multiple_tables() {
+        let actual_a = vec!["id".to_owned()];
+        let actual_b = vec!["name".to_owned()];
+        let input = [
+            ("table_a", &["id", "missing_a"][..], actual_a.as_slice()),
+            ("table_b", &["name", "missing_b"][..], actual_b.as_slice()),
+        ];
+        let err = check_column_presence(&input).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("table_a"), "{msg}");
+        assert!(msg.contains("missing_a"), "{msg}");
+        assert!(msg.contains("table_b"), "{msg}");
+        assert!(msg.contains("missing_b"), "{msg}");
+    }
+
+    #[test]
+    fn expected_table_columns_excludes_items_when_none() {
+        let tables = TableNames {
+            responses: "r".to_owned(),
+            conversations: "c".to_owned(),
+            items: None,
+        };
+        assert_eq!(
+            expected_table_columns(&tables).len(),
+            2,
+            "should have responses and conversations only"
+        );
+    }
+
+    #[test]
+    fn expected_table_columns_includes_items_when_configured() {
+        let tables = TableNames {
+            responses: "r".to_owned(),
+            conversations: "c".to_owned(),
+            items: Some("i".to_owned()),
+        };
+        let pairs = expected_table_columns(&tables);
+        assert_eq!(pairs.len(), 3, "should include items table");
+        assert_eq!(pairs[2].0, "i", "third pair should be the items table");
+        assert_eq!(pairs[2].1, ITEMS_COLUMNS, "items columns should match");
+    }
+
+    #[test]
+    fn schema_version_table_derives_name() {
+        assert_eq!(
+            schema_version_table("openai_responses"),
+            "openai_responses_schema_version"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_includes_version_table() {
+        let tables = TableNames {
+            responses: "test_responses".to_owned(),
+            conversations: "test_conversations".to_owned(),
+            items: None,
+        };
+        let ddl = generate_ddl(&tables).expect("valid names should produce DDL");
+        let version_ddl = ddl.last().expect("should have statements");
+        assert!(
+            version_ddl.contains("test_responses_schema_version"),
+            "last DDL should create version table: {version_ddl}"
+        );
+        assert!(
+            version_ddl.contains("version BIGINT NOT NULL"),
+            "version table should have version column: {version_ddl}"
+        );
+    }
+
+    #[test]
+    fn postgres_identifier_rejects_long_responses_for_version_table() {
+        let tables = TableNames {
+            responses: "r".repeat(POSTGRES_MAX_RESPONSES_TABLE_LEN + 1),
+            conversations: "c".to_owned(),
+            items: None,
+        };
+        let err = validate_postgres_identifiers(&tables).unwrap_err();
+        assert!(
+            err.to_string().contains("PostgreSQL identifier limit"),
+            "should reject responses name that makes version table too long: {err}"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_version_table_collision_with_conversations() {
+        let tables = TableNames {
+            responses: "test".to_owned(),
+            conversations: "test_schema_version".to_owned(),
+            items: None,
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string().contains("collides with conversation table"),
+            "should reject collision: {err}"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_version_table_collision_with_items() {
+        let tables = TableNames {
+            responses: "test".to_owned(),
+            conversations: "test_conversations".to_owned(),
+            items: Some("test_schema_version".to_owned()),
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string().contains("collides with items table"),
+            "should reject collision: {err}"
         );
     }
 }

--- a/apis/src/store/schemas.rs
+++ b/apis/src/store/schemas.rs
@@ -222,8 +222,8 @@ const POSTGRES_MAX_CONVERSATION_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN -
 const POSTGRES_MAX_ITEMS_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN - 17;
 
 /// Maximum responses table name length that leaves room for the
-/// `_schema_version` (15) suffix in the derived version table name.
-const POSTGRES_MAX_RESPONSES_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN - 15;
+/// `_schema_version` suffix in the derived version table name.
+const POSTGRES_MAX_RESPONSES_TABLE_LEN: usize = POSTGRES_MAX_IDENTIFIER_LEN - SCHEMA_VERSION_SUFFIX.len();
 
 /// Reject identifiers that could cause SQL injection or invalid DDL.
 pub(crate) fn validate_identifier(name: &str) -> Result<(), StoreError> {
@@ -568,6 +568,13 @@ mod tests {
         assert!(msg.contains("missing_a"), "{msg}");
         assert!(msg.contains("table_b"), "{msg}");
         assert!(msg.contains("missing_b"), "{msg}");
+    }
+
+    #[test]
+    fn check_column_presence_tolerates_extra_columns() {
+        let actual = vec!["id".to_owned(), "tenant_id".to_owned(), "extra_col".to_owned()];
+        let input = [("t", &["id", "tenant_id"][..], actual.as_slice())];
+        check_column_presence(&input).expect("extra columns should not cause failure");
     }
 
     #[test]

--- a/apis/src/store/sqlite.rs
+++ b/apis/src/store/sqlite.rs
@@ -12,7 +12,10 @@ use tracing::info;
 
 use super::{
     pool::{PoolConfig, apply_pool_config},
-    schemas::{TableNames, generate_ddl},
+    schemas::{
+        ColumnCheck, SCHEMA_VERSION, TableNames, VERSION_COLUMNS, check_column_presence, expected_table_columns,
+        generate_ddl, schema_version_table,
+    },
     trait_def::{ConversationItemStore, ResponseStore},
     types::{ConversationItemRecord, ConversationRecord, ResponseRecord, StoreError},
 };
@@ -77,6 +80,9 @@ impl SqliteResponseStore {
                 .await
                 .map_err(|e| StoreError::Database(e.to_string()))?;
         }
+
+        validate_schema(&pool, &tables).await?;
+        check_schema_version(&pool, &tables).await?;
 
         info!(
             responses = responses_table,
@@ -184,6 +190,69 @@ fn is_memory_database_url(database_url: &str) -> bool {
     query
         .split('&')
         .any(|param| param == "mode=memory" || param.starts_with("mode=memory&"))
+}
+
+/// Fetch column names for a `SQLite` table via `PRAGMA table_info`.
+async fn table_column_names(pool: &SqlitePool, table: &str) -> Result<Vec<String>, StoreError> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let rows = sqlx::query(AssertSqlSafe(pragma.as_str()))
+        .fetch_all(pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+    rows.iter()
+        .map(|row| row.try_get::<String, _>("name"))
+        .collect::<Result<_, _>>()
+        .map_err(|e| StoreError::Database(e.to_string()))
+}
+
+/// Query column metadata for each table and verify expected columns exist.
+async fn validate_schema(pool: &SqlitePool, tables: &TableNames) -> Result<(), StoreError> {
+    let version_table = schema_version_table(&tables.responses);
+    let expected = expected_table_columns(tables);
+    let mut results = Vec::with_capacity(expected.len() + 1);
+
+    for (table_name, expected_cols) in &expected {
+        results.push((*table_name, *expected_cols, table_column_names(pool, table_name).await?));
+    }
+    results.push((
+        version_table.as_str(),
+        VERSION_COLUMNS,
+        table_column_names(pool, &version_table).await?,
+    ));
+
+    let refs: Vec<ColumnCheck<'_>> = results
+        .iter()
+        .map(|(name, expected, actual)| (*name, *expected, actual.as_slice()))
+        .collect();
+
+    check_column_presence(&refs)
+}
+
+/// Stamp or validate the schema version.
+async fn check_schema_version(pool: &SqlitePool, tables: &TableNames) -> Result<(), StoreError> {
+    let vt = schema_version_table(&tables.responses);
+    let select = format!("SELECT version FROM {vt}");
+    let row: Option<i64> = sqlx::query_scalar(AssertSqlSafe(select.as_str()))
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+    match row {
+        None => {
+            let insert = format!("INSERT OR IGNORE INTO {vt} (version) VALUES (?)");
+            sqlx::query(AssertSqlSafe(insert.as_str()))
+                .bind(SCHEMA_VERSION)
+                .execute(pool)
+                .await
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        },
+        Some(v) if v == SCHEMA_VERSION => Ok(()),
+        Some(v) => Err(StoreError::Database(format!(
+            "schema version mismatch in '{vt}': stored version {v}, \
+             expected {SCHEMA_VERSION}; database migration required"
+        ))),
+    }
 }
 
 #[async_trait]

--- a/apis/src/store/tests.rs
+++ b/apis/src/store/tests.rs
@@ -1409,6 +1409,163 @@ async fn schema_migration_is_idempotent() {
 }
 
 // -----------------------------------------------------------------------------
+// Schema Validation (missing columns)
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sqlite_rejects_table_with_missing_columns() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let db_path = dir.path().join("bad_schema.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    let options = url
+        .parse::<sqlx::sqlite::SqliteConnectOptions>()
+        .expect("url should parse")
+        .create_if_missing(true);
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .expect("pool should connect");
+    sqlx::query("CREATE TABLE bad_responses (tenant_id TEXT NOT NULL, id TEXT NOT NULL, PRIMARY KEY (tenant_id, id))")
+        .execute(&pool)
+        .await
+        .expect("manual create should succeed");
+    pool.close().await;
+
+    let result = SqliteResponseStore::new(&url, "bad_responses", "ok_conversations", None).await;
+    let Err(err) = result else {
+        panic!("init should fail on schema mismatch");
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema validation failed"),
+        "error should mention schema validation: {msg}"
+    );
+    assert!(msg.contains("bad_responses"), "error should name the table: {msg}");
+    assert!(msg.contains("created_at"), "error should list missing column: {msg}");
+    assert!(msg.contains("model"), "error should list missing column: {msg}");
+}
+
+#[tokio::test]
+async fn sqlite_rejects_items_table_with_missing_columns() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let db_path = dir.path().join("bad_items.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    let options = url
+        .parse::<sqlx::sqlite::SqliteConnectOptions>()
+        .expect("url should parse")
+        .create_if_missing(true);
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .expect("pool should connect");
+    sqlx::query(
+        "CREATE TABLE bad_items (item_id TEXT NOT NULL, tenant_id TEXT NOT NULL, \
+         conversation_id TEXT NOT NULL, created_at BIGINT NOT NULL, position BIGINT NOT NULL, \
+         PRIMARY KEY (item_id, tenant_id, conversation_id))",
+    )
+    .execute(&pool)
+    .await
+    .expect("manual create should succeed");
+    pool.close().await;
+
+    let result = SqliteResponseStore::new(&url, "ok_responses", "ok_conversations", Some("bad_items")).await;
+    let Err(err) = result else {
+        panic!("init should fail on items schema mismatch");
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema validation failed"),
+        "error should mention schema validation: {msg}"
+    );
+    assert!(msg.contains("bad_items"), "error should name the table: {msg}");
+    assert!(msg.contains("item_data"), "error should list missing column: {msg}");
+}
+
+// -----------------------------------------------------------------------------
+// Schema Version
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sqlite_stamps_schema_version_on_fresh_db() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let db_path = dir.path().join("version.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    let _store = SqliteResponseStore::new(&url, "vr", "vc", None)
+        .await
+        .expect("store creation should succeed");
+
+    let options = url
+        .parse::<sqlx::sqlite::SqliteConnectOptions>()
+        .expect("url should parse");
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .expect("pool should connect");
+    let version: i64 = sqlx::query_scalar("SELECT version FROM vr_schema_version")
+        .fetch_one(&pool)
+        .await
+        .expect("version row should exist");
+    assert_eq!(version, 1, "fresh store should stamp version 1");
+}
+
+#[tokio::test]
+async fn sqlite_rejects_schema_version_mismatch() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let db_path = dir.path().join("bad_version.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    let options = url
+        .parse::<sqlx::sqlite::SqliteConnectOptions>()
+        .expect("url should parse")
+        .create_if_missing(true);
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .expect("pool should connect");
+    sqlx::query("CREATE TABLE vr_schema_version (version BIGINT NOT NULL PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .expect("create should succeed");
+    sqlx::query("INSERT INTO vr_schema_version (version) VALUES (99)")
+        .execute(&pool)
+        .await
+        .expect("insert should succeed");
+    pool.close().await;
+
+    let result = SqliteResponseStore::new(&url, "vr", "vc", None).await;
+    let Err(err) = result else {
+        panic!("init should fail on version mismatch");
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema version mismatch"),
+        "error should mention version mismatch: {msg}"
+    );
+    assert!(msg.contains("99"), "error should show stored version: {msg}");
+    assert!(
+        msg.contains("migration required"),
+        "error should mention migration: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn sqlite_accepts_matching_schema_version() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let db_path = dir.path().join("good_version.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    let _store = SqliteResponseStore::new(&url, "vr", "vc", None)
+        .await
+        .expect("first init should succeed");
+
+    let _store2 = SqliteResponseStore::new(&url, "vr", "vc", None)
+        .await
+        .expect("second init with matching version should succeed");
+}
+
+// -----------------------------------------------------------------------------
 // Concurrent Access
 // -----------------------------------------------------------------------------
 
@@ -1638,6 +1795,119 @@ async fn pg_nonexistent_ssl_root_cert_fails() {
         matches!(err, StoreError::Database(_)),
         "error should be StoreError::Database: {err}"
     );
+}
+
+#[tokio::test]
+#[ignore]
+async fn pg_rejects_table_with_missing_columns() {
+    use sqlx::AssertSqlSafe;
+
+    let url = pg_database_url();
+    let suffix = pg_unique_suffix();
+    let table_name = format!("bad_responses_{suffix}");
+
+    let options: sqlx::postgres::PgConnectOptions = url.parse().expect("url should parse");
+    let pool = Box::pin(sqlx::PgPool::connect_with(options))
+        .await
+        .expect("pool should connect");
+    let create_sql = format!(
+        "CREATE TABLE IF NOT EXISTS {table_name} \
+         (tenant_id TEXT NOT NULL, id TEXT NOT NULL, PRIMARY KEY (tenant_id, id))"
+    );
+    sqlx::query(AssertSqlSafe(create_sql.as_str()))
+        .execute(&pool)
+        .await
+        .expect("manual create should succeed");
+    pool.close().await;
+
+    let result = Box::pin(PostgresResponseStore::new(
+        &url,
+        &table_name,
+        &format!("ok_conversations_{suffix}"),
+        None,
+        Some(SslMode::Disable),
+        None,
+    ))
+    .await;
+    let Err(err) = result else {
+        panic!("init should fail on schema mismatch");
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema validation failed"),
+        "error should mention schema validation: {msg}"
+    );
+    assert!(msg.contains(&table_name), "error should name the table: {msg}");
+    assert!(msg.contains("created_at"), "error should list missing column: {msg}");
+
+    let cleanup_pool = Box::pin(sqlx::PgPool::connect(&url)).await.expect("cleanup pool");
+    let conv_table = format!("ok_conversations_{suffix}");
+    let ver_table = format!("{table_name}_schema_version");
+    for table in [&table_name, &conv_table, &ver_table] {
+        let drop_sql = format!("DROP TABLE IF EXISTS {table}");
+        sqlx::query(AssertSqlSafe(drop_sql.as_str()))
+            .execute(&cleanup_pool)
+            .await
+            .expect("cleanup should succeed");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn pg_rejects_schema_version_mismatch() {
+    use sqlx::AssertSqlSafe;
+
+    let url = pg_database_url();
+    let suffix = pg_unique_suffix();
+    let resp_table = format!("vr_{suffix}");
+    let conv_table = format!("vc_{suffix}");
+    let ver_table = format!("{resp_table}_schema_version");
+
+    let options: sqlx::postgres::PgConnectOptions = url.parse().expect("url should parse");
+    let pool = Box::pin(sqlx::PgPool::connect_with(options))
+        .await
+        .expect("pool should connect");
+    let create_sql = format!("CREATE TABLE IF NOT EXISTS {ver_table} (version BIGINT NOT NULL PRIMARY KEY)");
+    sqlx::query(AssertSqlSafe(create_sql.as_str()))
+        .execute(&pool)
+        .await
+        .expect("create should succeed");
+    let insert_sql = format!("INSERT INTO {ver_table} (version) VALUES (99)");
+    sqlx::query(AssertSqlSafe(insert_sql.as_str()))
+        .execute(&pool)
+        .await
+        .expect("insert should succeed");
+    pool.close().await;
+
+    let result = Box::pin(PostgresResponseStore::new(
+        &url,
+        &resp_table,
+        &conv_table,
+        None,
+        Some(SslMode::Disable),
+        None,
+    ))
+    .await;
+    let Err(err) = result else {
+        panic!("init should fail on version mismatch");
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema version mismatch"),
+        "error should mention version mismatch: {msg}"
+    );
+    assert!(msg.contains("99"), "error should show stored version: {msg}");
+
+    let cleanup_pool = Box::pin(sqlx::PgPool::connect(&url)).await.expect("cleanup pool");
+    for table in [&ver_table, &resp_table, &conv_table] {
+        let drop_sql = format!("DROP TABLE IF EXISTS {table}");
+        sqlx::query(AssertSqlSafe(drop_sql.as_str()))
+            .execute(&cleanup_pool)
+            .await
+            .expect("cleanup should succeed");
+    }
 }
 
 async fn make_pg_store() -> PostgresResponseStore {

--- a/apis/src/store/tests.rs
+++ b/apis/src/store/tests.rs
@@ -1431,7 +1431,7 @@ async fn sqlite_rejects_table_with_missing_columns() {
         .expect("manual create should succeed");
     pool.close().await;
 
-    let result = SqliteResponseStore::new(&url, "bad_responses", "ok_conversations", None).await;
+    let result = SqliteResponseStore::new(&url, "bad_responses", "ok_conversations", None, None).await;
     let Err(err) = result else {
         panic!("init should fail on schema mismatch");
     };
@@ -1469,7 +1469,7 @@ async fn sqlite_rejects_items_table_with_missing_columns() {
     .expect("manual create should succeed");
     pool.close().await;
 
-    let result = SqliteResponseStore::new(&url, "ok_responses", "ok_conversations", Some("bad_items")).await;
+    let result = SqliteResponseStore::new(&url, "ok_responses", "ok_conversations", Some("bad_items"), None).await;
     let Err(err) = result else {
         panic!("init should fail on items schema mismatch");
     };
@@ -1493,7 +1493,7 @@ async fn sqlite_stamps_schema_version_on_fresh_db() {
     let db_path = dir.path().join("version.db");
     let url = format!("sqlite://{}?mode=rwc", db_path.display());
 
-    let _store = SqliteResponseStore::new(&url, "vr", "vc", None)
+    let _store = SqliteResponseStore::new(&url, "vr", "vc", None, None)
         .await
         .expect("store creation should succeed");
 
@@ -1533,7 +1533,7 @@ async fn sqlite_rejects_schema_version_mismatch() {
         .expect("insert should succeed");
     pool.close().await;
 
-    let result = SqliteResponseStore::new(&url, "vr", "vc", None).await;
+    let result = SqliteResponseStore::new(&url, "vr", "vc", None, None).await;
     let Err(err) = result else {
         panic!("init should fail on version mismatch");
     };
@@ -1556,11 +1556,11 @@ async fn sqlite_accepts_matching_schema_version() {
     let db_path = dir.path().join("good_version.db");
     let url = format!("sqlite://{}?mode=rwc", db_path.display());
 
-    let _store = SqliteResponseStore::new(&url, "vr", "vc", None)
+    let _store = SqliteResponseStore::new(&url, "vr", "vc", None, None)
         .await
         .expect("first init should succeed");
 
-    let _store2 = SqliteResponseStore::new(&url, "vr", "vc", None)
+    let _store2 = SqliteResponseStore::new(&url, "vr", "vc", None, None)
         .await
         .expect("second init with matching version should succeed");
 }
@@ -1827,6 +1827,7 @@ async fn pg_rejects_table_with_missing_columns() {
         None,
         Some(SslMode::Disable),
         None,
+        None,
     ))
     .await;
     let Err(err) = result else {
@@ -1886,6 +1887,7 @@ async fn pg_rejects_schema_version_mismatch() {
         &conv_table,
         None,
         Some(SslMode::Disable),
+        None,
         None,
     ))
     .await;


### PR DESCRIPTION
## Summary

Add two complementary init-time checks to both SQLite and PostgreSQL store backends to catch schema issues at startup rather than at query time:

- **Column existence validation**: queries table metadata (`PRAGMA table_info` / `information_schema.columns`) at init and verifies every expected column is present across responses, conversations, items, and version tables. Catches external schema drift.
- **Schema version tracking**: a derived `{responses}_schema_version` table is stamped with version 1 on fresh databases and checked on subsequent inits. Version mismatch produces a clear error with stored vs expected version. Uses `BIGINT NOT NULL PRIMARY KEY` with conflict-safe INSERT (`INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`) for concurrent init safety.

Also tightens the PostgreSQL responses table name limit from 63 to 48 bytes to accommodate the `_schema_version` suffix, adds collision checks for the derived table name against conversations and items tables, and extracts a `table_column_names` helper in the SQLite backend.

## Related issue

N/A — proactive hardening, no existing issue.

## Validation

```
cargo test -p praxis-ai-apis -- schema  # 40 passed, 2 ignored (PG)
make fmt && make lint                   # all checks pass
```

PostgreSQL integration tests (`#[ignore]`) require a running instance with `DATABASE_URL` set.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Tests are added or updated when behavior changes.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

The PostgreSQL responses table name limit is reduced from 63 to 48 bytes to leave room for the `_schema_version` suffix. Existing configurations with responses table names between 49-63 bytes will fail validation at init.