### PR TITLE
fix(test): init new praxis-main context fields

### DIFF
--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -85,6 +85,8 @@ pub(crate) mod test_utils {
             health_registry: None,
             id_generator: &TEST_ID_GENERATOR,
             kv_stores: None,
+            #[cfg(feature = "praxis-main")]
+            session_stores: None,
             metrics_route: None,
             peer_identity: None,
             request: req,
@@ -109,6 +111,8 @@ pub(crate) mod test_utils {
             cluster_retry_state_released: false,
             #[cfg(feature = "praxis-main")]
             endpoint_reselector: None,
+            #[cfg(feature = "praxis-main")]
+            pinned_endpoint_address: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -88,6 +88,8 @@ pub(crate) mod test_utils {
             health_registry: None,
             id_generator: &TEST_ID_GENERATOR,
             kv_stores: None,
+            #[cfg(feature = "praxis-main")]
+            session_stores: None,
             metrics_route: None,
             peer_identity: None,
             request: req,
@@ -112,6 +114,8 @@ pub(crate) mod test_utils {
             cluster_retry_state_released: false,
             #[cfg(feature = "praxis-main")]
             endpoint_reselector: None,
+            #[cfg(feature = "praxis-main")]
+            pinned_endpoint_address: None,
             rewritten_path: None,
             selected_endpoint_index: None,
             time_source: &praxis_core::time::SystemTimeSource,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -239,6 +239,8 @@ fn register_admin_endpoints(
                 health_registry: Some(health_registry),
                 kv_registry: Some(kv_stores.clone()),
                 pipelines: None,
+                #[cfg(feature = "praxis-main")]
+                log_level: None,
                 verbose: config.admin.verbose,
             },
         );

--- a/tests/integration/tests/suite/openai_responses_format.rs
+++ b/tests/integration/tests/suite/openai_responses_format.rs
@@ -893,7 +893,7 @@ filter_chains:
             on_result:
               filter: openai_responses_format
               key: background
-              result: true
+              result: "true"
             rejoin: shared_load_balancer
             chains:
               - name: background_chain

--- a/tests/utils/src/net/backend/simple.rs
+++ b/tests/utils/src/net/backend/simple.rs
@@ -673,6 +673,9 @@ fn start_server(mut config: Config) -> u16 {
     }
 
     std::thread::spawn(move || {
+        #[cfg(feature = "praxis-main")]
+        praxis::run_server(config, None, None);
+        #[cfg(not(feature = "praxis-main"))]
         praxis::run_server(config, None);
     });
 


### PR DESCRIPTION
## Summary

Praxis main added session_stores and pinned_endpoint_address to HttpFilterContext. Compat CI constructs the struct by name, so the test helpers must set them.

## Related issue

## Validation

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

