### PR TITLE
fix(ci): bump vLLM integration test timeouts to 300s

### DIFF
--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -227,7 +227,7 @@ def _write_agentic_config(
     config = config.replace(
         '- "127.0.0.1:3001"',
         f'- "{vllm}"\n'
-        "                    read_timeout_ms: 120000",
+        "                    read_timeout_ms: 300000",
     )
     config = config.replace(
         "sqlite://responses.db?mode=rwc",
@@ -248,8 +248,8 @@ def _write_agentic_config(
     config = config.replace(
         "max_iterations: 11\n",
         "max_iterations: 11\n"
-        "        timeout_ms: 120000\n"
-        "        step_timeout_ms: 120000\n",
+        "        timeout_ms: 300000\n"
+        "        step_timeout_ms: 300000\n",
     )
     config = config.replace(
         "- filter: openai_web_search\n"
@@ -318,7 +318,7 @@ def openai_client(praxis_proxy):
         base_url=f"http://127.0.0.1:{praxis_proxy}/v1",
         api_key="test",
         max_retries=0,
-        timeout=180,
+        timeout=300,
     )
 
 
@@ -634,7 +634,7 @@ def agentic_client(agentic_proxy):
         base_url=f"http://127.0.0.1:{proxy_port}/v1",
         api_key="test",
         max_retries=0,
-        timeout=180,
+        timeout=300,
     )
 
 
@@ -943,7 +943,7 @@ def file_search_client(file_search_proxy):
         base_url=f"http://127.0.0.1:{file_search_proxy}/v1",
         api_key="test",
         max_retries=0,
-        timeout=180,
+        timeout=300,
     )
 
 


### PR DESCRIPTION
## Summary

Increase all timeout values in the vLLM Responses SDK integration tests
from 120/180s to 300s to reduce flaky failures caused by slow model
inference on CI runners.

Changes:
- `read_timeout_ms`: 120000 → 300000
- `timeout_ms`: 120000 → 300000
- `step_timeout_ms`: 120000 → 300000
- SDK client `timeout`: 180 → 300 (all three client fixtures)

## Related issue

Closes #

## Validation

- [ ] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.