### PR TITLE
fix(deps): update h2 for security audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

  Update the transitive h2 dependency in Cargo.lock from 0.4.15 to 0.4.16 to resolve RustSec advisory `RUSTSEC-2026-0258`. This fixes the failing security-audit and dependency-check CI jobs.

  ## Related issue

  RUSTSEC-2026-0258: https://rustsec.org/advisories/RUSTSEC-2026-0258

  ## Validation

  - [x] git diff --check
  - [x] cargo audit --no-fetch

  cargo audit --no-fetch passes. The existing allowed lru advisory warning remains unchanged.

  ## Checklist

  - [x] I reviewed every changed line and can explain the change.
  - [x] Commits are signed and include a Signed-off-by trailer.

  ## Breaking changes

  None. This is a dependency security update with no intended behavior or API changes.
