### PR TITLE
refactor(responses): centralize usage accumulation  #691

### DIFF
--- a/apis/src/openai/responses/agentic_loop/mod.rs
+++ b/apis/src/openai/responses/agentic_loop/mod.rs
@@ -120,7 +120,7 @@ use serde_json::{Value, json};
 use tracing::{debug, trace};
 
 use self::config::{AgenticLoopConfig, build_config};
-use super::{error::responses_error_rejection, state::ResponsesState, stream_events::accumulator::merge_usage};
+use super::{error::responses_error_rejection, state::ResponsesState, usage::merge_usage};
 
 // -----------------------------------------------------------------------------
 // Constants

--- a/apis/src/openai/responses/file_search_callout/mod.rs
+++ b/apis/src/openai/responses/file_search_callout/mod.rs
@@ -46,7 +46,7 @@ use crate::{
         config_validation::FailureMode,
         error::responses_error_rejection,
         state::{MAX_CITATION_FILES, ResponsesState},
-        stream_events::accumulator::merge_usage,
+        usage::merge_usage,
     },
     subrequest::SubRequestClient,
 };

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod responses_to_chat_completions;
 pub(crate) mod state;
 pub(crate) mod store;
 pub(crate) mod stream_events;
+pub(crate) mod usage;
 
 pub use doc_extract::DocExtractFilter;
 pub use file_resolve::FileResolveFilter;

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use tracing::{debug, warn};
 
 use super::StreamEventsState;
-use crate::openai::{responses::state::ResponsesState, sse::responses::ResponsesEvent};
+use crate::openai::{responses::{state::ResponsesState, usage::merge_usage}, sse::responses::ResponsesEvent};
 
 /// Process a single SSE event, updating `ResponsesState` in
 /// extensions and per-filter accumulation state.
@@ -105,30 +105,6 @@ pub(super) fn accumulate_response_object(
 
     debug!(status, "complete response received, ResponsesState updated");
     had_prior_usage
-}
-
-/// Saturating recursive sum for numeric token-usage fields.
-pub(crate) fn merge_usage(accumulated: &mut Value, current: &Value) {
-    match (accumulated, current) {
-        (Value::Object(accumulated), Value::Object(current)) => {
-            for (key, value) in current {
-                match accumulated.get_mut(key) {
-                    Some(existing) => merge_usage(existing, value),
-                    None => {
-                        accumulated.insert(key.clone(), value.clone());
-                    },
-                }
-            }
-        },
-        (Value::Number(accumulated), Value::Number(current)) => {
-            if let (Some(left), Some(right)) = (accumulated.as_u64(), current.as_u64()) {
-                *accumulated = serde_json::Number::from(left.saturating_add(right));
-            } else {
-                *accumulated = current.clone();
-            }
-        },
-        (accumulated, current) => current.clone_into(accumulated),
-    }
 }
 
 /// Push a new output item to the incremental accumulator.

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -14,7 +14,10 @@ use serde_json::Value;
 use tracing::{debug, warn};
 
 use super::StreamEventsState;
-use crate::openai::{responses::{state::ResponsesState, usage::merge_usage}, sse::responses::ResponsesEvent};
+use crate::openai::{
+    responses::{state::ResponsesState, usage::merge_usage},
+    sse::responses::ResponsesEvent,
+};
 
 /// Process a single SSE event, updating `ResponsesState` in
 /// extensions and per-filter accumulation state.

--- a/apis/src/openai/responses/usage.rs
+++ b/apis/src/openai/responses/usage.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Usage accumulation for the Responses API.
+//!
+//! Centralises the recursive merge so every iterative flow
+//! (streaming, agentic loop, file search) shares one implementation
+//! rather than coupling non-streaming filters to the SSE-specific
+//! `stream_events` module.
+
+use serde_json::Value;
+
+/// Saturating recursive sum for numeric token-usage fields.
+///
+/// Recursively merges `current` into `accumulated`:
+/// - Objects: fields are merged recursively; newly introduced keys
+///   are preserved.
+/// - Unsigned integers: saturating-add.
+/// - All other types (including signed/float numbers and type
+///   mismatches): `accumulated` is replaced with `current`.
+pub(crate) fn merge_usage(accumulated: &mut Value, current: &Value) {
+    match (accumulated, current) {
+        (Value::Object(accumulated), Value::Object(current)) => {
+            for (key, value) in current {
+                match accumulated.get_mut(key) {
+                    Some(existing) => merge_usage(existing, value),
+                    None => {
+                        accumulated.insert(key.clone(), value.clone());
+                    },
+                }
+            }
+        },
+        (Value::Number(accumulated), Value::Number(current)) => {
+            if let (Some(left), Some(right)) = (accumulated.as_u64(), current.as_u64()) {
+                *accumulated = serde_json::Number::from(left.saturating_add(right));
+            } else {
+                *accumulated = current.clone();
+            }
+        },
+        (accumulated, current) => current.clone_into(accumulated),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use serde_json::json;
+
+    use super::merge_usage;
+
+    #[test]
+    fn adds_unsigned_integer_fields() {
+        let mut acc = json!({"input_tokens": 10, "output_tokens": 5});
+        merge_usage(&mut acc, &json!({"input_tokens": 7, "output_tokens": 1}));
+        assert_eq!(acc["input_tokens"], 17);
+        assert_eq!(acc["output_tokens"], 6);
+    }
+
+    #[test]
+    fn preserves_new_keys() {
+        let mut acc = json!({"input_tokens": 10});
+        merge_usage(&mut acc, &json!({"output_tokens": 5}));
+        assert_eq!(acc["input_tokens"], 10);
+        assert_eq!(acc["output_tokens"], 5);
+    }
+
+    #[test]
+    fn merges_nested_objects() {
+        let mut acc = json!({"input_tokens_details": {"cached_tokens": 4}});
+        merge_usage(
+            &mut acc,
+            &json!({"input_tokens_details": {"cached_tokens": 2, "audio_tokens": 1}}),
+        );
+        assert_eq!(acc["input_tokens_details"]["cached_tokens"], 6);
+        assert_eq!(acc["input_tokens_details"]["audio_tokens"], 1);
+    }
+
+    #[test]
+    fn saturates_at_u64_max() {
+        let mut acc = json!({"input_tokens": u64::MAX});
+        merge_usage(&mut acc, &json!({"input_tokens": 1}));
+        assert_eq!(acc["input_tokens"], u64::MAX);
+    }
+
+    #[test]
+    fn replaces_on_type_mismatch() {
+        let mut acc = json!({"field": "old_string"});
+        merge_usage(&mut acc, &json!({"field": 42}));
+        assert_eq!(acc["field"], 42);
+    }
+
+    #[test]
+    fn replaces_non_unsigned_number() {
+        let mut acc = json!({"field": -1});
+        merge_usage(&mut acc, &json!({"field": 5}));
+        assert_eq!(acc["field"], 5, "signed/float numbers should replace rather than saturating-add");
+    }
+
+    #[test]
+    fn null_accumulated_replaced_by_object() {
+        let mut acc = serde_json::Value::Null;
+        merge_usage(&mut acc, &json!({"input_tokens": 3}));
+        assert_eq!(acc["input_tokens"], 3);
+    }
+}

--- a/apis/src/openai/responses/usage.rs
+++ b/apis/src/openai/responses/usage.rs
@@ -13,11 +13,9 @@ use serde_json::Value;
 /// Saturating recursive sum for numeric token-usage fields.
 ///
 /// Recursively merges `current` into `accumulated`:
-/// - Objects: fields are merged recursively; newly introduced keys
-///   are preserved.
+/// - Objects: fields are merged recursively; newly introduced keys are preserved.
 /// - Unsigned integers: saturating-add.
-/// - All other types (including signed/float numbers and type
-///   mismatches): `accumulated` is replaced with `current`.
+/// - All other types (including signed/float numbers and type mismatches): `accumulated` is replaced with `current`.
 pub(crate) fn merge_usage(accumulated: &mut Value, current: &Value) {
     match (accumulated, current) {
         (Value::Object(accumulated), Value::Object(current)) => {
@@ -94,7 +92,10 @@ mod tests {
     fn replaces_non_unsigned_number() {
         let mut acc = json!({"field": -1});
         merge_usage(&mut acc, &json!({"field": 5}));
-        assert_eq!(acc["field"], 5, "signed/float numbers should replace rather than saturating-add");
+        assert_eq!(
+            acc["field"], 5,
+            "signed/float numbers should replace rather than saturating-add"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`merge_usage` previously lived in `stream_events::accumulator` — an SSE-specific
module. Two non-streaming filters (`openai_agentic_loop` and
`openai_file_search_callout`) were already importing it from there, coupling
unrelated Responses filters to the SSE implementation.

This PR moves the helper to a neutral `responses::usage` module and wires all
three callers to the new location:

- **New `apis/src/openai/responses/usage.rs`** — owns `merge_usage` with full
  focused unit test coverage:
  - Recursive object merge
  - Saturating-add for unsigned numeric counters
  - New key preservation
  - Type mismatch and non-unsigned number replacement
  - Null-to-object replacement

- **`stream_events/accumulator.rs`** — removes the local `merge_usage` definition
  and imports from `responses::usage`. Existing SSE accumulation behavior is
  unchanged.

- **`agentic_loop/mod.rs` / `file_search_callout/mod.rs`** — update imports from
  `stream_events::accumulator::merge_usage` to `usage::merge_usage`. No behavior
  change.

- **`responses/mod.rs`** — registers `pub(crate) mod usage`.

