### PR TITLE
test: opt loopback fixtures into allow_private_endpoints

### DIFF
--- a/examples/configs/a2a-agent-card-routing.yaml
+++ b/examples/configs/a2a-agent-card-routing.yaml
@@ -46,3 +46,6 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:9000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/a2a-classifier-routing.yaml
+++ b/examples/configs/a2a-classifier-routing.yaml
@@ -127,3 +127,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:9000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/a2a-task-routing.yaml
+++ b/examples/configs/a2a-task-routing.yaml
@@ -87,3 +87,6 @@ filter_chains:
           - name: "agent-b"
             endpoints:
               - "127.0.0.1:9002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/ai-inference-body-based-routing.yaml
+++ b/examples/configs/ai-inference-body-based-routing.yaml
@@ -63,3 +63,6 @@ filter_chains:
           - name: default
             endpoints:
               - "10.0.3.1:8080"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/anthropic/messages-protocol.yaml
+++ b/examples/configs/anthropic/messages-protocol.yaml
@@ -32,3 +32,6 @@ filter_chains:
           - name: "anthropic-backend"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/anthropic/messages-to-openai.yaml
+++ b/examples/configs/anthropic/messages-to-openai.yaml
@@ -54,3 +54,6 @@ filter_chains:
           - name: "chat-completions-backend"
             endpoints:
               - "127.0.0.1:8000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/anthropic/messages-web-search.yaml
+++ b/examples/configs/anthropic/messages-web-search.yaml
@@ -57,3 +57,6 @@ filter_chains:
                 next: inference
               - default: true
                 done: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/anthropic/request-validate.yaml
+++ b/examples/configs/anthropic/request-validate.yaml
@@ -30,3 +30,6 @@ filter_chains:
           - name: "anthropic-backend"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/anthropic/unified-gateway.yaml
+++ b/examples/configs/anthropic/unified-gateway.yaml
@@ -62,3 +62,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3004"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/credential-injection.yaml
+++ b/examples/configs/credential-injection.yaml
@@ -78,3 +78,6 @@ filter_chains:
             header: x-api-key
             value: "internal-secret"
             strip_client_credential: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/inference/fallback-with-translation.yaml
+++ b/examples/configs/inference/fallback-with-translation.yaml
@@ -147,3 +147,6 @@ filter_chains:
             on_result:
               - default: true
                 done: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/intelligent-route-all-capabilities.yaml
+++ b/examples/configs/intelligent-route-all-capabilities.yaml
@@ -114,3 +114,6 @@ filter_chains:
 admin:
   address: "127.0.0.1:9901"
 shutdown_timeout_secs: 5
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/intelligent-route-inference.yaml
+++ b/examples/configs/intelligent-route-inference.yaml
@@ -62,3 +62,6 @@ filter_chains:
 admin:
   address: "127.0.0.1:9901"
 shutdown_timeout_secs: 5
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/intelligent-route-mcp.yaml
+++ b/examples/configs/intelligent-route-mcp.yaml
@@ -59,3 +59,6 @@ filter_chains:
 admin:
   address: "127.0.0.1:9901"
 shutdown_timeout_secs: 5
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/intelligent-route-overlay.yaml
+++ b/examples/configs/intelligent-route-overlay.yaml
@@ -51,3 +51,6 @@ filter_chains:
 admin:
   address: "127.0.0.1:9901"
 shutdown_timeout_secs: 5
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/json-rpc-routing.yaml
+++ b/examples/configs/json-rpc-routing.yaml
@@ -107,3 +107,6 @@ filter_chains:
           - name: default
             endpoints:
               - "127.0.0.1:9000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/mcp-classifier-routing.yaml
+++ b/examples/configs/mcp-classifier-routing.yaml
@@ -58,3 +58,6 @@ filter_chains:
           - name: "default-mcp"
             endpoints:
               - "127.0.0.1:9003"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/mcp-stateless-broker.yaml
+++ b/examples/configs/mcp-stateless-broker.yaml
@@ -61,3 +61,6 @@ filter_chains:
           - name: calendar-mcp
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/model-to-header-routing.yaml
+++ b/examples/configs/model-to-header-routing.yaml
@@ -64,3 +64,6 @@ filter_chains:
           - name: default
             endpoints:
               - "10.0.3.1:8080"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/nemo-guardrails.yaml
+++ b/examples/configs/nemo-guardrails.yaml
@@ -49,4 +49,6 @@ filter_chains:
           - name: provider
             endpoints:
               - "127.0.0.1:3000"
-              
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/conversations/conversations.yaml
+++ b/examples/configs/openai/conversations/conversations.yaml
@@ -53,3 +53,6 @@ filter_chains:
           - name: "fallback-backend"
             endpoints:
               - "127.0.0.1:8000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/embeddings/embeddings-routing.yaml
+++ b/examples/configs/openai/embeddings/embeddings-routing.yaml
@@ -36,3 +36,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/prompts/prompts-routing.yaml
+++ b/examples/configs/openai/prompts/prompts-routing.yaml
@@ -44,3 +44,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/agentic-loop-fixture.yaml
+++ b/examples/configs/openai/responses/agentic-loop-fixture.yaml
@@ -53,3 +53,6 @@ filter_chains:
             on_result:
               - default: true
                 done: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/agentic-loop.yaml
+++ b/examples/configs/openai/responses/agentic-loop.yaml
@@ -139,3 +139,6 @@ filter_chains:
                 next: inference
               - default: true
                 done: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/compact.yaml
+++ b/examples/configs/openai/responses/compact.yaml
@@ -70,3 +70,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:11434"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/doc-extract.yaml
+++ b/examples/configs/openai/responses/doc-extract.yaml
@@ -67,3 +67,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/file-resolve.yaml
+++ b/examples/configs/openai/responses/file-resolve.yaml
@@ -78,3 +78,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/file-search-callout.yaml
+++ b/examples/configs/openai/responses/file-search-callout.yaml
@@ -75,3 +75,6 @@ filter_chains:
                 next: inference
               - default: true
                 done: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/format-routing.yaml
+++ b/examples/configs/openai/responses/format-routing.yaml
@@ -62,3 +62,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3003"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/full-flow-agentic.yaml
+++ b/examples/configs/openai/responses/full-flow-agentic.yaml
@@ -177,3 +177,6 @@ filter_chains:
                 next: inference
               - default: true
                 done: true
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/full-flow.yaml
+++ b/examples/configs/openai/responses/full-flow.yaml
@@ -253,3 +253,6 @@ filter_chains:
           - name: "vector-stores-backend"
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/mcp-dispatch.yaml
+++ b/examples/configs/openai/responses/mcp-dispatch.yaml
@@ -43,3 +43,6 @@ filter_chains:
           - name: "inference"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/mcp-tool-resolve.yaml
+++ b/examples/configs/openai/responses/mcp-tool-resolve.yaml
@@ -99,3 +99,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/model-rewrite.yaml
+++ b/examples/configs/openai/responses/model-rewrite.yaml
@@ -63,3 +63,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3003"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/rehydrate.yaml
+++ b/examples/configs/openai/responses/rehydrate.yaml
@@ -63,3 +63,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:8000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/request-validate.yaml
+++ b/examples/configs/openai/responses/request-validate.yaml
@@ -57,3 +57,6 @@ filter_chains:
           - name: inference
             endpoints:
               - "127.0.0.1:8000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/response-store.yaml
+++ b/examples/configs/openai/responses/response-store.yaml
@@ -78,3 +78,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:8000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/responses-proxy.yaml
+++ b/examples/configs/openai/responses/responses-proxy.yaml
@@ -29,3 +29,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/responses-routing.yaml
+++ b/examples/configs/openai/responses/responses-routing.yaml
@@ -63,3 +63,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/responses-to-chat-completions.yaml
+++ b/examples/configs/openai/responses/responses-to-chat-completions.yaml
@@ -71,3 +71,6 @@ filter_chains:
           - name: "chat-completions-backend"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/stream-events.yaml
+++ b/examples/configs/openai/responses/stream-events.yaml
@@ -71,3 +71,6 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:8000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/tool-routing.yaml
+++ b/examples/configs/openai/responses/tool-routing.yaml
@@ -73,3 +73,6 @@ filter_chains:
           - name: "inference"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/vector-stores-routing.yaml
+++ b/examples/configs/openai/responses/vector-stores-routing.yaml
@@ -57,3 +57,6 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/vllm-agentic-api.yaml
+++ b/examples/configs/openai/responses/vllm-agentic-api.yaml
@@ -31,3 +31,6 @@ filter_chains:
           - name: "vllm-agentic-api"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/openai/responses/web-search.yaml
+++ b/examples/configs/openai/responses/web-search.yaml
@@ -39,3 +39,6 @@ filter_chains:
           - name: "inference"
             endpoints:
               - "127.0.0.1:3001"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/payload-processing/mcp-static-catalog.yaml
+++ b/examples/configs/payload-processing/mcp-static-catalog.yaml
@@ -58,3 +58,6 @@ filter_chains:
           - name: calendar-mcp
             endpoints:
               - "127.0.0.1:3002"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/prompt-enrichment.yaml
+++ b/examples/configs/prompt-enrichment.yaml
@@ -50,3 +50,6 @@ filter_chains:
           - name: provider
             endpoints:
               - "127.0.0.1:3000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/provider-route.yaml
+++ b/examples/configs/provider-route.yaml
@@ -66,4 +66,7 @@ filter_chains:
 
 admin:
   address: "127.0.0.1:9901"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends
 shutdown_timeout_secs: 5

--- a/examples/configs/time-to-first-token.yaml
+++ b/examples/configs/time-to-first-token.yaml
@@ -39,3 +39,6 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:3000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/token-counting.yaml
+++ b/examples/configs/token-counting.yaml
@@ -56,3 +56,6 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:3000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/examples/configs/token-usage-headers.yaml
+++ b/examples/configs/token-usage-headers.yaml
@@ -40,3 +40,6 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:3000"
+
+insecure_options:
+  allow_private_endpoints: true # example proxies to local backends

--- a/server/src/dump.rs
+++ b/server/src/dump.rs
@@ -370,6 +370,8 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:9090"
+insecure_options:
+  allow_private_endpoints: true
 "#;
 
     /// Assert a resolved filter's chain, indices, and type name.
@@ -510,6 +512,8 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:9090"
+insecure_options:
+  allow_private_endpoints: true
 "#;
 
     #[test]

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -376,6 +376,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["10.0.0.1:80"]
+insecure_options:
+  allow_private_endpoints: true
 "#,
         )
         .unwrap();
@@ -414,6 +416,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["10.0.0.1:80"]
+insecure_options:
+  allow_private_endpoints: true
 "#,
         )
         .unwrap();
@@ -669,6 +673,8 @@ filter_chains:
         clusters:
           - name: other
             endpoints: ["10.0.0.1:80"]
+insecure_options:
+  allow_private_endpoints: true
 "#,
         )
         .unwrap();
@@ -710,6 +716,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["10.0.0.1:80"]
+insecure_options:
+  allow_private_endpoints: true
 "#,
         )
         .unwrap();
@@ -735,6 +743,7 @@ filter_chains:
             r#"
 insecure_options:
   allow_open_security_filters: true
+  allow_private_endpoints: true
 listeners:
   - name: web
     address: "127.0.0.1:8080"
@@ -855,6 +864,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["10.0.0.1:80"]
+insecure_options:
+  allow_private_endpoints: true
 "#,
         )
         .unwrap()

--- a/tests/integration/tests/suite/a2a.rs
+++ b/tests/integration/tests/suite/a2a.rs
@@ -1008,6 +1008,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1074,6 +1076,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1109,6 +1113,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1145,6 +1151,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1182,6 +1190,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1208,6 +1218,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1255,6 +1267,8 @@ filter_chains:
           - name: "agent-b"
             endpoints:
               - "127.0.0.1:{agent_b_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1293,6 +1307,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1345,6 +1361,8 @@ filter_chains:
           - name: "agent-b"
             endpoints:
               - "127.0.0.1:{agent_b_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1371,6 +1389,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1431,6 +1451,8 @@ filter_chains:
           - name: "agent-b"
             endpoints:
               - "127.0.0.1:{agent_b_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -1483,6 +1505,8 @@ filter_chains:
           - name: "agent-b"
             endpoints:
               - "127.0.0.1:{agent_b_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }

--- a/tests/integration/tests/suite/anthropic_messages.rs
+++ b/tests/integration/tests/suite/anthropic_messages.rs
@@ -436,6 +436,9 @@ filter_chains:
           - name: mock
             endpoints:
               - "127.0.0.1:{backend_port}"
+
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/conversations_rehydrate.rs
+++ b/tests/integration/tests/suite/conversations_rehydrate.rs
@@ -308,6 +308,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/examples/model_to_header.rs
+++ b/tests/integration/tests/suite/examples/model_to_header.rs
@@ -95,6 +95,8 @@ filter_chains:
           - name: fallback
             endpoints:
               - "127.0.0.1:{port_default}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/examples/openai_file_resolve.rs
+++ b/tests/integration/tests/suite/examples/openai_file_resolve.rs
@@ -546,6 +546,9 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:{}"
+
+insecure_options:
+  allow_private_endpoints: true
 "#,
         inference_guard.port(),
         default_guard.port()
@@ -628,6 +631,9 @@ filter_chains:
           - name: "inference-backend"
             endpoints:
               - "127.0.0.1:{}"
+
+insecure_options:
+  allow_private_endpoints: true
 "#,
         inference_guard.port()
     );
@@ -762,6 +768,9 @@ filter_chains:
           - name: "default-backend"
             endpoints:
               - "127.0.0.1:{}"
+
+insecure_options:
+  allow_private_endpoints: true
 "#,
         inference_guard.port(),
         default_guard.port()

--- a/tests/integration/tests/suite/examples/openai_responses_validate.rs
+++ b/tests/integration/tests/suite/examples/openai_responses_validate.rs
@@ -213,6 +213,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/examples/token_count.rs
+++ b/tests/integration/tests/suite/examples/token_count.rs
@@ -111,6 +111,8 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/failure_mode.rs
+++ b/tests/integration/tests/suite/failure_mode.rs
@@ -41,6 +41,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     );
     let config = Config::from_yaml(&yaml).unwrap();
@@ -80,6 +82,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     );
     let config = Config::from_yaml(&yaml).unwrap();
@@ -119,6 +123,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     );
     let config = Config::from_yaml(&yaml).unwrap();
@@ -179,6 +185,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     );
     let config = Config::from_yaml(&yaml).unwrap();
@@ -258,6 +266,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/guardrails.rs
+++ b/tests/integration/tests/suite/guardrails.rs
@@ -129,6 +129,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     );
 
@@ -522,6 +524,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -624,6 +628,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/mcp.rs
+++ b/tests/integration/tests/suite/mcp.rs
@@ -505,6 +505,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -530,6 +532,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -567,6 +571,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -594,6 +600,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -622,6 +630,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -648,6 +658,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -684,6 +696,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }

--- a/tests/integration/tests/suite/mcp_broker.rs
+++ b/tests/integration/tests/suite/mcp_broker.rs
@@ -885,6 +885,8 @@ filter_chains:
           - name: calendar-mcp
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -930,6 +932,8 @@ filter_chains:
           - name: calendar-mcp
             endpoints:
               - "127.0.0.1:{calendar_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -961,6 +965,8 @@ filter_chains:
           - name: weather-mcp
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }
@@ -992,6 +998,8 @@ filter_chains:
           - name: weather-mcp
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
     )
 }

--- a/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
+++ b/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
@@ -713,6 +713,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -742,6 +744,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -770,6 +774,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -799,6 +805,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -829,6 +837,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -864,6 +874,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/openai_responses_format.rs
+++ b/tests/integration/tests/suite/openai_responses_format.rs
@@ -715,6 +715,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -741,6 +743,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -767,6 +771,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -792,6 +798,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -817,6 +825,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -860,6 +870,8 @@ filter_chains:
           - name: "responses"
             endpoints:
               - "127.0.0.1:{responses_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -903,6 +915,8 @@ filter_chains:
           - name: "background"
             endpoints:
               - "127.0.0.1:{background_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -942,6 +956,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -974,6 +990,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/openai_responses_model_rewrite.rs
+++ b/tests/integration/tests/suite/openai_responses_model_rewrite.rs
@@ -390,6 +390,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -421,6 +423,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -450,6 +454,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -494,6 +500,8 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/openai_tool_parse.rs
+++ b/tests/integration/tests/suite/openai_tool_parse.rs
@@ -415,6 +415,8 @@ filter_chains:
           - name: "tools"
             endpoints:
               - "127.0.0.1:{tools_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -458,6 +460,8 @@ filter_chains:
           - name: "required"
             endpoints:
               - "127.0.0.1:{required_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -483,6 +487,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -531,6 +537,8 @@ filter_chains:
           - name: "web"
             endpoints:
               - "127.0.0.1:{web_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -574,6 +582,8 @@ filter_chains:
           - name: "web"
             endpoints:
               - "127.0.0.1:{web_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/prompt_enrich.rs
+++ b/tests/integration/tests/suite/prompt_enrich.rs
@@ -262,6 +262,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -289,6 +291,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -317,6 +321,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -354,6 +360,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -382,6 +390,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/integration/tests/suite/responses_routing.rs
+++ b/tests/integration/tests/suite/responses_routing.rs
@@ -186,6 +186,8 @@ filter_chains:
           - name: "stateful"
             endpoints:
               - "127.0.0.1:{stateful_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/schema/tests/suite/cross_cutting.rs
+++ b/tests/schema/tests/suite/cross_cutting.rs
@@ -129,6 +129,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["127.0.0.1:3000"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
 

--- a/tests/schema/tests/suite/edge_cases.rs
+++ b/tests/schema/tests/suite/edge_cases.rs
@@ -103,6 +103,8 @@ filter_chains:
             load_balancer_strategy:
               consistent_hash:
                 header: "X-User-Id"
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
     assert_eq!(
@@ -241,6 +243,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["127.0.0.1:3000"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
     let filters = &config.filter_chains[0].filters;
@@ -284,6 +288,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["127.0.0.1:3000"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let err = Config::from_yaml(yaml).unwrap_err();
     assert!(err.to_string().contains("exactly one"), "got: {err}");

--- a/tests/schema/tests/suite/examples/ai/intelligent_route.rs
+++ b/tests/schema/tests/suite/examples/ai/intelligent_route.rs
@@ -315,6 +315,8 @@ filter_chains:
           - name: llama-remote
             endpoints:
               - "127.0.0.1:{remote_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
         overlay = overlay_path.display()
     )
@@ -358,6 +360,8 @@ filter_chains:
           - name: llama-remote
             endpoints:
               - "127.0.0.1:{remote_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -397,6 +401,8 @@ filter_chains:
           - name: tools-site-b
             endpoints:
               - "127.0.0.1:{remote_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -488,6 +494,8 @@ filter_chains:
           - name: tools-site-b
             endpoints:
               - "127.0.0.1:{remote_tool_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/schema/tests/suite/examples/ai/model_to_header.rs
+++ b/tests/schema/tests/suite/examples/ai/model_to_header.rs
@@ -89,6 +89,8 @@ filter_chains:
           - name: fallback
             endpoints:
               - "127.0.0.1:{port_default}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/schema/tests/suite/examples/ai/openai_responses_proxy.rs
+++ b/tests/schema/tests/suite/examples/ai/openai_responses_proxy.rs
@@ -55,6 +55,8 @@ filter_chains:
           - name: backend
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }

--- a/tests/schema/tests/suite/filter_chain.rs
+++ b/tests/schema/tests/suite/filter_chain.rs
@@ -170,6 +170,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["127.0.0.1:3000"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
     assert_eq!(config.listeners.len(), 2, "should have 2 listeners");
@@ -206,6 +208,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["127.0.0.1:3000"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
     assert_eq!(

--- a/tests/schema/tests/suite/route.rs
+++ b/tests/schema/tests/suite/route.rs
@@ -32,6 +32,8 @@ filter_chains:
             endpoints: ["10.0.0.1:8080"]
           - name: web
             endpoints: ["10.0.0.2:8080"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
     assert_eq!(config.filter_chains.len(), 1, "should have 1 filter chain");
@@ -61,6 +63,8 @@ filter_chains:
             endpoints: ["10.0.0.1:80"]
           - name: v2
             endpoints: ["10.0.0.2:80"]
+insecure_options:
+  allow_private_endpoints: true
 "#;
     let config = Config::from_yaml(yaml).unwrap();
     assert_eq!(config.filter_chains.len(), 1, "should have 1 filter chain");

--- a/tests/schema/tests/suite/test_utils.rs
+++ b/tests/schema/tests/suite/test_utils.rs
@@ -30,6 +30,8 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["127.0.0.1:3000"]
+insecure_options:
+  allow_private_endpoints: true
 "#
     .to_owned()
 }

--- a/tests/utils/src/example_config.rs
+++ b/tests/utils/src/example_config.rs
@@ -39,8 +39,34 @@ use praxis_core::config::Config;
 pub fn load_example_config(filename: &str, listener_port: u16, port_map: HashMap<&str, u16>) -> Config {
     let path = example_config_path(filename);
     let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
-    let patched = patch_yaml(&yaml, listener_port, &port_map);
+    let patched = allow_loopback_endpoints(&patch_yaml(&yaml, listener_port, &port_map));
     Config::from_yaml(&patched).unwrap_or_else(|e| panic!("parse {filename}: {e}"))
+}
+
+/// Enable `allow_private_endpoints` on a patched example config.
+///
+/// The port map rewrites example endpoints to loopback test backends, which
+/// the endpoint SSRF validation would otherwise reject; the flag is a
+/// property of the test harness rewrite, not of the example itself.
+///
+/// # Examples
+///
+/// ```
+/// let yaml = praxis_test_utils::allow_loopback_endpoints("listeners: []\n");
+/// assert!(yaml.contains("allow_private_endpoints: true"));
+/// ```
+pub fn allow_loopback_endpoints(yaml: &str) -> String {
+    if yaml.contains("allow_private_endpoints") {
+        return yaml.to_owned();
+    }
+    if yaml.contains("\ninsecure_options:") || yaml.starts_with("insecure_options:") {
+        return yaml.replacen(
+            "insecure_options:\n",
+            "insecure_options:\n  allow_private_endpoints: true\n",
+            1,
+        );
+    }
+    format!("{yaml}\ninsecure_options:\n  allow_private_endpoints: true\n")
 }
 
 /// Resolve the absolute path to an example config file.

--- a/tests/utils/src/inference_fixture/replay.rs
+++ b/tests/utils/src/inference_fixture/replay.rs
@@ -2342,9 +2342,14 @@ mod tests {
 
     #[test]
     fn replay_config_rejects_a_nonloopback_admin_bind() {
+        // The example config already carries a top-level `insecure_options:`
+        // (allow_private_endpoints for its loopback backend), so merge
+        // `allow_public_admin` under that block rather than emitting a second
+        // top-level `insecure_options:` key.
         let source = format!(
-            "{}\nadmin:\n  address: \"192.0.2.10:19090\"\ninsecure_options:\n  allow_public_admin: true\n",
+            "{}\nadmin:\n  address: \"192.0.2.10:19090\"\n",
             replay_config_source("openai/responses/responses-proxy.yaml")
+                .replace("insecure_options:\n", "insecure_options:\n  allow_public_admin: true\n")
         );
 
         let error = build_replay_config(&source, 19_001, "127.0.0.1:3001", 19_002)
@@ -2535,9 +2540,16 @@ mod tests {
 
     #[test]
     fn replay_config_rejects_background_cluster_health_checks() {
-        let mut source = replay_config_source("openai/responses/responses-proxy.yaml");
+        // The example config already carries a top-level `insecure_options:`
+        // (allow_private_endpoints for its loopback backend), so merge
+        // `allow_private_health_checks` under that block rather than emitting a
+        // second top-level `insecure_options:` key.
+        let mut source = replay_config_source("openai/responses/responses-proxy.yaml").replace(
+            "insecure_options:\n",
+            "insecure_options:\n  allow_private_health_checks: true\n",
+        );
         source.push_str(
-            "\nclusters:\n  - name: probe\n    endpoints: [\"127.0.0.1:3001\"]\n    health_check:\n      type: http\ninsecure_options:\n  allow_private_health_checks: true\n",
+            "\nclusters:\n  - name: probe\n    endpoints: [\"127.0.0.1:3001\"]\n    health_check:\n      type: http\n",
         );
 
         let error = build_replay_config(&source, 19_001, "127.0.0.1:3001", 19_002)

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -31,7 +31,7 @@ pub use agentic::{
     McpToolFixture, start_a2a_mock_server, start_a2a_mock_server_with_config, start_mcp_mock_server,
     start_mcp_mock_server_with_config,
 };
-pub use example_config::{example_config_path, load_example_config, patch_yaml};
+pub use example_config::{allow_loopback_endpoints, example_config_path, load_example_config, patch_yaml};
 pub use net::*;
 pub use proxy::{
     ProxyGuard, ProxyShutdownError, ReloadableProxyGuard, build_pipeline, custom_filter_yaml, registry_with,

--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -526,6 +526,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }
@@ -552,6 +554,8 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#
     )
 }


### PR DESCRIPTION
## Summary

praxis-core main now validates clusters defined **inline** in `load_balancer` filters and rejects private/loopback/link-local endpoints unless the config sets `insecure_options.allow_private_endpoints: true`. Core updated its own conformance fixtures and shipped examples for this change, but nothing propagated to `ai`, so the entire tree fails `test-praxis-main` (unit, schema, **and** integration steps) against core main.

Upstream commits this mirrors (no associated PR is discoverable via the API — core main uses a linear/rebase history, so referencing the commits directly):

- [`894ac18` — fix(core): validate clusters defined inline in load-balancer filters](https://github.com/praxis-proxy/praxis/commit/894ac18313ff447ae9692fdf75148b158197e584)
- [`185545a` — test(conformance): opt loopback fixtures into allow_private_endpoints](https://github.com/praxis-proxy/praxis/commit/185545ae2445c9d666772890f212cfd374117ba8)

The flag already ships in released **praxis 0.5.3**, so this fix is **release-independent** — unlike the `parse_json_rpc_body` / `cpex-policy-engine` drift tracked in #794, which is blocked on a core release. Verified green on both the 0.5.3 pin and core main.

## Changes (mirrors core's remediation)

- Append a top-level `insecure_options.allow_private_endpoints: true` block to the **52 shipped example configs** whose inline `load_balancer` cluster targets a loopback/private backend.
- Port core's `allow_loopback_endpoints()` helper into `praxis-test-utils` so harness-loaded example configs opt in centrally at load time.
- Add the flag inline to every **raw-parse fixture** (schema, integration, and the `dump`/`pipelines` unit tests) that builds an inline `load_balancer` cluster on a private endpoint.
- Merge (rather than duplicate) `insecure_options` in the two replay negative tests that append their own block onto a now-flagged example config.

Public-endpoint fixtures, listener addresses, `ip_acl` allow lists, tcp upstreams, and top-level `clusters:` blocks are left untouched.

## Verification (locally, patched against core main)

- **Unit:** 0 failed (2530 + 1072 + 59, plus `dump`/`pipelines`)
- **Schema:** 98 passed, 0 failed
- **Integration:** 469 passed, 0 failed
- **Inference fixtures:** 0 failed
- Default 0.5.3 pin: all green · `fmt`/`clippy` clean · example README + filter docs in sync

Refs #794 (the remaining, release-blocked drift items are unaffected by this PR).