### PR TITLE
ci: prototype vllm-vcr backend for faster Responses integration tests

### DIFF
--- a/.github/workflows/vllm-vcr-prototype.yaml
+++ b/.github/workflows/vllm-vcr-prototype.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Pull CPU-only vLLM frontend
         run: docker pull "$VLLM_FRONTEND_IMAGE"
 
-      - name: Start vLLM frontend and vllm-vcr
+      - name: Start vLLM frontend
         run: |
           docker run --detach --name vllm-vcr-frontend --network host \
             "$VLLM_FRONTEND_IMAGE" \
@@ -68,6 +68,29 @@ jobs:
             --port=8000 \
             --max-model-len=4096
 
+      - name: Build Praxis while frontend starts
+        run: cargo build -p praxis-ai-proxy
+
+      - name: Start vllm-vcr
+        run: |
+          echo "Waiting for the vLLM data-plane handshake listener..."
+          handshake_ready=false
+          for _ in {1..180}; do
+            if ss -H -ltn "sport = :29550" | grep -q .; then
+              handshake_ready=true
+              break
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' vllm-vcr-frontend)" != true ]; then
+              echo "vLLM frontend exited before opening the handshake listener" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$handshake_ready" != true ]; then
+            echo "vLLM frontend did not open the handshake listener within 180 seconds" >&2
+            exit 1
+          fi
+
           inference-sim \
             --handshake-address tcp://127.0.0.1:29550 \
             --vllm-version v0.22.0 \
@@ -77,16 +100,31 @@ jobs:
             > /tmp/vllm-vcr.log 2>&1 &
           echo $! > /tmp/vllm-vcr.pid
 
-      - name: Build Praxis while frontend starts
-        run: cargo build -p praxis-ai-proxy
-
       - name: Wait for vLLM frontend readiness
         run: |
           echo "Waiting for the frontend-only vLLM server..."
-          timeout 180 bash -c 'until curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
-                                     curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
+          simulator_pid=$(cat /tmp/vllm-vcr.pid)
+          frontend_ready=false
+          for _ in {1..90}; do
+            if curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
+               curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; then
+              frontend_ready=true
+              break
+            fi
+            if ! kill -0 "$simulator_pid" 2>/dev/null; then
+              echo "vllm-vcr exited before the frontend became ready" >&2
+              exit 1
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' vllm-vcr-frontend)" != true ]; then
+              echo "vLLM frontend exited before becoming ready" >&2
+              exit 1
+            fi
             sleep 2
-          done'
+          done
+          if [ "$frontend_ready" != true ]; then
+            echo "vLLM frontend did not become ready within 180 seconds" >&2
+            exit 1
+          fi
           echo "vLLM frontend is ready"
 
       - name: Run protocol-safe Responses tests

--- a/.github/workflows/vllm-vcr-prototype.yaml
+++ b/.github/workflows/vllm-vcr-prototype.yaml
@@ -1,0 +1,111 @@
+name: vLLM VCR Prototype
+
+# Branch-scoped prototype for measuring a vllm-vcr-backed Responses test lane.
+# It deliberately uses random tokens and runs only the three protocol-safe
+# tests selected by VLLM_TEST_BACKEND=vcr-random. It is not a replacement for
+# the live-inference job until a captured token trace is added. The push trigger
+# makes the new workflow runnable before it exists on the default branch.
+on:
+  push:
+    branches: [leseb/evaluate-vllm-vcr]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+  VLLM_MODEL: "Qwen/Qwen3-0.6B"
+  VLLM_VCR_VERSION: "v0.1.3"
+  VLLM_VCR_ARCHIVE_SHA256: "c73a61904d735e66030f15ba55a0688cab0d10fe0a0a7d7062ea7981ee1ddb4f"
+  # Experimental CPU-only Python frontend built from a vLLM 0.22 protocol pin.
+  # Keep the digest: the tag is maintained outside praxis-proxy.
+  VLLM_FRONTEND_IMAGE: "quay.io/wseaton/mock-engine-nixl:vllm-frontend-cpu-c9340e6f3@sha256:b3465ca8dc720728080b9c362e69955a72ca816b569130727ec53cdfdda28b4d"
+
+jobs:
+  vllm-vcr-responses:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@7e1e8d97c2dc820d24b31f9a65b119c4d0e5342c # v0.1.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install vllm-vcr 0.22 binary
+        run: |
+          archive=/tmp/vllm-vcr.tar.gz
+          install_dir=/tmp/vllm-vcr-bin
+          mkdir -p "$install_dir"
+          curl --fail --location --silent --show-error \
+            "https://github.com/neuralmagic/vllm-vcr/releases/download/${VLLM_VCR_VERSION}/inference-sim-vllm0.22-x86_64-unknown-linux-musl.tar.gz" \
+            --output "$archive"
+          echo "${VLLM_VCR_ARCHIVE_SHA256}  ${archive}" | sha256sum --check --strict
+          tar -xzf "$archive" -C "$install_dir" inference-sim
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Pull CPU-only vLLM frontend
+        run: docker pull "$VLLM_FRONTEND_IMAGE"
+
+      - name: Start vLLM frontend and vllm-vcr
+        run: |
+          docker run --detach --name vllm-vcr-frontend --network host \
+            "$VLLM_FRONTEND_IMAGE" \
+            serve "$VLLM_MODEL" \
+            --data-parallel-size=1 \
+            --data-parallel-size-local=0 \
+            --data-parallel-address=127.0.0.1 \
+            --data-parallel-rpc-port=29550 \
+            --host=127.0.0.1 \
+            --port=8000 \
+            --max-model-len=4096
+
+          inference-sim \
+            --handshake-address tcp://127.0.0.1:29550 \
+            --vllm-version v0.22.0 \
+            --max-model-len 4096 \
+            --seed 0 \
+            --log-requests \
+            > /tmp/vllm-vcr.log 2>&1 &
+          echo $! > /tmp/vllm-vcr.pid
+
+      - name: Build Praxis while frontend starts
+        run: cargo build -p praxis-ai-proxy
+
+      - name: Wait for vLLM frontend readiness
+        run: |
+          echo "Waiting for the frontend-only vLLM server..."
+          timeout 180 bash -c 'until curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
+                                     curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
+            sleep 2
+          done'
+          echo "vLLM frontend is ready"
+
+      - name: Run protocol-safe Responses tests
+        env:
+          VLLM_TEST_BACKEND: vcr-random
+        run: uv run tests/integration/sdk/openai/test_openai_responses_vllm.py -s
+
+      - name: vLLM frontend logs
+        if: failure()
+        run: docker logs vllm-vcr-frontend
+
+      - name: vllm-vcr logs
+        if: failure()
+        run: cat /tmp/vllm-vcr.log 2>/dev/null || true
+
+      - name: Stop prototype services
+        if: always()
+        run: |
+          docker rm -f vllm-vcr-frontend || true
+          if [ -f /tmp/vllm-vcr.pid ]; then
+            kill "$(cat /tmp/vllm-vcr.pid)" 2>/dev/null || true
+          fi

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -8,11 +8,16 @@
 # ]
 # ///
 """
-OpenAI Responses API integration tests against a real vLLM CPU backend.
+OpenAI Responses API integration tests against a vLLM backend.
 
 Starts a Praxis proxy with the full responses pipeline backed by vLLM,
 then exercises stateless requests, persistence, rehydration, and streaming
 using the official OpenAI Python SDK.
+
+The default backend is a real vLLM CPU engine. The experimental
+``VLLM_TEST_BACKEND=vcr-random`` mode runs only protocol-safe smoke tests
+against a real vLLM frontend backed by vllm-vcr random tokens. Tests that
+need model semantics or deterministic tool-call tokens are skipped.
 
 Usage:
     cargo build -p praxis-ai-proxy
@@ -40,11 +45,28 @@ from openai import OpenAI
 
 VLLM_BASE_URL = os.environ.get("VLLM_BASE_URL", "http://127.0.0.1:8000")
 VLLM_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-0.6B")
+VLLM_TEST_BACKEND = os.environ.get("VLLM_TEST_BACKEND", "live")
 OGX_BASE_URL = os.environ.get("OGX_BASE_URL", "http://127.0.0.1:8321")
 PRAXIS_AI_BIN = os.environ.get("PRAXIS_AI_BIN")
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 CONFIG_PATH = "examples/configs/openai/responses/full-flow.yaml"
 AGENTIC_CONFIG_PATH = "examples/configs/openai/responses/agentic-loop.yaml"
+
+if VLLM_TEST_BACKEND not in {"live", "vcr-random"}:
+    raise RuntimeError(
+        "VLLM_TEST_BACKEND must be either 'live' or 'vcr-random'; "
+        f"got {VLLM_TEST_BACKEND!r}"
+    )
+
+VLLM_VCR_RANDOM = VLLM_TEST_BACKEND == "vcr-random"
+requires_live_inference = pytest.mark.skipif(
+    VLLM_VCR_RANDOM,
+    reason="test requires real model inference, not vllm-vcr random tokens",
+)
+requires_replayed_tool_tokens = pytest.mark.skipif(
+    VLLM_VCR_RANDOM,
+    reason="test requires a captured vllm-vcr tool-call token trace",
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -351,8 +373,12 @@ class TestOpenAIResponsesVLLM:
             max_output_tokens=128,
         )
 
-        assert response.status == "completed"
-        assert "HELLO-PRAXIS" in response.output_text
+        if VLLM_VCR_RANDOM:
+            assert response.status in ("completed", "incomplete")
+            assert response.output_text
+        else:
+            assert response.status == "completed"
+            assert "HELLO-PRAXIS" in response.output_text
 
     def test_store_and_retrieve(self, openai_client):
         response = openai_client.responses.create(
@@ -362,14 +388,18 @@ class TestOpenAIResponsesVLLM:
             max_output_tokens=128,
         )
 
-        assert response.status == "completed"
+        if VLLM_VCR_RANDOM:
+            assert response.status in ("completed", "incomplete")
+        else:
+            assert response.status == "completed"
         assert response.id
 
         retrieved = openai_client.responses.retrieve(response.id)
 
         assert retrieved.id == response.id
-        assert retrieved.status == "completed"
+        assert retrieved.status == response.status
 
+    @requires_live_inference
     def test_rehydrated_second_turn(self, openai_client):
         first = openai_client.responses.create(
             model=VLLM_MODEL,
@@ -397,6 +427,7 @@ class TestOpenAIResponsesVLLM:
         assert second.status == "completed"
         assert "VIOLET-7319" in second.output_text
 
+    @requires_live_inference
     def test_doc_extract_inline_file_to_input_text(self, openai_client):
         """Issue #397: inline file_data is extracted to input_text and
         consumed by vLLM inference.
@@ -449,6 +480,7 @@ class TestOpenAIResponsesVLLM:
             f"marker '{marker}'; got: {response.output_text}"
         )
 
+    @requires_live_inference
     def test_file_id_resolution_through_ogx(self, openai_client):
         """End-to-end: upload to OGX via Praxis, reference by file_id,
         verify vLLM output contains the file content.
@@ -503,6 +535,7 @@ class TestOpenAIResponsesVLLM:
             except Exception:
                 pass
 
+    @requires_replayed_tool_tokens
     def test_client_function_call_returns_to_client(self, openai_client):
         """Client-side function tools are returned without auto-execution.
 
@@ -564,13 +597,21 @@ class TestOpenAIResponsesVLLM:
             event_types.append(event.type)
             if event.type == "response.output_text.delta":
                 text_parts.append(event.delta)
-            if event.type == "response.completed":
+            if event.type in ("response.completed", "response.incomplete"):
                 final_status = event.response.status
 
         assert event_types[0] == "response.created"
-        assert event_types[-1] == "response.completed"
-        assert final_status == "completed"
-        assert "STREAM-OK" in "".join(text_parts)
+        if VLLM_VCR_RANDOM:
+            assert event_types[-1] in (
+                "response.completed",
+                "response.incomplete",
+            )
+            assert final_status in ("completed", "incomplete")
+            assert text_parts
+        else:
+            assert event_types[-1] == "response.completed"
+            assert final_status == "completed"
+            assert "STREAM-OK" in "".join(text_parts)
 
 
 # ---------------------------------------------------------------------------
@@ -656,6 +697,7 @@ def agentic_client(agentic_proxy):
 # ---------------------------------------------------------------------------
 
 
+@requires_replayed_tool_tokens
 class TestAgenticLoopVLLM:
     """Integration tests for the agentic loop against a vLLM backend."""
 
@@ -960,6 +1002,7 @@ def file_search_client(file_search_proxy):
     )
 
 
+@requires_replayed_tool_tokens
 class TestFileSearchVLLM:
     """File search integration tests: vLLM -> Praxis -> OGX -> vLLM."""
 


### PR DESCRIPTION
## Summary

Prototype a vllm-vcr-backed CI lane to measure the speedup from
eliminating the ~8 minute vLLM CPU model startup penalty. The
branch-scoped workflow runs the vLLM frontend with vllm-vcr random
tokens instead of real inference. The test file gains a
`VLLM_TEST_BACKEND=vcr-random` mode that runs 3 protocol-safe tests
(smoke, store/retrieve, streaming) and skips 7 that need real model
inference or captured tool-call traces.

## Related issue

N/A — exploratory prototype to evaluate CI runtime savings.

## Validation

- [x] `make lint`
- [x] `make build`
- [ ] CI prototype workflow (will run on push to this branch)

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None — branch-scoped prototype workflow, no changes to existing CI or test behavior.