### PR TITLE
fix(openai_responses): place web-search sources inside action object

### DIFF
--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -64,6 +64,9 @@ const ACTION_LOOP: &str = "loop";
 /// Action value signalling no web search dispatch needed.
 const ACTION_DONE: &str = "done";
 
+/// Include value that gates `action.sources` in the output item.
+const INCLUDE_ACTION_SOURCES: &str = "web_search_call.action.sources";
+
 // -----------------------------------------------------------------------------
 // WebSearchFilter
 // -----------------------------------------------------------------------------
@@ -277,9 +280,6 @@ impl HttpFilter for WebSearchFilter {
         Ok(FilterAction::Continue)
     }
 }
-
-/// Include value that gates `action.sources` in the output item.
-const INCLUDE_ACTION_SOURCES: &str = "web_search_call.action.sources";
 
 /// Append search results to [`ResponsesState`].
 fn append_result(ctx: &mut HttpFilterContext<'_>, call_id: &str, status: &str, query: &str, results: &[SearchResult]) {

--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -335,32 +335,26 @@ pub(crate) fn emit_status(ctx: &mut HttpFilterContext<'_>, call_id: &str, status
 
 /// Build a `web_search_call` output item for the response.
 pub(crate) fn build_output_item(call_id: &str, status: &str, query: &str, results: &[SearchResult]) -> Value {
-    let mut item = serde_json::json!({
+    let sources: Vec<Value> = results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "type": "url",
+                "url": r.url,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
         "type": "web_search_call",
         "id": call_id,
         "status": status,
         "action": {
             "type": "search",
             "query": query,
+            "sources": sources,
         },
-    });
-
-    if !results.is_empty() {
-        let sources: Vec<Value> = results
-            .iter()
-            .map(|r| {
-                serde_json::json!({
-                    "title": r.title,
-                    "url": r.url,
-                })
-            })
-            .collect();
-        if let Some(obj) = item.as_object_mut() {
-            obj.insert("sources".to_owned(), Value::Array(sources));
-        }
-    }
-
-    item
+    })
 }
 
 /// Build a tool result message to append to conversation history.

--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -278,9 +278,17 @@ impl HttpFilter for WebSearchFilter {
     }
 }
 
+/// Include value that gates `action.sources` in the output item.
+const INCLUDE_ACTION_SOURCES: &str = "web_search_call.action.sources";
+
 /// Append search results to [`ResponsesState`].
 fn append_result(ctx: &mut HttpFilterContext<'_>, call_id: &str, status: &str, query: &str, results: &[SearchResult]) {
-    let output_item = build_output_item(call_id, status, query, results);
+    let include_sources = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .is_some_and(|s| s.include.iter().any(|v| v == INCLUDE_ACTION_SOURCES));
+
+    let output_item = build_output_item(call_id, status, query, results, include_sources);
     let tool_result = build_tool_result_message(call_id, results);
 
     if let Some(state) = ctx.extensions.get_mut::<ResponsesState>() {
@@ -334,26 +342,41 @@ pub(crate) fn emit_status(ctx: &mut HttpFilterContext<'_>, call_id: &str, status
 }
 
 /// Build a `web_search_call` output item for the response.
-pub(crate) fn build_output_item(call_id: &str, status: &str, query: &str, results: &[SearchResult]) -> Value {
-    let sources: Vec<Value> = results
-        .iter()
-        .map(|r| {
-            serde_json::json!({
-                "type": "url",
-                "url": r.url,
+///
+/// `action.sources` is only included when `include_sources` is true,
+/// matching the `web_search_call.action.sources` include gate.
+pub(crate) fn build_output_item(
+    call_id: &str,
+    status: &str,
+    query: &str,
+    results: &[SearchResult],
+    include_sources: bool,
+) -> Value {
+    let mut action = serde_json::json!({
+        "type": "search",
+        "query": query,
+    });
+
+    if include_sources {
+        let sources: Vec<Value> = results
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "type": "url",
+                    "url": r.url,
+                })
             })
-        })
-        .collect();
+            .collect();
+        if let Some(obj) = action.as_object_mut() {
+            obj.insert("sources".to_owned(), Value::Array(sources));
+        }
+    }
 
     serde_json::json!({
         "type": "web_search_call",
         "id": call_id,
         "status": status,
-        "action": {
-            "type": "search",
-            "query": query,
-            "sources": sources,
-        },
+        "action": action,
     })
 }
 

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -377,9 +377,11 @@ async fn on_request_body_executes_search_and_populates_state() {
     assert_eq!(output["id"], "ws_exec_1");
     assert_eq!(output["status"], "completed");
     assert_eq!(output["action"]["query"], "rust language");
-    let sources = output["sources"].as_array().unwrap();
+    assert!(output.get("sources").is_none(), "no top-level sources");
+    let sources = output["action"]["sources"].as_array().unwrap();
     assert_eq!(sources.len(), 1);
-    assert_eq!(sources[0]["title"], "Rust Lang");
+    assert_eq!(sources[0]["type"], "url");
+    assert_eq!(sources[0]["url"], "https://rust-lang.org");
 }
 
 #[tokio::test]
@@ -424,7 +426,8 @@ fn build_output_item_completed() {
     assert_eq!(item["status"], "completed");
     assert_eq!(item["action"]["type"], "search");
     assert_eq!(item["action"]["query"], "test query");
-    assert!(item.get("sources").is_none(), "no sources when results empty");
+    let sources = item["action"]["sources"].as_array().unwrap();
+    assert!(sources.is_empty(), "no sources when results empty");
 }
 
 #[test]
@@ -442,10 +445,14 @@ fn build_output_item_with_results() {
         },
     ];
     let item = build_output_item("ws_123", "completed", "search query", &results);
-    let sources = item["sources"].as_array().unwrap();
+    assert!(item.get("sources").is_none(), "no top-level sources");
+    let sources = item["action"]["sources"].as_array().unwrap();
     assert_eq!(sources.len(), 2);
-    assert_eq!(sources[0]["title"], "Rust Lang");
+    assert_eq!(sources[0]["type"], "url");
     assert_eq!(sources[0]["url"], "https://rust-lang.org");
+    assert!(sources[0].get("title").is_none(), "title excluded from url source");
+    assert_eq!(sources[1]["type"], "url");
+    assert_eq!(sources[1]["url"], "https://crates.io");
 }
 
 #[test]

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -345,7 +345,11 @@ async fn on_request_body_executes_search_and_populates_state() {
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
 
-    let body = serde_json::json!({"model": "gpt-4o", "input": "test"});
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "test",
+        "include": ["web_search_call.action.sources"],
+    });
     let mut state = ResponsesState::from_request_body(body);
     state.web_search_calls = vec![serde_json::json!({
         "type": "web_search_call",
@@ -385,6 +389,39 @@ async fn on_request_body_executes_search_and_populates_state() {
 }
 
 #[tokio::test]
+async fn on_request_body_omits_sources_without_include() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    spawn_brave_mock(listener);
+
+    let yaml = make_filter_yaml_with_base_url("brave", "test-key", &format!("http://{addr}"));
+    let filter = WebSearchFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let body = serde_json::json!({"model": "gpt-4o", "input": "test"});
+    let mut state = ResponsesState::from_request_body(body);
+    state.web_search_calls = vec![serde_json::json!({
+        "type": "web_search_call",
+        "id": "ws_exec_2",
+        "action": {"type": "search", "query": "rust language"}
+    })];
+    ctx.extensions.insert(state);
+
+    let action = filter.on_request_body(&mut ctx, &mut None, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    let output = &state.accumulated_output[0];
+    assert_eq!(output["action"]["query"], "rust language");
+    assert!(
+        output["action"].get("sources").is_none(),
+        "sources omitted when not in include"
+    );
+}
+
+#[tokio::test]
 async fn on_request_body_missing_query_produces_incomplete_status() {
     let yaml = make_filter_yaml("brave", "test-key");
     let filter = WebSearchFilter::from_config(&yaml).unwrap();
@@ -419,8 +456,8 @@ async fn on_request_body_missing_query_produces_incomplete_status() {
 // -----------------------------------------------------------------------------
 
 #[test]
-fn build_output_item_completed() {
-    let item = build_output_item("ws_123", "completed", "test query", &[]);
+fn build_output_item_completed_with_sources_included() {
+    let item = build_output_item("ws_123", "completed", "test query", &[], true);
     assert_eq!(item["type"], "web_search_call");
     assert_eq!(item["id"], "ws_123");
     assert_eq!(item["status"], "completed");
@@ -428,6 +465,22 @@ fn build_output_item_completed() {
     assert_eq!(item["action"]["query"], "test query");
     let sources = item["action"]["sources"].as_array().unwrap();
     assert!(sources.is_empty(), "no sources when results empty");
+}
+
+#[test]
+fn build_output_item_omits_sources_when_not_included() {
+    let results = vec![SearchResult {
+        title: "Rust Lang".into(),
+        url: "https://rust-lang.org".into(),
+        snippet: "Systems".into(),
+    }];
+    let item = build_output_item("ws_123", "completed", "test query", &results, false);
+    assert_eq!(item["action"]["type"], "search");
+    assert_eq!(item["action"]["query"], "test query");
+    assert!(
+        item["action"].get("sources").is_none(),
+        "sources omitted when include_sources is false"
+    );
 }
 
 #[test]
@@ -444,7 +497,7 @@ fn build_output_item_with_results() {
             snippet: "Packages".into(),
         },
     ];
-    let item = build_output_item("ws_123", "completed", "search query", &results);
+    let item = build_output_item("ws_123", "completed", "search query", &results, true);
     assert!(item.get("sources").is_none(), "no top-level sources");
     let sources = item["action"]["sources"].as_array().unwrap();
     assert_eq!(sources.len(), 2);


### PR DESCRIPTION
## Summary

Move `sources` from the top-level `web_search_call` output item into
`action.sources` and encode each source as `{"type":"url","url":"..."}`
to conform to the OpenAI Responses API schema. Previously, consumers
requesting `web_search_call.action.sources` would see no sources.

## Related issue

Closes #561

## Validation

- `cargo test -p praxis-ai-apis -- web_search` — 105 tests pass
- `make lint` — all checks pass

- [x] Unit tests
- [ ] Integration or functional tests
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.