### PR TITLE
ci: fix security audit for h2 vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary\n\nUpdate the transitive h2 dependency in Cargo.lock from 0.4.15 to 0.4.16.\n\n## Why\n\nThe Supply Chain security-audit and dependency-check jobs fail on RUSTSEC-2026-0258, which affects h2 0.4.15. The advisory recommends h2 >= 0.4.16.\n\nThis is an independent dependency-only CI fix and is not part of provider-selection PR #731.\n\n## Validation\n\n- git diff --check — passed\n- cargo audit --no-fetch — passed\n- The existing allowed lru RUSTSEC-2026-0253 warning remains unchanged.\n\nSigned-off-by: Brent Salisbury <bsalisbu@redhat.com>