### PR TITLE
Revert "fix(guardrails): fail closed on NeMo redact verdict until body replac…"

### DIFF
--- a/examples/configs/nemo-guardrails.yaml
+++ b/examples/configs/nemo-guardrails.yaml
@@ -5,7 +5,7 @@
 #
 #   passed   → request forwarded to the upstream unchanged
 #   blocked  → 403 returned to the client (triggered rail names in body)
-#   modified → 403 returned to the client (triggered rail names in body)
+#   modified → forwarded unchanged (body replacement deferred to #579)
 #
 # Start a local NeMo Guardrails instance before running this config
 #

--- a/filters/src/guardrails/filter.rs
+++ b/filters/src/guardrails/filter.rs
@@ -164,10 +164,9 @@ fn record_verdict(ctx: &mut HttpFilterContext<'_>, result: GuardResult) -> Resul
             Ok(FilterAction::Reject(Rejection::status(403).with_body(reason)))
         },
         GuardResult::Redact { reason, .. } => {
-            // Fail closed: the original content must not be forwarded while the
-            // status is recorded as redacted.
-            tracing::warn!(verdict, %reason, "ai_guardrails: redact verdict; rejecting request");
-            Ok(FilterAction::Reject(Rejection::status(403).with_body(reason)))
+            // Full body replacement deferred to #579 (NeMo mask/redact action).
+            tracing::warn!(verdict, %reason, "ai_guardrails: provider verdict; forwarding unchanged until #579");
+            Ok(FilterAction::Continue)
         },
     }
 }

--- a/filters/src/guardrails/tests.rs
+++ b/filters/src/guardrails/tests.rs
@@ -38,25 +38,6 @@ fn as_rejection(action: praxis_filter::FilterAction) -> praxis_filter::Rejection
     .unwrap()
 }
 
-/// Build a `NeMo` guardrail filter backed by a mock that returns a
-/// `"modified"` (PII redact) verdict. Returns the filter and the
-/// mock server (whose lifetime must be held for the duration of
-/// the test).
-async fn nemo_pii_redact_filter() -> (Box<dyn praxis_filter::HttpFilter>, wiremock::MockServer) {
-    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
-    let mock_server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "status": "modified",
-            "content": "my ssn is [REDACTED]",
-            "rails_status": {"pii masking": {"status": "blocked"}}
-        })))
-        .mount(&mock_server)
-        .await;
-    let filter = nemo_filter(&format!("{}/v1/guardrail/checks", mock_server.uri()));
-    (filter, mock_server)
-}
-
 // =============================================================================
 // General config
 // =============================================================================
@@ -360,45 +341,36 @@ async fn on_request_body_blocked_writes_filter_results() {
 }
 
 #[tokio::test]
-async fn on_request_body_modified_rejects_with_403() {
-    let (filter, _server) = nemo_pii_redact_filter().await;
+async fn on_request_body_modified_writes_filter_results() {
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "modified",
+            "content": "my ssn is [REDACTED]",
+            "rails_status": {"pii masking": {"status": "blocked"}}
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let endpoint = format!("{}/v1/guardrail/checks", mock_server.uri());
+    let filter = nemo_filter(&endpoint);
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     let mut body = Some(bytes::Bytes::from_static(
         br#"{"messages":[{"role":"user","content":"my ssn is 123-45-6789"}]}"#,
     ));
 
-    let rejection = as_rejection(filter.on_request_body(&mut ctx, &mut body, true).await.unwrap());
-    assert_eq!(rejection.status, 403, "redact verdict must reject with HTTP 403");
-    let body_text = String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default());
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
     assert!(
-        body_text.contains("pii masking"),
-        "rejection body should include the blocked rail name, got: {body_text}"
+        matches!(action, praxis_filter::FilterAction::Continue),
+        "modified verdict should forward unchanged (redact placeholder deferred to #579)"
     );
     assert_eq!(
         ctx.filter_results.get("ai_guardrails").unwrap().get("status"),
         Some("redacted"),
-        "redact verdict should record 'redacted' status in filter_results even when rejecting"
-    );
-}
-
-#[tokio::test]
-async fn on_request_body_modified_never_forwards_original_secret() {
-    let (filter, _server) = nemo_pii_redact_filter().await;
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    let original_body = br#"{"messages":[{"role":"user","content":"my ssn is 123-45-6789"}]}"#;
-    let mut body = Some(bytes::Bytes::from_static(original_body));
-
-    let rejection = as_rejection(filter.on_request_body(&mut ctx, &mut body, true).await.unwrap());
-    assert!(
-        !String::from_utf8_lossy(rejection.body.as_deref().unwrap_or_default()).contains("123-45-6789"),
-        "the original secret must not appear in the rejection body"
-    );
-    assert_eq!(
-        ctx.filter_results.get("ai_guardrails").unwrap().get("status"),
-        Some("redacted"),
-        "status must be 'redacted', not 'passed', so downstream branch logic is not misled"
+        "modified verdict should record a 'redacted' status in filter_results"
     );
 }
 

--- a/tests/integration/tests/suite/examples/guardrails.rs
+++ b/tests/integration/tests/suite/examples/guardrails.rs
@@ -73,10 +73,10 @@ fn nemo_guardrails_block_rejects_with_403() {
     );
 }
 
-/// `NeMo` returns `"modified"` (redact verdict) → proxy rejects with 403.
-/// The original sensitive body must never be forwarded to the upstream.
+/// `NeMo` returns `"modified"` (redact placeholder) → request is forwarded
+/// to the upstream unchanged and the upstream response is returned.
 #[test]
-fn nemo_guardrails_redact_rejects_with_403() {
+fn nemo_guardrails_redact_placeholder_continues() {
     let backend = start_backend_with_shutdown("ok");
     let nemo = nemo_mock(
         r#"{"status":"modified","content":"my ssn is [REDACTED]","rails_status":{"pii masking":{"status":"blocked"}}}"#,
@@ -95,11 +95,11 @@ fn nemo_guardrails_redact_rejects_with_403() {
         r#"{"model":"test","messages":[{"role":"user","content":"my ssn is 123-45-6789"}]}"#,
     );
 
-    assert_eq!(status, 403, "NeMo 'modified' must reject with 403");
-    assert!(
-        body.contains("pii masking"),
-        "triggered rail name should appear in rejection body; got: {body}"
+    assert_eq!(
+        status, 200,
+        "NeMo 'modified' should continue (body replacement deferred to #579)"
     );
+    assert_eq!(body, "ok", "upstream response should reach the client");
 }
 
 /// `NeMo` is unreachable → provider error propagates and the proxy does not


### PR DESCRIPTION
Reverts praxis-proxy/ai#721

The Continue on GuardResult::Redact was intentional - we have a dedicated task for implementing the actual redaction flow in https://github.com/praxis-proxy/ai/issues/49, which includes extracting the masked content from NeMo and replacing the request body in-flight. The Continue was a placeholder until that work lands.

The /v1/guardrail/checks endpoint does not support redaction today - TrustyAI originally planned to add it but decided not to. Redaction ("modified" status + transformed content) is only available on the /v1/checks endpoint. We are planning to migrate to /v1/checks to support redaction.

In the meantime, I have https://github.com/praxis-proxy/ai/pull/792 which removes the "modified" match arm entirely since /v1/guardrail/checks never returns it. This aligns the code with the actual endpoint behavior and eliminates the misleading redacted status.
