### PR TITLE
fix(compat): align AI with Praxis main body and branch routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ filters and protocol support. Before opening a pull request, please read the
 [development setup](docs/developing/getting-started.md).
 
 For larger changes, open a [feature request] and follow the
-[proposal process](docs/proposals.md) so we can shape the idea together.
+[proposal process](https://github.com/praxis-proxy/enhancements) so we can shape the idea together.
 
 [Open an issue][issues] · [Request a feature][feature request] ·
 [Open a pull request][pull requests]

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -97,6 +97,18 @@ pub(crate) mod test_utils {
             response_headers_modified: false,
             subrequest_client: None,
             subrequest_response_mode: praxis_filter::SubRequestResponseMode::Buffered,
+            #[cfg(feature = "praxis-main")]
+            attempted_endpoints: Vec::new(),
+            #[cfg(feature = "praxis-main")]
+            retry_policy: None,
+            #[cfg(feature = "praxis-main")]
+            route_retry_policy: None,
+            #[cfg(feature = "praxis-main")]
+            cluster_retry_state: None,
+            #[cfg(feature = "praxis-main")]
+            cluster_retry_state_released: false,
+            #[cfg(feature = "praxis-main")]
+            endpoint_reselector: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ provider API integrations on top of [Praxis](https://github.com/praxis-proxy/pra
 - [Adding filters](developing/adding-filters.md)
 - [Type design](developing/type-design.md)
 - [Project management](developing/project-management.md)
-- [Proposal process](proposals.md)
+- [Proposal process](https://github.com/praxis-proxy/enhancements)
 
 ## Operations and releases
 

--- a/docs/anthropic-messages-replay-test-plan.md
+++ b/docs/anthropic-messages-replay-test-plan.md
@@ -13,7 +13,7 @@ owns locally, then preserve the request and response bodies as much as possible
 when passing them through.
 
 This test plan extends the broader Messages API filter proposal in
-[00484_anthropic-messages-api-filters.md](proposals/00484_anthropic-messages-api-filters.md)
+[00484_anthropic-messages-api-filters.md](https://github.com/praxis-proxy/enhancements/blob/main/proposals/00484_anthropic-messages-api-filters.md)
 with concrete fixture and test coverage.
 
 ## Sources

--- a/examples/configs/openai/responses/responses-routing.yaml
+++ b/examples/configs/openai/responses/responses-routing.yaml
@@ -49,12 +49,7 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "inference-backend"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "inference-backend"
-                        endpoints:
-                          - "127.0.0.1:3001"
-            rejoin: terminal
+            rejoin: shared_load_balancer
 
       # Stateless: no branch matched — proxy directly to backend
       # with zero additional filter processing.
@@ -62,7 +57,8 @@ filter_chains:
         routes:
           - path_prefix: "/"
             cluster: "inference-backend"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "inference-backend"
             endpoints:

--- a/examples/configs/openai/responses/tool-routing.yaml
+++ b/examples/configs/openai/responses/tool-routing.yaml
@@ -60,19 +60,15 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "inference"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "inference"
-                        endpoints:
-                          - "127.0.0.1:3001"
-            rejoin: terminal
+            rejoin: shared_load_balancer
 
       # Default: all other requests (with or without tools)
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "inference"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "inference"
             endpoints:

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -94,6 +94,18 @@ pub(crate) mod test_utils {
             response_headers_modified: false,
             subrequest_client: None,
             subrequest_response_mode: praxis_filter::SubRequestResponseMode::Buffered,
+            #[cfg(feature = "praxis-main")]
+            attempted_endpoints: Vec::new(),
+            #[cfg(feature = "praxis-main")]
+            retry_policy: None,
+            #[cfg(feature = "praxis-main")]
+            route_retry_policy: None,
+            #[cfg(feature = "praxis-main")]
+            cluster_retry_state: None,
+            #[cfg(feature = "praxis-main")]
+            cluster_retry_state_released: false,
+            #[cfg(feature = "praxis-main")]
+            endpoint_reselector: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
 
     let config_path = praxis_ai::resolve_config_path(explicit.as_deref());
     let config = praxis_ai::load_config(explicit.as_deref()).unwrap_or_else(|e| praxis_ai::fatal(&e));
-    praxis_ai::init_tracing(&config).unwrap_or_else(|e| praxis_ai::fatal(&e));
+    let _tracing_guard = praxis_ai::init_tracing(&config).unwrap_or_else(|e| praxis_ai::fatal(&e));
     info!("starting server");
     praxis_ai::run_server(config, config_path)
 }

--- a/tests/integration/tests/suite/openai_responses_format.rs
+++ b/tests/integration/tests/suite/openai_responses_format.rs
@@ -839,7 +839,7 @@ filter_chains:
               filter: openai_responses_format
               key: format
               result: openai_responses
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: responses_chain
                 filters:
@@ -847,20 +847,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "responses"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "responses"
-                        endpoints:
-                          - "127.0.0.1:{responses_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "responses"
+            endpoints:
+              - "127.0.0.1:{responses_port}"
 "#
     )
 }
@@ -883,7 +882,7 @@ filter_chains:
               filter: openai_responses_format
               key: background
               result: true
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: background_chain
                 filters:
@@ -891,20 +890,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "background"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "background"
-                        endpoints:
-                          - "127.0.0.1:{background_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "background"
+            endpoints:
+              - "127.0.0.1:{background_port}"
 "#
     )
 }

--- a/tests/integration/tests/suite/openai_tool_parse.rs
+++ b/tests/integration/tests/suite/openai_tool_parse.rs
@@ -394,7 +394,7 @@ filter_chains:
               filter: openai_tool_parse
               key: has_tools
               result: "true"
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: tools_chain
                 filters:
@@ -402,20 +402,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "tools"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "tools"
-                        endpoints:
-                          - "127.0.0.1:{tools_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "tools"
+            endpoints:
+              - "127.0.0.1:{tools_port}"
 "#
     )
 }
@@ -438,7 +437,7 @@ filter_chains:
               filter: openai_tool_parse
               key: tool_choice
               result: "required"
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: required_chain
                 filters:
@@ -446,20 +445,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "required"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "required"
-                        endpoints:
-                          - "127.0.0.1:{required_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "required"
+            endpoints:
+              - "127.0.0.1:{required_port}"
 "#
     )
 }
@@ -512,7 +510,7 @@ filter_chains:
               filter: openai_tool_parse
               key: has_web_search
               result: "true"
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: web_chain
                 filters:
@@ -520,20 +518,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "web"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "web"
-                        endpoints:
-                          - "127.0.0.1:{web_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "web"
+            endpoints:
+              - "127.0.0.1:{web_port}"
 "#
     )
 }
@@ -556,7 +553,7 @@ filter_chains:
               filter: openai_tool_parse
               key: has_web_search
               result: "true"
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: web_chain
                 filters:
@@ -564,20 +561,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "web"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "web"
-                        endpoints:
-                          - "127.0.0.1:{web_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "web"
+            endpoints:
+              - "127.0.0.1:{web_port}"
 "#
     )
 }

--- a/tests/integration/tests/suite/responses_routing.rs
+++ b/tests/integration/tests/suite/responses_routing.rs
@@ -165,7 +165,7 @@ filter_chains:
               filter: openai_responses_format
               key: mode
               result: stateful
-            rejoin: terminal
+            rejoin: shared_load_balancer
             chains:
               - name: stateful_chain
                 filters:
@@ -173,20 +173,19 @@ filter_chains:
                     routes:
                       - path_prefix: "/"
                         cluster: "stateful"
-                  - filter: load_balancer
-                    clusters:
-                      - name: "stateful"
-                        endpoints:
-                          - "127.0.0.1:{stateful_port}"
       - filter: router
         routes:
           - path_prefix: "/"
             cluster: "default"
-      - filter: load_balancer
+      - name: shared_load_balancer
+        filter: load_balancer
         clusters:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+          - name: "stateful"
+            endpoints:
+              - "127.0.0.1:{stateful_port}"
 "#
     )
 }


### PR DESCRIPTION
## Summary

Align AI with the current Praxis API and terminal-branch semantics.

This PR contains three compatibility corrections:

1. Routing examples and integration tests now use a shared load-balancer filter after provider-selection branches. Praxis requires `rejoin: terminal` branches to produce the final client response; routing-only branches now rejoin the shared load balancer instead.
2. The AI API and filter test context constructors initialize the retry-related fields required by current Praxis main, behind the existing `praxis-main` feature.
3. The server retains the `TracingGuard` returned by current Praxis main's tracing initialization for the lifetime of the process. This resolves the new `unused_must_use` CI error while preserving the tracing provider lifecycle.

The second and third changes are proper compatibility fixes, not workarounds. Current Praxis main requires the additional context fields and a live tracing guard, while released Praxis builds do not. Feature-gating the context fields keeps both dependency versions supported, and retaining the guard is required for tracing to remain active. Neither change alters request routing or quota behavior.

The third issue surfaced only after the earlier compatibility compiler failure was fixed: CI progressed far enough to compile the server binary and then reported that the tracing guard was being dropped immediately. The fix is included in the same compatibility PR because it is part of the same current-Praxis-main build contract.

The three documentation-only changes update stale links left behind when proposals moved to the central `praxis-proxy/enhancements` repository. They restore the repository’s markdown-link lint without changing documentation content or runtime behavior.

## Files changed

- `apis/src/lib.rs`
- `filters/src/lib.rs`
- `server/src/main.rs`
- `README.md`
- `docs/README.md`
- `docs/anthropic-messages-replay-test-plan.md`
- `examples/configs/openai/responses/responses-routing.yaml`
- `examples/configs/openai/responses/tool-routing.yaml`
- `tests/integration/tests/suite/openai_responses_format.rs`
- `tests/integration/tests/suite/openai_tool_parse.rs`
- `tests/integration/tests/suite/responses_routing.rs`

No production routing algorithm or provider-selection implementation is changed. The server change only preserves the tracing guard that Praxis main requires.

## Validation

The branch is rebased onto current AI main and uses released Praxis `v0.5.3` by default.

Passed:

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `make lint`
- `cargo test -p praxis-ai-filters` — 1,072 passed; 2 doctests passed, 5 ignored
- `cargo test -p praxis-ai-apis` — 2,530 passed, 27 ignored; 2 doctests passed
- `cargo test -p praxis-ai-proxy` — 59 library tests, 29 binary tests, 1 external-filter integration test, and 2 doctests passed
- Praxis-main API, filter, proxy, and schema compatibility tests previously passed against current Praxis main
- Affected routing tests previously passed

The earlier local Praxis-main integration build reached linking but rust-lld terminated with a system `Bus error`; no Rust compilation or test assertion failure was reported.

## Compatibility details

The following current-Praxis-main fields are initialized only under `#[cfg(feature = "praxis-main")]`:

- attempted endpoints;
- retry policy;
- route retry policy;
- shared cluster retry state;
- retry-state release marker;
- endpoint reselector.

This preserves compatibility with released Praxis while allowing the Praxis-main CI workflow to compile against the newer context shape.

The tracing initialization result is bound to `_tracing_guard` rather than ignored. The underscore-prefixed binding suppresses the unused-variable warning while keeping the guard alive until `main` exits. When the Praxis release containing this API is consumed as the normal dependency, this line remains correct and does not need to be reverted.

## Breaking changes

None intended.
