### PR TITLE
fix(guardrails): align NeMo status with /v1/guardrail/checks endpoint

### DIFF
--- a/examples/configs/nemo-guardrails.yaml
+++ b/examples/configs/nemo-guardrails.yaml
@@ -3,9 +3,9 @@
 # Evaluates all incoming requests against a NeMo Guardrails service
 # before forwarding to the upstream provider.
 #
-#   passed   → request forwarded to the upstream unchanged
+#   success  → request forwarded to the upstream unchanged
 #   blocked  → 403 returned to the client (triggered rail names in body)
-#   modified → forwarded unchanged (body replacement deferred to #579)
+#   error    → 500 returned to the client
 #
 # Start a local NeMo Guardrails instance before running this config
 #

--- a/filters/src/guardrails/providers/mod.rs
+++ b/filters/src/guardrails/providers/mod.rs
@@ -52,6 +52,10 @@ pub enum GuardResult {
         reason: String,
     },
     /// Content contains sensitive data — forward with masked text.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used once /v1/checks migration adds redaction support")
+    )]
     Redact {
         /// Provider-rewritten text with sensitive data masked.
         modified_text: String,

--- a/filters/src/guardrails/providers/nemo.rs
+++ b/filters/src/guardrails/providers/nemo.rs
@@ -53,16 +53,17 @@ struct NemoRequest {
 /// Incoming response payload for `NeMo`
 #[derive(Deserialize)]
 struct NemoResponse {
-    /// Overall verdict: `"passed"`, `"blocked"`, or `"modified"`.
+    /// Overall verdict: `"success"`, `"blocked"`, or `"error"`.
     status: String,
 
     /// Per-rail evaluation results. The names of rails whose `status` is
-    /// `"blocked"` are joined to form the [`GuardResult::Block::reason`] /
-    /// [`GuardResult::Redact::reason`] string.
+    /// `"blocked"` are joined to form the [`GuardResult::Block::reason`]
+    /// string.
     rails_status: Option<serde_json::Value>,
 
-    /// Post-processing text. Only present when `status` is `"modified"`; absent for all other statuses.
-    content: Option<String>,
+    /// Error details returned when `status` is `"error"`.
+    /// Contains `"error"` and optionally `"details"` keys.
+    guardrails_data: Option<serde_json::Value>,
 }
 
 /// `NeMo` Guardrails provider.
@@ -127,7 +128,7 @@ impl GuardProvider for NemoProvider {
         let response_body = read_response_body(response).await?;
         let nemo_response: NemoResponse = serde_json::from_slice(&response_body)
             .map_err(|e| -> FilterError { format!("ai_guardrails (nemo): failed to parse response: {e}").into() })?;
-        map_nemo_response(nemo_response)
+        map_nemo_response(&nemo_response)
     }
 }
 
@@ -181,17 +182,21 @@ async fn read_response_body(response: reqwest::Response) -> Result<Bytes, Filter
 }
 
 /// Map a deserialized [`NemoResponse`] to a [`GuardResult`].
-fn map_nemo_response(nemo: NemoResponse) -> Result<GuardResult, FilterError> {
+///
+/// The `/v1/guardrail/checks` endpoint returns three statuses:
+/// - `"success"` - all rails passed
+/// - `"blocked"` - at least one rail blocked the content
+/// - `"error"` - `NeMo` internal processing error (fail-closed)
+fn map_nemo_response(nemo: &NemoResponse) -> Result<GuardResult, FilterError> {
     match nemo.status.as_str() {
-        "passed" => Ok(GuardResult::Pass),
+        "success" => Ok(GuardResult::Pass),
         "blocked" => {
             let reason = blocked_rail_names(nemo.rails_status.as_ref());
             Ok(GuardResult::Block { reason })
         },
-        "modified" => {
-            let reason = blocked_rail_names(nemo.rails_status.as_ref());
-            let modified_text = nemo.content.unwrap_or_default();
-            Ok(GuardResult::Redact { modified_text, reason })
+        "error" => {
+            let detail = extract_error_detail(nemo.guardrails_data.as_ref());
+            Err(format!("ai_guardrails (nemo): NeMo returned error status: {detail}").into())
         },
         other => Err(format!("ai_guardrails (nemo): unknown status '{other}'").into()),
     }
@@ -214,11 +219,28 @@ fn blocked_rail_names(rails_status: Option<&serde_json::Value>) -> String {
     names.join(", ")
 }
 
+/// Extract a human-readable error string from the `guardrails_data` object
+/// returned by `NeMo` when `status` is `"error"`.
+///
+/// Expected shape: `{"error": "...", "details": "..."}`.
+fn extract_error_detail(data: Option<&serde_json::Value>) -> String {
+    let Some(obj) = data.and_then(|v| v.as_object()) else {
+        return "no details available".to_owned();
+    };
+    let error = obj.get("error").and_then(|v| v.as_str()).unwrap_or("unknown error");
+    match obj.get("details").and_then(|v| v.as_str()) {
+        Some(details) => format!("{error} ({details})"),
+        None => error.to_owned(),
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 
 #[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::str_to_string, reason = "tests")]
 mod tests {
     use super::*;
 
@@ -236,7 +258,7 @@ mod tests {
     fn blocked_rail_names_filters_out_non_blocked_rails() {
         let rails = serde_json::json!({
             "toxicity": {"status": "blocked"},
-            "jailbreak": {"status": "passed"},
+            "jailbreak": {"status": "success"},
         });
         assert_eq!(
             blocked_rail_names(Some(&rails)),
@@ -264,5 +286,101 @@ mod tests {
     fn blocked_rail_names_non_object_rails_status_returns_empty_string() {
         let rails = serde_json::json!("not an object");
         assert_eq!(blocked_rail_names(Some(&rails)), "");
+    }
+
+    #[test]
+    fn map_nemo_response_success_returns_pass() {
+        let resp = NemoResponse {
+            status: "success".to_string(),
+            rails_status: None,
+            guardrails_data: None,
+        };
+        let result = map_nemo_response(&resp).unwrap();
+        assert!(matches!(result, GuardResult::Pass));
+    }
+
+    #[test]
+    fn map_nemo_response_blocked_returns_block_with_reason() {
+        let resp = NemoResponse {
+            status: "blocked".to_string(),
+            rails_status: Some(serde_json::json!({
+                "toxicity": {"status": "blocked"},
+            })),
+            guardrails_data: None,
+        };
+        let result = map_nemo_response(&resp).unwrap();
+        assert!(
+            matches!(result, GuardResult::Block { reason } if reason == "toxicity"),
+            "blocked response should produce GuardResult::Block with rail name as reason"
+        );
+    }
+
+    #[test]
+    fn map_nemo_response_error_extracts_guardrails_data() {
+        let resp = NemoResponse {
+            status: "error".to_string(),
+            rails_status: None,
+            guardrails_data: Some(serde_json::json!({
+                "error": "Could not load guardrails configuration.",
+                "details": "Invalid config path /app/config/nonexistent-config."
+            })),
+        };
+        let err_msg = format!("{}", map_nemo_response(&resp).unwrap_err());
+        assert!(
+            err_msg.contains("Could not load guardrails configuration."),
+            "{err_msg}"
+        );
+        assert!(err_msg.contains("Invalid config path"), "{err_msg}");
+    }
+
+    #[test]
+    fn map_nemo_response_error_without_guardrails_data() {
+        let resp = NemoResponse {
+            status: "error".to_string(),
+            rails_status: None,
+            guardrails_data: None,
+        };
+        let err_msg = format!("{}", map_nemo_response(&resp).unwrap_err());
+        assert!(err_msg.contains("no details available"), "{err_msg}");
+    }
+
+    #[test]
+    fn map_nemo_response_error_with_error_key_only() {
+        let resp = NemoResponse {
+            status: "error".to_string(),
+            rails_status: None,
+            guardrails_data: Some(serde_json::json!({"error": "Internal failure"})),
+        };
+        let err_msg = format!("{}", map_nemo_response(&resp).unwrap_err());
+        assert!(err_msg.contains("Internal failure"), "{err_msg}");
+        assert!(
+            !err_msg.contains("Internal failure ("),
+            "should not append details in parens when details key is absent: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn map_nemo_response_error_with_missing_error_key() {
+        let resp = NemoResponse {
+            status: "error".to_string(),
+            rails_status: None,
+            guardrails_data: Some(serde_json::json!({"unexpected": "shape"})),
+        };
+        let err_msg = format!("{}", map_nemo_response(&resp).unwrap_err());
+        assert!(err_msg.contains("unknown error"), "{err_msg}");
+    }
+
+    #[test]
+    fn map_nemo_response_unknown_status_returns_error() {
+        let resp = NemoResponse {
+            status: "garbage".to_string(),
+            rails_status: None,
+            guardrails_data: None,
+        };
+        let err_msg = format!("{}", map_nemo_response(&resp).unwrap_err());
+        assert!(
+            err_msg.contains("unknown status 'garbage'"),
+            "unknown status should produce a descriptive error: {err_msg}"
+        );
     }
 }

--- a/filters/src/guardrails/tests.rs
+++ b/filters/src/guardrails/tests.rs
@@ -279,7 +279,7 @@ async fn on_request_body_passes_through() {
 
     let mock_server = MockServer::start().await;
     Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "passed"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "success"})))
         .mount(&mock_server)
         .await;
 
@@ -294,7 +294,7 @@ async fn on_request_body_passes_through() {
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
     assert!(
         matches!(action, praxis_filter::FilterAction::Continue),
-        "nemo provider should pass through when status is 'passed'"
+        "nemo provider should pass through when status is 'success'"
     );
     assert_eq!(
         ctx.filter_results.get("ai_guardrails").unwrap().get("status"),
@@ -341,15 +341,18 @@ async fn on_request_body_blocked_writes_filter_results() {
 }
 
 #[tokio::test]
-async fn on_request_body_modified_writes_filter_results() {
+async fn on_request_body_error_status_fails_closed() {
     use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
 
     let mock_server = MockServer::start().await;
     Mock::given(method("POST"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "status": "modified",
-            "content": "my ssn is [REDACTED]",
-            "rails_status": {"pii masking": {"status": "blocked"}}
+            "status": "error",
+            "rails_status": {},
+            "guardrails_data": {
+                "error": "Could not load guardrails configuration.",
+                "details": "Invalid config path."
+            }
         })))
         .mount(&mock_server)
         .await;
@@ -359,18 +362,13 @@ async fn on_request_body_modified_writes_filter_results() {
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let mut body = Some(bytes::Bytes::from_static(
-        br#"{"messages":[{"role":"user","content":"my ssn is 123-45-6789"}]}"#,
+        br#"{"messages":[{"role":"user","content":"hello"}]}"#,
     ));
 
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    let result = filter.on_request_body(&mut ctx, &mut body, true).await;
     assert!(
-        matches!(action, praxis_filter::FilterAction::Continue),
-        "modified verdict should forward unchanged (redact placeholder deferred to #579)"
-    );
-    assert_eq!(
-        ctx.filter_results.get("ai_guardrails").unwrap().get("status"),
-        Some("redacted"),
-        "modified verdict should record a 'redacted' status in filter_results"
+        result.is_err(),
+        "NeMo error status should fail closed rather than pass through"
     );
 }
 
@@ -503,7 +501,7 @@ async fn on_request_body_empty_messages_array_still_evaluated() {
 
     let mock_server = MockServer::start().await;
     Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "passed"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "success"})))
         .mount(&mock_server)
         .await;
 

--- a/tests/integration/tests/suite/examples/guardrails.rs
+++ b/tests/integration/tests/suite/examples/guardrails.rs
@@ -27,7 +27,7 @@ fn nemo_guardrails_config_parses_correctly() {
 #[test]
 fn nemo_guardrails_forwards_to_backend() {
     let backend = start_backend_with_shutdown("ok");
-    let nemo = nemo_mock(r#"{"status":"passed","rails_status":{"self check input":{"status":"success"}}}"#);
+    let nemo = nemo_mock(r#"{"status":"success","rails_status":{"self check input":{"status":"success"}}}"#);
     let proxy_port = free_port();
     let config = load_example_config(
         "nemo-guardrails.yaml",
@@ -42,7 +42,7 @@ fn nemo_guardrails_forwards_to_backend() {
         r#"{"model":"test","messages":[{"role":"user","content":"Hello, how are you?"}]}"#,
     );
 
-    assert_eq!(status, 200, "NeMo 'passed' should forward to upstream");
+    assert_eq!(status, 200, "NeMo 'success' should forward to upstream");
     assert_eq!(body, "ok", "upstream response should reach the client");
 }
 
@@ -73,13 +73,13 @@ fn nemo_guardrails_block_rejects_with_403() {
     );
 }
 
-/// `NeMo` returns `"modified"` (redact placeholder) → request is forwarded
-/// to the upstream unchanged and the upstream response is returned.
+/// `NeMo` returns `"error"` with `guardrails_data` → proxy fails closed
+/// with a 500 and does not forward to the upstream.
 #[test]
-fn nemo_guardrails_redact_placeholder_continues() {
+fn nemo_guardrails_error_status_does_not_forward() {
     let backend = start_backend_with_shutdown("ok");
     let nemo = nemo_mock(
-        r#"{"status":"modified","content":"my ssn is [REDACTED]","rails_status":{"pii masking":{"status":"blocked"}}}"#,
+        r#"{"status":"error","rails_status":{},"guardrails_data":{"error":"Config load failed.","details":"bad path"}}"#,
     );
     let proxy_port = free_port();
     let config = load_example_config(
@@ -89,17 +89,16 @@ fn nemo_guardrails_redact_placeholder_continues() {
     );
     let proxy = start_proxy(&config);
 
-    let (status, body) = http_post(
+    let (status, _body) = http_post(
         proxy.addr(),
         "/v1/guardrail/checks",
-        r#"{"model":"test","messages":[{"role":"user","content":"my ssn is 123-45-6789"}]}"#,
+        r#"{"model":"test","messages":[{"role":"user","content":"hello"}]}"#,
     );
 
     assert_eq!(
-        status, 200,
-        "NeMo 'modified' should continue (body replacement deferred to #579)"
+        status, 500,
+        "NeMo 'error' status should fail closed with a 500, not forward to upstream"
     );
-    assert_eq!(body, "ok", "upstream response should reach the client");
 }
 
 /// `NeMo` is unreachable → provider error propagates and the proxy does not


### PR DESCRIPTION
## Summary

- Fix NeMo provider status mapping to match the actual `/v1/guardrail/checks`
  endpoint responses. The code expected `"passed"` but the endpoint returns
  `"success"`, causing every non-toxic request to hit the unknown-status
  error path and get rejected.
- Remove dead `"modified"` match arm and `content` field - the
  `/v1/guardrail/checks` endpoint does not support redaction. TrustyAI
  originally planned to add it but decided not to.
- Add `"error"` status handling with `guardrails_data` extraction so NeMo
  processing errors produce actionable log messages instead of
  `unknown status 'error'`.
- Add unit tests covering `success`, `blocked`, and `error` status paths.

## Related issue

Companion to [opendatahub-io/ai-gateway-payload-processing#432](https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/432)
(same fix for the Go side).

## Fix
#791 

## Validation

- [x] Unit tests
- [X] Integration or functional tests
- [X] `make lint`

Bug confirmed by sending a non-toxic request to a live TrustyAI NeMo instance
and observing the `"success"` status in the response, which the old code
would reject as unknown.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. This is a bug fix - the previous behavior was incorrect (all
non-toxic requests were rejected).