### PR TITLE
chore(deps): switch Praxis crates from git tags to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,12 +68,12 @@ utoipa = "5.5.0"
 wiremock = "0.6.5"
 zeroize = "1.9.0"
 
-# Praxis core dependencies (git tag until v0.5.2 is published on crates.io)
-praxis-core = { git = "https://github.com/praxis-proxy/praxis.git", tag = "v0.5.2", package = "praxis-proxy-core" }
-praxis-filter = { git = "https://github.com/praxis-proxy/praxis.git", tag = "v0.5.2", package = "praxis-proxy-filter" }
-praxis-protocol = { git = "https://github.com/praxis-proxy/praxis.git", tag = "v0.5.2", package = "praxis-proxy-protocol" }
-praxis-tls = { git = "https://github.com/praxis-proxy/praxis.git", tag = "v0.5.2", package = "praxis-proxy-tls" }
-praxis = { git = "https://github.com/praxis-proxy/praxis.git", tag = "v0.5.2", package = "praxis-proxy" }
+# Praxis core dependencies
+praxis-core = { version = "0.5.2", package = "praxis-proxy-core" }
+praxis-filter = { version = "0.5.2", package = "praxis-proxy-filter" }
+praxis-protocol = { version = "0.5.2", package = "praxis-proxy-protocol" }
+praxis-tls = { version = "0.5.2", package = "praxis-proxy-tls" }
+praxis = { version = "0.5.2", package = "praxis-proxy" }
 praxis-test-utils = { path = "tests/utils" }
 
 # Praxis AI workspace dependencies


### PR DESCRIPTION
## Summary

Now that Praxis v0.5.2 is published on crates.io, this removes the
temporary git tag workaround introduced in #701 and switches all five
Praxis workspace dependencies to use crates.io versions directly.

Follow-up to #701.

## Checklist

- [x] I reviewed every changed line and can explain the change.