### PR TITLE
fix(ci): stabilize flaky vLLM integration job

### DIFF
--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -124,7 +124,7 @@ jobs:
             --enable-auto-tool-choice \
             --tool-call-parser hermes \
             --reasoning-parser deepseek_r1 \
-            --gpu-memory-utilization 0.7
+            --gpu-memory-utilization 0.5
 
       - name: Start OGX
         run: |
@@ -139,6 +139,11 @@ jobs:
           echo "Waiting for vLLM health and model endpoints..."
           timeout 900 bash -c 'until curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
                                      curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
+            if ! docker inspect --format="{{.State.Running}}" vllm 2>/dev/null | grep -q true; then
+              echo "::error::vLLM container exited unexpectedly"
+              docker logs vllm 2>&1 | tail -30
+              exit 1
+            fi
             sleep 5
           done'
           echo "vLLM is ready"

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -141,7 +141,7 @@ jobs:
                                      curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
             if ! docker inspect --format="{{.State.Running}}" vllm 2>/dev/null | grep -q true; then
               echo "::error::vLLM container exited unexpectedly"
-              docker logs vllm 2>&1 | tail -30
+              docker logs vllm 2>&1
               exit 1
             fi
             sleep 5


### PR DESCRIPTION
## Summary
- Lower `--gpu-memory-utilization` from `0.7` to `0.5` — on the CPU backend this controls CPU memory reservation, and at 0.7 the runner's ~15.6 GiB total minus other processes (cargo build, OGX, docker) often left less than the 10.93 GiB demanded, causing a `WorkerProc` crash on startup.
- Add a container liveness check in the readiness loop so a crashed vLLM container fails immediately instead of curling a dead endpoint for 15 minutes.

## Root cause
```
ValueError: Available memory on node 0 (10.78/15.61 GiB) on startup is less
than desired CPU memory utilization (0.7, 10.93 GiB).
```
The Qwen3-0.6B model needs ~1.2 GiB so 0.5 (~7.8 GiB) is plenty of headroom.

## Test plan
- [ ] vLLM integration job passes on this PR
- [ ] Verify fail-fast behavior by inspecting the readiness loop logic