### PR TITLE
fix(a2a): defer route commit until EOS to prevent prefix-poisoning

### DIFF
--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -450,11 +450,12 @@ fn handle_non_streaming_capture(
     }
 }
 
-/// Called when EOS is confirmed (either `end_of_stream=true` on the current
-/// call, or after a tentative parse was promoted by a whitespace-only EOS
-/// callback). Parses the full accumulated buffer and, on success, stores the
-/// extracted routes. A failed parse is unconditionally terminal and clears
-/// capture state.
+/// Called from the `is_complete || end_of_stream` branch of
+/// [`handle_non_streaming_capture`] -- either the fast path where both
+/// conditions are true simultaneously, or the fallback where EOS arrives
+/// with an incomplete buffer. Parses the full accumulated hex buffer and,
+/// on success, stores the extracted routes. A failed parse is
+/// unconditionally terminal and clears capture state.
 fn try_capture_from_buffer(
     ctx: &mut HttpFilterContext<'_>,
     store: &LocalTaskRouteStore,

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -503,6 +503,11 @@ fn parse_to_tentative(ctx: &mut HttpFilterContext<'_>) {
             if let Ok(json_str) = serde_json::to_string(&value) {
                 ctx.filter_metadata
                     .insert("a2a.response.tentative_json".to_owned(), json_str);
+            } else {
+                // Serialization failure is effectively infallible for a Value
+                // that was just deserialized, but clear state defensively so
+                // the tentative guard cannot be bypassed on subsequent chunks.
+                clear_capture_metadata(ctx);
             }
         }
         None => {

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -382,6 +382,33 @@ fn lookup_task_route(
     }
 }
 
+/// Advances or abandons a pending tentative route. Returns `true` if the
+/// caller should return early (tentative guard handled this chunk).
+fn handle_pending_tentative(
+    ctx: &mut HttpFilterContext<'_>,
+    body: &Option<Bytes>,
+    end_of_stream: bool,
+    store: &LocalTaskRouteStore,
+    config: &config::TaskRoutingConfig,
+) -> bool {
+    if !ctx.filter_metadata.contains_key("a2a.response.tentative_json") {
+        return false;
+    }
+    let has_new_content = body
+        .as_ref()
+        .is_some_and(|b| b.iter().any(|byte| !byte.is_ascii_whitespace()));
+    if has_new_content {
+        debug!("tentative route discarded: trailing non-whitespace after balanced JSON prefix");
+        clear_capture_metadata(ctx);
+    } else if end_of_stream {
+        debug!("tentative route confirmed at EOS: no trailing content");
+        commit_tentative_capture(ctx, store, config);
+        clear_capture_metadata(ctx);
+    }
+    // else: whitespace-only chunk, EOS not yet seen — keep waiting.
+    true
+}
+
 /// Drives non-streaming A2A task-route capture for one `on_response_body`
 /// call: accumulate the chunk, update the [`JsonBalanceState`] scanner,
 /// and either abandon capture (invalid buffer), attempt a parse (buffer
@@ -393,26 +420,7 @@ fn handle_non_streaming_capture(
     store: &LocalTaskRouteStore,
     config: &config::TaskRoutingConfig,
 ) {
-    // If a previous chunk reached a structurally complete JSON value without
-    // EOS, a tentative parse was stored. Any non-whitespace bytes arriving
-    // afterward prove the response is not valid JSON — the complete prefix
-    // would have been a poisoned route. Abandon or confirm now.
-    if ctx.filter_metadata.contains_key("a2a.response.tentative_json") {
-        let has_new_content = body
-            .as_ref()
-            .is_some_and(|b| b.iter().any(|byte| !byte.is_ascii_whitespace()));
-
-        if has_new_content {
-            // Non-whitespace bytes after the balanced prefix: the full response
-            // is not valid JSON. Discard the tentative route.
-            clear_capture_metadata(ctx);
-        } else if end_of_stream {
-            // EOS with no further non-whitespace bytes: the prefix is the
-            // complete response. Commit the tentative route.
-            commit_tentative_capture(ctx, store, config);
-            clear_capture_metadata(ctx);
-        }
-        // else: whitespace-only chunk, EOS not yet seen — keep waiting.
+    if handle_pending_tentative(ctx, body, end_of_stream, store, config) {
         return;
     }
 
@@ -509,7 +517,7 @@ fn parse_to_tentative(ctx: &mut HttpFilterContext<'_>) {
 /// Called only after [`handle_non_streaming_capture`] confirms EOS arrived
 /// with no non-whitespace bytes following the balanced JSON prefix.
 fn commit_tentative_capture(
-    ctx: &mut HttpFilterContext<'_>,
+    ctx: &HttpFilterContext<'_>,
     store: &LocalTaskRouteStore,
     config: &config::TaskRoutingConfig,
 ) {

--- a/filters/src/agentic/a2a/mod.rs
+++ b/filters/src/agentic/a2a/mod.rs
@@ -393,6 +393,29 @@ fn handle_non_streaming_capture(
     store: &LocalTaskRouteStore,
     config: &config::TaskRoutingConfig,
 ) {
+    // If a previous chunk reached a structurally complete JSON value without
+    // EOS, a tentative parse was stored. Any non-whitespace bytes arriving
+    // afterward prove the response is not valid JSON — the complete prefix
+    // would have been a poisoned route. Abandon or confirm now.
+    if ctx.filter_metadata.contains_key("a2a.response.tentative_json") {
+        let has_new_content = body
+            .as_ref()
+            .is_some_and(|b| b.iter().any(|byte| !byte.is_ascii_whitespace()));
+
+        if has_new_content {
+            // Non-whitespace bytes after the balanced prefix: the full response
+            // is not valid JSON. Discard the tentative route.
+            clear_capture_metadata(ctx);
+        } else if end_of_stream {
+            // EOS with no further non-whitespace bytes: the prefix is the
+            // complete response. Commit the tentative route.
+            commit_tentative_capture(ctx, store, config);
+            clear_capture_metadata(ctx);
+        }
+        // else: whitespace-only chunk, EOS not yet seen — keep waiting.
+        return;
+    }
+
     if let Some(chunk) = body.as_ref()
         && !accumulate_response_hex(ctx, chunk, config.max_response_body_bytes)
     {
@@ -414,26 +437,24 @@ fn handle_non_streaming_capture(
         // remaining chunk up to max_response_body_bytes only to hit
         // this same dead end at end_of_stream.
         clear_capture_metadata(ctx);
+    } else if is_complete && !end_of_stream {
+        // Structurally complete but EOS not yet confirmed. Parse tentatively
+        // and hold: the route is committed only when EOS arrives with no
+        // further non-whitespace bytes. This prevents a valid JSON prefix
+        // followed by trailing garbage from poisoning task-route ownership.
+        parse_to_tentative(ctx);
     } else if is_complete || end_of_stream {
+        // EOS is confirmed (either directly or together with is_complete):
+        // the full response is in the buffer; commit immediately.
         try_capture_from_buffer(ctx, store, config);
     }
 }
 
-/// Pingora may not deliver a separate EOS callback after the final data
-/// chunk, so callers attempt this as soon as [`JsonBalanceState`] reports
-/// the buffer holds a balanced top-level JSON value, rather than waiting
-/// for `end_of_stream`. This avoids repeating a full hex-decode and
-/// `serde_json` parse of the whole accumulated buffer on every chunk.
-///
-/// [`JsonBalanceState`] is a heuristic gate, not a validator: a buffer
-/// can be balanced and type-matched yet still fail to parse (e.g.
-/// trailing bytes after a complete object, or a trailing comma). Bytes
-/// already accumulated up to a structurally-closed offset cannot become
-/// parseable by appending more bytes afterward — any further data can
-/// only add trailing content, which `serde_json` rejects just the same.
-/// So a failed parse here is unconditionally terminal: clear capture
-/// state immediately rather than holding the (still-growing) buffer and
-/// re-attempting the same doomed parse at `end_of_stream`.
+/// Called when EOS is confirmed (either `end_of_stream=true` on the current
+/// call, or after a tentative parse was promoted by a whitespace-only EOS
+/// callback). Parses the full accumulated buffer and, on success, stores the
+/// extracted routes. A failed parse is unconditionally terminal and clears
+/// capture state.
 fn try_capture_from_buffer(
     ctx: &mut HttpFilterContext<'_>,
     store: &LocalTaskRouteStore,
@@ -451,6 +472,56 @@ fn try_capture_from_buffer(
         store_task_route(&value, cluster, store, config);
     }
     clear_capture_metadata(ctx);
+}
+
+/// Parse the accumulated buffer and, on success, store the result in filter
+/// metadata under `a2a.response.tentative_json` without committing to the
+/// route store. The route is committed only once
+/// [`handle_non_streaming_capture`] receives EOS with no further
+/// non-whitespace bytes, proving no trailing content follows.
+///
+/// A failed parse clears capture state immediately — a balanced-but-invalid
+/// buffer (e.g. trailing comma) cannot be salvaged by later bytes.
+fn parse_to_tentative(ctx: &mut HttpFilterContext<'_>) {
+    let parsed = ctx
+        .filter_metadata
+        .get("a2a.response.buffer_hex")
+        .and_then(|hex| decode_hex(hex))
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok());
+
+    match parsed {
+        Some(value) => {
+            if let Ok(json_str) = serde_json::to_string(&value) {
+                ctx.filter_metadata
+                    .insert("a2a.response.tentative_json".to_owned(), json_str);
+            }
+        }
+        None => {
+            // Balanced but unparseable: unconditionally terminal.
+            clear_capture_metadata(ctx);
+        }
+    }
+}
+
+/// Commit a previously tentative capture to the route store.
+///
+/// Called only after [`handle_non_streaming_capture`] confirms EOS arrived
+/// with no non-whitespace bytes following the balanced JSON prefix.
+fn commit_tentative_capture(
+    ctx: &mut HttpFilterContext<'_>,
+    store: &LocalTaskRouteStore,
+    config: &config::TaskRoutingConfig,
+) {
+    let Some(json_str) = ctx.filter_metadata.get("a2a.response.tentative_json") else {
+        return;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) else {
+        return;
+    };
+    let Some(cluster) = ctx.filter_metadata.get("a2a.response.cluster") else {
+        return;
+    };
+    store_task_route(&value, cluster, store, config);
 }
 
 /// Store task and context routes extracted from a response body.
@@ -517,6 +588,7 @@ fn clear_capture_metadata(ctx: &mut HttpFilterContext<'_>) {
     ctx.filter_metadata.remove("a2a.response.json_in_string");
     ctx.filter_metadata.remove("a2a.response.json_escaped");
     ctx.filter_metadata.remove("a2a.response.json_invalid");
+    ctx.filter_metadata.remove("a2a.response.tentative_json");
 }
 
 /// Accumulate raw bytes as hex to avoid corruption when chunk boundaries

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -1673,8 +1673,6 @@ async fn json_response_split_across_chunks_defers_capture_until_eos() {
         "incomplete JSON should not capture"
     );
 
-    // chunk2 completes the JSON structure but end_of_stream is false:
-    // the route must be held as tentative, not yet committed.
     let mut body2 = Some(Bytes::from(chunk2.to_owned()));
     drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
     assert!(
@@ -1686,7 +1684,6 @@ async fn json_response_split_across_chunks_defers_capture_until_eos() {
         "tentative parse must be held pending EOS"
     );
 
-    // EOS arrives with no further bytes: confirm and commit.
     let mut eos = None;
     drop(filter.on_response_body(&mut ctx, &mut eos, true).unwrap());
     assert_eq!(

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -1655,7 +1655,7 @@ async fn task_route_hit_records_bounded_route_metadata() {
 // -----------------------------------------------------------------------------
 
 #[tokio::test]
-async fn json_response_split_across_chunks_captures_opportunistically() {
+async fn json_response_split_across_chunks_defers_capture_until_eos() {
     let filter = make_task_routing_filter();
     let store = filter.task_route_store.as_ref().unwrap();
     let req = make_a2a_request(&[]);
@@ -1673,13 +1673,84 @@ async fn json_response_split_across_chunks_captures_opportunistically() {
         "incomplete JSON should not capture"
     );
 
+    // chunk2 completes the JSON structure but end_of_stream is false:
+    // the route must be held as tentative, not yet committed.
     let mut body2 = Some(Bytes::from(chunk2.to_owned()));
     drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-split").is_none(),
+        "route must not be committed before EOS is confirmed"
+    );
+    assert!(
+        ctx.filter_metadata.contains_key("a2a.response.tentative_json"),
+        "tentative parse must be held pending EOS"
+    );
 
+    // EOS arrives with no further bytes: confirm and commit.
+    let mut eos = None;
+    drop(filter.on_response_body(&mut ctx, &mut eos, true).unwrap());
     assert_eq!(
         store.get_by_task_id("task-split").as_deref(),
         Some("agent-a"),
-        "route should be captured as soon as JSON is complete, before EOS"
+        "route must be committed once EOS confirms no trailing bytes"
+    );
+    assert_capture_scratch_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn complete_json_prefix_then_garbage_does_not_capture_route() {
+    // Regression test for fnd_sig-feat-custom-ai-agentic-class_e1322f3e62:
+    // a valid JSON prefix followed by non-whitespace bytes must not poison
+    // task-route ownership.
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    // Chunk 1: structurally complete JSON (end_of_stream=false) → tentative.
+    let json =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-poison","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let mut body1 = Some(Bytes::from(json));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-poison").is_none(),
+        "route must not be committed before EOS"
+    );
+
+    // Chunk 2: trailing garbage with end_of_stream=true → tentative discarded.
+    let mut body2 = Some(Bytes::from_static(b"garbage!"));
+    drop(filter.on_response_body(&mut ctx, &mut body2, true).unwrap());
+    assert!(
+        store.get_by_task_id("task-poison").is_none(),
+        "trailing garbage must prevent the route from being committed"
+    );
+    assert_capture_scratch_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn complete_json_followed_by_whitespace_at_eos_captures_route() {
+    // EOS arriving with only whitespace after a tentative capture must
+    // confirm and commit the route — whitespace is not a trailing-content
+    // violation because serde_json accepts it as legal trailing bytes.
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-ws","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let mut body1 = Some(Bytes::from(json));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+    // Whitespace-only chunk at EOS: should confirm the tentative route.
+    let mut eos = Some(Bytes::from_static(b"   \n"));
+    drop(filter.on_response_body(&mut ctx, &mut eos, true).unwrap());
+    assert_eq!(
+        store.get_by_task_id("task-ws").as_deref(),
+        Some("agent-a"),
+        "whitespace at EOS must confirm the tentative route"
     );
     assert_capture_scratch_cleared(&ctx);
 }
@@ -1856,7 +1927,7 @@ async fn mixed_case_sse_content_type_skips_capture() {
 }
 
 #[tokio::test]
-async fn many_single_byte_chunks_still_capture_route_before_eos() {
+async fn many_single_byte_chunks_capture_route_at_eos() {
     let filter = make_task_routing_filter();
     let store = filter.task_route_store.as_ref().unwrap();
 
@@ -1871,11 +1942,20 @@ async fn many_single_byte_chunks_still_capture_route_before_eos() {
         drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
     }
 
+    // All bytes delivered without EOS: tentative parse held, not yet committed.
+    assert!(
+        store.get_by_task_id("task-many-chunks").is_none(),
+        "route must not be committed until EOS is confirmed"
+    );
+
+    // EOS arrives (as a separate empty callback, as Pingora may deliver).
+    let mut eos = None;
+    drop(filter.on_response_body(&mut ctx, &mut eos, true).unwrap());
+
     assert_eq!(
         store.get_by_task_id("task-many-chunks").as_deref(),
         Some("agent-a"),
-        "route should be captured once the JSON is balanced, even when delivered as many \
-         single-byte chunks, without waiting for end_of_stream"
+        "route should be captured at EOS even when delivered as many single-byte chunks"
     );
     assert_capture_scratch_cleared(&ctx);
 }
@@ -2326,11 +2406,18 @@ async fn split_json_response_with_context_stores_context_route() {
 
     let mut body2 = Some(Bytes::from(chunk2.to_owned()));
     drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+    assert!(
+        store.get_by_context_id("ctx-split").is_none(),
+        "context route must not be committed before EOS is confirmed"
+    );
 
+    // EOS confirms no trailing bytes: commit.
+    let mut eos = None;
+    drop(filter.on_response_body(&mut ctx, &mut eos, true).unwrap());
     assert_eq!(
         store.get_by_context_id("ctx-split").as_deref(),
         Some("agent-a"),
-        "context route should be captured once JSON completes"
+        "context route should be captured at EOS"
     );
 }
 
@@ -3400,6 +3487,10 @@ fn assert_capture_scratch_cleared(ctx: &praxis_filter::HttpFilterContext<'_>) {
     assert!(
         !ctx.filter_metadata.contains_key("a2a.response.json_invalid"),
         "json_invalid not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.tentative_json"),
+        "tentative_json not cleared"
     );
 }
 

--- a/filters/src/agentic/a2a/tests.rs
+++ b/filters/src/agentic/a2a/tests.rs
@@ -1729,6 +1729,42 @@ async fn complete_json_prefix_then_garbage_does_not_capture_route() {
 }
 
 #[tokio::test]
+async fn tentative_survives_whitespace_chunk_before_eos() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-ws-wait","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let mut body1 = Some(Bytes::from(json));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+    // Whitespace-only chunk with EOS=false: tentative must survive, route not yet committed.
+    let mut ws = Some(Bytes::from_static(b"  \n"));
+    drop(filter.on_response_body(&mut ctx, &mut ws, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-ws-wait").is_none(),
+        "route must not be committed while EOS has not arrived"
+    );
+    assert!(
+        ctx.filter_metadata.contains_key("a2a.response.tentative_json"),
+        "tentative must survive a whitespace-only intermediate chunk"
+    );
+
+    // EOS with no body: commit.
+    let mut eos = None;
+    drop(filter.on_response_body(&mut ctx, &mut eos, true).unwrap());
+    assert_eq!(
+        store.get_by_task_id("task-ws-wait").as_deref(),
+        Some("agent-a"),
+        "route must be committed once EOS arrives after whitespace-only intermediate chunks"
+    );
+    assert_capture_scratch_cleared(&ctx);
+}
+
+#[tokio::test]
 async fn complete_json_followed_by_whitespace_at_eos_captures_route() {
     // EOS arriving with only whitespace after a tentative capture must
     // confirm and commit the route — whitespace is not a trailing-content


### PR DESCRIPTION
## fix(a2a): defer route commit until EOS to prevent prefix-poisoning

### Summary

Addresses Clawpatch finding `fnd_sig-feat-custom-ai-agentic-class_e1322f3e62` (severity: medium / security / confidence: high).

The A2A non-streaming capture path committed task-route ownership as soon
as the JSON balance scanner reported a structurally complete value, regardless
of `end_of_stream`. A backend could deliver a valid JSON task response with
`end_of_stream=false`, have the route stored, then append trailing garbage —
producing an overall-invalid response while poisoning task ownership.

---

### Root Cause

```rust
// Before — VULNERABLE
} else if is_complete || end_of_stream {
    try_capture_from_buffer(ctx, store, config);  // ← commits immediately on is_complete
}
```

```rust
// try_capture_from_buffer — COMMITS AND CLEARS STATE
if let Some(value) = parsed && let Some(cluster) = ... {
    store_task_route(&value, cluster, store, config);  // ← route poisoned
}
clear_capture_metadata(ctx);  // ← any follow-up garbage ignored
```

Once the route was in the store and state was cleared, no subsequent chunk
could retract it. Trailing garbage arriving after a balanced JSON prefix was
silently dropped.

---

### Fix

```rust
} else if is_complete && !end_of_stream {
    // Hold tentatively — commit only when EOS confirms no trailing bytes.
    parse_to_tentative(ctx);
} else if is_complete || end_of_stream {
    // EOS confirmed: commit immediately (common fast path unchanged).
    try_capture_from_buffer(ctx, store, config);
}
```

When `is_complete && !end_of_stream`, the parsed value is stored in filter
metadata under `a2a.response.tentative_json`. On every subsequent call:

| Condition | Action |
|-----------|--------|
| Non-whitespace bytes arrive before EOS | Discard tentative — trailing content proves invalid JSON |
| EOS with no further non-whitespace bytes | Commit tentative route to store |
| Whitespace-only bytes, EOS not yet seen | Keep waiting |

The `end_of_stream=true` + `is_complete=true` fast path is unchanged.

---

### Changes

| File | Change |
|------|--------|
| `filters/src/agentic/a2a/mod.rs` | `handle_non_streaming_capture` — tentative guard + new branch |
| `filters/src/agentic/a2a/mod.rs` | `parse_to_tentative()` — new helper |
| `filters/src/agentic/a2a/mod.rs` | `commit_tentative_capture()` — new helper |
| `filters/src/agentic/a2a/mod.rs` | `clear_capture_metadata()` — clears `a2a.response.tentative_json` |
| `filters/src/agentic/a2a/tests.rs` | 4 existing tests updated + 2 regression tests added |

**Updated tests:**
- `json_response_split_across_chunks_defers_capture_until_eos` (renamed from `captures_opportunistically`)
- `many_single_byte_chunks_capture_route_at_eos` (renamed, adds EOS call)
- `split_json_response_with_context_stores_context_route` (adds EOS call)
- `assert_capture_scratch_cleared` (checks `tentative_json` cleared)

**New regression tests:**
- `complete_json_prefix_then_garbage_does_not_capture_route` — the exact attack scenario: valid JSON prefix + trailing garbage → no route stored
- `complete_json_followed_by_whitespace_at_eos_captures_route` — whitespace at EOS confirms and commits the tentative route

---

### Test Results

```
test result: ok. 1011 passed; 0 failed; 0 ignored (unit tests)
test result: ok. 2 passed; 0 failed; 5 ignored (integration tests)
```

---


### Resolve

https://github.com/praxis-proxy/ai/issues/675