### PR TITLE
fix(server): maintain Prometheus recorder state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,8 +3183,10 @@ dependencies = [
 name = "praxis-ai-proxy"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "cargo_metadata",
  "clap",
+ "metrics-exporter-prometheus",
  "nix",
  "notify",
  "praxis-ai-apis",
@@ -3193,6 +3195,7 @@ dependencies = [
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "praxis-proxy-protocol",
+ "quixotic-plecostomus-core",
  "serde",
  "tempfile",
  "tikv-jemallocator",
@@ -3205,7 +3208,8 @@ dependencies = [
 [[package]]
 name = "praxis-proxy"
 version = "0.5.2"
-source = "git+https://github.com/praxis-proxy/praxis.git?tag=v0.5.2#af54edcd24de01e4dac7da59a809bf88bd246fe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8c33408ff78ce9eb011c83e04961b8d8cb80bc7f82852d34c99f72ff96b7e8"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3225,7 +3229,8 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-core"
 version = "0.5.2"
-source = "git+https://github.com/praxis-proxy/praxis.git?tag=v0.5.2#af54edcd24de01e4dac7da59a809bf88bd246fe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cdde88169a2237ad74e0a41211c8ed08a04ed183ad64f18574000009e19232"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -3246,7 +3251,8 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-filter"
 version = "0.5.2"
-source = "git+https://github.com/praxis-proxy/praxis.git?tag=v0.5.2#af54edcd24de01e4dac7da59a809bf88bd246fe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0844747ee66c06b060ae145b201a31ec828670bf95d38adb6058b483d4050c0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3274,7 +3280,8 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-protocol"
 version = "0.5.2"
-source = "git+https://github.com/praxis-proxy/praxis.git?tag=v0.5.2#af54edcd24de01e4dac7da59a809bf88bd246fe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6504d74ea05b2fc0ba9e934e845b8c40febc6c929194d5ca18c148cdd5f5bb7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3298,7 +3305,8 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-tls"
 version = "0.5.2"
-source = "git+https://github.com/praxis-proxy/praxis.git?tag=v0.5.2#af54edcd24de01e4dac7da59a809bf88bd246fe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671e446adbc6edb635bf2af81b712abf628fc1ecce74799515fd860eba38247d"
 dependencies = [
  "arc-swap",
  "notify",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,13 +29,16 @@ praxis-main = ["praxis-ai-filters/praxis-main", "praxis-ai-apis/praxis-main"]
 workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 clap = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 notify = { workspace = true }
 praxis-ai-filters = { workspace = true }
 praxis-ai-apis = { workspace = true }
 praxis-core = { workspace = true }
 praxis-filter = { workspace = true }
 praxis-protocol = { workspace = true }
+pingora-core = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time", "fs"] }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -6,8 +6,14 @@
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
+use async_trait::async_trait;
+use pingora_core::{
+    server::ShutdownWatch,
+    services::background::{BackgroundService, background_service},
+};
 use praxis_core::{
     PingoraServerRuntime,
     config::{Config, ProtocolKind},
@@ -19,6 +25,33 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::pipelines::resolve_pipelines;
+
+/// Prometheus recorder maintenance interval.
+///
+/// `PrometheusBuilder::install_recorder` does not spawn the exporter upkeep
+/// task. Keep upkeep independent of `/metrics` scrape traffic so histogram
+/// sample buffers are drained even when the admin endpoint is not scraped.
+/// This does not expire stale metric series; that requires recorder
+/// recency/idle-timeout configuration in Praxis.
+const PROMETHEUS_UPKEEP_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Pingora-managed Prometheus recorder maintenance.
+struct PrometheusUpkeepService {
+    /// Handle for the recorder installed by the Praxis admin service.
+    handle: metrics_exporter_prometheus::PrometheusHandle,
+}
+
+#[async_trait]
+impl BackgroundService for PrometheusUpkeepService {
+    async fn start(&self, mut shutdown: ShutdownWatch) {
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => break,
+                () = tokio::time::sleep(PROMETHEUS_UPKEEP_INTERVAL) => self.handle.run_upkeep(),
+            }
+        }
+    }
+}
 
 // -----------------------------------------------------------------------------
 // Config Path Resolution
@@ -232,6 +265,12 @@ fn register_admin_endpoints(
     kv_stores: &praxis_core::kv::KvStoreRegistry,
 ) {
     if let Some(admin_addr) = &config.admin.address {
+        let upkeep = PrometheusUpkeepService {
+            handle: praxis_protocol::http::pingora::metrics::install_prometheus_recorder().clone(),
+        };
+        server
+            .server_mut()
+            .add_service(background_service("Prometheus upkeep", upkeep));
         praxis_protocol::http::pingora::health::add_admin_endpoints_to_pingora_server(
             server.server_mut(),
             admin_addr,


### PR DESCRIPTION
## Summary

  Ensure the Prometheus recorder performs periodic upkeep even when `/metrics` is not being scraped. Praxis AI installs the Prometheus recorder when the admin endpoint is configured. `PrometheusBuilder::install_recorder()` exposes the recorder and its handle, but it does not start the exporter's upkeep task. Without an external scrape, buffered  histogram samples may remain pending and accumulate over time. 

This change registers a Pingora-managed background service that calls `PrometheusHandle::run_upkeep()` every five seconds. The service starts only when the admin endpoint is configured, reuses the existing recorder handle, does not install another recorder or exporter, waits five seconds before its first upkeep pass, operates independently of `/metrics` scrape traffic, exits through Pingora's graceful-shutdown signal, and does not log metric values, requests, or credentials. The existing /metrics endpoint and recorder installation behavior remain unchanged.

  ## Why a Pingora background service?

  An unmanaged `tokio::spawn` task would not participate in the server lifecycle and could continue running during shutdown. Using Pingora's `BackgroundService` integrates upkeep
  with the existing runtime and provides an explicit ShutdownWatch. The service stops when shutdown begins and does not require a separate runtime or worker thread.

  ## Scope

  This change addresses Prometheus histogram recorder upkeep when /metrics is not scraped. It drains the recorder's buffered histogram observations on a predictable schedule. It does not expire inactive metric series. Stale dynamic-label series still require Praxis to expose and configure the Prometheus recorder's recency or `idle_timeout` behavior. That should be handled as a separate Praxis capability.

  ## Implementation

  The server registers `PrometheusUpkeepService` alongside the existing admin endpoint when `config.admin.address` is present. The service retains a clone of the public `PrometheusHandle` and performs upkeep after a five-second interval, while listening for Pingora's shutdown signal. The interval provides regular buffer maintenance without  coupling upkeep frequency to Prometheus's configured scrape interval.

## Alternatives Considered

  - Call upkeep during `/metrics` scrapes: simpler, but fails when metrics are not being scraped, which is the condition this fixes.
  - Use `tokio::spawn:` works mechanically, but creates an unmanaged task without Pingora’s graceful-shutdown lifecycle.

## Perf/Risk

It adds a small amount of background work, but no per-request hot-path work.

  Every five seconds, one task calls PrometheusHandle::run_upkeep(). The cost depends on the number of histogram buffers and metric series, but it is generally modest and is work the recorder already expects to perform. It does not inspect requests, block proxy workers, create another exporter, or run once per request.

  The practical risk is only unusually high metric cardinality, where any recorder maintenance becomes more expensive. This change should reduce the greater risk of buffered histogram state accumulating indefinitely when /metrics is not scraped. Benchmarking or observing upkeep duration would still be appropriate before claiming zero overhead.

  ## Validation

  - [x] cargo +nightly fmt --all -- --check
  - [x] git diff --check
  - [x] make lint
  - [x] cargo test -p praxis-ai-proxy
  - [x] make test

  make test completed with 2,524 passing tests, 27 ignored tests, and one pre-existing SQLite database is locked failure. The affected test passed when run independently.

  ## Breaking changes

  None. The behavior is limited to deployments with the admin endpoint enabled, and the existing Prometheus endpoint and metric format are unchanged.

Closes #734