### PR TITLE
feat(file_search): full-flow-agentic example with IRR file search callout

### DIFF
--- a/apis/src/openai/responses/file_search_callout/mod.rs
+++ b/apis/src/openai/responses/file_search_callout/mod.rs
@@ -284,6 +284,10 @@ impl FileSearchCalloutFilter {
     }
 
     /// Execute pending calls before the next inference body is serialized.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "linear sequence: plan → callout → apply → size check"
+    )]
     async fn execute_pending(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
         if let Some(rejection) = unsupported_streaming_rejection(ctx) {
             return Ok(rejection);
@@ -291,17 +295,15 @@ impl FileSearchCalloutFilter {
         let Some(state) = ctx.extensions.get::<ResponsesState>() else {
             return Ok(FilterAction::Continue);
         };
-
         let plan = build_search_plan(state);
         if !plan.has_pending_calls {
             return Ok(FilterAction::Continue);
         }
-
-        let batch = self.execute_plan(&plan, &ctx.request.headers).await;
+        let hdrs = callout_request_headers(ctx);
+        let batch = self.execute_plan(&plan, &hdrs).await;
         if let Some(rejection) = self.failure_rejection(&batch) {
             return Ok(rejection);
         }
-
         let framework_bytes = retained_iteration_bytes(ctx);
         let state = ctx
             .extensions
@@ -313,10 +315,8 @@ impl FileSearchCalloutFilter {
         if !continuation_state_fits(framework_bytes, state, self.max_state_bytes, 0) {
             return Ok(continuation_state_rejection());
         }
-
         reset_tool_choice(state);
         state.iteration = state.iteration.saturating_add(1);
-
         Ok(FilterAction::Continue)
     }
 
@@ -500,6 +500,24 @@ impl HttpFilter for FileSearchCalloutFilter {
         }
         Self::capture_response(ctx, body, self.max_state_bytes)
     }
+}
+
+/// On IRR continuation iterations the synthetic request lacks client
+/// credentials; return the original request headers so `forward_headers`
+/// can reach the vector store. Borrows on the first iteration; on
+/// continuations filters out headers nominated by `Connection`.
+fn callout_request_headers<'a>(ctx: &'a HttpFilterContext<'_>) -> Cow<'a, HeaderMap> {
+    let Some(state) = ctx.extensions.get::<IterationState>().filter(|s| s.iteration() > 0) else {
+        return Cow::Borrowed(&ctx.request.headers);
+    };
+    let original = &state.original_request.headers;
+    let mut filtered = HeaderMap::with_capacity(original.len());
+    for (name, value) in original {
+        if !connection_nominates_header(original, name) {
+            filtered.append(name.clone(), value.clone());
+        }
+    }
+    Cow::Owned(filtered)
 }
 
 /// Restore end-to-end client headers after the iterative router isolates a

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,7 @@ before sending requests.
 | [file-resolve.yaml](configs/openai/responses/file-resolve.yaml) | Resolves `file_id` and `file_url` references in Responses API input by fetching file metadata and content, then inlining base64 content as `file_data` or `image_url` before forwarding |
 | [file-search-callout.yaml](configs/openai/responses/file-search-callout.yaml) | Demonstrates the `openai_file_search_callout` filter configuration |
 | [format-routing.yaml](configs/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |
+| [full-flow-agentic.yaml](configs/openai/responses/full-flow-agentic.yaml) | Extends the full-flow pipeline with an iterative_request_router (IRR) around the inference step, enabling server-side file search execution |
 | [full-flow.yaml](configs/openai/responses/full-flow.yaml) | Combines conversations, format classification, request validation, file resolution, and backend routing into a single pipeline |
 | [mcp-dispatch.yaml](configs/openai/responses/mcp-dispatch.yaml) | Demonstrates the `openai_mcp_dispatch` filter configuration |
 | [mcp-tool-resolve.yaml](configs/openai/responses/mcp-tool-resolve.yaml) | Demonstrates the `openai_mcp_tool_resolve` filter, which resolves MCP tool entries in the Responses API `tools` array into concrete tool definitions by calling `tools/list` on each upstream MCP server |

--- a/examples/configs/openai/responses/full-flow-agentic.yaml
+++ b/examples/configs/openai/responses/full-flow-agentic.yaml
@@ -1,0 +1,179 @@
+# Responses API Full Flow — File Search Callout (Non-Streaming)
+#
+# Extends the full-flow pipeline with an iterative_request_router (IRR)
+# around the inference step, enabling server-side file search execution.
+# The IRR sends the request to the model, executes any returned
+# file_search_call through the vector store, and feeds the search
+# context back for a second model inference before returning the
+# final Responses API object.
+#
+# Because IRR fully buffers responses, this config does NOT support
+# streaming or WebSocket. For streaming without the agentic loop,
+# see full-flow.yaml. For MCP-driven agentic tool loops, see
+# agentic-loop.yaml (these two loop types cannot share an IRR step
+# because agentic_loop and file_search_callout use incompatible
+# response-body accumulation strategies).
+#
+# Pre-IRR filters run once on the client request to set up shared
+# state (ResponsesState) which persists across all IRR iterations
+# via extension swapping.
+#
+# Pre-IRR pipeline (runs once):
+#   1. openai_conversations — CRUD for the Conversations API
+#   2. openai_responses_format — classifies body, promotes metadata
+#   3. openai_responses_validate — validates parameters, generates IDs
+#   4. openai_tool_parse — parses tools array, promotes summary facts
+#   5. openai_response_store — persists responses, registers store backend
+#   6. openai_stream_events — accumulates SSE events (no-op here since
+#      IRR buffers the response; retained for pipeline consistency)
+#   7. openai_responses_rehydrate — loads previous_response_id / conversation
+#   8. openai_file_resolve — resolves file_id references via Files API
+#   9. openai_doc_extract — converts input_file to input_text for backends
+#      that do not natively support input_file
+#  10. openai_mcp_tool_resolve — resolves MCP tool entries via tools/list
+#
+# IRR inference filter chain (all routing lives inside the IRR step
+# because the IRR must be the terminal filter in the chain):
+#   Request phase (forward):
+#     openai_file_search_callout → openai_responses_proxy
+#       → headers → router → load_balancer
+#   Response phase (reverse):
+#     load_balancer → router → headers → openai_responses_proxy
+#       → openai_file_search_callout
+#
+# Only Responses API traffic (/v1/responses) is routed by this
+# config. Non-Responses paths (/v1/prompts, /v1/embeddings, etc.)
+# receive a route-miss error. For a full gateway that also routes
+# non-Responses traffic, see full-flow.yaml (without IRR).
+#
+# Transition rules (evaluated after each step's response-body):
+#   openai_file_search_callout.pending = "true" → next: inference
+#   default                                     → done (exit to client)
+#
+# Model responses that combine file_search_call with a client-executed
+# function_call are rejected until cross-request continuation state
+# exists.
+#
+# Security: StreamBuffer body callouts run before this listener's
+# header-phase filters. Deploy this example behind an outer
+# authentication and authorization boundary before enabling the
+# required allow_pre_security_callout acknowledgement below.
+#
+# Example requests:
+#
+#   # Simple — validated and routed through the IRR (single pass)
+#   curl -X POST http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"gpt-4.1","input":"Hello, world!"}'
+#
+#   # Multi-turn with previous_response_id
+#   curl -X POST http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"gpt-4.1","input":"What next?","previous_response_id":"resp_abc"}'
+#
+#   # File search — model issues file_search_call, executed via vector store
+#   curl -X POST http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{
+#       "model": "gpt-4.1",
+#       "input": "What does the README say about deployment?",
+#       "tools": [{"type": "file_search", "vector_store_ids": ["vs_abc"]}]
+#     }'
+#
+# Build:
+#   cargo build -p praxis-ai-proxy
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [full-flow-agentic-pipeline]
+
+filter_chains:
+  - name: full-flow-agentic-pipeline
+    filters:
+      - filter: openai_conversations
+        backend: sqlite
+        database_url: "sqlite://responses.db?mode=rwc"
+        conversations_table: openai_conversations
+        items_table: openai_conversation_items
+
+      - filter: openai_responses_format
+        on_invalid: continue
+        headers:
+          format: x-praxis-ai-format
+          model: x-praxis-ai-model
+          stream: x-praxis-ai-stream
+          mode: x-praxis-responses-mode
+
+      - filter: openai_responses_validate
+
+      - filter: openai_tool_parse
+
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "sqlite://responses.db?mode=rwc"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+
+      - filter: openai_stream_events
+
+      - filter: openai_responses_rehydrate
+
+      - filter: openai_file_resolve
+        files_api_url: "http://127.0.0.1:9999"
+        allow_private_files_api_url: true
+        allow_pre_security_callout: true
+        forward_headers:
+          - authorization
+          - x-tenant-id
+        on_missing: reject
+        timeout_ms: 10000
+
+      - filter: openai_doc_extract
+        allow_pre_security_callout: true
+        on_unsupported: continue
+
+      - filter: openai_mcp_tool_resolve
+
+      - filter: iterative_request_router
+        initial_step: inference
+        max_iterations: 8
+        timeout_ms: 120000
+        step_timeout_ms: 60000
+        max_response_bytes: 67108864
+        max_state_bytes: 136314880
+        steps:
+          - name: inference
+            filters:
+              - filter: openai_file_search_callout
+                vector_store_url: http://127.0.0.1:3002
+                allow_private_url: true
+                timeout_ms: 5000
+                max_response_bytes: 10485760
+                max_total_response_bytes: 67108864
+                max_state_bytes: 136314880
+                callout_failure_mode: closed
+                forward_headers:
+                  - authorization
+              - filter: openai_responses_proxy
+                name: inference
+              - filter: headers
+                request_set:
+                  - name: Content-Type
+                    value: application/json
+              - filter: router
+                routes:
+                  - path: "/v1/responses"
+                    cluster: "inference-backend"
+              - filter: load_balancer
+                clusters:
+                  - name: "inference-backend"
+                    endpoints:
+                      - "127.0.0.1:3001"
+            on_result:
+              - filter: openai_file_search_callout
+                key: pending
+                value: "true"
+                next: inference
+              - default: true
+                done: true

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -77,6 +77,8 @@
 #   IRR fully buffers responses, which is incompatible with streaming
 #   and WebSocket. For MCP-driven agentic tool loops, see
 #   agentic-loop.yaml which wraps the inference step in an IRR.
+#   For file-search callout (vector store backed) with the full
+#   pipeline, see full-flow-agentic.yaml.
 #
 # Security: StreamBuffer body callouts run before this listener's
 # header-phase filters. Deploy this example behind an outer

--- a/tests/integration/tests/suite/examples/full_flow_agentic.rs
+++ b/tests/integration/tests/suite/examples/full_flow_agentic.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for the full-flow-agentic example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    StatefulCapturingBackend, TempSqlite, example_config_path, free_port, http_send, json_post, parse_body,
+    parse_status, patch_yaml, start_backend_with_shutdown, start_proxy, start_stateful_backend,
+};
+use serde_json::{Value, json};
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+fn load_full_flow_agentic_config(
+    proxy_port: u16,
+    port_map: &HashMap<&str, u16>,
+) -> (praxis_core::config::Config, TempSqlite) {
+    let db = TempSqlite::new("full_flow_agentic");
+    let path = example_config_path("openai/responses/full-flow-agentic.yaml");
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let yaml = yaml.replace("sqlite://responses.db?mode=rwc", db.url());
+    let patched = patch_yaml(&yaml, proxy_port, port_map);
+    let config = praxis_core::config::Config::from_yaml(&patched)
+        .unwrap_or_else(|e| panic!("parse full-flow-agentic.yaml: {e}"));
+    (config, db)
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn full_flow_agentic_single_pass_completes() {
+    let backend =
+        start_backend_with_shutdown(r#"{"id":"resp_1","object":"response","status":"completed","output":[]}"#);
+    let proxy_port = free_port();
+    let (config, _db) = load_full_flow_agentic_config(proxy_port, &HashMap::from([("127.0.0.1:3001", backend.port())]));
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", r#"{"model":"gpt-4.1","input":"Hello"}"#),
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "single-pass request through IRR should succeed"
+    );
+}
+
+#[test]
+fn full_flow_agentic_file_search_round_trip() {
+    let first_model_response = json!({
+        "id": "resp_search",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "id": "fs_1",
+            "type": "file_search_call",
+            "status": "searching",
+            "queries": ["What were the Q4 results?"]
+        }],
+        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    });
+    let final_model_response = json!({
+        "id": "resp_final",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "id": "msg_final",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{
+                "type": "output_text",
+                "text": "Q4 revenue was $42 million <|file-q4|>",
+                "annotations": []
+            }]
+        }],
+        "usage": {"input_tokens": 20, "output_tokens": 7, "total_tokens": 27}
+    });
+    let model = start_stateful_backend(vec![
+        (200, first_model_response.to_string()),
+        (200, final_model_response.to_string()),
+    ]);
+    let search_response = json!({
+        "data": [{
+            "file_id": "file-q4",
+            "filename": "q4-results.txt",
+            "score": 0.99,
+            "content": [{"type": "text", "text": "Q4 revenue was $42 million."}],
+            "attributes": null
+        }]
+    });
+    let search = StatefulCapturingBackend::new(vec![(200, search_response.to_string())]).start_with_shutdown();
+    let proxy_port = free_port();
+    let (config, _db) = load_full_flow_agentic_config(
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", model.port()), ("127.0.0.1:3002", search.port())]),
+    );
+    let proxy = start_proxy(&config);
+
+    let request = json!({
+        "model": "gpt-4.1",
+        "input": "What do the documents say about Q4?",
+        "tools": [{"type": "file_search", "vector_store_ids": ["vs_q4"]}]
+    });
+    let request = json_post("/v1/responses", &request.to_string()).replacen(
+        "Content-Type: application/json",
+        "Authorization: Bearer search-key\r\nContent-Type: application/json",
+        1,
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "file search round trip failed: {raw}");
+    let response: Value = serde_json::from_str(&parse_body(&raw)).expect("response should be JSON");
+    assert_eq!(response["id"], "resp_final");
+    assert_eq!(response["output"][0]["type"], "file_search_call");
+    assert_eq!(response["output"][0]["status"], "completed");
+    assert_eq!(response["output"][1]["type"], "message");
+
+    let search_requests = search.requests();
+    let search_callouts: Vec<_> = search_requests.iter().filter(|r| r.method == "POST").collect();
+    assert_eq!(search_callouts.len(), 1, "expected one vector store callout");
+    assert!(
+        search_callouts[0]
+            .headers
+            .to_lowercase()
+            .contains("authorization: bearer search-key"),
+        "vector store callout should forward the authorization header: {}",
+        search_callouts[0].headers,
+    );
+}
+
+#[test]
+fn full_flow_agentic_without_tools_passthrough() {
+    let response = r#"{"id":"resp_456","object":"response","output":[{"id":"msg_456","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello","annotations":[]}]}]}"#;
+    let backend = start_backend_with_shutdown(response);
+    let proxy_port = free_port();
+    let (config, _db) = load_full_flow_agentic_config(proxy_port, &HashMap::from([("127.0.0.1:3001", backend.port())]));
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", r#"{"model":"gpt-4.1","input":"Hello"}"#),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "request failed: {raw}");
+    assert_eq!(parse_body(&raw), response, "request without tools should pass through");
+}
+
+#[test]
+fn full_flow_agentic_rejects_non_responses_path() {
+    let backend =
+        start_backend_with_shutdown(r#"{"id":"resp_1","object":"response","status":"completed","output":[]}"#);
+    let proxy_port = free_port();
+    let (config, _db) = load_full_flow_agentic_config(proxy_port, &HashMap::from([("127.0.0.1:3001", backend.port())]));
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), "GET /v1/prompts HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+    let status = parse_status(&raw);
+    assert_ne!(status, 200, "non-responses path should not reach a backend: {raw}");
+}
+
+#[test]
+fn full_flow_agentic_rejects_responses_subpath() {
+    let backend =
+        start_backend_with_shutdown(r#"{"id":"resp_1","object":"response","status":"completed","output":[]}"#);
+    let proxy_port = free_port();
+    let (config, _db) = load_full_flow_agentic_config(proxy_port, &HashMap::from([("127.0.0.1:3001", backend.port())]));
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses/resp_123/cancel", r#"{"model":"gpt-4.1"}"#),
+    );
+
+    let status = parse_status(&raw);
+    assert_ne!(status, 200, "subpath should not reach inference backend: {raw}");
+}
+
+#[test]
+fn full_flow_agentic_connection_nominated_header_not_forwarded() {
+    let first_model_response = json!({
+        "id": "resp_conn",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "id": "fs_conn",
+            "type": "file_search_call",
+            "status": "searching",
+            "queries": ["test query"]
+        }],
+        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    });
+    let final_model_response = json!({
+        "id": "resp_conn_final",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "id": "msg_conn",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "done", "annotations": []}]
+        }],
+        "usage": {"input_tokens": 20, "output_tokens": 7, "total_tokens": 27}
+    });
+    let model = start_stateful_backend(vec![
+        (200, first_model_response.to_string()),
+        (200, final_model_response.to_string()),
+    ]);
+    let search_response = json!({
+        "data": [{
+            "file_id": "file-conn",
+            "filename": "test.txt",
+            "score": 0.9,
+            "content": [{"type": "text", "text": "test content"}],
+            "attributes": null
+        }]
+    });
+    let search = StatefulCapturingBackend::new(vec![(200, search_response.to_string())]).start_with_shutdown();
+    let proxy_port = free_port();
+    let (config, _db) = load_full_flow_agentic_config(
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", model.port()), ("127.0.0.1:3002", search.port())]),
+    );
+    let proxy = start_proxy(&config);
+
+    let request = json!({
+        "model": "gpt-4.1",
+        "input": "test",
+        "tools": [{"type": "file_search", "vector_store_ids": ["vs_test"]}]
+    });
+    let request = json_post("/v1/responses", &request.to_string()).replacen(
+        "Content-Type: application/json",
+        "Authorization: Bearer secret\r\nConnection: authorization\r\nContent-Type: application/json",
+        1,
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "round trip should succeed: {raw}");
+    let search_requests = search.requests();
+    let search_callouts: Vec<_> = search_requests.iter().filter(|r| r.method == "POST").collect();
+    assert_eq!(search_callouts.len(), 1, "expected one vector store callout");
+    assert!(
+        !search_callouts[0].headers.to_lowercase().contains("authorization"),
+        "connection-nominated authorization must not be forwarded to vector store: {}",
+        search_callouts[0].headers,
+    );
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -15,6 +15,7 @@ mod compact;
 mod credential_injection;
 mod file_search_callout;
 mod full_flow;
+mod full_flow_agentic;
 mod guardrails;
 mod mcp_broker;
 mod model_to_header;


### PR DESCRIPTION
## Summary

Add a `full-flow-agentic.yaml` example config that extends the full-flow
pipeline with an `iterative_request_router` (IRR) around the inference step,
enabling server-side file search execution through vector store callouts.

On IRR continuation iterations the synthetic request lacks the original
client headers. `callout_request_headers` now returns the original headers
from `IterationState` (via `Cow` to avoid cloning on iteration 0) with
`Connection`-nominated hop-by-hop headers filtered out so credentials
reach the vector store but single-hop headers do not leak.

## Related issue

<!-- Contributors must be assigned to the issue before opening a PR. -->

Closes #

## Validation

- [x] Unit tests — 100 `file_search_callout` tests pass
- [x] Integration or functional tests — 6 new `full_flow_agentic` tests (single pass, file search round trip, passthrough, path rejection, subpath rejection, connection-nominated header filtering)
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.