### PR TITLE
feat(openai): resolve connector_id through configured MCP connectors

### DIFF
--- a/apis/src/openai/responses/openai_mcp_tool_resolve/config.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/config.rs
@@ -3,11 +3,14 @@
 
 //! Configuration for the `openai_mcp_tool_resolve` filter.
 
+use std::collections::HashSet;
+
 use praxis_filter::{
     FilterError, body::DEFAULT_JSON_BODY_MAX_BYTES,
     builtins::http::payload_processing::config_validation::validate_max_body_bytes,
 };
 use serde::Deserialize;
+use url::Url;
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -21,6 +24,27 @@ const DEFAULT_MAX_SERVERS: usize = 10;
 
 /// Default maximum number of tools returned by a single MCP server.
 const DEFAULT_MAX_TOOLS: usize = 128;
+
+/// Maximum number of connectors allowed in filter configuration.
+const MAX_CONNECTORS: usize = 64;
+/// Maximum length in bytes for a connector ID.
+pub(super) const MAX_CONNECTOR_ID_LEN: usize = 128;
+/// Maximum length in bytes for a connector server URL.
+const MAX_CONNECTOR_URL_LEN: usize = 2048;
+
+// -----------------------------------------------------------------------------
+// ConnectorConfig
+// -----------------------------------------------------------------------------
+
+/// Configuration for a named MCP connector.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConnectorConfig {
+    /// Connector identifier referenced in requests.
+    pub id: String,
+    /// MCP server URL for this connector.
+    pub server_url: String,
+}
 
 // -----------------------------------------------------------------------------
 // McpToolResolveConfig
@@ -52,6 +76,10 @@ pub(crate) struct McpToolResolveConfig {
     /// servers run locally.
     #[serde(default)]
     pub allow_loopback: bool,
+
+    /// Named connectors mapping connector IDs to server URLs.
+    #[serde(default)]
+    pub connectors: Vec<ConnectorConfig>,
 }
 
 /// Default max body bytes.
@@ -86,5 +114,86 @@ pub(crate) fn build_config(cfg: McpToolResolveConfig) -> Result<McpToolResolveCo
     if cfg.max_tools == 0 {
         return Err("openai_mcp_tool_resolve: max_tools must be greater than 0".into());
     }
+    validate_connectors(&cfg.connectors)?;
     Ok(cfg)
+}
+
+/// Validate connector configuration entries.
+fn validate_connectors(connectors: &[ConnectorConfig]) -> Result<(), FilterError> {
+    if connectors.len() > MAX_CONNECTORS {
+        return Err(format!(
+            "openai_mcp_tool_resolve: too many connectors: {} exceeds limit of {MAX_CONNECTORS}",
+            connectors.len()
+        )
+        .into());
+    }
+    let mut seen_ids = HashSet::new();
+    for connector in connectors {
+        validate_single_connector(connector)?;
+        if !seen_ids.insert(&connector.id) {
+            return Err(format!("openai_mcp_tool_resolve: duplicate connector id \"{}\"", connector.id).into());
+        }
+    }
+    Ok(())
+}
+
+/// Validate a single connector's ID and URL.
+fn validate_single_connector(connector: &ConnectorConfig) -> Result<(), FilterError> {
+    validate_connector_id(&connector.id)?;
+    validate_connector_server_url(&connector.server_url, &connector.id)
+}
+
+/// Validate connector ID is non-empty and within length limit.
+fn validate_connector_id(id: &str) -> Result<(), FilterError> {
+    if id.is_empty() {
+        return Err("openai_mcp_tool_resolve: connector id must not be empty".into());
+    }
+    if id.len() > MAX_CONNECTOR_ID_LEN {
+        return Err(
+            format!("openai_mcp_tool_resolve: connector id \"{id}\" exceeds {MAX_CONNECTOR_ID_LEN} bytes").into(),
+        );
+    }
+    Ok(())
+}
+
+/// Validate connector server URL string and parse it.
+fn validate_connector_server_url(server_url: &str, id: &str) -> Result<(), FilterError> {
+    if server_url.is_empty() {
+        return Err(format!("openai_mcp_tool_resolve: connector \"{id}\" has empty server_url").into());
+    }
+    if server_url.len() > MAX_CONNECTOR_URL_LEN {
+        return Err(format!(
+            "openai_mcp_tool_resolve: connector \"{id}\" server_url exceeds {MAX_CONNECTOR_URL_LEN} bytes"
+        )
+        .into());
+    }
+    let url = Url::parse(server_url).map_err(|e| {
+        FilterError::from(format!(
+            "openai_mcp_tool_resolve: connector \"{id}\" has invalid server_url: {e}"
+        ))
+    })?;
+    validate_connector_url(&url, id)
+}
+
+/// Validate a connector URL's scheme, host, and credentials.
+fn validate_connector_url(url: &Url, connector_id: &str) -> Result<(), FilterError> {
+    match url.scheme() {
+        "http" | "https" => {},
+        scheme => {
+            return Err(format!(
+                "openai_mcp_tool_resolve: connector \"{connector_id}\" server_url must use http or https, got \"{scheme}\""
+            )
+            .into());
+        },
+    }
+    if url.host().is_none() {
+        return Err(format!("openai_mcp_tool_resolve: connector \"{connector_id}\" server_url has no host").into());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(format!(
+            "openai_mcp_tool_resolve: connector \"{connector_id}\" server_url must not contain credentials"
+        )
+        .into());
+    }
+    Ok(())
 }

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -93,6 +93,9 @@ pub struct McpToolResolveFilter {
     /// Allow connections to loopback addresses.
     allow_loopback: bool,
 
+    /// Connector ID to server URL mapping.
+    connectors: HashMap<String, url::Url>,
+
     /// Maximum request body bytes for `StreamBuffer`.
     max_body_bytes: usize,
 
@@ -115,8 +118,18 @@ impl McpToolResolveFilter {
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         let cfg: McpToolResolveConfig = parse_filter_config("openai_mcp_tool_resolve", config)?;
         let validated = build_config(cfg)?;
+        let connectors = validated
+            .connectors
+            .iter()
+            .map(|c| {
+                let url = url::Url::parse(&c.server_url)
+                    .map_err(|e| FilterError::from(format!("openai_mcp_tool_resolve: connector \"{}\": {e}", c.id)))?;
+                Ok((c.id.clone(), url))
+            })
+            .collect::<Result<HashMap<String, url::Url>, FilterError>>()?;
         Ok(Box::new(Self {
             allow_loopback: validated.allow_loopback,
+            connectors,
             max_body_bytes: validated.max_body_bytes,
             max_servers: validated.max_servers,
             max_tools: validated.max_tools,
@@ -134,33 +147,31 @@ impl McpToolResolveFilter {
         body: &mut Option<Bytes>,
         original_bytes: Bytes,
     ) -> Result<FilterAction, ResolveError> {
-        let mcp_entries = extract_mcp_entries(&original_bytes);
+        let mut mcp_entries = extract_mcp_entries(&original_bytes);
         if mcp_entries.is_empty() {
             return Ok(FilterAction::Continue);
         }
 
-        let server_count = count_distinct_servers(&mcp_entries);
-        if server_count > self.max_servers {
-            return Err(ResolveError::TooManyServers {
-                count: server_count,
-                max: self.max_servers,
-            });
-        }
-
-        check_duplicate_labels(&mcp_entries)?;
+        resolve_connector_ids(&self.connectors, &mut mcp_entries)?;
+        self.validate_entries(&mcp_entries)?;
 
         let previous_tools = ctx.extensions.get::<ResponsesState>().map(|s| &s.previous_tools);
 
         let resolution = self.resolve_all_entries(&mcp_entries, previous_tools).await?;
 
-        if resolution.tool_map.is_empty() {
+        if !resolution.has_resolved {
             return Ok(FilterAction::Continue);
         }
 
         debug!(tool_count = resolution.tool_map.len(), "mcp_tool_map built");
 
-        let Resolution { per_entry, tool_map } = resolution;
-        let Some(serialized) = rewrite_request_body(&original_bytes, per_entry, &tool_map)? else {
+        let Resolution {
+            per_entry,
+            tool_map,
+            resolved_labels,
+            ..
+        } = resolution;
+        let Some(serialized) = rewrite_request_body(&original_bytes, per_entry, &tool_map, &resolved_labels)? else {
             return Ok(FilterAction::Continue);
         };
         check_body_size(&serialized, self.max_body_bytes)?;
@@ -169,6 +180,18 @@ impl McpToolResolveFilter {
         let body_for_state = body.as_ref().map_or_else(|| original_bytes.as_ref(), |b| b.as_ref());
         write_state(ctx, body_for_state, tool_map);
         Ok(FilterAction::Continue)
+    }
+
+    /// Validate MCP entries: check server count and duplicate labels.
+    fn validate_entries(&self, entries: &[serde_json::Value]) -> Result<(), ResolveError> {
+        let server_count = count_distinct_servers(entries);
+        if server_count > self.max_servers {
+            return Err(ResolveError::TooManyServers {
+                count: server_count,
+                max: self.max_servers,
+            });
+        }
+        check_duplicate_labels(entries)
     }
 
     /// Resolve all MCP entries, building both the global dispatch
@@ -189,31 +212,14 @@ impl McpToolResolveFilter {
         let futures: Vec<_> = task_entries
             .iter()
             .zip(&task_allowed_names)
-            .map(|(entry, allowed)| self.resolve_entry(entry, previous_tools, allowed.as_deref()))
+            .map(|(entry, allowed)| async {
+                let result = self.resolve_entry(entry, previous_tools, allowed.as_deref()).await;
+                redact_connector_client_error(result, entry)
+            })
             .collect();
         let task_results = futures::future::try_join_all(futures).await?;
 
-        let mut tool_map = HashMap::new();
-        let mut per_entry = Vec::with_capacity(entries.len());
-
-        for (entry, task_idx) in entries.iter().zip(&entry_to_task) {
-            let tools_opt = task_idx.and_then(|idx| task_results.get(idx)?.clone());
-            let Some(tools) = tools_opt else {
-                per_entry.push(Vec::new());
-                continue;
-            };
-            let allowed = extract_allowed_tools(entry);
-            let filtered = apply_allowed_tools_filter(tools, &allowed);
-            let label = server_label(entry);
-            let function_tools: Vec<serde_json::Value> = filtered
-                .iter()
-                .map(|def| mcp_tool_to_function_tool(label, def))
-                .collect();
-            insert_tools(filtered, entry, &mut tool_map);
-            per_entry.push(function_tools);
-        }
-
-        Ok(Resolution { per_entry, tool_map })
+        Ok(collect_resolutions(entries, &entry_to_task, &task_results))
     }
 
     /// Resolve tools for a single MCP entry independently.
@@ -232,11 +238,13 @@ impl McpToolResolveFilter {
             return Ok(None);
         };
         let label = server_label(entry);
+        let is_connector = entry.get("connector_id").is_some();
         mcp_client::validate_mcp_url(server_url, self.timeout, self.allow_loopback)
             .await
             .map_err(ResolveError::Client)?;
         if !has_entry_credentials(entry)
-            && let Some(cached) = find_cached_listing(previous_tools, label, server_url, cache_allowed_names)
+            && let Some(cached) =
+                find_cached_listing(previous_tools, label, server_url, cache_allowed_names, is_connector)
         {
             debug!(label, tool_count = cached.len(), "reusing cached MCP tool listing");
             return Ok(Some(cached));
@@ -334,15 +342,59 @@ enum ResolveError {
         /// Configured `max_body_bytes` limit.
         limit: usize,
     },
+
+    /// Unknown `connector_id` was referenced.
+    #[error("unknown connector_id \"{0}\"")]
+    UnknownConnector(String),
+
+    /// Both `connector_id` and `server_url` were provided.
+    #[error("connector_id and server_url are mutually exclusive on entry \"{0}\"")]
+    MutuallyExclusiveTarget(String),
+
+    /// Connector ID combined with `defer_loading`.
+    #[error("connector_id cannot be combined with defer_loading on entry \"{0}\"")]
+    DeferredConnector(String),
+
+    /// Invalid `connector_id` value (not a non-empty string).
+    #[error("connector_id must be a non-empty string")]
+    InvalidConnectorId,
+
+    /// Connector entry missing required `server_label`.
+    #[error("connector_id requires a non-empty server_label on entry \"{0}\"")]
+    MissingConnectorLabel(String),
+
+    /// Connector-backed MCP resolution failed (URL redacted).
+    #[error("connector \"{connector_id}\" failed to resolve for server_label \"{label}\"")]
+    ConnectorClient {
+        /// The connector ID from the request.
+        connector_id: String,
+        /// The server label from the request.
+        label: String,
+    },
+
+    /// A `tool_choice` references a resolved server with zero tools.
+    #[error("tool_choice references server_label \"{0}\" which resolved to zero eligible tools")]
+    EmptyResolvedToolChoice(String),
+}
+
+/// Per-entry resolution outcome.
+enum EntryResolution {
+    /// Entry was not resolved (deferred or no `server_url`).
+    PassThrough,
+    /// Entry was resolved to zero or more function tools.
+    Resolved(Vec<serde_json::Value>),
 }
 
 /// Result of resolving all MCP entries.
 struct Resolution {
-    /// Pre-built function tools parallel to the input MCP entries.
-    /// Empty vec means the entry was not resolved.
-    per_entry: Vec<Vec<serde_json::Value>>,
+    /// Per-entry resolution outcomes parallel to the input MCP entries.
+    per_entry: Vec<EntryResolution>,
     /// Global dispatch map keyed by `(server_label, tool_name)`.
     tool_map: HashMap<(String, String), serde_json::Value>,
+    /// Whether any entry was resolved (used to skip body rewrite when nothing resolved).
+    has_resolved: bool,
+    /// Labels of entries that were resolved (including those that produced zero tools).
+    resolved_labels: HashSet<String>,
 }
 
 // -----------------------------------------------------------------------------
@@ -365,14 +417,147 @@ fn check_body_size(serialized: &SerializedJson, max_body_bytes: usize) -> Result
     Ok(())
 }
 
+/// Collect per-entry resolutions from task results.
+fn collect_resolutions(
+    entries: &[serde_json::Value],
+    entry_to_task: &[Option<usize>],
+    task_results: &[Option<Vec<serde_json::Value>>],
+) -> Resolution {
+    let mut tool_map = HashMap::new();
+    let mut per_entry = Vec::with_capacity(entries.len());
+    let mut has_resolved = false;
+    let mut resolved_labels = HashSet::new();
+    for (entry, task_idx) in entries.iter().zip(entry_to_task) {
+        if let Some(resolution) = build_entry_resolution(entry, *task_idx, task_results, &mut tool_map) {
+            has_resolved = true;
+            resolved_labels.insert(server_label(entry).to_owned());
+            per_entry.push(resolution);
+        } else {
+            per_entry.push(EntryResolution::PassThrough);
+        }
+    }
+    Resolution {
+        per_entry,
+        tool_map,
+        has_resolved,
+        resolved_labels,
+    }
+}
+
+/// Resolve connector IDs to server URLs for MCP tool entries.
+///
+/// Mutates entries in place, replacing `connector_id` with the
+/// corresponding `server_url` from the configured connectors map.
+fn resolve_connector_ids(
+    connectors: &HashMap<String, url::Url>,
+    entries: &mut [serde_json::Value],
+) -> Result<(), ResolveError> {
+    for entry in entries.iter_mut() {
+        let Some(connector_id_value) = entry.get("connector_id") else {
+            continue;
+        };
+
+        let connector_id = match connector_id_value.as_str() {
+            Some(s) if !s.is_empty() && s.len() <= config::MAX_CONNECTOR_ID_LEN => s.to_owned(),
+            _ => return Err(ResolveError::InvalidConnectorId),
+        };
+
+        validate_connector_entry(entry, &connector_id)?;
+
+        let resolved_url = connectors
+            .get(&connector_id)
+            .ok_or(ResolveError::UnknownConnector(connector_id))?;
+
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert(
+                "server_url".to_owned(),
+                serde_json::Value::String(resolved_url.to_string()),
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Validate that a connector entry has required fields and no conflicts.
+fn validate_connector_entry(entry: &serde_json::Value, connector_id: &str) -> Result<(), ResolveError> {
+    let label = entry
+        .get("server_label")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty());
+    if label.is_none() {
+        return Err(ResolveError::MissingConnectorLabel(connector_id.to_owned()));
+    }
+
+    if entry.get("server_url").is_some() {
+        return Err(ResolveError::MutuallyExclusiveTarget(connector_id.to_owned()));
+    }
+
+    if entry
+        .get("defer_loading")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(ResolveError::DeferredConnector(connector_id.to_owned()));
+    }
+
+    Ok(())
+}
+
+/// Build resolution for a single entry given task results.
+fn build_entry_resolution(
+    entry: &serde_json::Value,
+    task_idx: Option<usize>,
+    task_results: &[Option<Vec<serde_json::Value>>],
+    tool_map: &mut HashMap<(String, String), serde_json::Value>,
+) -> Option<EntryResolution> {
+    let tools = task_idx.and_then(|idx| task_results.get(idx)?.clone())?;
+    let allowed = extract_allowed_tools(entry);
+    let filtered = apply_allowed_tools_filter(tools, &allowed);
+    let label = server_label(entry);
+    let function_tools: Vec<serde_json::Value> = filtered
+        .iter()
+        .map(|def| mcp_tool_to_function_tool(label, def))
+        .collect();
+    insert_tools(filtered, entry, tool_map);
+    Some(EntryResolution::Resolved(function_tools))
+}
+
+/// Replace a [`ResolveError::Client`] with [`ResolveError::ConnectorClient`]
+/// when the failing entry was connector-resolved, preventing internal URLs
+/// from leaking to clients.
+fn redact_connector_client_error(
+    result: Result<Option<Vec<serde_json::Value>>, ResolveError>,
+    entry: &serde_json::Value,
+) -> Result<Option<Vec<serde_json::Value>>, ResolveError> {
+    match result {
+        Err(ResolveError::Client(client_err)) if entry.get("connector_id").is_some() => {
+            debug!(error = %client_err, "connector resolution failed (redacting URL for client)");
+            let connector_id = entry
+                .get("connector_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_owned();
+            let label = server_label(entry).to_owned();
+            Err(ResolveError::ConnectorClient { connector_id, label })
+        },
+        other => other,
+    }
+}
+
 /// Map a [`ResolveError`] to an appropriate rejection response.
 fn resolve_error_rejection(err: &ResolveError, streaming: bool) -> FilterAction {
     let (status, error_type) = match err {
-        ResolveError::DuplicateLabel(_) | ResolveError::TooManyServers { .. } | ResolveError::NameCollision(_) => {
-            (400, "invalid_request_error")
-        },
+        ResolveError::DuplicateLabel(_)
+        | ResolveError::TooManyServers { .. }
+        | ResolveError::NameCollision(_)
+        | ResolveError::UnknownConnector(_)
+        | ResolveError::MutuallyExclusiveTarget(_)
+        | ResolveError::DeferredConnector(_)
+        | ResolveError::InvalidConnectorId
+        | ResolveError::MissingConnectorLabel(_)
+        | ResolveError::EmptyResolvedToolChoice(_) => (400, "invalid_request_error"),
         ResolveError::BodyTooLarge { .. } => (413, "invalid_request_error"),
-        ResolveError::Client(_) => (502, "server_error"),
+        ResolveError::Client(_) | ResolveError::ConnectorClient { .. } => (502, "server_error"),
         ResolveError::Serialization(_) => (500, "server_error"),
     };
     let msg = err.to_string();
@@ -522,10 +707,14 @@ async fn fetch_tools(
 /// empty tools array, or no resolved entries). The caller is
 /// responsible for checking the serialized size against
 /// `max_body_bytes` before committing.
+///
+/// MCP entries that were not resolved (no `server_url` or deferred)
+/// are left unchanged for upstream to handle.
 fn rewrite_request_body(
     original_bytes: &[u8],
-    per_entry: Vec<Vec<serde_json::Value>>,
+    per_entry: Vec<EntryResolution>,
     tool_map: &HashMap<(String, String), serde_json::Value>,
+    resolved_labels: &HashSet<String>,
 ) -> Result<Option<SerializedJson>, ResolveError> {
     let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(original_bytes) else {
         return Ok(None);
@@ -545,7 +734,7 @@ fn rewrite_request_body(
 
     let rewritten_count = rewritten.len();
     obj.insert("tools".to_owned(), serde_json::Value::Array(rewritten));
-    rewrite_tool_choice(obj, tool_map);
+    rewrite_tool_choice(obj, tool_map, resolved_labels)?;
 
     let serialized = serialize_json_body(&parsed).map_err(|e| {
         debug!(error = %e, "failed to serialize rewritten body");
@@ -559,7 +748,7 @@ fn rewrite_request_body(
 /// pre-built function tools from `per_entry`.
 fn rewrite_tools_array(
     tools: Vec<serde_json::Value>,
-    per_entry: Vec<Vec<serde_json::Value>>,
+    per_entry: Vec<EntryResolution>,
 ) -> (Vec<serde_json::Value>, HashSet<String>) {
     let mut result = Vec::with_capacity(tools.len());
     let mut generated_names = HashSet::new();
@@ -571,18 +760,20 @@ fn rewrite_tools_array(
             continue;
         }
 
-        let function_tools = entries.next().unwrap_or_default();
+        let resolution = entries.next().unwrap_or(EntryResolution::PassThrough);
 
-        if function_tools.is_empty() {
-            result.push(tool);
-            continue;
-        }
-
-        for ft in function_tools {
-            if let Some(name) = ft.get("name").and_then(serde_json::Value::as_str) {
-                generated_names.insert(name.to_owned());
-            }
-            result.push(ft);
+        match resolution {
+            EntryResolution::PassThrough => {
+                result.push(tool);
+            },
+            EntryResolution::Resolved(function_tools) => {
+                for ft in function_tools {
+                    if let Some(name) = ft.get("name").and_then(serde_json::Value::as_str) {
+                        generated_names.insert(name.to_owned());
+                    }
+                    result.push(ft);
+                }
+            },
         }
     }
 
@@ -624,25 +815,33 @@ fn detect_name_collisions(tools: &[serde_json::Value], generated_names: &HashSet
 fn rewrite_tool_choice(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     tool_map: &HashMap<(String, String), serde_json::Value>,
-) {
+    resolved_labels: &HashSet<String>,
+) -> Result<(), ResolveError> {
     let Some(serde_json::Value::Object(choice_obj)) = obj.get("tool_choice").cloned() else {
-        return;
+        return Ok(());
     };
     let choice_type = choice_obj.get("type").and_then(serde_json::Value::as_str);
 
     match choice_type {
-        Some("mcp") => rewrite_mcp_tool_choice(obj, &choice_obj, tool_map),
-        Some("allowed_tools") => rewrite_allowed_tools_choice(obj, &choice_obj, tool_map),
-        _ => {},
+        Some("mcp") => rewrite_mcp_tool_choice(obj, &choice_obj, tool_map, resolved_labels),
+        Some("allowed_tools") => {
+            rewrite_allowed_tools_choice(obj, &choice_obj, tool_map);
+            Ok(())
+        },
+        _ => Ok(()),
     }
 }
 
 /// Rewrite an MCP-typed `tool_choice` to its function equivalent.
+///
+/// Returns [`ResolveError::EmptyResolvedToolChoice`] when the
+/// targeted label was resolved but produced zero eligible tools.
 fn rewrite_mcp_tool_choice(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     choice_obj: &serde_json::Map<String, serde_json::Value>,
     tool_map: &HashMap<(String, String), serde_json::Value>,
-) {
+    resolved_labels: &HashSet<String>,
+) -> Result<(), ResolveError> {
     let label = choice_obj
         .get("server_label")
         .and_then(serde_json::Value::as_str)
@@ -655,8 +854,10 @@ fn rewrite_mcp_tool_choice(
                 "tool_choice".to_owned(),
                 serde_json::json!({"type": "function", "name": function_name}),
             );
+        } else if resolved_labels.contains(label) {
+            return Err(ResolveError::EmptyResolvedToolChoice(label.to_owned()));
         }
-        return;
+        return Ok(());
     }
 
     let function_refs = collect_function_refs_for_label(label, tool_map);
@@ -665,7 +866,10 @@ fn rewrite_mcp_tool_choice(
             "tool_choice".to_owned(),
             serde_json::json!({"type": "allowed_tools", "mode": "required", "tools": function_refs}),
         );
+    } else if resolved_labels.contains(label) {
+        return Err(ResolveError::EmptyResolvedToolChoice(label.to_owned()));
     }
+    Ok(())
 }
 
 /// Rewrite MCP selectors inside an `allowed_tools`-typed
@@ -968,6 +1172,7 @@ fn find_cached_listing(
     label: &str,
     server_url: &str,
     allowed_tools: Option<&[String]>,
+    require_url_match: bool,
 ) -> Option<Vec<serde_json::Value>> {
     let previous = previous_tools?;
     let allowed = allowed_tools?;
@@ -976,7 +1181,7 @@ fn find_cached_listing(
         let label_matches = pt.get("server_label").and_then(serde_json::Value::as_str) == Some(label);
         let url_ok = match pt.get("server_url").and_then(serde_json::Value::as_str) {
             Some(cached_url) => cached_url == server_url,
-            None => true,
+            None => !require_url_match,
         };
         label_matches && url_ok
     })?;
@@ -1047,6 +1252,7 @@ fn insert_tools(
     let headers = entry.get("headers").cloned();
     let authorization = entry.get("authorization").cloned();
     let require_approval = entry.get("require_approval").cloned();
+    let connector_id = entry.get("connector_id").cloned();
 
     for tool in tools {
         let tool_name = tool.get("name").and_then(serde_json::Value::as_str).map(str::to_owned);
@@ -1063,6 +1269,7 @@ fn insert_tools(
                 "headers": headers,
                 "authorization": authorization,
                 "require_approval": require_approval,
+                "connector_id": connector_id,
                 "tool_definition": tool,
             }),
         );

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -143,7 +143,7 @@ fn cache_hit_when_all_allowed_tools_present() {
     })];
     let allowed = vec!["get_weather".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "weather", url, Some(&allowed));
+    let result = find_cached_listing(Some(&previous), "weather", url, Some(&allowed), false);
     assert!(result.is_some(), "should hit cache");
     assert_eq!(result.unwrap().len(), 2, "should return full cached listing");
 }
@@ -158,7 +158,7 @@ fn cache_miss_when_allowed_tool_not_in_cache() {
     })];
     let allowed = vec!["unknown_tool".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "weather", url, Some(&allowed));
+    let result = find_cached_listing(Some(&previous), "weather", url, Some(&allowed), false);
     assert!(result.is_none(), "should miss cache for unknown tool");
 }
 
@@ -171,7 +171,7 @@ fn cache_miss_when_unrestricted_allowed_tools() {
         "tools": [{"name": "get_weather"}, {"name": "get_forecast"}]
     })];
 
-    let result = find_cached_listing(Some(&previous), "weather", url, None);
+    let result = find_cached_listing(Some(&previous), "weather", url, None, false);
     assert!(
         result.is_none(),
         "unrestricted entries must miss to avoid reusing partial listings"
@@ -187,7 +187,7 @@ fn cache_miss_when_unrestricted_widens_narrow_cached_listing() {
         "tools": [{"name": "get_weather"}]
     })];
 
-    let result = find_cached_listing(Some(&previous), "weather", url, None);
+    let result = find_cached_listing(Some(&previous), "weather", url, None, false);
     assert!(
         result.is_none(),
         "unrestricted must miss when cached listing is a narrow subset"
@@ -204,14 +204,14 @@ fn cache_miss_when_wrong_server_label() {
     })];
     let allowed = vec!["get_weather".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "calendar", url, Some(&allowed));
+    let result = find_cached_listing(Some(&previous), "calendar", url, Some(&allowed), false);
     assert!(result.is_none(), "should miss cache for different server");
 }
 
 #[test]
 fn cache_miss_when_no_previous_tools() {
     let allowed = vec!["get_weather".to_owned()];
-    let result = find_cached_listing(None, "weather", "http://10.0.0.5/mcp", Some(&allowed));
+    let result = find_cached_listing(None, "weather", "http://10.0.0.5/mcp", Some(&allowed), false);
     assert!(result.is_none(), "should miss when no previous_tools");
 }
 
@@ -224,7 +224,13 @@ fn cache_miss_when_server_url_changed() {
     })];
     let allowed = vec!["get_weather".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "weather", "http://10.0.0.99/mcp", Some(&allowed));
+    let result = find_cached_listing(
+        Some(&previous),
+        "weather",
+        "http://10.0.0.99/mcp",
+        Some(&allowed),
+        false,
+    );
     assert!(
         result.is_none(),
         "should miss cache when server_url differs from cached entry"
@@ -241,10 +247,106 @@ fn cache_miss_when_continuation_changes_allowed_tools() {
     })];
     let new_allowed = vec!["get_forecast".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "weather", url, Some(&new_allowed));
+    let result = find_cached_listing(Some(&previous), "weather", url, Some(&new_allowed), false);
     assert!(
         result.is_none(),
         "cache should miss when continuation requests a tool not in the cached listing"
+    );
+}
+
+// =========================================================================
+// Cache: connector entries require URL match
+// =========================================================================
+
+#[test]
+fn cache_miss_for_connector_when_cached_entry_lacks_server_url() {
+    let previous = vec![serde_json::json!({
+        "server_label": "drive",
+        "tools": [{"name": "search"}]
+    })];
+    let allowed = vec!["search".to_owned()];
+
+    let result = find_cached_listing(
+        Some(&previous),
+        "drive",
+        "https://drive.example.com/mcp",
+        Some(&allowed),
+        true,
+    );
+    assert!(
+        result.is_none(),
+        "connector entries must not match label-only cached listings"
+    );
+}
+
+#[test]
+fn cache_hit_for_connector_when_cached_entry_has_matching_url() {
+    let url = "https://drive.example.com/mcp";
+    let previous = vec![serde_json::json!({
+        "server_label": "drive",
+        "server_url": url,
+        "tools": [{"name": "search"}]
+    })];
+    let allowed = vec!["search".to_owned()];
+
+    let result = find_cached_listing(Some(&previous), "drive", url, Some(&allowed), true);
+    assert!(result.is_some(), "exact URL match should hit cache");
+}
+
+#[test]
+fn cache_hit_for_direct_url_label_only_still_works() {
+    let previous = vec![serde_json::json!({
+        "server_label": "weather",
+        "tools": [{"name": "get_weather"}]
+    })];
+    let allowed = vec!["get_weather".to_owned()];
+
+    let result = find_cached_listing(Some(&previous), "weather", "http://10.0.0.5/mcp", Some(&allowed), false);
+    assert!(
+        result.is_some(),
+        "direct URL entries should still use label-only matching"
+    );
+}
+
+// =========================================================================
+// Dispatch Metadata: connector_id preserved
+// =========================================================================
+
+#[test]
+fn insert_tools_preserves_connector_id() {
+    let tools = vec![serde_json::json!({"name": "search"})];
+    let entry = serde_json::json!({
+        "type": "mcp",
+        "server_label": "drive",
+        "connector_id": "corp_drive",
+        "server_url": "https://drive.example.com/mcp"
+    });
+    let mut tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
+    insert_tools(tools, &entry, &mut tool_map);
+
+    let val = &tool_map[&("drive".to_owned(), "search".to_owned())];
+    assert_eq!(
+        val.get("connector_id").and_then(serde_json::Value::as_str),
+        Some("corp_drive"),
+        "connector_id must be preserved in dispatch metadata"
+    );
+}
+
+#[test]
+fn insert_tools_without_connector_id_has_null() {
+    let tools = vec![serde_json::json!({"name": "tool_a"})];
+    let entry = serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "server_url": "http://10.0.0.5/mcp"
+    });
+    let mut tool_map: HashMap<(String, String), serde_json::Value> = HashMap::new();
+    insert_tools(tools, &entry, &mut tool_map);
+
+    let val = &tool_map[&("s".to_owned(), "tool_a".to_owned())];
+    assert!(
+        val.get("connector_id").is_none() || val["connector_id"].is_null(),
+        "no connector_id should produce null or absent field"
     );
 }
 
@@ -432,11 +534,8 @@ async fn no_spurious_state_creation_without_existing_state() {
     );
 }
 
-/// MCP entries with `connector_id` but no `server_url` should
-/// be skipped, not rejected — the backend handles connector
-/// resolution.
 #[tokio::test]
-async fn connector_id_entry_without_server_url_is_skipped() {
+async fn connector_id_entry_without_configured_connectors_rejected() {
     let filter = McpToolResolveFilter::from_config(&serde_yaml::from_str("{}").unwrap()).unwrap();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -451,8 +550,8 @@ async fn connector_id_entry_without_server_url_is_skipped() {
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
     assert!(
-        matches!(action, FilterAction::Continue),
-        "connector_id entry should be skipped, not rejected"
+        matches!(action, FilterAction::Reject(_)),
+        "unknown connector_id should be rejected"
     );
 }
 
@@ -679,7 +778,7 @@ fn cache_hit_when_cached_entry_has_no_server_url() {
     })];
     let allowed = vec!["get_weather".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "weather", "http://10.0.0.5/mcp", Some(&allowed));
+    let result = find_cached_listing(Some(&previous), "weather", "http://10.0.0.5/mcp", Some(&allowed), false);
     assert!(
         result.is_some(),
         "real mcp_list_tools items lack server_url; label-only match"
@@ -695,7 +794,13 @@ fn cache_miss_when_same_label_different_server_url() {
     })];
     let allowed = vec!["get_weather".to_owned()];
 
-    let result = find_cached_listing(Some(&previous), "weather", "http://10.0.0.99/mcp", Some(&allowed));
+    let result = find_cached_listing(
+        Some(&previous),
+        "weather",
+        "http://10.0.0.99/mcp",
+        Some(&allowed),
+        false,
+    );
     assert!(
         result.is_none(),
         "different server_url with same label should not match"
@@ -795,12 +900,8 @@ fn insert_tools_preserves_authorization_and_require_approval() {
     );
 }
 
-// =========================================================================
-// connector_id pass-through: body preserved
-// =========================================================================
-
 #[tokio::test]
-async fn connector_id_entry_preserves_body() {
+async fn connector_id_entry_without_configured_connectors_rejects_with_400() {
     let filter = McpToolResolveFilter::from_config(&serde_yaml::from_str("{}").unwrap()).unwrap();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -812,19 +913,14 @@ async fn connector_id_entry_preserves_body() {
         "tools": [{"type": "mcp", "server_label": "remote",
                     "connector_id": "mcp_conn_abc123"}]
     });
-    let body_bytes = serde_json::to_vec(&body_json).unwrap();
-    let mut body = Some(Bytes::from(body_bytes.clone()));
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
-    assert!(
-        matches!(action, FilterAction::Continue),
-        "connector_id entry should continue"
-    );
-    assert_eq!(
-        body.as_ref().map(AsRef::as_ref),
-        Some(body_bytes.as_slice()),
-        "body should be unchanged"
-    );
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 400, "unknown connector_id should be 400");
 }
 
 // =========================================================================
@@ -873,18 +969,18 @@ fn dedup_entries_keeps_credentialed_independent() {
 }
 
 #[test]
-fn dedup_entries_skips_non_resolvable() {
+fn dedup_entries_includes_resolved_connector() {
     let entries = vec![
-        serde_json::json!({"server_label": "a", "connector_id": "conn_1"}),
+        serde_json::json!({"server_label": "a", "connector_id": "c1", "server_url": "https://a.example.com/mcp"}),
         serde_json::json!({"server_label": "b", "server_url": "http://10.0.0.1/mcp", "defer_loading": true}),
         serde_json::json!({"server_label": "c", "server_url": "http://10.0.0.2/mcp"}),
     ];
     let (mapping, tasks, _) = dedup_entries(&entries);
 
-    assert_eq!(tasks.len(), 1, "only one resolvable entry");
-    assert!(mapping[0].is_none(), "connector_id entry not resolvable");
+    assert_eq!(tasks.len(), 2, "resolved connector + direct URL = two tasks");
+    assert!(mapping[0].is_some(), "resolved connector entry IS resolvable");
     assert!(mapping[1].is_none(), "deferred entry not resolvable");
-    assert_eq!(mapping[2], Some(0), "resolvable entry maps to task 0");
+    assert!(mapping[2].is_some(), "direct URL entry resolvable");
 }
 
 // =========================================================================
@@ -1003,16 +1099,16 @@ fn count_distinct_servers_dedupes_same_label_url() {
 }
 
 #[test]
-fn count_distinct_servers_excludes_connector_and_deferred() {
+fn count_distinct_servers_includes_resolved_connectors() {
     let entries = vec![
-        serde_json::json!({"server_label": "a", "connector_id": "conn_1"}),
+        serde_json::json!({"server_label": "a", "connector_id": "c1", "server_url": "https://a.example.com/mcp"}),
         serde_json::json!({"server_label": "b", "server_url": "http://10.0.0.1/mcp", "defer_loading": true}),
         serde_json::json!({"server_label": "c", "server_url": "http://10.0.0.2/mcp"}),
     ];
     assert_eq!(
         count_distinct_servers(&entries),
-        1,
-        "only resolvable entries should be counted"
+        2,
+        "resolved connector + direct URL, deferred excluded"
     );
 }
 
@@ -1089,8 +1185,18 @@ async fn max_servers_exceeded_returns_rejection() {
 }
 
 #[tokio::test]
-async fn connector_only_entries_not_counted_against_max_servers() {
-    let yaml: serde_yaml::Value = serde_yaml::from_str("max_servers: 1").unwrap();
+async fn connector_entries_counted_against_max_servers_when_configured() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+max_servers: 1
+connectors:
+  - id: conn_1
+    server_url: https://a.example.com/mcp
+  - id: conn_2
+    server_url: https://b.example.com/mcp
+",
+    )
+    .unwrap();
     let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
@@ -1107,8 +1213,8 @@ async fn connector_only_entries_not_counted_against_max_servers() {
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
 
     assert!(
-        matches!(action, FilterAction::Continue),
-        "connector-only entries should not count against max_servers"
+        matches!(action, FilterAction::Reject(_)),
+        "resolved connectors should count against max_servers"
     );
 }
 
@@ -1166,6 +1272,57 @@ fn write_state_skips_state_creation_with_previous_response_id() {
 }
 
 // =========================================================================
+// EntryResolution: zero-tool and passthrough behavior
+// =========================================================================
+
+#[test]
+fn rewrite_tools_array_drops_resolved_empty_entry() {
+    let tools = vec![
+        serde_json::json!({"type": "function", "name": "calc"}),
+        serde_json::json!({"type": "mcp", "server_label": "empty_srv", "server_url": "http://10.0.0.5/mcp"}),
+    ];
+    let per_entry = vec![EntryResolution::Resolved(Vec::new())];
+
+    let (rewritten, generated) = rewrite_tools_array(tools, per_entry);
+
+    assert_eq!(rewritten.len(), 1, "resolved-empty MCP entry should be dropped");
+    assert_eq!(rewritten[0]["name"], "calc", "function tool preserved");
+    assert!(generated.is_empty(), "no generated names");
+}
+
+#[test]
+fn rewrite_tools_array_preserves_passthrough_entry() {
+    let tools = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "deferred",
+        "server_url": "http://10.0.0.5/mcp",
+        "defer_loading": true
+    })];
+    let per_entry = vec![EntryResolution::PassThrough];
+
+    let (rewritten, _) = rewrite_tools_array(tools, per_entry);
+
+    assert_eq!(rewritten.len(), 1, "passthrough entry should be preserved");
+    assert_eq!(rewritten[0]["type"], "mcp", "passthrough keeps original type");
+}
+
+#[test]
+fn rewrite_tools_array_expands_resolved_nonempty() {
+    let tools = vec![serde_json::json!({"type": "mcp", "server_label": "srv"})];
+    let per_entry = vec![EntryResolution::Resolved(vec![mcp_tool_to_function_tool(
+        "srv",
+        &serde_json::json!({"name": "tool_a", "description": "A"}),
+    )])];
+
+    let (rewritten, generated) = rewrite_tools_array(tools, per_entry);
+
+    assert_eq!(rewritten.len(), 1, "one MCP entry → one function tool");
+    assert_eq!(rewritten[0]["type"], "function");
+    assert_eq!(rewritten[0]["name"], "srv__tool_a");
+    assert!(generated.contains("srv__tool_a"));
+}
+
+// =========================================================================
 // Body Rewrite: MCP to Function
 // =========================================================================
 
@@ -1198,19 +1355,27 @@ fn make_resolution(raw_per_entry: &[Vec<serde_json::Value>]) -> Resolution {
             .iter()
             .map(|def| mcp_tool_to_function_tool(label, def))
             .collect();
-        for tool in raw_tools {
-            let name = tool
-                .get("name")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("unknown");
-            tool_map.insert(
+        tool_map.extend(raw_tools.iter().map(|tool| {
+            let name = tool["name"].as_str().unwrap_or("unknown");
+            (
                 (label.to_owned(), name.to_owned()),
                 serde_json::json!({"server_label": label, "tool_definition": tool}),
-            );
-        }
-        per_entry.push(function_tools);
+            )
+        }));
+        per_entry.push(EntryResolution::Resolved(function_tools));
     }
-    Resolution { per_entry, tool_map }
+    let has_resolved = !raw_per_entry.is_empty();
+    let resolved_labels = if has_resolved {
+        HashSet::from([label.to_owned()])
+    } else {
+        HashSet::new()
+    };
+    Resolution {
+        per_entry,
+        tool_map,
+        has_resolved,
+        resolved_labels,
+    }
 }
 
 /// Pre-built function tools in `per_entry` are moved into the
@@ -1256,7 +1421,7 @@ fn rewrite_tools_array_preserves_unresolved_mcp() {
         "server_url": "http://10.0.0.99/mcp"
     })];
 
-    let (rewritten, generated) = rewrite_tools_array(tools, vec![Vec::new()]);
+    let (rewritten, generated) = rewrite_tools_array(tools, vec![EntryResolution::PassThrough]);
 
     assert_eq!(rewritten.len(), 1, "should preserve unresolved entry");
     assert_eq!(rewritten[0]["type"], "mcp", "unresolved MCP left unchanged");
@@ -1292,7 +1457,7 @@ fn rewrite_tools_array_expands_multiple_tools() {
         "server_url": "http://10.0.0.5/mcp"
     })];
 
-    let per_entry = vec![vec![
+    let per_entry = vec![EntryResolution::Resolved(vec![
         mcp_tool_to_function_tool(
             "math",
             &serde_json::json!({"name": "add", "description": "Add numbers"}),
@@ -1301,7 +1466,7 @@ fn rewrite_tools_array_expands_multiple_tools() {
             "math",
             &serde_json::json!({"name": "subtract", "description": "Subtract numbers"}),
         ),
-    ]];
+    ])];
 
     let (rewritten, generated) = rewrite_tools_array(tools, per_entry);
 
@@ -1404,7 +1569,7 @@ fn rewrite_tool_choice_translates_mcp_to_function() {
         serde_json::json!({"type": "mcp", "server_label": "weather", "name": "get_weather"}),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let choice = &obj["tool_choice"];
     assert_eq!(choice["type"], "function", "type rewritten to function");
@@ -1419,7 +1584,7 @@ fn rewrite_tool_choice_ignores_non_mcp() {
     let mut obj = serde_json::Map::new();
     obj.insert("tool_choice".to_owned(), serde_json::json!("auto"));
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     assert_eq!(obj["tool_choice"], "auto", "non-MCP tool_choice unchanged");
 }
@@ -1430,7 +1595,7 @@ fn rewrite_tool_choice_ignores_missing() {
     let tool_map = weather_tool_map();
     let mut obj = serde_json::Map::new();
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     assert!(obj.get("tool_choice").is_none(), "no tool_choice inserted");
 }
@@ -1446,7 +1611,7 @@ fn rewrite_tool_choice_skips_unknown_mcp_tool() {
         serde_json::json!({"type": "mcp", "server_label": "weather", "name": "nonexistent"}),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     assert_eq!(
         obj["tool_choice"]["type"], "mcp",
@@ -1509,14 +1674,14 @@ fn rewrite_per_entry_respects_allowed_tools_filter() {
     ];
 
     let per_entry = vec![
-        vec![mcp_tool_to_function_tool(
+        EntryResolution::Resolved(vec![mcp_tool_to_function_tool(
             "s",
             &serde_json::json!({"name": "tool_a", "description": "A"}),
-        )],
-        vec![mcp_tool_to_function_tool(
+        )]),
+        EntryResolution::Resolved(vec![mcp_tool_to_function_tool(
             "s",
             &serde_json::json!({"name": "tool_b", "description": "B"}),
-        )],
+        )]),
     ];
 
     let (rewritten, _) = rewrite_tools_array(tools, per_entry);
@@ -1542,7 +1707,7 @@ fn rewrite_tool_choice_server_level_becomes_allowed_tools() {
         serde_json::json!({"type": "mcp", "server_label": "weather"}),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let choice = &obj["tool_choice"];
     assert_eq!(
@@ -1572,7 +1737,7 @@ fn rewrite_tool_choice_server_level_unknown_label_unchanged() {
         serde_json::json!({"type": "mcp", "server_label": "nonexistent"}),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     assert_eq!(
         obj["tool_choice"]["type"], "mcp",
@@ -1602,7 +1767,7 @@ fn rewrite_tool_choice_expands_mcp_selectors_in_allowed_tools() {
         }),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let choice = &obj["tool_choice"];
     assert_eq!(choice["type"], "allowed_tools", "type preserved");
@@ -1633,7 +1798,7 @@ fn rewrite_tool_choice_translates_named_mcp_selector_in_allowed_tools() {
         }),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
     assert_eq!(tool_refs.len(), 1, "one selector → one function ref");
@@ -1654,7 +1819,7 @@ fn rewrite_tool_choice_allowed_tools_without_mcp_unchanged() {
     let mut obj = serde_json::Map::new();
     obj.insert("tool_choice".to_owned(), original.clone());
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     assert_eq!(obj["tool_choice"], original, "no MCP selectors → unchanged");
 }
@@ -1677,7 +1842,7 @@ fn rewrite_tool_choice_preserves_unresolved_named_mcp_selector() {
         }),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
     assert_eq!(tool_refs.len(), 2, "unresolved selector preserved alongside function");
@@ -1707,7 +1872,7 @@ fn rewrite_tool_choice_preserves_unresolved_server_mcp_selector() {
         }),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
     assert_eq!(tool_refs.len(), 1, "unresolved server selector preserved");
@@ -1736,7 +1901,7 @@ fn rewrite_tool_choice_mixed_resolved_and_unresolved_selectors() {
         }),
     );
 
-    rewrite_tool_choice(&mut obj, &tool_map);
+    rewrite_tool_choice(&mut obj, &tool_map, &HashSet::new()).unwrap();
 
     let choice = &obj["tool_choice"];
     let tool_refs = choice["tools"].as_array().expect("tools array");
@@ -1894,14 +2059,14 @@ fn distinct_labels_accepted() {
 }
 
 #[test]
-fn duplicate_label_connector_id_not_counted() {
+fn duplicate_label_connector_resolved_entry_counted() {
     let entries = vec![
         serde_json::json!({"server_label": "s", "server_url": "http://10.0.0.1/mcp"}),
-        serde_json::json!({"server_label": "s", "connector_id": "conn_1"}),
+        serde_json::json!({"server_label": "s", "connector_id": "c1", "server_url": "https://a.example.com/mcp"}),
     ];
     assert!(
-        check_duplicate_labels(&entries).is_ok(),
-        "connector_id entries are not resolvable and should not trigger duplicate check"
+        check_duplicate_labels(&entries).is_err(),
+        "resolved connector entries should be counted in duplicate check"
     );
 }
 
@@ -2138,4 +2303,656 @@ fn body_too_large_maps_to_413() {
         "error type should be invalid_request_error: {body_str}"
     );
     assert!(body_str.contains("1000000"), "should include actual size: {body_str}");
+}
+
+// =========================================================================
+// Connector Resolution
+// =========================================================================
+
+#[test]
+fn resolve_connector_ids_injects_server_url() {
+    let connectors = HashMap::from([(
+        "corp_drive".to_owned(),
+        url::Url::parse("https://drive.example.com/mcp").unwrap(),
+    )]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "drive",
+        "connector_id": "corp_drive"
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_ok(), "valid connector should resolve");
+    assert_eq!(
+        entries[0]["server_url"].as_str(),
+        Some("https://drive.example.com/mcp"),
+        "server_url should be injected"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_rejects_unknown_id() {
+    let connectors = HashMap::from([(
+        "known".to_owned(),
+        url::Url::parse("https://a.example.com/mcp").unwrap(),
+    )]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "drive",
+        "connector_id": "nonexistent"
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("unknown connector_id"), "error: {err}");
+    assert!(err.to_string().contains("nonexistent"), "should name the ID: {err}");
+}
+
+#[test]
+fn resolve_connector_ids_rejects_mutual_exclusivity() {
+    let connectors = HashMap::from([("c1".to_owned(), url::Url::parse("https://a.example.com/mcp").unwrap())]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "connector_id": "c1",
+        "server_url": "https://other.example.com/mcp"
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("mutually exclusive"),
+        "should mention mutual exclusivity"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_rejects_null_server_url_as_mutual_exclusivity() {
+    let connectors = HashMap::from([("c1".to_owned(), url::Url::parse("https://a.example.com/mcp").unwrap())]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "connector_id": "c1",
+        "server_url": null
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("mutually exclusive"),
+        "null server_url key presence should trigger mutual exclusivity"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_rejects_deferred_connector() {
+    let connectors = HashMap::from([("c1".to_owned(), url::Url::parse("https://a.example.com/mcp").unwrap())]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "connector_id": "c1",
+        "defer_loading": true
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("defer_loading"),
+        "should reject deferred connector"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_rejects_non_string_connector_id() {
+    let connectors = HashMap::from([(
+        "valid".to_owned(),
+        url::Url::parse("https://a.example.com/mcp").unwrap(),
+    )]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "connector_id": 42
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("must be a non-empty string"),
+        "should reject non-string connector_id"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_rejects_empty_connector_id() {
+    let connectors = HashMap::from([(
+        "valid".to_owned(),
+        url::Url::parse("https://a.example.com/mcp").unwrap(),
+    )]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "connector_id": ""
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("must be a non-empty string"),
+        "should reject empty connector_id"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_rejects_missing_server_label() {
+    let connectors = HashMap::from([("c1".to_owned(), url::Url::parse("https://a.example.com/mcp").unwrap())]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "connector_id": "c1"
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("server_label"),
+        "should require server_label with connector_id"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_skips_entries_without_connector_id() {
+    let connectors = HashMap::new();
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "server_url": "http://10.0.0.5/mcp"
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_ok(), "entries without connector_id should be skipped");
+    assert_eq!(
+        entries[0]["server_url"].as_str(),
+        Some("http://10.0.0.5/mcp"),
+        "original server_url should be unchanged"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_preserves_request_fields() {
+    let connectors = HashMap::from([("c1".to_owned(), url::Url::parse("https://a.example.com/mcp").unwrap())]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "s",
+        "connector_id": "c1",
+        "authorization": "Bearer tok",
+        "require_approval": "always",
+        "allowed_tools": ["tool_a"]
+    })];
+
+    let result = resolve_connector_ids(&connectors, &mut entries);
+    assert!(result.is_ok());
+    assert_eq!(
+        entries[0]["authorization"].as_str(),
+        Some("Bearer tok"),
+        "authorization preserved"
+    );
+    assert_eq!(
+        entries[0]["require_approval"].as_str(),
+        Some("always"),
+        "require_approval preserved"
+    );
+    assert!(entries[0]["allowed_tools"].is_array(), "allowed_tools preserved");
+}
+
+// =========================================================================
+// Connector Config
+// =========================================================================
+
+#[test]
+fn config_with_connectors_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: corp_drive
+    server_url: https://drive-mcp.example.com/mcp
+  - id: internal_search
+    server_url: https://search-mcp.example.com/mcp
+",
+    )
+    .unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "openai_mcp_tool_resolve");
+}
+
+#[test]
+fn config_with_empty_connectors_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("connectors: []").unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "openai_mcp_tool_resolve");
+}
+
+#[test]
+fn config_rejects_duplicate_connector_ids() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: dup
+    server_url: https://a.example.com/mcp
+  - id: dup
+    server_url: https://b.example.com/mcp
+",
+    )
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_empty_connector_id() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+connectors:
+  - id: ""
+    server_url: https://a.example.com/mcp
+"#,
+    )
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_empty_connector_url() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+connectors:
+  - id: valid
+    server_url: ""
+"#,
+    )
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_connector_id_too_long() {
+    let long_id = "a".repeat(129);
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        "connectors:\n  - id: {long_id}\n    server_url: https://a.example.com/mcp"
+    ))
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_connector_url_too_long() {
+    let long_url = format!("https://a.example.com/{}", "x".repeat(2049));
+    let yaml: serde_yaml::Value =
+        serde_yaml::from_str(&format!("connectors:\n  - id: valid\n    server_url: {long_url}")).unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_too_many_connectors() {
+    let entries: String = (0..65)
+        .map(|i| format!("  - id: conn_{i}\n    server_url: https://{i}.example.com/mcp"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!("connectors:\n{entries}")).unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_connector_with_non_http_scheme() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: bad
+    server_url: ftp://a.example.com/mcp
+",
+    )
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_connector_url_with_credentials() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: bad
+    server_url: https://user:pass@a.example.com/mcp
+",
+    )
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_connector_url_without_host() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: bad
+    server_url: https:///
+",
+    )
+    .unwrap();
+    assert!(McpToolResolveFilter::from_config(&yaml).is_err());
+}
+
+#[test]
+fn config_rejects_unknown_connector_fields() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: c1
+    server_url: https://a.example.com/mcp
+    extra: true
+",
+    )
+    .unwrap();
+    assert!(
+        McpToolResolveFilter::from_config(&yaml).is_err(),
+        "unknown fields in connector entries should be rejected"
+    );
+}
+
+// =========================================================================
+// Connector Filter-Level Tests
+// =========================================================================
+
+#[tokio::test]
+async fn connector_entry_rejected_when_no_connectors_configured() {
+    let filter = McpToolResolveFilter::from_config(&serde_yaml::from_str("{}").unwrap()).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [{"type": "mcp", "server_label": "drive", "connector_id": "corp_drive"}]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 400, "unknown connector should be 400");
+    let body_str = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    assert!(body_str.contains("unknown connector_id"), "body: {body_str}");
+}
+
+#[tokio::test]
+async fn connector_mutual_exclusivity_rejected_at_filter_level() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: c1
+    server_url: https://a.example.com/mcp
+",
+    )
+    .unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [{
+            "type": "mcp", "server_label": "s",
+            "connector_id": "c1",
+            "server_url": "https://other.example.com/mcp"
+        }]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 400);
+    let body_str = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    assert!(body_str.contains("mutually exclusive"), "body: {body_str}");
+}
+
+#[tokio::test]
+async fn connector_deferred_rejected_at_filter_level() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: c1
+    server_url: https://a.example.com/mcp
+",
+    )
+    .unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [{
+            "type": "mcp", "server_label": "s",
+            "connector_id": "c1",
+            "defer_loading": true
+        }]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 400);
+    let body_str = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    assert!(body_str.contains("defer_loading"), "body: {body_str}");
+}
+
+#[tokio::test]
+async fn connector_missing_label_rejected_at_filter_level() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+connectors:
+  - id: c1
+    server_url: https://a.example.com/mcp
+",
+    )
+    .unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [{"type": "mcp", "connector_id": "c1"}]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let rejection = match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    };
+    assert_eq!(rejection.status, 400);
+    let body_str = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    assert!(body_str.contains("server_label"), "body: {body_str}");
+}
+
+#[tokio::test]
+async fn direct_url_alongside_connector_both_counted() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+max_servers: 1
+connectors:
+  - id: c1
+    server_url: https://a.example.com/mcp
+",
+    )
+    .unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o", "input": "test",
+        "tools": [
+            {"type": "mcp", "server_label": "a", "connector_id": "c1"},
+            {"type": "mcp", "server_label": "b", "server_url": "http://10.0.0.5/mcp"}
+        ]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "two distinct servers with max_servers=1 should be rejected"
+    );
+}
+
+// =========================================================================
+// Request connector_id length cap
+// =========================================================================
+
+#[test]
+fn resolve_connector_ids_rejects_oversized_id() {
+    let connectors = HashMap::new();
+    let long_id = "a".repeat(129);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "test",
+        "connector_id": long_id,
+    })];
+    let err = resolve_connector_ids(&connectors, &mut entries).unwrap_err();
+    assert!(
+        matches!(err, ResolveError::InvalidConnectorId),
+        "oversized connector_id should be rejected: {err}"
+    );
+}
+
+#[test]
+fn resolve_connector_ids_accepts_max_length_id() {
+    let id = "a".repeat(128);
+    let url: url::Url = "https://example.com/mcp".parse().unwrap();
+    let connectors = HashMap::from([(id.clone(), url)]);
+    let mut entries = vec![serde_json::json!({
+        "type": "mcp",
+        "server_label": "test",
+        "connector_id": id,
+    })];
+    assert!(
+        resolve_connector_ids(&connectors, &mut entries).is_ok(),
+        "128-byte connector_id should be accepted"
+    );
+}
+
+// =========================================================================
+// Connector URL redaction in errors
+// =========================================================================
+
+#[test]
+fn redact_connector_client_error_replaces_url() {
+    let entry = serde_json::json!({
+        "type": "mcp",
+        "server_label": "drive",
+        "connector_id": "corp_drive",
+        "server_url": "https://internal.corp.example.com/mcp",
+    });
+    let uri: http::Uri = "https://internal.corp.example.com/mcp".parse().unwrap();
+    let client_err = mcp_client::McpClientError::Connection {
+        url: mcp_client::McpDisplayUrl::from_uri(&uri),
+    };
+    let result: Result<Option<Vec<serde_json::Value>>, ResolveError> = Err(ResolveError::Client(client_err));
+
+    let redacted = redact_connector_client_error(result, &entry);
+    let err = redacted.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("internal.corp.example.com"),
+        "internal URL should not appear in error: {msg}"
+    );
+    assert!(msg.contains("corp_drive"), "connector_id should appear in error: {msg}");
+    assert!(msg.contains("drive"), "server_label should appear in error: {msg}");
+}
+
+#[test]
+fn redact_connector_client_error_passes_through_direct_url() {
+    let entry = serde_json::json!({
+        "type": "mcp",
+        "server_label": "drive",
+        "server_url": "https://external.example.com/mcp",
+    });
+    let uri: http::Uri = "https://external.example.com/mcp".parse().unwrap();
+    let client_err = mcp_client::McpClientError::Connection {
+        url: mcp_client::McpDisplayUrl::from_uri(&uri),
+    };
+    let result: Result<Option<Vec<serde_json::Value>>, ResolveError> = Err(ResolveError::Client(client_err));
+
+    let redacted = redact_connector_client_error(result, &entry);
+    let err = redacted.unwrap_err();
+    assert!(
+        matches!(err, ResolveError::Client(_)),
+        "direct URL errors should not be redacted"
+    );
+}
+
+// =========================================================================
+// tool_choice rejects resolved server with zero tools
+// =========================================================================
+
+#[test]
+fn rewrite_tool_choice_rejects_resolved_label_zero_tools_named() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["empty_server".to_owned()]);
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "empty_server", "name": "some_tool"}),
+    );
+
+    let err = rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap_err();
+    assert!(
+        matches!(err, ResolveError::EmptyResolvedToolChoice(_)),
+        "should reject named tool_choice for resolved server with zero tools: {err}"
+    );
+}
+
+#[test]
+fn rewrite_tool_choice_rejects_resolved_label_zero_tools_server_level() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["empty_server".to_owned()]);
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "empty_server"}),
+    );
+
+    let err = rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap_err();
+    assert!(
+        matches!(err, ResolveError::EmptyResolvedToolChoice(_)),
+        "should reject server-level tool_choice for resolved server with zero tools: {err}"
+    );
+}
+
+#[test]
+fn rewrite_tool_choice_passes_unresolved_label_zero_tools() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::new();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({"type": "mcp", "server_label": "passthrough_server"}),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap();
+    assert_eq!(
+        obj["tool_choice"]["type"], "mcp",
+        "unresolved label should be left unchanged"
+    );
 }

--- a/docs/filters/openai_mcp_tool_resolve.md
+++ b/docs/filters/openai_mcp_tool_resolve.md
@@ -18,6 +18,9 @@ Rejects the request with HTTP 400 before any callouts if two or more resolvable 
 | `max_servers` | integer | no | Maximum number of distinct MCP servers per request. |
 | `max_tools` | integer | no | Maximum number of tools returned by a single MCP server. |
 | `allow_loopback` | bool | no | Allow connections to loopback addresses (`127.0.0.0/8`, `::1`, `localhost`). Disabled by default for SSRF protection; enable for development environments where MCP servers run locally. |
+| `connectors` | ConnectorConfig[] | no | Named connectors mapping connector IDs to server URLs. |
+| `connectors[].id` | string | yes | Connector identifier referenced in requests. |
+| `connectors[].server_url` | string | yes | MCP server URL for this connector. |
 
 ## Examples
 

--- a/examples/configs/openai/responses/mcp-tool-resolve.yaml
+++ b/examples/configs/openai/responses/mcp-tool-resolve.yaml
@@ -41,6 +41,20 @@
 #     -H "Content-Type: application/json" \
 #     -d '{"model": "gpt-4.1", "input": "Hello, world!"}'
 #
+#   # Request with connector_id (resolved from filter config)
+#   curl -X POST http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{
+#       "model": "gpt-4.1",
+#       "input": "Search for quarterly reports",
+#       "tools": [{
+#         "type": "mcp",
+#         "server_label": "drive",
+#         "connector_id": "corp_drive",
+#         "allowed_tools": ["search"]
+#       }]
+#     }'
+#
 # Build:
 #   cargo build -p praxis-ai-proxy
 
@@ -64,6 +78,11 @@ filter_chains:
 
       - filter: openai_mcp_tool_resolve
         timeout_ms: 5000
+        connectors:
+          - id: corp_drive
+            server_url: https://drive-mcp.internal:8443/mcp
+          - id: internal_search
+            server_url: https://search-mcp.internal:8443/mcp
 
       - filter: openai_responses_proxy
         name: inference

--- a/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
+++ b/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
@@ -528,6 +528,160 @@ fn duplicate_server_label_rejected_before_callout() {
 }
 
 // =============================================================================
+// Connector Resolution
+// =============================================================================
+
+#[test]
+fn connector_resolves_to_mock_mcp_server() {
+    let mcp_config = McpMockConfig {
+        tools: vec![McpToolFixture::new("search").with_description("Search files")],
+        ..McpMockConfig::default()
+    };
+    let mcp_server = start_mcp_mock_server_with_config(mcp_config);
+    let backend_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let mcp_url = format!("http://127.0.0.1:{}/mcp", mcp_server.port());
+    let connectors = format!("        connectors:\n          - id: corp_drive\n            server_url: {mcp_url}");
+    let yaml = resolve_yaml_loopback_with_connectors_and_proxy(proxy_port, backend_guard.port(), &connectors);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","tools":[{"type":"mcp","server_label":"drive","connector_id":"corp_drive","allowed_tools":["search"]}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "connector resolution should succeed");
+
+    let echoed = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&echoed).unwrap();
+    let tools = parsed["tools"].as_array().expect("tools should be an array");
+    assert_eq!(tools.len(), 1, "should have 1 resolved function tool");
+    assert_eq!(tools[0]["type"], "function", "MCP tool rewritten to function");
+    assert_eq!(tools[0]["name"], "drive__search", "name prefixed with server_label");
+
+    assert!(
+        !echoed.contains("connector_id"),
+        "connector_id must not appear in rewritten body"
+    );
+    assert!(
+        !echoed.contains(&mcp_url),
+        "resolved server_url must not appear in rewritten body"
+    );
+
+    assert!(
+        mcp_server.method_count("tools/list") >= 1,
+        "should have called tools/list on the resolved MCP server"
+    );
+}
+
+#[test]
+fn unknown_connector_rejected_before_callout() {
+    let mcp_config = McpMockConfig {
+        tools: vec![McpToolFixture::new("tool_a")],
+        ..McpMockConfig::default()
+    };
+    let mcp_server = start_mcp_mock_server_with_config(mcp_config);
+    let backend_guard = start_backend_with_shutdown("inference");
+    let proxy_port = free_port();
+
+    let yaml = resolve_yaml_loopback(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","tools":[{"type":"mcp","server_label":"s","connector_id":"nonexistent"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 400, "unknown connector should be 400");
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("unknown connector_id"),
+        "response: {response_body}"
+    );
+
+    assert_eq!(
+        mcp_server.method_count("initialize"),
+        0,
+        "no MCP calls should be made for unknown connectors"
+    );
+}
+
+#[test]
+fn connector_with_authorization_forwarded() {
+    let mcp_config = McpMockConfig {
+        tools: vec![McpToolFixture::new("tool_a")],
+        ..McpMockConfig::default()
+    };
+    let mcp_server = start_mcp_mock_server_with_config(mcp_config);
+    let backend_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let mcp_url = format!("http://127.0.0.1:{}/mcp", mcp_server.port());
+    let connectors = format!("        connectors:\n          - id: authed\n            server_url: {mcp_url}");
+    let yaml = resolve_yaml_loopback_with_connectors_and_proxy(proxy_port, backend_guard.port(), &connectors);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","tools":[{"type":"mcp","server_label":"s","connector_id":"authed","authorization":"Bearer tok_test","allowed_tools":["tool_a"]}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "connector with auth should succeed");
+
+    assert!(
+        mcp_server.method_count("tools/list") >= 1,
+        "should have called tools/list with forwarded auth"
+    );
+
+    let requests = mcp_server.received_requests();
+    let has_auth = requests.iter().any(|r| {
+        r.headers
+            .iter()
+            .any(|(name, value)| name.eq_ignore_ascii_case("authorization") && value.contains("tok_test"))
+    });
+    assert!(has_auth, "authorization token should be forwarded to MCP server");
+}
+
+#[test]
+fn direct_url_alongside_connector_both_resolved() {
+    let mcp_config_a = McpMockConfig {
+        tools: vec![McpToolFixture::new("tool_a")],
+        ..McpMockConfig::default()
+    };
+    let mcp_server_a = start_mcp_mock_server_with_config(mcp_config_a);
+
+    let mcp_config_b = McpMockConfig {
+        tools: vec![McpToolFixture::new("tool_b")],
+        ..McpMockConfig::default()
+    };
+    let mcp_server_b = start_mcp_mock_server_with_config(mcp_config_b);
+
+    let backend_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let mcp_url_a = format!("http://127.0.0.1:{}/mcp", mcp_server_a.port());
+    let connectors = format!("        connectors:\n          - id: c1\n            server_url: {mcp_url_a}");
+    let yaml = resolve_yaml_loopback_with_connectors_and_proxy(proxy_port, backend_guard.port(), &connectors);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let mcp_url_b = format!("http://127.0.0.1:{}/mcp", mcp_server_b.port());
+    let body = format!(
+        r#"{{"model":"gpt-4.1","input":"test","tools":[{{"type":"mcp","server_label":"conn","connector_id":"c1","allowed_tools":["tool_a"]}},{{"type":"mcp","server_label":"direct","server_url":"{mcp_url_b}","allowed_tools":["tool_b"]}}]}}"#
+    );
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(parse_status(&raw), 200, "mixed connector + direct should succeed");
+
+    let echoed = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&echoed).unwrap();
+    let tools = parsed["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 2, "should have 2 resolved function tools");
+
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"conn__tool_a"), "connector tool resolved");
+    assert!(names.contains(&"direct__tool_b"), "direct URL tool resolved");
+}
+
+// =============================================================================
 // YAML Helpers
 // =============================================================================
 
@@ -664,6 +818,41 @@ filter_chains:
       - filter: openai_tool_parse
       - filter: openai_mcp_tool_resolve
         allow_loopback: true
+      - filter: openai_responses_proxy
+        name: inference
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn resolve_yaml_loopback_with_connectors_and_proxy(
+    proxy_port: u16,
+    backend_port: u16,
+    connectors_yaml: &str,
+) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: openai_responses_format
+        on_invalid: continue
+      - filter: openai_tool_parse
+      - filter: openai_mcp_tool_resolve
+        allow_loopback: true
+{connectors_yaml}
       - filter: openai_responses_proxy
         name: inference
       - filter: router


### PR DESCRIPTION
## Summary

Adds `connector_id` resolution to the `openai_mcp_tool_resolve` filter, allowing requests to reference named MCP connectors instead of embedding raw `server_url` values. Configured connectors map short IDs to validated server URLs, keeping client payloads free of infrastructure details. Includes URL redaction in client-facing errors, zero-tool `tool_choice` rejection, request-side ID length caps, and authorization header forwarding.

## Related issue

Closes #316

## Validation

- [x] Unit tests (149 passing in `openai_mcp_tool_resolve`)
- [x] Integration or functional tests (6 new integration tests including connector resolution, authorization forwarding, unknown connector rejection, and example config)
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. Existing configurations without `connectors` are unaffected. Requests using `connector_id` without a matching connector config receive HTTP 400.