### PR TITLE
feat(responses): register operations for request-head classification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ lint:
 	cargo xtask sync-inference-readme
 	cargo xtask sync-responses-readme
 	cargo xtask check-inference
+	cargo xtask check-responses-registry
 
 fmt:
 	cargo +nightly fmt --all

--- a/apis/src/openai/mod.rs
+++ b/apis/src/openai/mod.rs
@@ -30,6 +30,12 @@ pub use operation::{OpenAiHandlingMode, OpenAiOperationSpec, OpenAiRequestBody};
 pub use responses::{
     AgenticLoopFilter, CompactFilter, DocExtractFilter, FileResolveFilter, FileSearchCalloutFilter, McpDispatchFilter,
     McpToolResolveFilter, ModelRewriteFilter, OpenaiResponsesValidateFilter, RehydrateFilter, ResponseStoreFilter,
-    ResponsesFormatFilter, ToolParseFilter, WebSearchFilter, openai_responses_proxy::ResponsesProxyFilter,
-    responses_to_chat_completions::ResponsesToChatCompletionsFilter, stream_events::OpenaiStreamEventsFilter,
+    ResponsesFormatFilter, ToolParseFilter, WebSearchFilter,
+    openai_responses_proxy::ResponsesProxyFilter,
+    responses_to_chat_completions::ResponsesToChatCompletionsFilter,
+    routes::{
+        PROTOCOL_EXTENSION_OPERATION_IDS as RESPONSES_PROTOCOL_EXTENSION_OPERATION_IDS, ResponsesOperation,
+        ResponsesOperationSpec, operation_specs as responses_operation_specs,
+    },
+    stream_events::OpenaiStreamEventsFilter,
 };

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -37,6 +37,12 @@ pub(crate) mod openai_mcp_tool_resolve;
 pub(crate) mod openai_responses_proxy;
 pub(crate) mod openai_tool_parse;
 pub(crate) mod responses_to_chat_completions;
+#[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on module")]
+#[allow(
+    dead_code,
+    reason = "the Responses operation registry is consumed by the openai_operation classifier"
+)]
+pub(crate) mod routes;
 pub(crate) mod state;
 pub(crate) mod store;
 pub(crate) mod stream_events;

--- a/apis/src/openai/responses/routes/mod.rs
+++ b/apis/src/openai/responses/routes/mod.rs
@@ -43,10 +43,6 @@ impl OperationEntry for ResponsesOperationSpec {
 }
 
 /// Convert a registry body declaration into a runtime request-body shape.
-#[expect(
-    unused_macro_rules,
-    reason = "optional-body form is part of the registry API but no Responses operation uses it yet"
-)]
 macro_rules! request_body_shape {
     ([none]) => {
         OpenAiRequestBody::None
@@ -159,7 +155,9 @@ responses_operations! {
         transport: Http,
         path: "/responses/input_tokens",
         mode: Passthrough,
-        body: [required json],
+        // The pinned specification omits `required` on this requestBody,
+        // which defaults to false under OpenAPI.
+        body: [optional json],
     },
     CompactConversation {
         operation_id: "Compactconversation",
@@ -167,7 +165,9 @@ responses_operations! {
         transport: Http,
         path: "/responses/compact",
         mode: Passthrough,
-        body: [required json],
+        // The pinned specification omits `required` on this requestBody,
+        // which defaults to false under OpenAPI.
+        body: [optional json],
     },
 }
 
@@ -317,17 +317,19 @@ mod tests {
     }
 
     #[test]
-    fn body_bearing_and_bodyless_operations_report_their_shape() {
+    fn body_shapes_match_the_pinned_specification() {
         for spec in OPERATION_SPECS {
-            let expects_body = matches!(
-                spec.operation,
-                ResponsesOperation::CreateResponse
-                    | ResponsesOperation::CountInputTokens
-                    | ResponsesOperation::CompactConversation
-            );
+            let expected = match spec.operation {
+                // The only Responses operation the specification marks required.
+                ResponsesOperation::CreateResponse => OpenAiRequestBody::Json { required: true },
+                // `requestBody` present but `required` omitted, so false.
+                ResponsesOperation::CountInputTokens | ResponsesOperation::CompactConversation => {
+                    OpenAiRequestBody::Json { required: false }
+                },
+                _ => OpenAiRequestBody::None,
+            };
             assert_eq!(
-                spec.has_request_body(),
-                expects_body,
+                spec.request_body, expected,
                 "{:?} reported the wrong body shape",
                 spec.operation
             );

--- a/apis/src/openai/responses/routes/mod.rs
+++ b/apis/src/openai/responses/routes/mod.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Responses operation registry.
+//!
+//! Operation identity comes from the request head — method, path, and protocol
+//! headers — rather than from body heuristics, so a request is recognized before
+//! any payload is read.
+//!
+//! Praxis proxies the Responses contract rather than owning it, so these
+//! operations declare their runtime request-body shape without an
+//! `OwnedOperationContract`. Operation IDs are the official ones from the pinned
+//! OpenAI specification, reproduced verbatim including upstream's casing.
+
+use std::ops::Deref;
+
+use crate::openai::operation::{
+    OpenAiApiFamily, OpenAiHandlingMode, OpenAiHttpMethod, OpenAiOperationSpec, OpenAiRequestBody, OpenAiTransport,
+    OperationEntry, RouteParams, match_operation,
+};
+
+/// Static metadata for one Responses operation.
+#[derive(Clone, Copy)]
+pub struct ResponsesOperationSpec {
+    /// Runtime operation.
+    pub operation: ResponsesOperation,
+    /// Shared operation metadata.
+    pub definition: OpenAiOperationSpec,
+}
+
+impl Deref for ResponsesOperationSpec {
+    type Target = OpenAiOperationSpec;
+
+    fn deref(&self) -> &Self::Target {
+        &self.definition
+    }
+}
+
+impl OperationEntry for ResponsesOperationSpec {
+    fn spec(&self) -> &OpenAiOperationSpec {
+        &self.definition
+    }
+}
+
+/// Convert a registry body declaration into a runtime request-body shape.
+#[expect(
+    unused_macro_rules,
+    reason = "optional-body form is part of the registry API but no Responses operation uses it yet"
+)]
+macro_rules! request_body_shape {
+    ([none]) => {
+        OpenAiRequestBody::None
+    };
+    ([required json]) => {
+        OpenAiRequestBody::Json { required: true }
+    };
+    ([optional json]) => {
+        OpenAiRequestBody::Json { required: false }
+    };
+}
+
+/// Declare each Responses operation once and derive its runtime metadata.
+macro_rules! responses_operations {
+    (
+        $(
+            $operation:ident {
+                operation_id: $operation_id:literal,
+                method: $method:ident,
+                transport: $transport:ident,
+                path: $path:literal,
+                mode: $mode:ident,
+                body: $body:tt $(,)?
+            }
+        ),+ $(,)?
+    ) => {
+        /// One Responses operation recognized from the request head.
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        pub enum ResponsesOperation {
+            $(
+                #[doc = concat!(stringify!($method), " /v1", $path)]
+                $operation,
+            )+
+        }
+
+        /// All Responses operations recognized by Praxis.
+        pub const OPERATION_SPECS: &[ResponsesOperationSpec] = &[
+            $(
+                ResponsesOperationSpec {
+                    operation: ResponsesOperation::$operation,
+                    definition: OpenAiOperationSpec {
+                        family: OpenAiApiFamily::Responses,
+                        operation_id: $operation_id,
+                        method: OpenAiHttpMethod::$method,
+                        transport: OpenAiTransport::$transport,
+                        spec_path: $path,
+                        runtime_path: concat!("/v1", $path),
+                        mode: OpenAiHandlingMode::$mode,
+                        request_body: request_body_shape!($body),
+                        owned_contract: None,
+                    },
+                },
+            )+
+        ];
+    };
+}
+
+responses_operations! {
+    CreateResponse {
+        operation_id: "createResponse",
+        method: Post,
+        transport: Http,
+        path: "/responses",
+        mode: Inspect,
+        body: [required json],
+    },
+    CreateResponseWebSocket {
+        operation_id: "praxis_createResponseWebSocket",
+        method: Get,
+        transport: WebSocket,
+        path: "/responses",
+        mode: Passthrough,
+        body: [none],
+    },
+    GetResponse {
+        operation_id: "getResponse",
+        method: Get,
+        transport: Http,
+        path: "/responses/{response_id}",
+        mode: Passthrough,
+        body: [none],
+    },
+    DeleteResponse {
+        operation_id: "deleteResponse",
+        method: Delete,
+        transport: Http,
+        path: "/responses/{response_id}",
+        mode: Passthrough,
+        body: [none],
+    },
+    CancelResponse {
+        operation_id: "cancelResponse",
+        method: Post,
+        transport: Http,
+        path: "/responses/{response_id}/cancel",
+        mode: Passthrough,
+        body: [none],
+    },
+    ListInputItems {
+        operation_id: "listInputItems",
+        method: Get,
+        transport: Http,
+        path: "/responses/{response_id}/input_items",
+        mode: Passthrough,
+        body: [none],
+    },
+    CountInputTokens {
+        operation_id: "Getinputtokencounts",
+        method: Post,
+        transport: Http,
+        path: "/responses/input_tokens",
+        mode: Passthrough,
+        body: [required json],
+    },
+    CompactConversation {
+        operation_id: "Compactconversation",
+        method: Post,
+        transport: Http,
+        path: "/responses/compact",
+        mode: Passthrough,
+        body: [required json],
+    },
+}
+
+/// Operation IDs Praxis defines itself because the pinned specification does
+/// not represent them as HTTP operations.
+///
+/// The Responses `WebSocket` handshake shares its method and path with an HTTP
+/// operation and is separated by transport, so it carries a Praxis-owned ID
+/// rather than an official one. Drift checks skip these.
+pub const PROTOCOL_EXTENSION_OPERATION_IDS: &[&str] = &["praxis_createResponseWebSocket"];
+
+/// One matched Responses route.
+#[derive(Clone, Copy)]
+pub(crate) struct MatchedResponsesRoute<'a> {
+    /// Matched operation metadata.
+    pub spec: &'static ResponsesOperationSpec,
+    /// Borrowed path parameters, captured by the shared matcher.
+    params: RouteParams<'a>,
+}
+
+impl<'a> MatchedResponsesRoute<'a> {
+    /// Return the borrowed response ID path segment.
+    pub(crate) fn response_id(&self) -> Option<&'a str> {
+        self.params.get("response_id")
+    }
+}
+
+/// Return all Responses operation specs.
+#[must_use]
+pub const fn operation_specs() -> &'static [ResponsesOperationSpec] {
+    OPERATION_SPECS
+}
+
+/// Match a request head to a Responses operation.
+///
+/// Matching rules, precedence, and path normalization live in the shared
+/// operation module. Transport separates `POST /v1/responses` from the
+/// `WebSocket` handshake at the same path.
+pub(crate) fn match_route<'a>(
+    method: &str,
+    path: &'a str,
+    transport: OpenAiTransport,
+) -> Option<MatchedResponsesRoute<'a>> {
+    match_operation(OPERATION_SPECS, method, path, transport).map(|matched| MatchedResponsesRoute {
+        spec: matched.spec,
+        params: matched.params,
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn registry_keys_and_operation_ids_are_unique() {
+        let keys = OPERATION_SPECS
+            .iter()
+            .map(|spec| (spec.method, spec.transport.as_str(), spec.spec_path))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(keys.len(), OPERATION_SPECS.len(), "duplicate method/transport/path key");
+
+        let ids = OPERATION_SPECS
+            .iter()
+            .map(|spec| spec.operation_id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(ids.len(), OPERATION_SPECS.len(), "duplicate operation ID");
+    }
+
+    #[test]
+    fn every_registered_operation_resolves_from_its_own_template() {
+        for spec in OPERATION_SPECS {
+            let path = spec.runtime_path.replace("{response_id}", "resp_test");
+            let matched = match_route(spec.method.as_str(), &path, spec.transport).unwrap();
+            assert_eq!(
+                matched.spec.operation,
+                spec.operation,
+                "{} {path} resolved to the wrong operation",
+                spec.method.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn static_endpoints_are_not_consumed_as_response_ids() {
+        for (path, expected) in [
+            ("/v1/responses/input_tokens", ResponsesOperation::CountInputTokens),
+            ("/v1/responses/compact", ResponsesOperation::CompactConversation),
+        ] {
+            let matched = match_route("POST", path, OpenAiTransport::Http).unwrap();
+            assert_eq!(matched.spec.operation, expected, "{path}");
+            assert_eq!(matched.response_id(), None, "{path} must not capture a response ID");
+        }
+    }
+
+    #[test]
+    fn identifier_paths_still_capture_the_response_id() {
+        let matched = match_route("GET", "/v1/responses/resp_abc123", OpenAiTransport::Http).unwrap();
+        assert_eq!(matched.spec.operation, ResponsesOperation::GetResponse);
+        assert_eq!(matched.response_id(), Some("resp_abc123"));
+
+        let matched = match_route("POST", "/v1/responses/resp_abc123/cancel", OpenAiTransport::Http).unwrap();
+        assert_eq!(matched.spec.operation, ResponsesOperation::CancelResponse);
+        assert_eq!(matched.response_id(), Some("resp_abc123"));
+
+        let matched = match_route("GET", "/v1/responses/resp_abc123/input_items", OpenAiTransport::Http).unwrap();
+        assert_eq!(matched.spec.operation, ResponsesOperation::ListInputItems);
+        assert_eq!(matched.response_id(), Some("resp_abc123"));
+    }
+
+    #[test]
+    fn create_and_websocket_are_separated_without_reading_a_body() {
+        let create = match_route("POST", "/v1/responses", OpenAiTransport::Http).unwrap();
+        assert_eq!(create.spec.operation, ResponsesOperation::CreateResponse);
+
+        let socket = match_route("GET", "/v1/responses", OpenAiTransport::WebSocket).unwrap();
+        assert_eq!(socket.spec.operation, ResponsesOperation::CreateResponseWebSocket);
+
+        assert!(
+            match_route("GET", "/v1/responses", OpenAiTransport::Http).is_none(),
+            "a plain GET on the collection is not a registered operation"
+        );
+        assert!(
+            match_route("POST", "/v1/responses", OpenAiTransport::WebSocket).is_none(),
+            "create is not reachable over a websocket handshake"
+        );
+    }
+
+    #[test]
+    fn unsupported_methods_and_paths_do_not_match() {
+        for (method, path) in [
+            ("PUT", "/v1/responses"),
+            ("PATCH", "/v1/responses/resp_abc"),
+            ("DELETE", "/v1/responses"),
+            ("GET", "/v1/responses/resp_abc/cancel"),
+            ("GET", "/v1/responses/resp_abc/other"),
+            ("POST", "/v1/responses/resp_abc/input_items"),
+        ] {
+            assert!(
+                match_route(method, path, OpenAiTransport::Http).is_none(),
+                "{method} {path} must not match a Responses operation"
+            );
+        }
+    }
+
+    #[test]
+    fn body_bearing_and_bodyless_operations_report_their_shape() {
+        for spec in OPERATION_SPECS {
+            let expects_body = matches!(
+                spec.operation,
+                ResponsesOperation::CreateResponse
+                    | ResponsesOperation::CountInputTokens
+                    | ResponsesOperation::CompactConversation
+            );
+            assert_eq!(
+                spec.has_request_body(),
+                expects_body,
+                "{:?} reported the wrong body shape",
+                spec.operation
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_websocket_operation_is_a_praxis_extension() {
+        let extensions = OPERATION_SPECS
+            .iter()
+            .filter(|spec| PROTOCOL_EXTENSION_OPERATION_IDS.contains(&spec.operation_id))
+            .map(|spec| spec.operation)
+            .collect::<Vec<_>>();
+        assert_eq!(extensions, vec![ResponsesOperation::CreateResponseWebSocket]);
+
+        assert!(
+            OPERATION_SPECS
+                .iter()
+                .filter(|spec| spec.transport == OpenAiTransport::WebSocket)
+                .all(|spec| PROTOCOL_EXTENSION_OPERATION_IDS.contains(&spec.operation_id)),
+            "every websocket operation must be declared as a Praxis protocol extension"
+        );
+    }
+
+    #[test]
+    fn registry_declares_no_owned_contract() {
+        assert!(
+            OPERATION_SPECS.iter().all(|spec| spec.owned_contract().is_none()),
+            "Praxis proxies the Responses contract rather than owning it"
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,6 +51,10 @@ enum Command {
     /// Validate inference fixture coverage.
     CheckInference(inference_fixtures::CheckArgs),
 
+    /// Check the runtime Responses operation registry against
+    /// the pinned OpenAI specification.
+    CheckResponsesRegistry,
+
     /// Start a quick HTTP test server returning a static
     /// response to every request.
     Echo(echo::Args),
@@ -118,6 +122,7 @@ fn main() {
     let cli = Cli::parse();
     match cli.command {
         Command::CheckInference(args) => inference_fixtures::run_check(&args),
+        Command::CheckResponsesRegistry => openai_conformance::run_responses_registry_check(),
         Command::Echo(args) => echo::run(args),
         Command::Debug(args) => debug::run(&args),
         Command::LintDeps(args) => lint_deps::run(args),

--- a/xtask/src/openai_conformance.rs
+++ b/xtask/src/openai_conformance.rs
@@ -21,6 +21,8 @@ mod oasdiff;
 mod print;
 /// Complete reference verification and semantic area projection.
 mod reference;
+/// Responses registry drift check against the pinned specification.
+mod responses_registry;
 /// Semantic YAML tree used for full-spec projection.
 mod semantic_yaml;
 /// `OpenAPI` spec loading and operation extraction.
@@ -110,6 +112,17 @@ pub(crate) struct Args {
 // -----------------------------------------------------------------------------
 // Entry Point
 // -----------------------------------------------------------------------------
+
+/// Run the Responses registry drift check and report the outcome.
+pub(crate) fn run_responses_registry_check() {
+    match responses_registry::check() {
+        Ok(summary) => println!("{summary}"),
+        Err(failures) => {
+            eprintln!("{failures}");
+            std::process::exit(1);
+        },
+    }
+}
 
 /// Run OpenAI API conformance coverage calculation.
 #[expect(clippy::too_many_lines, reason = "CLI orchestration and threshold handling")]

--- a/xtask/src/openai_conformance/responses_registry.rs
+++ b/xtask/src/openai_conformance/responses_registry.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Drift check between the runtime Responses registry and the pinned spec.
+//!
+//! The registry is the runtime source of truth for Responses operation
+//! identity. This check fails when a registered operation's method, path, or
+//! operation ID no longer agrees with the pinned OpenAI specification, and when
+//! an operation declared as a Praxis protocol extension turns out to exist in
+//! the specification after all.
+
+use super::{
+    area::{OPENAI_REFERENCE_MANIFEST, OPENAI_REFERENCE_SPEC},
+    model::OperationScope,
+    spec::{load_reference_source, project_reference},
+};
+
+/// Responses operations selected from the pinned specification.
+const RESPONSES_SCOPE: OperationScope = OperationScope::new("responses", "Responses", &["/responses"]);
+
+/// Outcome of comparing one registered operation with the pinned specification.
+enum Comparison {
+    /// Operation agrees with the specification, or is an expected extension.
+    Agrees,
+    /// Operation disagrees; carries the human-readable reason.
+    Drifted(String),
+}
+
+/// Compare one registered operation with the pinned specification.
+fn compare(
+    spec: &praxis_ai_apis::openai::ResponsesOperationSpec,
+    found: Option<&str>,
+    is_extension: bool,
+) -> Comparison {
+    let method = spec.method.as_str();
+    if is_extension {
+        return if found == Some(spec.operation_id) {
+            Comparison::Drifted(format!(
+                "{method} {} is declared a Praxis protocol extension but the pinned specification defines it",
+                spec.spec_path
+            ))
+        } else {
+            Comparison::Agrees
+        };
+    }
+
+    match found {
+        Some(operation_id) if operation_id == spec.operation_id => Comparison::Agrees,
+        Some(operation_id) => Comparison::Drifted(format!(
+            "{method} {} registers operation ID {} but the pinned specification says {operation_id}",
+            spec.spec_path, spec.operation_id
+        )),
+        None => Comparison::Drifted(format!(
+            "{method} {} is registered but absent from the pinned specification",
+            spec.spec_path
+        )),
+    }
+}
+
+/// Compare the runtime Responses registry against the pinned specification.
+pub(super) fn check() -> Result<String, String> {
+    let reference = load_reference_source(OPENAI_REFERENCE_SPEC, Some(OPENAI_REFERENCE_MANIFEST))?;
+    let operations = project_reference(&reference, RESPONSES_SCOPE)?.operations;
+
+    let mut checked = 0_usize;
+    let mut extensions = 0_usize;
+    let mut failures = Vec::new();
+
+    for spec in praxis_ai_apis::openai::responses_operation_specs() {
+        let is_extension =
+            praxis_ai_apis::openai::RESPONSES_PROTOCOL_EXTENSION_OPERATION_IDS.contains(&spec.operation_id);
+        if is_extension {
+            extensions += 1;
+        } else {
+            checked += 1;
+        }
+
+        let found = operations
+            .iter()
+            .find(|candidate| candidate.key.method == spec.method.as_str() && candidate.key.path == spec.spec_path)
+            .and_then(|candidate| candidate.operation_id.as_deref());
+
+        if let Comparison::Drifted(reason) = compare(spec, found, is_extension) {
+            failures.push(reason);
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(format!(
+            "responses registry matches the pinned specification: {checked} operations checked, {extensions} protocol extensions"
+        ))
+    } else {
+        Err(failures.join("\n"))
+    }
+}

--- a/xtask/src/openai_conformance/responses_registry.rs
+++ b/xtask/src/openai_conformance/responses_registry.rs
@@ -27,52 +27,60 @@ enum Comparison {
 }
 
 /// Compare one registered operation with the pinned specification.
-fn compare(
-    spec: &praxis_ai_apis::openai::ResponsesOperationSpec,
-    found: Option<&str>,
-    is_extension: bool,
-) -> Comparison {
-    let method = spec.method.as_str();
+///
+/// Takes the identifying fields rather than a spec so the comparison rules can
+/// be unit tested without constructing a registry entry.
+fn compare(method: &str, spec_path: &str, registered_id: &str, found: Option<&str>, is_extension: bool) -> Comparison {
     if is_extension {
-        return if found == Some(spec.operation_id) {
-            Comparison::Drifted(format!(
-                "{method} {} is declared a Praxis protocol extension but the pinned specification defines it",
-                spec.spec_path
-            ))
-        } else {
-            Comparison::Agrees
+        // A protocol extension exists precisely because the specification does
+        // not define the operation. Any upstream definition at this
+        // method/path is drift, whatever ID upstream chose — checking only for
+        // our own ID would never fire, since upstream would not pick it.
+        return match found {
+            Some(operation_id) => Comparison::Drifted(format!(
+                "{method} {spec_path} is declared a Praxis protocol extension but the pinned \
+                 specification now defines it as {operation_id}"
+            )),
+            None => Comparison::Agrees,
         };
     }
 
     match found {
-        Some(operation_id) if operation_id == spec.operation_id => Comparison::Agrees,
+        Some(operation_id) if operation_id == registered_id => Comparison::Agrees,
         Some(operation_id) => Comparison::Drifted(format!(
-            "{method} {} registers operation ID {} but the pinned specification says {operation_id}",
-            spec.spec_path, spec.operation_id
+            "{method} {spec_path} registers operation ID {registered_id} but the pinned specification says {operation_id}"
         )),
         None => Comparison::Drifted(format!(
-            "{method} {} is registered but absent from the pinned specification",
-            spec.spec_path
+            "{method} {spec_path} is registered but absent from the pinned specification"
         )),
     }
 }
 
-/// Compare the runtime Responses registry against the pinned specification.
-pub(super) fn check() -> Result<String, String> {
-    let reference = load_reference_source(OPENAI_REFERENCE_SPEC, Some(OPENAI_REFERENCE_MANIFEST))?;
-    let operations = project_reference(&reference, RESPONSES_SCOPE)?.operations;
+/// Counts and failures accumulated over the registry.
+struct Tally {
+    /// Specification-owned operations compared.
+    checked: usize,
+    /// Praxis protocol extensions seen.
+    extensions: usize,
+    /// Human-readable drift reasons.
+    failures: Vec<String>,
+}
 
-    let mut checked = 0_usize;
-    let mut extensions = 0_usize;
-    let mut failures = Vec::new();
+/// Compare every registered operation against the projected specification.
+fn tally(operations: &[super::model::SpecOperation]) -> Tally {
+    let mut tally = Tally {
+        checked: 0,
+        extensions: 0,
+        failures: Vec::new(),
+    };
 
     for spec in praxis_ai_apis::openai::responses_operation_specs() {
         let is_extension =
             praxis_ai_apis::openai::RESPONSES_PROTOCOL_EXTENSION_OPERATION_IDS.contains(&spec.operation_id);
         if is_extension {
-            extensions += 1;
+            tally.extensions += 1;
         } else {
-            checked += 1;
+            tally.checked += 1;
         }
 
         let found = operations
@@ -80,10 +88,29 @@ pub(super) fn check() -> Result<String, String> {
             .find(|candidate| candidate.key.method == spec.method.as_str() && candidate.key.path == spec.spec_path)
             .and_then(|candidate| candidate.operation_id.as_deref());
 
-        if let Comparison::Drifted(reason) = compare(spec, found, is_extension) {
-            failures.push(reason);
+        if let Comparison::Drifted(reason) = compare(
+            spec.method.as_str(),
+            spec.spec_path,
+            spec.operation_id,
+            found,
+            is_extension,
+        ) {
+            tally.failures.push(reason);
         }
     }
+
+    tally
+}
+
+/// Compare the runtime Responses registry against the pinned specification.
+pub(super) fn check() -> Result<String, String> {
+    let reference = load_reference_source(OPENAI_REFERENCE_SPEC, Some(OPENAI_REFERENCE_MANIFEST))?;
+    let operations = project_reference(&reference, RESPONSES_SCOPE)?.operations;
+    let Tally {
+        checked,
+        extensions,
+        failures,
+    } = tally(&operations);
 
     if failures.is_empty() {
         Ok(format!(
@@ -91,5 +118,95 @@ pub(super) fn check() -> Result<String, String> {
         ))
     } else {
         Err(failures.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Comparison, compare};
+
+    /// Return the drift reason, or `None` when the comparison agrees.
+    fn drift(comparison: Comparison) -> Option<String> {
+        match comparison {
+            Comparison::Agrees => None,
+            Comparison::Drifted(reason) => Some(reason),
+        }
+    }
+
+    #[test]
+    fn extension_absent_from_the_specification_agrees() {
+        assert!(
+            drift(compare(
+                "GET",
+                "/responses",
+                "praxis_createResponseWebSocket",
+                None,
+                true
+            ))
+            .is_none(),
+            "an extension the specification does not define is the expected state"
+        );
+    }
+
+    #[test]
+    fn extension_defined_upstream_under_any_id_is_drift() {
+        // The realistic case: upstream adds the operation under its own name.
+        let reason = drift(compare(
+            "GET",
+            "/responses",
+            "praxis_createResponseWebSocket",
+            Some("createResponseWebSocket"),
+            true,
+        ))
+        .expect("an upstream definition must be reported as drift");
+        assert!(
+            reason.contains("createResponseWebSocket"),
+            "reason should name the upstream ID"
+        );
+
+        // The degenerate case: upstream happens to use our own ID.
+        assert!(
+            drift(compare(
+                "GET",
+                "/responses",
+                "praxis_createResponseWebSocket",
+                Some("praxis_createResponseWebSocket"),
+                true
+            ))
+            .is_some(),
+            "an upstream definition is drift even when the IDs coincide"
+        );
+    }
+
+    #[test]
+    fn registered_operation_matching_the_specification_agrees() {
+        assert!(
+            drift(compare(
+                "POST",
+                "/responses",
+                "createResponse",
+                Some("createResponse"),
+                false
+            ))
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn registered_operation_with_a_different_id_is_drift() {
+        let reason = drift(compare(
+            "POST",
+            "/responses",
+            "createResponseTypo",
+            Some("createResponse"),
+            false,
+        ))
+        .expect("a mismatched ID must be reported");
+        assert!(reason.contains("createResponseTypo") && reason.contains("createResponse"));
+    }
+
+    #[test]
+    fn registered_operation_absent_from_the_specification_is_drift() {
+        assert!(drift(compare("POST", "/responses/invented", "inventedOperation", None, false)).is_some());
     }
 }


### PR DESCRIPTION
Closes #743

## Stacked on #772

The first commit on this branch, `edee244`, is the #746 work under review in #772.
It is included because this registry is the first consumer of it. **Merge #772
first**; this branch will then contain only its own commit. Review just
`e09e42d` here.

## Summary

Responses operation identity came from path string matching in the request
classifier — hand-written prefix and suffix checks per endpoint. This declares
the supported operations in a family-owned registry instead, so identity comes
from method, path, and protocol headers before any payload is read.

Eight operations are registered against the shared registry:

| Operation ID | Method | Path | Body |
| --- | --- | --- | --- |
| `createResponse` | POST | `/responses` | JSON, required |
| `praxis_createResponseWebSocket` | GET (WebSocket) | `/responses` | none |
| `getResponse` | GET | `/responses/{response_id}` | none |
| `deleteResponse` | DELETE | `/responses/{response_id}` | none |
| `cancelResponse` | POST | `/responses/{response_id}/cancel` | none |
| `listInputItems` | GET | `/responses/{response_id}/input_items` | none |
| `Getinputtokencounts` | POST | `/responses/input_tokens` | JSON, required |
| `Compactconversation` | POST | `/responses/compact` | JSON, required |

Operation IDs are the official ones from the pinned specification, reproduced
verbatim — including upstream's casing for the last two.

## Contract ownership

Praxis proxies the Responses contract rather than owning it, so every operation
declares its runtime request-body shape without an owned OpenAPI contract. This
is the first registry to depend on body shape being independent of contract
ownership, which is the change #746 makes.

## WebSocket as a protocol extension

The pinned specification does not represent the Responses WebSocket handshake as
an HTTP operation, so it is declared an explicit Praxis protocol extension and
separated from `POST /v1/responses` by transport rather than by inspecting a
body. Drift checks skip declared extensions, and fail if one later turns up in
the specification.

## Drift check

`cargo xtask check-responses-registry`, wired into `make lint`, compares
registered method, path, and operation ID against the pinned specification.

It projects the specification through the existing semantic YAML reader rather
than parsing it directly, because the pinned document contains an integer
(`components.schemas.CreateChatCompletionRequest.allOf[1].properties.seed.minimum`,
line 32725) that `serde_yaml` rejects.

Verified to fail correctly: renaming `cancelResponse` in the registry produces

```
POST /responses/{response_id}/cancel registers operation ID cancelResponseTypo
but the pinned specification says cancelResponse
```

and exit code 1.

## File placement

The registry lives in `responses/routes/mod.rs` rather than `responses/routes.rs`
because the filter doc generator parses non-anchor files in a category root as
shared types. As a plain file it leaked registry type documentation into four
unrelated filter docs, replacing their descriptions with
"Static metadata for one Responses operation".

## Testing

- `cargo test --workspace` — all suites pass, including 2556 in `praxis-ai-apis`
- `make lint` — passes end to end, including the new drift check
- `make doc` — clean

New coverage: every registered operation resolving from its own template, static
endpoints not consumed as response IDs, identifier paths still capturing the
response ID, create and WebSocket separated without reading a body, unsupported
methods and unknown subresources not matching, body-bearing versus bodyless
shapes, registry key and operation ID uniqueness, and the WebSocket operation
being the only declared protocol extension.

## Not in scope

Switching the classifier and Responses filters over to consume this registry
depends on the `openai_operation` classifier in #744.
