### PR TITLE
fix(openai_responses): enforce max_body_bytes after MCP tool expansion

### DIFF
--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -54,7 +54,10 @@ use tracing::debug;
 
 use self::config::{McpToolResolveConfig, build_config};
 use super::{error::responses_error_rejection, state::ResponsesState};
-use crate::{json_body::serialize_json_body, mcp_client};
+use crate::{
+    json_body::{SerializedJson, serialize_json_body},
+    mcp_client,
+};
 
 /// Maximum length for generated function names per the OpenAI
 /// Responses POST schema (`^[a-zA-Z0-9_-]+$`, max 64 chars).
@@ -157,7 +160,11 @@ impl McpToolResolveFilter {
         debug!(tool_count = resolution.tool_map.len(), "mcp_tool_map built");
 
         let Resolution { per_entry, tool_map } = resolution;
-        rewrite_request_body(body, &original_bytes, per_entry, &tool_map, self.name())?;
+        let Some(serialized) = rewrite_request_body(&original_bytes, per_entry, &tool_map)? else {
+            return Ok(FilterAction::Continue);
+        };
+        check_body_size(&serialized, self.max_body_bytes)?;
+        serialized.commit(body, self.name(), "tools");
 
         let body_for_state = body.as_ref().map_or_else(|| original_bytes.as_ref(), |b| b.as_ref());
         write_state(ctx, body_for_state, tool_map);
@@ -318,6 +325,15 @@ enum ResolveError {
         /// Configured maximum.
         max: usize,
     },
+
+    /// Expanded request body exceeds `max_body_bytes`.
+    #[error("expanded request body is {actual} bytes, exceeding the {limit} byte limit")]
+    BodyTooLarge {
+        /// Serialized body size after MCP tool expansion.
+        actual: usize,
+        /// Configured `max_body_bytes` limit.
+        limit: usize,
+    },
 }
 
 /// Result of resolving all MCP entries.
@@ -333,12 +349,29 @@ struct Resolution {
 // Private Helpers
 // -----------------------------------------------------------------------------
 
+/// Reject the expanded body if it exceeds `max_body_bytes`.
+fn check_body_size(serialized: &SerializedJson, max_body_bytes: usize) -> Result<(), ResolveError> {
+    if serialized.len() > max_body_bytes {
+        debug!(
+            actual = serialized.len(),
+            limit = max_body_bytes,
+            "expanded request body exceeds configured limit"
+        );
+        return Err(ResolveError::BodyTooLarge {
+            actual: serialized.len(),
+            limit: max_body_bytes,
+        });
+    }
+    Ok(())
+}
+
 /// Map a [`ResolveError`] to an appropriate rejection response.
 fn resolve_error_rejection(err: &ResolveError, streaming: bool) -> FilterAction {
     let (status, error_type) = match err {
         ResolveError::DuplicateLabel(_) | ResolveError::TooManyServers { .. } | ResolveError::NameCollision(_) => {
             (400, "invalid_request_error")
         },
+        ResolveError::BodyTooLarge { .. } => (413, "invalid_request_error"),
         ResolveError::Client(_) => (502, "server_error"),
         ResolveError::Serialization(_) => (500, "server_error"),
     };
@@ -485,34 +518,29 @@ async fn fetch_tools(
 /// entries with `type: "function"` entries and translating any
 /// MCP `tool_choice` references.
 ///
-/// MCP entries that were not resolved (no `server_url`, deferred,
-/// or `connector_id` only) are left unchanged for upstream to
-/// handle.
+/// Returns `None` when no rewrite is needed (unparseable body,
+/// empty tools array, or no resolved entries). The caller is
+/// responsible for checking the serialized size against
+/// `max_body_bytes` before committing.
 fn rewrite_request_body(
-    body: &mut Option<Bytes>,
     original_bytes: &[u8],
     per_entry: Vec<Vec<serde_json::Value>>,
     tool_map: &HashMap<(String, String), serde_json::Value>,
-    filter_name: &'static str,
-) -> Result<(), ResolveError> {
+) -> Result<Option<SerializedJson>, ResolveError> {
     let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(original_bytes) else {
-        return Ok(());
+        return Ok(None);
     };
-
     let Some(obj) = parsed.as_object_mut() else {
-        return Ok(());
+        return Ok(None);
     };
-
     let Some(serde_json::Value::Array(tools)) = obj.remove("tools") else {
-        return Ok(());
+        return Ok(None);
     };
 
     let (rewritten, generated_names) = rewrite_tools_array(tools, per_entry);
-
     if rewritten.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
-
     detect_name_collisions(&rewritten, &generated_names)?;
 
     let rewritten_count = rewritten.len();
@@ -523,11 +551,8 @@ fn rewrite_request_body(
         debug!(error = %e, "failed to serialize rewritten body");
         ResolveError::Serialization(e)
     })?;
-
-    serialized.commit(body, filter_name, "tools");
-
     debug!(tool_count = rewritten_count, "rewrote MCP tools to function tools");
-    Ok(())
+    Ok(Some(serialized))
 }
 
 /// Rewrite a tools array, replacing resolved MCP entries with

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -1985,3 +1985,157 @@ async fn duplicate_label_entries_rejected_at_filter_level() {
         "response body should mention the duplicate: {body_str}"
     );
 }
+
+// =========================================================================
+// Body Size Limit After MCP Tool Expansion
+// =========================================================================
+
+/// Build a filter with a specific `max_body_bytes` limit.
+fn filter_with_max_body_bytes(limit: usize) -> Box<dyn HttpFilter> {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!("max_body_bytes: {limit}")).unwrap();
+    McpToolResolveFilter::from_config(&yaml).unwrap()
+}
+
+/// Build a cached tool listing with a schema large enough to
+/// expand a small request body past a given byte threshold.
+fn large_cached_tools(desc_len: usize) -> Vec<serde_json::Value> {
+    vec![serde_json::json!({
+        "name": "get_weather",
+        "description": "x".repeat(desc_len),
+        "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}}
+    })]
+}
+
+/// Expansion past `max_body_bytes` produces a 413 rejection with
+/// `invalid_request_error`. Body and `ResponsesState` are unchanged.
+#[tokio::test]
+async fn expanded_body_exceeding_limit_returns_413() {
+    let filter = filter_with_max_body_bytes(256);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let server_url = "http://10.0.0.5/mcp";
+    let body_json = mcp_body(server_url);
+    let mut state = ResponsesState::from_request_body(body_json.clone());
+    state.previous_tools = vec![serde_json::json!({
+        "server_label": "weather", "server_url": server_url,
+        "tools": large_cached_tools(4096),
+    })];
+    ctx.extensions.insert(state);
+
+    let body_bytes = serde_json::to_vec(&body_json).unwrap();
+    let mut body = Some(Bytes::from(body_bytes.clone()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 413, "should be HTTP 413");
+    let resp = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    assert!(resp.contains("invalid_request_error"), "error type: {resp}");
+    assert_eq!(body.as_deref(), Some(body_bytes.as_slice()), "body must be unchanged");
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert!(
+        state.mcp_tool_map.is_empty(),
+        "tool map must not be populated on rejection"
+    );
+}
+
+/// Expansion within `max_body_bytes` continues and commits the
+/// rewritten body to `ResponsesState`.
+#[tokio::test]
+async fn expanded_body_within_limit_continues() {
+    let filter = filter_with_max_body_bytes(1_048_576);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let server_url = "http://10.0.0.5/mcp";
+    let body_json = mcp_body(server_url);
+    let mut state = ResponsesState::from_request_body(body_json.clone());
+    state.previous_tools = vec![serde_json::json!({
+        "server_label": "weather", "server_url": server_url,
+        "tools": [{"name": "get_weather", "description": "Get weather"}],
+    })];
+    ctx.extensions.insert(state);
+
+    let body_bytes = serde_json::to_vec(&body_json).unwrap();
+    let mut body = Some(Bytes::from(body_bytes.clone()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue), "should continue");
+    assert_ne!(body.as_deref(), Some(body_bytes.as_slice()), "body should be rewritten");
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert!(!state.mcp_tool_map.is_empty(), "tool map should be populated");
+}
+
+/// Run MCP tool expansion through the filter and return the
+/// expanded body length.
+async fn measure_expanded_body_len(server_url: &str, cached: &[serde_json::Value]) -> usize {
+    let filter = filter_with_max_body_bytes(1_048_576);
+    let body_json = mcp_body(server_url);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+    let mut state = ResponsesState::from_request_body(body_json.clone());
+    state.previous_tools = vec![serde_json::json!({
+        "server_label": "weather", "server_url": server_url, "tools": cached,
+    })];
+    ctx.extensions.insert(state);
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    body.as_ref().unwrap().len()
+}
+
+/// Expanded body whose length equals `max_body_bytes` exactly is
+/// accepted (the guard rejects strictly *over* the limit).
+#[tokio::test]
+async fn expanded_body_at_exact_limit_continues() {
+    let server_url = "http://10.0.0.5/mcp";
+    let cached = vec![serde_json::json!({
+        "name": "get_weather", "description": "Get weather",
+        "inputSchema": {"type": "object"},
+    })];
+    let expanded_len = measure_expanded_body_len(server_url, &cached).await;
+
+    let filter_exact = filter_with_max_body_bytes(expanded_len);
+    let body_json = mcp_body(server_url);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+    let mut state = ResponsesState::from_request_body(body_json.clone());
+    state.previous_tools = vec![serde_json::json!({
+        "server_label": "weather", "server_url": server_url, "tools": cached,
+    })];
+    ctx.extensions.insert(state);
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter_exact.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "body at exact limit ({expanded_len} bytes) should be accepted"
+    );
+}
+
+/// `BodyTooLarge` maps to HTTP 413 with `invalid_request_error`.
+#[test]
+fn body_too_large_maps_to_413() {
+    let err = ResolveError::BodyTooLarge {
+        actual: 1_000_000,
+        limit: 65_536,
+    };
+    let action = resolve_error_rejection(&err, false);
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 413, "should be HTTP 413");
+    let body_str = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    assert!(
+        body_str.contains("invalid_request_error"),
+        "error type should be invalid_request_error: {body_str}"
+    );
+    assert!(body_str.contains("1000000"), "should include actual size: {body_str}");
+}


### PR DESCRIPTION
## Summary

The `openai_mcp_tool_resolve` filter applied `max_body_bytes` only when buffering the original client body via `StreamBuffer`, but after expanding MCP tool definitions into function tools (inserting potentially large schemas from untrusted MCP servers), the rewritten body could exceed `max_body_bytes` unchecked. This adds a post-serialization size guard that returns HTTP 413 with `invalid_request_error` before committing the expanded body, following the same serialize-then-check pattern used by `file_resolve`, `doc_extract`, and `rehydrate`.

## Related issue

Closes #549

## Validation

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

```
cargo test -p praxis-ai-apis -- openai_mcp_tool_resolve
make lint
make build
```

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.