### PR TITLE
fix(openai_responses): avoid double-encoding MCP approval arguments

### DIFF
--- a/apis/src/openai/responses/mcp_dispatch/mod.rs
+++ b/apis/src/openai/responses/mcp_dispatch/mod.rs
@@ -345,9 +345,34 @@ fn extract_call_id(tc: &serde_json::Value) -> String {
         .to_owned()
 }
 
+/// Normalize raw tool call arguments.
+///
+/// Function calls carry arguments either as a JSON string
+/// (e.g., `"{\"city\":\"Paris\"}"`) or directly as a JSON value.
+/// Returns `(parsed_value, canonical_string)` or an error for
+/// malformed JSON strings.
+fn normalize_arguments(raw: &serde_json::Value) -> Result<(serde_json::Value, String), String> {
+    match raw {
+        serde_json::Value::String(s) => {
+            let parsed = serde_json::from_str(s).map_err(|e| format!("malformed tool arguments: {e}"))?;
+            Ok((parsed, s.clone()))
+        },
+        other => Ok((other.clone(), other.to_string())),
+    }
+}
+
 /// Extract serialised arguments from a tool call value.
+///
+/// Uses the same string-vs-non-string convention as
+/// [`normalize_arguments`] but only produces the canonical string,
+/// avoiding the deep clone that full normalization performs on
+/// non-string values.
 fn extract_arguments(tc: &serde_json::Value) -> String {
-    tc.get("arguments").map(ToString::to_string).unwrap_or_default()
+    match tc.get("arguments") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
 }
 
 /// Check a single tool call for approval requirement.
@@ -531,24 +556,16 @@ fn parse_call_arguments(
         .get("arguments")
         .cloned()
         .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-    let arguments = match &raw {
-        serde_json::Value::String(s) => match serde_json::from_str(s) {
-            Ok(parsed) => parsed,
-            Err(e) => {
-                warn!(tool_name, error = %e, "malformed JSON in tool call arguments");
-                return Err(Box::new(build_error_result(
-                    call_id,
-                    server_label,
-                    tool_name,
-                    s,
-                    &format!("malformed tool arguments: {e}"),
-                )));
-            },
-        },
-        other => other.clone(),
-    };
-    let arguments_string = arguments.to_string();
-    Ok((arguments, arguments_string))
+    normalize_arguments(&raw).map_err(|e| {
+        warn!(tool_name, error = %e, "malformed JSON in tool call arguments");
+        Box::new(build_error_result(
+            call_id,
+            server_label,
+            tool_name,
+            raw.as_str().unwrap_or_default(),
+            &e,
+        ))
+    })
 }
 
 /// Build result from a completed (successful or failed) MCP call.

--- a/apis/src/openai/responses/mcp_dispatch/tests.rs
+++ b/apis/src/openai/responses/mcp_dispatch/tests.rs
@@ -12,8 +12,8 @@ use serde_json::json;
 use super::{
     McpDispatchFilter, build_error_result, build_success_result, content_blocks_to_text, encode_function_name,
     execute_mcp_calls, execute_single_call, extract_arguments, extract_call_id, extract_mcp_tool_calls,
-    find_approval_required, find_by_encoded_name, is_mcp_tool_call, parse_call_arguments, process_call_result,
-    resolve_tool_entry,
+    find_approval_required, find_by_encoded_name, is_mcp_tool_call, normalize_arguments, parse_call_arguments,
+    process_call_result, resolve_tool_entry,
 };
 use crate::{
     openai::responses::{
@@ -672,6 +672,40 @@ fn process_call_result_transport_error() {
 }
 
 // =========================================================================
+// normalize_arguments
+// =========================================================================
+
+#[test]
+fn normalize_arguments_parses_json_string() {
+    let raw = serde_json::json!("{\"city\":\"Paris\"}");
+    let (parsed, canonical) = normalize_arguments(&raw).unwrap();
+    assert_eq!(parsed["city"], "Paris");
+    assert_eq!(canonical, "{\"city\":\"Paris\"}");
+}
+
+#[test]
+fn normalize_arguments_object_passthrough() {
+    let raw = serde_json::json!({"city": "Paris"});
+    let (parsed, canonical) = normalize_arguments(&raw).unwrap();
+    assert_eq!(parsed["city"], "Paris");
+    assert!(canonical.contains("Paris"));
+}
+
+#[test]
+fn normalize_arguments_malformed_string_returns_error() {
+    let raw = serde_json::json!("not-json");
+    assert!(normalize_arguments(&raw).is_err());
+}
+
+#[test]
+fn normalize_arguments_empty_object_string() {
+    let raw = serde_json::json!("{}");
+    let (parsed, canonical) = normalize_arguments(&raw).unwrap();
+    assert!(parsed.is_object());
+    assert_eq!(canonical, "{}");
+}
+
+// =========================================================================
 // extract_call_id / extract_arguments
 // =========================================================================
 
@@ -704,6 +738,23 @@ fn extract_arguments_present() {
 fn extract_arguments_absent() {
     let tc = serde_json::json!({});
     assert_eq!(extract_arguments(&tc), "");
+}
+
+#[test]
+fn extract_arguments_string_not_double_encoded() {
+    let tc = serde_json::json!({"arguments": "{\"city\":\"Paris\"}"});
+    let args = extract_arguments(&tc);
+    assert_eq!(
+        args, "{\"city\":\"Paris\"}",
+        "string arguments must not be double-encoded"
+    );
+}
+
+#[test]
+fn extract_arguments_malformed_string_passes_through() {
+    let tc = serde_json::json!({"arguments": "not-json"});
+    let args = extract_arguments(&tc);
+    assert_eq!(args, "not-json", "malformed string should pass through unchanged");
 }
 
 // =========================================================================
@@ -952,6 +1003,34 @@ fn on_response_body_approval_required_sets_done_metadata() {
         Some(&"done".to_owned())
     );
     assert_dispatch_action(&ctx, "done");
+}
+
+#[test]
+fn on_response_body_approval_emits_correct_arguments() {
+    let filter = make_dispatch_filter();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(&req);
+    let state = ResponsesState {
+        mcp_tool_map: sample_tool_map(),
+        tool_calls: vec![json!({
+            "name": "weather__get_weather",
+            "call_id": "c1",
+            "arguments": "{\"city\":\"Paris\"}"
+        })],
+        ..ResponsesState::default()
+    };
+    ctx.extensions.insert(state);
+    let mut body = None;
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.accumulated_output.len(), 1);
+    let event = &state.accumulated_output[0];
+    assert_eq!(event["type"], "mcp_approval_request");
+    assert_eq!(
+        event["arguments"], "{\"city\":\"Paris\"}",
+        "approval event arguments must not be double-encoded"
+    );
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

`extract_arguments` used `Value::to_string()` which re-serializes JSON string values, wrapping them in an extra layer of quotes and escapes. For example, `{"arguments":"{\"city\":\"Paris\"}"}` became `"\"{\\\"city\\\":\\\"Paris\\\"}\""` in the emitted `mcp_approval_request` instead of the original JSON text.

Extracts a shared `normalize_arguments` helper for the string-vs-non-string dispatch, used by `parse_call_arguments` (execution path). `extract_arguments` (approval path) uses the same convention but serializes directly from the reference to avoid a wasteful deep clone.

## Related issue

Closes #558

## Validation

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.