### PR TITLE
fix(azure_ad): schedule token refresh within skewed validity window

### DIFF
--- a/docs/filters/azure_ad.md
+++ b/docs/filters/azure_ad.md
@@ -20,5 +20,5 @@ client_id: 11111111-1111-1111-1111-111111111111
 scope: https://cognitiveservices.azure.com/.default
 client_secret_env_var: AZURE_CLIENT_SECRET
 authority_host: login.microsoftonline.com   # optional, for sovereign clouds
-refresh_ratio: 0.75                          # optional, refresh at 75% of TTL
+refresh_ratio: 0.75                          # optional, refresh at 75% of the usable lifetime
 ```

--- a/filters/src/azure/azure_ad.rs
+++ b/filters/src/azure/azure_ad.rs
@@ -60,7 +60,10 @@
 //! ```
 
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     thread::JoinHandle,
     time::{Duration, Instant},
 };
@@ -337,18 +340,30 @@ async fn refresh_once(client: &reqwest::Client, params: &RefresherParams) -> Opt
                     "azure_ad: token TTL is unusually short; validity margin reduced"
                 );
             }
-            let expires_at = Instant::now() + ttl.saturating_sub(effective_skew(ttl));
-            params.shared.store(Arc::new(Some(CachedToken {
-                authorization,
-                expires_at,
-            })));
-            Some(refresh_delay(ttl, params.refresh_ratio))
+            Some(publish_token(params, authorization, ttl))
         },
         Err(error) => {
             warn!(%error, "azure_ad: token refresh failed; will retry");
             None
         },
     }
+}
+
+/// Cache a freshly fetched token and return the delay until the next
+/// scheduled refresh.
+///
+/// Both the cached expiry and the refresh schedule are computed from the
+/// skew-adjusted usable lifetime. Scheduling from the raw TTL instead
+/// (`ratio * ttl`) can land past `ttl - skew`, leaving a window every
+/// cycle where the cached token is already invalid but the refresh has
+/// not fired yet — deterministic 503s on a healthy token endpoint.
+fn publish_token(params: &RefresherParams, authorization: HeaderValue, ttl: Duration) -> Duration {
+    let usable = ttl.saturating_sub(effective_skew(ttl));
+    params.shared.store(Arc::new(Some(CachedToken {
+        authorization,
+        expires_at: Instant::now() + usable,
+    })));
+    refresh_delay(usable, params.refresh_ratio)
 }
 
 /// Repeatedly acquire a token, publish it to the shared cache, and sleep
@@ -364,7 +379,14 @@ async fn refresh_loop(params: RefresherParams, shutdown: CancellationToken) {
 
     let mut failures: u32 = 0;
     loop {
-        let delay = if let Some(delay) = refresh_once(&client, &params).await {
+        // Race the fetch against cancellation so a pipeline drop is not
+        // blocked behind an in-flight token request (up to its 30s
+        // timeout) — `RefreshHandle::drop` only waits `JOIN_TIMEOUT`.
+        let refreshed = tokio::select! {
+            refreshed = refresh_once(&client, &params) => refreshed,
+            () = shutdown.cancelled() => break,
+        };
+        let delay = if let Some(delay) = refreshed {
             failures = 0;
             delay
         } else {
@@ -395,6 +417,11 @@ pub struct AzureAdFilter {
     /// Lock-free cache of the current token, populated by the background
     /// refresher and read on every request.
     token: Arc<ArcSwap<Option<CachedToken>>>,
+
+    /// Whether the filter is currently failing closed, so the missing-
+    /// token condition is logged on state transitions instead of once
+    /// per rejected request.
+    failing: AtomicBool,
 
     /// Background refresher; stops when the filter is dropped.
     _refresh: RefreshHandle,
@@ -437,6 +464,7 @@ impl AzureAdFilter {
 
         Ok(Self {
             token: shared,
+            failing: AtomicBool::new(false),
             _refresh: refresh,
         })
     }
@@ -471,9 +499,12 @@ impl praxis_filter::HttpFilter for AzureAdFilter {
         &self,
         ctx: &mut praxis_filter::HttpFilterContext<'_>,
     ) -> Result<praxis_filter::FilterAction, FilterError> {
-        let cached = self.token.load_full();
+        let cached = self.token.load();
         match cached.as_ref() {
             Some(token) if token.is_valid(Instant::now()) => {
+                if self.failing.swap(false, Ordering::Relaxed) {
+                    warn!("azure_ad: valid token available again; resuming request forwarding");
+                }
                 // Cheap: clone a pre-formatted, sensitive HeaderValue.
                 ctx.request_headers_to_set
                     .push((header::AUTHORIZATION, token.authorization.clone()));
@@ -481,7 +512,11 @@ impl praxis_filter::HttpFilter for AzureAdFilter {
             },
             _ => {
                 // Fail closed: never forward an unauthenticated request.
-                warn!("azure_ad: no valid cached token; rejecting with 503");
+                // Log on the state transition, not per rejected request,
+                // so a token outage under load cannot flood the logs.
+                if !self.failing.swap(true, Ordering::Relaxed) {
+                    warn!("azure_ad: no valid cached token; rejecting requests with 503 until one is available");
+                }
                 Ok(praxis_filter::FilterAction::Reject(praxis_filter::Rejection::status(
                     503,
                 )))
@@ -812,6 +847,7 @@ mod tests {
     fn test_filter(token: Option<CachedToken>) -> AzureAdFilter {
         AzureAdFilter {
             token: std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(token)),
+            failing: std::sync::atomic::AtomicBool::new(false),
             _refresh: RefreshHandle {
                 shutdown: tokio_util::sync::CancellationToken::new(),
                 thread: None,
@@ -933,13 +969,21 @@ mod tests {
         assert!(delay >= MIN_REFRESH_DELAY, "refresh delay must respect the floor");
 
         let cached = shared.load_full();
-        match &*cached {
-            Some(token) => assert!(
-                token.is_valid(std::time::Instant::now()),
-                "a 40s token must be usable now, not cached already-expired"
-            ),
-            None => panic!("a successful fetch must cache a token"),
-        }
+        let token = cached.as_ref().as_ref().expect("a successful fetch must cache a token");
+        let now = std::time::Instant::now();
+        assert!(
+            token.is_valid(now),
+            "a 40s token must be usable now, not cached already-expired"
+        );
+        // Regression: the refresh must be scheduled from the
+        // skew-adjusted usable lifetime. Scheduling from the raw
+        // TTL (0.75 * 40s = 30s) lands past the cached expiry
+        // (40s - 20s skew = 20s), leaving a guaranteed window of
+        // 503s every cycle even with a healthy token endpoint.
+        assert!(
+            token.is_valid(now + delay),
+            "the cached token must still be valid when the scheduled refresh fires"
+        );
         server.join().unwrap();
     }
 

--- a/filters/src/azure/azure_ad.rs
+++ b/filters/src/azure/azure_ad.rs
@@ -56,7 +56,7 @@
 //! scope: https://cognitiveservices.azure.com/.default
 //! client_secret_env_var: AZURE_CLIENT_SECRET
 //! authority_host: login.microsoftonline.com   # optional, for sovereign clouds
-//! refresh_ratio: 0.75                          # optional, refresh at 75% of TTL
+//! refresh_ratio: 0.75                          # optional, refresh at 75% of the usable lifetime
 //! ```
 
 use std::{
@@ -201,10 +201,12 @@ async fn fetch_token(
     Ok((authorization, Duration::from_secs(token.expires_in)))
 }
 
-/// Compute how long to wait before the next refresh: `ttl * ratio`,
-/// floored at [`MIN_REFRESH_DELAY`].
-fn refresh_delay(ttl: Duration, ratio: f64) -> Duration {
-    ttl.mul_f64(ratio).max(MIN_REFRESH_DELAY)
+/// Compute how long to wait before the next refresh: `lifetime * ratio`,
+/// floored at [`MIN_REFRESH_DELAY`]. Callers pass the skew-adjusted
+/// usable lifetime, not the raw TTL, so the refresh always fires while
+/// the cached token is still valid.
+fn refresh_delay(lifetime: Duration, ratio: f64) -> Duration {
+    lifetime.mul_f64(ratio).max(MIN_REFRESH_DELAY)
 }
 
 /// Safety margin to subtract from a token's TTL before caching its
@@ -242,7 +244,8 @@ struct RefresherParams {
     /// `OAuth2` scope (e.g. `https://cognitiveservices.azure.com/.default`).
     scope: String,
 
-    /// Fraction of a token's TTL at which to refresh it.
+    /// Fraction of a token's usable lifetime (TTL minus the expiry
+    /// safety margin) at which to refresh it.
     refresh_ratio: f64,
 
     /// Shared cache the filter's hot path reads from.
@@ -551,8 +554,9 @@ pub(crate) struct AzureAdConfig {
     #[serde(default = "default_authority_host")]
     pub(crate) authority_host: String,
 
-    /// Fraction of a token's TTL at which to refresh it. Must be in the
-    /// open interval `(0, 1)`.
+    /// Fraction of a token's usable lifetime (TTL minus the expiry
+    /// safety margin) at which to refresh it. Must be in the open
+    /// interval `(0, 1)`.
     #[serde(default = "default_refresh_ratio")]
     pub(crate) refresh_ratio: f64,
 }


### PR DESCRIPTION
## Summary

Fixes a scheduling gap in the `azure_ad` token refresher that produces deterministic windows of 503s, plus three smaller hardening changes on the same file.

**Refresh scheduling (the bug):** the next refresh was scheduled at `refresh_ratio * ttl`, while the cached token is treated as expired at `ttl - skew`. Whenever `ratio * ttl` lands past `ttl - skew`, the cached token goes invalid before the refresh fires, so every cycle has a window where all requests fail closed against a perfectly healthy token endpoint. At the defaults (`refresh_ratio` 0.75, 30s skew) this hits any token with a TTL under 120s — e.g. a 60s token is valid for 30s but only refreshed at 45s, a guaranteed 15s outage per 45s cycle. A high `refresh_ratio` (e.g. 0.99) reproduces it even with standard 3600s tokens. The refresh is now scheduled from the skew-adjusted usable lifetime (`ttl - skew`) via a new `publish_token` helper, and the short-TTL regression test now asserts the cached token is still valid at the scheduled refresh instant (the assertion fails without the fix).

Also in this change:

- The token fetch is raced against cancellation in the refresh loop, so dropping a pipeline (hot reload, shutdown) is not blocked behind an in-flight token request for up to its 30s timeout — `RefreshHandle::drop` only waits its 2s join bound.
- The missing-token condition is logged on state transitions (fail-closed entered / token available again) instead of once per rejected request, so a token outage under load cannot flood the logs.
- The request path reads the token cache with `arc_swap`'s `load()` instead of `load_full()`, avoiding an atomic refcount bump per request.

Behavior note: the refresh cadence shifts slightly earlier for healthy tokens (a 3600s token refreshes at ~2677s instead of 2700s); no configuration changes are required.

## Related issue

Follow-up hardening on the filter added for #811. The refresher-thread pattern itself is slated to move onto the shared background-task primitive tracked in praxis-proxy/praxis#1042 and praxis-proxy/praxis#1043; these fixes apply to the current implementation until that lands.

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-filters --features azure-ad-filter azure` (22 passed, including the extended short-TTL regression test)
- [x] Integration or functional tests — no change to the example config path; the existing gated `examples::azure_ad` test still passes
- [x] `make lint` (`cargo clippy -p praxis-ai-filters --all-targets --features azure-ad-filter -- -D warnings` clean; note the default-features lint does not compile this gated module — #828 adds experimental-feature coverage to the make targets)
