### PR TITLE
fix(subrequest): honor runtime.subrequest_circuit_breaker on the shared client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,8 +2736,10 @@ dependencies = [
 name = "praxis-ai-proxy"
 version = "0.2.0"
 dependencies = [
+ "bytes",
  "cargo_metadata",
  "clap",
+ "http 1.5.0",
  "nix",
  "notify",
  "praxis-ai-apis",
@@ -2748,12 +2750,14 @@ dependencies = [
  "praxis-proxy-filter",
  "praxis-proxy-protocol",
  "praxis-proxy-tls",
+ "quixotic-plecostomus-core",
  "serde",
  "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "yaml_serde",
 ]
 

--- a/apis/src/openai/api_client/mod.rs
+++ b/apis/src/openai/api_client/mod.rs
@@ -128,6 +128,11 @@ impl ApiClient {
         resource_url(&self.api_base_url, path_prefix, resource_id, suffix)
     }
 
+    /// Shared sub-request client used for callouts.
+    pub(crate) fn subrequest_client(&self) -> &SubRequestClient {
+        &self.client
+    }
+
     /// Send a GET request and return a bounded HTTP response.
     pub(crate) async fn get(
         &self,

--- a/apis/src/openai/responses/file_search_callout/tests.rs
+++ b/apis/src/openai/responses/file_search_callout/tests.rs
@@ -21,9 +21,10 @@ use super::{
         MAX_QUERY_BYTES, MAX_SEARCH_REQUEST_BYTES, MAX_VECTOR_STORE_ID_BYTES, SearchResult, VectorStoreSearchRequest,
         VectorStoreSearchResponse, request_error,
     },
-    config::{FileSearchFilterConfig, ValidatedConfig, build_config},
+    config::{FileSearchFilterConfig, ValidatedConfig, build_config, build_config_with_client},
     *,
 };
+use crate::subrequest::{SubRequestError, SubResponse};
 // -----------------------------------------------------------------------------
 // Configuration and transport validation
 // -----------------------------------------------------------------------------
@@ -98,6 +99,65 @@ fn config_rejects_dns_and_sensitive_ip_targets_by_default() {
 fn config_private_override_is_explicit() {
     let config = parse_config("vector_store_url: 'http://localhost:8001'\nallow_private_url: true\n").unwrap();
     assert_eq!(config.api_client.api_base_url(), "http://localhost:8001");
+}
+
+#[tokio::test]
+async fn build_config_with_client_shares_connector_circuit_state() {
+    use praxis_core::{
+        circuit::CircuitBreakerConfig,
+        subrequest::{SubRequestClient, SubRequestConnector, SubRequestConnectorOptions, SubRequestError},
+    };
+
+    let shared = SubRequestClient::with_max_response_bytes(
+        SubRequestConnector::with_options(SubRequestConnectorOptions {
+            keepalive_pool_size: 4,
+            max_connections: None,
+            circuit_breaker: Some(CircuitBreakerConfig {
+                threshold: 1,
+                recovery_window: Duration::from_secs(30),
+                half_open_timeout: Duration::from_secs(30),
+            }),
+        }),
+        usize::MAX,
+    );
+    let raw: FileSearchFilterConfig = serde_yaml::from_str(
+        "
+vector_store_url: http://127.0.0.1:9
+allow_private_url: true
+",
+    )
+    .unwrap();
+    let inherited = build_config_with_client(&raw, shared.clone()).unwrap();
+    let isolated = build_config(&raw).unwrap();
+    let peer_addr = closed_loopback_addr();
+
+    let first = execute_against(&shared, &peer_addr).await;
+    assert!(
+        matches!(first, Err(SubRequestError::Connect(_))),
+        "first refusal should record a failure on the shared connector; got {first:?}"
+    );
+    let second = execute_against(&shared, &peer_addr).await;
+    assert!(
+        matches!(second, Err(SubRequestError::CircuitOpen { .. })),
+        "shared connector should open after threshold 1; got {second:?}"
+    );
+
+    let inherited_result = execute_against(inherited.api_client.subrequest_client(), &peer_addr).await;
+    assert!(
+        matches!(inherited_result, Err(SubRequestError::CircuitOpen { .. })),
+        "from_config_with_client must keep the callout on the same connector Arc; got {inherited_result:?}"
+    );
+
+    let isolated_debug = format!("{:?}", isolated.api_client.subrequest_client());
+    assert!(
+        isolated_debug.contains("circuit_breakers: false"),
+        "isolated from_config must not install a breaker; got {isolated_debug}"
+    );
+    let isolated_result = execute_against(isolated.api_client.subrequest_client(), &peer_addr).await;
+    assert!(
+        matches!(isolated_result, Err(SubRequestError::Connect(_))),
+        "isolated client must not observe the shared connector's open circuit; got {isolated_result:?}"
+    );
 }
 
 #[test]
@@ -1830,6 +1890,29 @@ fn parse_config(yaml: &str) -> Result<ValidatedConfig, FilterError> {
     let raw: FileSearchFilterConfig =
         serde_yaml::from_str(yaml).map_err(|error| -> FilterError { error.to_string().into() })?;
     build_config(&raw)
+}
+
+fn closed_loopback_addr() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr.to_string()
+}
+
+async fn execute_against(client: &SubRequestClient, peer_addr: &str) -> Result<SubResponse, SubRequestError> {
+    use bytes::Bytes;
+    use http::HeaderMap;
+    use pingora_core::upstreams::peer::HttpPeer;
+    use praxis_core::subrequest::SubRequest;
+
+    let peer = HttpPeer::new(peer_addr.to_owned(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    Box::pin(client.execute(&peer, &request, 1024, Duration::from_secs(2), None)).await
 }
 
 fn make_filter(port: u16, extra: &str) -> Box<dyn HttpFilter> {

--- a/examples/configs/openai/responses/file-search-callout.yaml
+++ b/examples/configs/openai/responses/file-search-callout.yaml
@@ -18,6 +18,15 @@
 #   callout_failure_mode:     closed (fail closed) or open (fail open)
 #   forward_headers:          Headers to forward from the client request
 #                             (e.g. Authorization) to the vector store API
+#
+# Shared sub-request connector settings under `runtime` are restart-required.
+# When `runtime.subrequest_circuit_breaker` is set, client-aware filters such
+# as this one inherit peer-level failure isolation from the shared client:
+#
+# runtime:
+#   subrequest_circuit_breaker:
+#     consecutive_failures: 5
+#     recovery_window_secs: 30
 
 listeners:
   - name: ai-gateway

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -63,4 +63,8 @@ cargo_metadata = { workspace = true }
 praxis-ai-build-support = { workspace = true }
 
 [dev-dependencies]
+bytes = { workspace = true }
+http = { workspace = true }
+pingora-core = { workspace = true }
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -32,17 +32,7 @@ pub(crate) fn load_and_validate_for_cli(
 /// Validate a parsed configuration by building filter pipelines.
 pub(crate) fn validate_config_for_startup(config: &Config) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     praxis_core::logging::validate_log_overrides(config)?;
-    let pool_size = config
-        .runtime
-        .subrequest_pool_size
-        .unwrap_or(praxis_core::config::DEFAULT_SUBREQUEST_POOL_SIZE);
-    let subrequest_connector =
-        praxis_core::subrequest::SubRequestConnector::new(pool_size, config.runtime.subrequest_max_connections);
-    let subrequest_response_ceiling = config.body_limits.max_response_bytes.unwrap_or(usize::MAX);
-    let subrequest_client = praxis_core::subrequest::SubRequestClient::with_max_response_bytes(
-        subrequest_connector,
-        subrequest_response_ceiling,
-    );
+    let subrequest_client = praxis_ai::create_subrequest_client(config);
     let registry = praxis_ai::build_full_registry(&subrequest_client);
     let health_registry = praxis_core::health::build_health_registry(&config.clusters);
     let kv_stores = praxis_core::kv::KvStoreRegistry::new();
@@ -171,6 +161,33 @@ filter_chains:
             err.contains("nonexistent_chain"),
             "error should mention the missing chain name: {err}"
         );
+    }
+
+    #[test]
+    fn validate_accepts_subrequest_circuit_breaker_config() {
+        let config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+runtime:
+  subrequest_circuit_breaker:
+    consecutive_failures: 3
+    recovery_window_secs: 30
+"#,
+        )
+        .unwrap();
+        assert!(
+            config.runtime.subrequest_circuit_breaker.is_some(),
+            "CLI validation path should parse runtime.subrequest_circuit_breaker"
+        );
+        validate_config_for_startup(&config).expect("configured circuit breaker should not fail startup validation");
     }
 
     static CWD_MUTEX: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -6,10 +6,12 @@
 pub(crate) mod pipelines;
 pub(crate) mod reload;
 mod server;
+mod subrequest;
 pub(crate) mod watcher;
 pub use pipelines::resolve_pipelines;
 pub use praxis_core::logging::init_tracing;
 pub use server::{check_root_privilege, fatal, resolve_config_path, run_server, run_server_with_registry};
+pub use subrequest::create_subrequest_client;
 
 // -----------------------------------------------------------------------------
 // Constants

--- a/server/src/reload.rs
+++ b/server/src/reload.rs
@@ -277,6 +277,36 @@ fn detect_subrequest_connector_changes(old: &Config, new: &Config) {
             "subrequest max connections changed; requires restart"
         );
     }
+    detect_subrequest_circuit_breaker_change(old, new);
+}
+
+/// Detect `runtime.subrequest_circuit_breaker` changes that require a restart.
+fn detect_subrequest_circuit_breaker_change(old: &Config, new: &Config) {
+    let old_cb = &old.runtime.subrequest_circuit_breaker;
+    let new_cb = &new.runtime.subrequest_circuit_breaker;
+    let changed = match (old_cb, new_cb) {
+        (None, None) => false,
+        (None, Some(_)) | (Some(_), None) => true,
+        (Some(a), Some(b)) => {
+            a.consecutive_failures != b.consecutive_failures
+                || a.recovery_window_secs != b.recovery_window_secs
+                || a.half_open_timeout_secs != b.half_open_timeout_secs
+        },
+    };
+    if changed {
+        warn!(
+            old = ?old_cb.as_ref().map(|c| format!(
+                "failures={}, recovery={}s, half_open={}s",
+                c.consecutive_failures, c.recovery_window_secs, c.half_open_timeout_secs
+            )),
+            new = ?new_cb.as_ref().map(|c| format!(
+                "failures={}, recovery={}s, half_open={}s",
+                c.consecutive_failures, c.recovery_window_secs, c.half_open_timeout_secs
+            )),
+            "runtime.subrequest_circuit_breaker changed; requires restart \
+             (circuit breaker registry is bound to the connector)"
+        );
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -322,6 +352,7 @@ mod tests {
     use praxis_core::{config::Config, health::HealthRegistry};
     use praxis_filter::FilterRegistry;
     use tokio_util::sync::CancellationToken;
+    use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::*;
 
@@ -633,6 +664,49 @@ filter_chains:
         log_restart_required_changes(&old, &new);
     }
 
+    #[test]
+    fn circuit_breaker_added_warns() {
+        let old = valid_config();
+        let new = config_with_circuit_breaker(Some(5));
+        let warnings = capture_warnings(|| detect_subrequest_circuit_breaker_change(&old, &new));
+        assert_eq!(warnings.len(), 1, "adding breaker should produce one warning");
+        assert!(
+            warnings[0].contains("subrequest_circuit_breaker"),
+            "warning should mention circuit breaker: {:?}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn circuit_breaker_removed_warns() {
+        let old = config_with_circuit_breaker(Some(5));
+        let new = valid_config();
+        let warnings = capture_warnings(|| detect_subrequest_circuit_breaker_change(&old, &new));
+        assert_eq!(warnings.len(), 1, "removing breaker should produce one warning");
+    }
+
+    #[test]
+    fn circuit_breaker_threshold_changed_warns() {
+        let old = config_with_circuit_breaker(Some(3));
+        let new = config_with_circuit_breaker(Some(5));
+        let warnings = capture_warnings(|| detect_subrequest_circuit_breaker_change(&old, &new));
+        assert_eq!(warnings.len(), 1, "changed threshold should produce one warning");
+    }
+
+    #[test]
+    fn circuit_breaker_unchanged_no_warning() {
+        let config = config_with_circuit_breaker(Some(5));
+        let warnings = capture_warnings(|| detect_subrequest_circuit_breaker_change(&config, &config));
+        assert!(warnings.is_empty(), "unchanged config should produce no warnings");
+    }
+
+    #[test]
+    fn circuit_breaker_both_none_no_warning() {
+        let config = valid_config();
+        let warnings = capture_warnings(|| detect_subrequest_circuit_breaker_change(&config, &config));
+        assert!(warnings.is_empty(), "both-absent should produce no warnings");
+    }
+
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
@@ -674,5 +748,50 @@ filter_chains:
     /// Minimal sub-request client for tests.
     fn test_client() -> praxis_core::subrequest::SubRequestClient {
         praxis_core::subrequest::SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(8, None))
+    }
+
+    fn config_with_circuit_breaker(failures: Option<u32>) -> Config {
+        let cb = failures.map_or_else(String::new, |n| {
+            format!(
+                "runtime:\n  subrequest_circuit_breaker:\n    \
+                 consecutive_failures: {n}\n    recovery_window_secs: 30\n"
+            )
+        });
+        Config::from_yaml(&format!(
+            "listeners:\n  - name: web\n    address: \"127.0.0.1:8080\"\n    \
+             filter_chains: [main]\n{cb}filter_chains:\n  - name: main\n    \
+             filters:\n      - filter: static_response\n        status: 200\n"
+        ))
+        .unwrap()
+    }
+
+    fn capture_warnings<F: FnOnce()>(f: F) -> Vec<String> {
+        let messages = Arc::new(Mutex::new(Vec::<String>::new()));
+        let capture = WarningCapture(Arc::clone(&messages));
+        let subscriber = tracing_subscriber::registry().with(capture);
+        tracing::subscriber::with_default(subscriber, f);
+        std::mem::take(&mut *messages.lock().unwrap())
+    }
+
+    struct WarningCapture(Arc<Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WarningCapture {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+            if *event.metadata().level() == tracing::Level::WARN {
+                let mut visitor = MessageVisitor(String::new());
+                event.record(&mut visitor);
+                self.0.lock().unwrap().push(visitor.0);
+            }
+        }
+    }
+
+    struct MessageVisitor(String);
+
+    impl tracing::field::Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.0 = format!("{value:?}");
+            }
+        }
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -18,7 +18,10 @@ use praxis_protocol::{CertWatcherShutdowns, ListenerPipelines, Protocol as _, ht
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::pipelines::resolve_pipelines;
+use crate::{
+    pipelines::resolve_pipelines,
+    subrequest::{create_subrequest_client, spawn_circuit_eviction_if_configured},
+};
 
 // -----------------------------------------------------------------------------
 // Config Path Resolution
@@ -126,26 +129,6 @@ struct ServerState {
     health_shutdown: Arc<Mutex<CancellationToken>>,
 }
 
-/// Create a [`SubRequestClient`] from the runtime configuration.
-///
-/// Called early in startup so the shared client can be captured by
-/// filter factories during registry construction.
-///
-/// [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
-fn create_subrequest_client(config: &Config) -> praxis_core::subrequest::SubRequestClient {
-    let pool_size = config
-        .runtime
-        .subrequest_pool_size
-        .unwrap_or(praxis_core::config::DEFAULT_SUBREQUEST_POOL_SIZE);
-    let subrequest_connector =
-        praxis_core::subrequest::SubRequestConnector::new(pool_size, config.runtime.subrequest_max_connections);
-    let subrequest_response_ceiling = config.body_limits.max_response_bytes.unwrap_or(usize::MAX);
-    praxis_core::subrequest::SubRequestClient::with_max_response_bytes(
-        subrequest_connector,
-        subrequest_response_ceiling,
-    )
-}
-
 /// Build filter pipelines, health checks, and registries.
 fn build_server_state(
     config: &Config,
@@ -161,6 +144,7 @@ fn build_server_state(
 
     let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
     spawn_health_check_tasks(config, Arc::clone(health_registry), &health_shutdown);
+    spawn_circuit_eviction_if_configured(config, &subrequest_client);
 
     ServerState {
         pipelines: Arc::new(pipelines),

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -144,7 +144,11 @@ fn build_server_state(
 
     let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
     spawn_health_check_tasks(config, Arc::clone(health_registry), &health_shutdown);
-    spawn_circuit_eviction_if_configured(config, &subrequest_client);
+    // Dedicated token: `health_shutdown` is cancelled on every reload, but
+    // circuit-breaker config is restart-required and eviction must keep running.
+    let circuit_eviction_shutdown = CancellationToken::new();
+    let _circuit_eviction =
+        spawn_circuit_eviction_if_configured(config, &subrequest_client, &circuit_eviction_shutdown);
 
     ServerState {
         pipelines: Arc::new(pipelines),

--- a/server/src/subrequest.rs
+++ b/server/src/subrequest.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Shared sub-request client construction from runtime configuration.
+
+use std::time::Duration;
+
+use praxis_core::{
+    circuit::CircuitBreakerConfig,
+    config::Config,
+    subrequest::{SubRequestClient, SubRequestConnector, SubRequestConnectorOptions},
+};
+use tracing::debug;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// How often the sub-request circuit breaker eviction loop runs.
+const CIRCUIT_EVICTION_INTERVAL: Duration = Duration::from_secs(300); // 5 min
+
+/// How long a healthy breaker must sit idle before eviction.
+const CIRCUIT_IDLE_THRESHOLD: Duration = Duration::from_secs(600); // 10 min
+
+// -----------------------------------------------------------------------------
+// Construction
+// -----------------------------------------------------------------------------
+
+/// Build the process-wide [`SubRequestClient`] from runtime and body-limit config.
+///
+/// Maps `subrequest_pool_size`, `subrequest_max_connections`, and
+/// `subrequest_circuit_breaker` through one [`SubRequestConnectorOptions`]
+/// path so startup and `--validate`/`--dump` cannot drift. Absent circuit-breaker
+/// configuration leaves isolation disabled, matching [`SubRequestConnector::new`].
+///
+/// [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
+/// [`SubRequestConnectorOptions`]: praxis_core::subrequest::SubRequestConnectorOptions
+/// [`SubRequestConnector::new`]: praxis_core::subrequest::SubRequestConnector::new
+#[must_use]
+pub fn create_subrequest_client(config: &Config) -> SubRequestClient {
+    let pool_size = config
+        .runtime
+        .subrequest_pool_size
+        .unwrap_or(praxis_core::config::DEFAULT_SUBREQUEST_POOL_SIZE);
+    let connector = SubRequestConnector::with_options(SubRequestConnectorOptions {
+        keepalive_pool_size: pool_size,
+        max_connections: config.runtime.subrequest_max_connections,
+        circuit_breaker: config
+            .runtime
+            .subrequest_circuit_breaker
+            .as_ref()
+            .map(|cb| CircuitBreakerConfig {
+                threshold: cb.consecutive_failures,
+                recovery_window: Duration::from_secs(cb.recovery_window_secs),
+                half_open_timeout: Duration::from_secs(cb.half_open_timeout_secs),
+            }),
+    });
+    let response_ceiling = config.body_limits.max_response_bytes.unwrap_or(usize::MAX);
+    SubRequestClient::with_max_response_bytes(connector, response_ceiling)
+}
+
+/// Spawn idle-circuit eviction when `runtime.subrequest_circuit_breaker` is set.
+///
+/// Interval and idle threshold match the Praxis server so AI and core
+/// bound circuit state the same way. No-op when the breaker is absent.
+#[expect(clippy::expect_used, reason = "fatal if the eviction runtime cannot start")]
+pub(crate) fn spawn_circuit_eviction_if_configured(config: &Config, client: &SubRequestClient) {
+    if config.runtime.subrequest_circuit_breaker.is_none() {
+        return;
+    }
+    let client = client.clone();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("circuit breaker eviction runtime");
+        rt.block_on(async move {
+            let mut interval = tokio::time::interval(CIRCUIT_EVICTION_INTERVAL);
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let evicted = client.evict_idle_circuits(CIRCUIT_IDLE_THRESHOLD);
+                if evicted > 0 {
+                    debug!(evicted, "circuit breaker: evicted idle entries");
+                }
+            }
+        });
+    });
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use bytes::Bytes;
+    use http::HeaderMap;
+    use pingora_core::upstreams::peer::HttpPeer;
+    use praxis_core::subrequest::{SubRequest, SubRequestError, SubResponse};
+
+    use super::*;
+
+    #[test]
+    fn absent_circuit_breaker_leaves_isolation_disabled() {
+        let client = create_subrequest_client(&minimal_config(""));
+        let debug = format!("{client:?}");
+        assert!(
+            debug.contains("circuit_breakers: false"),
+            "absent runtime.subrequest_circuit_breaker should not install a registry; got {debug}"
+        );
+        assert_eq!(
+            client.evict_idle_circuits(Duration::from_secs(1)),
+            0,
+            "idle eviction is a no-op without a circuit registry"
+        );
+    }
+
+    #[test]
+    fn configured_circuit_breaker_enables_shared_connector() {
+        let client = create_subrequest_client(&minimal_config(
+            "
+runtime:
+  subrequest_pool_size: 16
+  subrequest_max_connections: 32
+  subrequest_circuit_breaker:
+    consecutive_failures: 3
+    recovery_window_secs: 30
+    half_open_timeout_secs: 15
+",
+        ));
+        let debug = format!("{client:?}");
+        assert!(
+            debug.contains("circuit_breakers: true"),
+            "configured breaker should install the connector registry; got {debug}"
+        );
+        assert!(
+            debug.contains("max_connections: Some(32)"),
+            "max_connections should still be applied alongside the breaker; got {debug}"
+        );
+    }
+
+    #[test]
+    fn client_aware_factories_accept_configured_client() {
+        let config = minimal_config(
+            "
+runtime:
+  subrequest_circuit_breaker:
+    consecutive_failures: 3
+    recovery_window_secs: 30
+",
+        );
+        let client = create_subrequest_client(&config);
+        let registry = crate::build_full_registry(&client);
+        let filter_config = serde_yaml::from_str(
+            "
+vector_store_url: http://127.0.0.1:9
+allow_private_url: true
+callout_failure_mode: closed
+",
+        )
+        .unwrap();
+        registry
+            .create("openai_file_search_callout", &filter_config)
+            .expect("file-search factory should build against the shared client");
+    }
+
+    #[tokio::test]
+    async fn configured_breaker_trips_on_connect_failure() {
+        let client = create_subrequest_client(&minimal_config(
+            "
+runtime:
+  subrequest_circuit_breaker:
+    consecutive_failures: 1
+    recovery_window_secs: 30
+    half_open_timeout_secs: 30
+",
+        ));
+        let peer_addr = closed_loopback_addr();
+        let first = execute_against(&client, &peer_addr).await;
+        assert!(
+            matches!(first, Err(SubRequestError::Connect(_))),
+            "first refusal should be a connect error that records the failure; got {first:?}"
+        );
+        let second = execute_against(&client, &peer_addr).await;
+        assert!(
+            matches!(second, Err(SubRequestError::CircuitOpen { .. })),
+            "threshold 1 must fail-fast as CircuitOpen before recovery; got {second:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn absent_breaker_does_not_fail_fast_as_circuit_open() {
+        let client = create_subrequest_client(&minimal_config(""));
+        let peer_addr = closed_loopback_addr();
+        let first = execute_against(&client, &peer_addr).await;
+        assert!(
+            matches!(first, Err(SubRequestError::Connect(_))),
+            "absent breaker should still surface the connect error; got {first:?}"
+        );
+        let second = execute_against(&client, &peer_addr).await;
+        assert!(
+            matches!(second, Err(SubRequestError::Connect(_))),
+            "absent breaker must not fail-fast as CircuitOpen; got {second:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    fn minimal_config(runtime: &str) -> Config {
+        Config::from_yaml(&format!(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+{runtime}
+"#
+        ))
+        .unwrap()
+    }
+
+    fn closed_loopback_addr() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        addr.to_string()
+    }
+
+    async fn execute_against(client: &SubRequestClient, peer_addr: &str) -> Result<SubResponse, SubRequestError> {
+        let peer = HttpPeer::new(peer_addr.to_owned(), false, String::new());
+        let request = SubRequest {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        };
+        Box::pin(client.execute(&peer, &request, 1024, Duration::from_secs(2), None)).await
+    }
+}

--- a/server/src/subrequest.rs
+++ b/server/src/subrequest.rs
@@ -3,13 +3,14 @@
 
 //! Shared sub-request client construction from runtime configuration.
 
-use std::time::Duration;
+use std::{thread::JoinHandle, time::Duration};
 
 use praxis_core::{
     circuit::CircuitBreakerConfig,
     config::Config,
     subrequest::{SubRequestClient, SubRequestConnector, SubRequestConnectorOptions},
 };
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 // -----------------------------------------------------------------------------
@@ -62,30 +63,58 @@ pub fn create_subrequest_client(config: &Config) -> SubRequestClient {
 /// Spawn idle-circuit eviction when `runtime.subrequest_circuit_breaker` is set.
 ///
 /// Interval and idle threshold match the Praxis server so AI and core
-/// bound circuit state the same way. No-op when the breaker is absent.
+/// bound circuit state the same way. Returns `None` when the breaker is
+/// absent. The loop exits when `shutdown` is cancelled so the thread can
+/// participate in graceful process teardown; Pingora may still reap the
+/// process first, matching health-check background tasks.
 #[expect(clippy::expect_used, reason = "fatal if the eviction runtime cannot start")]
-pub(crate) fn spawn_circuit_eviction_if_configured(config: &Config, client: &SubRequestClient) {
-    if config.runtime.subrequest_circuit_breaker.is_none() {
-        return;
+pub(crate) fn spawn_circuit_eviction_if_configured(
+    config: &Config,
+    client: &SubRequestClient,
+    shutdown: &CancellationToken,
+) -> Option<JoinHandle<()>> {
+    if config.runtime.subrequest_circuit_breaker.is_some() {
+        let client = client.clone();
+        let shutdown = shutdown.clone();
+        return Some(std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("circuit breaker eviction runtime");
+            rt.block_on(run_circuit_eviction_loop(
+                client,
+                shutdown,
+                CIRCUIT_EVICTION_INTERVAL,
+                CIRCUIT_IDLE_THRESHOLD,
+            ));
+        }));
     }
-    let client = client.clone();
-    std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("circuit breaker eviction runtime");
-        rt.block_on(async move {
-            let mut interval = tokio::time::interval(CIRCUIT_EVICTION_INTERVAL);
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                let evicted = client.evict_idle_circuits(CIRCUIT_IDLE_THRESHOLD);
+    None
+}
+
+/// Tick idle-circuit eviction until `shutdown` is cancelled.
+async fn run_circuit_eviction_loop(
+    client: SubRequestClient,
+    shutdown: CancellationToken,
+    period: Duration,
+    idle_threshold: Duration,
+) {
+    let mut interval = tokio::time::interval(period);
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                let evicted = client.evict_idle_circuits(idle_threshold);
                 if evicted > 0 {
                     debug!(evicted, "circuit breaker: evicted idle entries");
                 }
             }
-        });
-    });
+            () = shutdown.cancelled() => {
+                debug!("circuit breaker eviction shutting down");
+                return;
+            }
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -205,6 +234,71 @@ runtime:
             matches!(second, Err(SubRequestError::Connect(_))),
             "absent breaker must not fail-fast as CircuitOpen; got {second:?}"
         );
+    }
+
+    #[test]
+    fn eviction_spawn_is_noop_when_breaker_absent() {
+        let config = minimal_config("");
+        let client = create_subrequest_client(&config);
+        let shutdown = CancellationToken::new();
+        assert!(
+            spawn_circuit_eviction_if_configured(&config, &client, &shutdown).is_none(),
+            "absent breaker must not spawn an eviction thread"
+        );
+    }
+
+    #[test]
+    fn eviction_spawn_exits_when_shutdown_cancelled() {
+        let config = minimal_config(
+            "
+runtime:
+  subrequest_circuit_breaker:
+    consecutive_failures: 5
+    recovery_window_secs: 30
+",
+        );
+        let client = create_subrequest_client(&config);
+        let shutdown = CancellationToken::new();
+        let handle = spawn_circuit_eviction_if_configured(&config, &client, &shutdown)
+            .expect("configured breaker should spawn eviction");
+        shutdown.cancel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            handle.join().expect("eviction thread should not panic");
+            let _ = done_tx.send(());
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("eviction thread should exit after shutdown cancel");
+    }
+
+    #[tokio::test]
+    async fn eviction_loop_ticks_then_exits_on_shutdown() {
+        let client = create_subrequest_client(&minimal_config(
+            "
+runtime:
+  subrequest_circuit_breaker:
+    consecutive_failures: 5
+    recovery_window_secs: 30
+",
+        ));
+        let shutdown = CancellationToken::new();
+        let loop_shutdown = shutdown.clone();
+        let task = tokio::spawn(async move {
+            run_circuit_eviction_loop(
+                client,
+                loop_shutdown,
+                Duration::from_millis(10),
+                Duration::from_millis(1),
+            )
+            .await;
+        });
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("eviction loop should finish after shutdown")
+            .expect("eviction loop should not panic");
     }
 
     // -------------------------------------------------------------------------

--- a/server/src/subrequest.rs
+++ b/server/src/subrequest.rs
@@ -265,7 +265,7 @@ runtime:
         let (done_tx, done_rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             handle.join().expect("eviction thread should not panic");
-            let _ = done_tx.send(());
+            done_tx.send(()).expect("join notifier should still have a receiver");
         });
         done_rx
             .recv_timeout(Duration::from_secs(2))

--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -27,9 +27,14 @@ use tokio::sync::Notify;
 // Shared Test Client
 // -----------------------------------------------------------------------------
 
-/// Default sub-request client for integration tests.
+/// Default sub-request client for registry-only tests without a config.
 fn test_subrequest_client() -> praxis_core::subrequest::SubRequestClient {
     praxis_core::subrequest::SubRequestClient::new(praxis_core::subrequest::SubRequestConnector::new(8, None))
+}
+
+/// Shared client honoring runtime connector settings, including the circuit breaker.
+fn configured_subrequest_client(config: &Config) -> praxis_core::subrequest::SubRequestClient {
+    praxis_ai::create_subrequest_client(config)
 }
 
 // -----------------------------------------------------------------------------
@@ -44,7 +49,12 @@ fn test_subrequest_client() -> praxis_core::subrequest::SubRequestClient {
 ///
 /// [`FilterPipeline`]: praxis_filter::FilterPipeline
 /// [`FilterEntry`]: praxis_core::config::FilterEntry
-fn resolve_listener_pipeline(config: &Config, listener: &Listener, registry: &FilterRegistry) -> Arc<FilterPipeline> {
+fn resolve_listener_pipeline(
+    config: &Config,
+    listener: &Listener,
+    registry: &FilterRegistry,
+    client: &praxis_core::subrequest::SubRequestClient,
+) -> Arc<FilterPipeline> {
     let chains: HashMap<&str, &[_]> = config
         .filter_chains
         .iter()
@@ -67,13 +77,7 @@ fn resolve_listener_pipeline(config: &Config, listener: &Listener, registry: &Fi
             config.insecure_options.allow_unbounded_body,
         )
         .unwrap();
-    let pool_size = config
-        .runtime
-        .subrequest_pool_size
-        .unwrap_or(praxis_core::config::DEFAULT_SUBREQUEST_POOL_SIZE);
-    pipeline.set_subrequest_client(praxis_core::subrequest::SubRequestClient::new(
-        praxis_core::subrequest::SubRequestConnector::new(pool_size, config.runtime.subrequest_max_connections),
-    ));
+    pipeline.set_subrequest_client(client.clone());
     pipeline.add_pipeline_extension(Box::new(praxis_ai_apis::store::ResponseStoreRegistry::new()));
     Arc::new(pipeline)
 }
@@ -88,13 +92,14 @@ fn resolve_listener_pipeline(config: &Config, listener: &Listener, registry: &Fi
 ///
 /// [`build_with_chains`]: FilterPipeline::build_with_chains
 pub fn build_pipeline(config: &Config) -> FilterPipeline {
-    let registry = praxis_ai::build_full_registry(&test_subrequest_client());
+    let client = configured_subrequest_client(config);
+    let registry = praxis_ai::build_full_registry(&client);
     let listener = config
         .listeners
         .first()
         .expect("config must have at least one listener");
 
-    Arc::try_unwrap(resolve_listener_pipeline(config, listener, &registry))
+    Arc::try_unwrap(resolve_listener_pipeline(config, listener, &registry, &client))
         .unwrap_or_else(|_| panic!("pipeline Arc should have single owner"))
 }
 
@@ -276,12 +281,18 @@ impl Drop for ProxyGuard {
 /// and the optional admin endpoint.
 ///
 /// [`Server`]: pingora_core::server::Server
-fn build_pingora_server(config: &Config, registry: &FilterRegistry) -> pingora_core::server::Server {
+fn build_pingora_server(
+    config: &Config,
+    registry: &FilterRegistry,
+    client: &praxis_core::subrequest::SubRequestClient,
+) -> pingora_core::server::Server {
     let mut server = praxis_core::server::build_http_server(config.shutdown_timeout_secs, &RuntimeOptions::default());
 
     let mut cert_shutdowns = Vec::new();
     for listener in &config.listeners {
-        let pipeline = Arc::new(ArcSwap::from(resolve_listener_pipeline(config, listener, registry)));
+        let pipeline = Arc::new(ArcSwap::from(resolve_listener_pipeline(
+            config, listener, registry, client,
+        )));
         load_http_handler(&mut server, listener, pipeline, &mut cert_shutdowns).unwrap();
     }
     drop(cert_shutdowns);
@@ -300,14 +311,18 @@ fn build_pingora_server(config: &Config, registry: &FilterRegistry) -> pingora_c
 
 /// Build a [`ProxyGuard`] by spawning a Pingora server that
 /// shuts down when the guard is dropped.
-fn spawn_proxy_server(config: &Config, registry: &FilterRegistry) -> ProxyGuard {
+fn spawn_proxy_server(
+    config: &Config,
+    registry: &FilterRegistry,
+    client: &praxis_core::subrequest::SubRequestClient,
+) -> ProxyGuard {
     let addr = config
         .listeners
         .first()
         .expect("config must have at least one listener")
         .address
         .clone();
-    let server = build_pingora_server(config, registry);
+    let server = build_pingora_server(config, registry, client);
 
     let notify = Arc::new(Notify::new());
     let watch_notify = Arc::clone(&notify);
@@ -345,7 +360,11 @@ fn spawn_proxy_server(config: &Config, registry: &FilterRegistry) -> ProxyGuard 
 ///
 /// Panics if `config.listeners` is empty.
 pub fn start_proxy(config: &Config) -> ProxyGuard {
-    start_proxy_with_registry(config, &praxis_ai::build_full_registry(&test_subrequest_client()))
+    let client = configured_subrequest_client(config);
+    let registry = praxis_ai::build_full_registry(&client);
+    let guard = spawn_proxy_server(config, &registry, &client);
+    crate::net::wait::wait_for_http(&guard.addr);
+    guard
 }
 
 /// Start the proxy server without issuing an HTTP readiness request.
@@ -357,7 +376,9 @@ pub fn start_proxy(config: &Config) -> ProxyGuard {
 ///
 /// Panics if `config.listeners` is empty.
 pub fn start_proxy_no_wait(config: &Config) -> ProxyGuard {
-    spawn_proxy_server(config, &praxis_ai::build_full_registry(&test_subrequest_client()))
+    let client = configured_subrequest_client(config);
+    let registry = praxis_ai::build_full_registry(&client);
+    spawn_proxy_server(config, &registry, &client)
 }
 
 /// Start the proxy with a custom filter registry.
@@ -369,7 +390,8 @@ pub fn start_proxy_no_wait(config: &Config) -> ProxyGuard {
 ///
 /// Panics if `config.listeners` is empty.
 pub fn start_proxy_with_registry(config: &Config, registry: &FilterRegistry) -> ProxyGuard {
-    let guard = spawn_proxy_server(config, registry);
+    let client = configured_subrequest_client(config);
+    let guard = spawn_proxy_server(config, registry, &client);
     crate::net::wait::wait_for_http(&guard.addr);
     guard
 }
@@ -484,7 +506,9 @@ pub fn start_reloadable_proxy(yaml: &str) -> ReloadableProxyGuard {
 ///
 /// Panics if `config.listeners` is empty.
 pub fn start_tls_proxy(config: &Config, client_config: &Arc<rustls::ClientConfig>) -> ProxyGuard {
-    let guard = spawn_proxy_server(config, &praxis_ai::build_full_registry(&test_subrequest_client()));
+    let client = configured_subrequest_client(config);
+    let registry = praxis_ai::build_full_registry(&client);
+    let guard = spawn_proxy_server(config, &registry, &client);
     crate::net::tls::wait_for_https(&guard.addr, client_config);
     guard
 }
@@ -499,7 +523,9 @@ pub fn start_tls_proxy(config: &Config, client_config: &Arc<rustls::ClientConfig
 ///
 /// Panics if `config.listeners` is empty.
 pub fn start_tls_proxy_no_wait(config: &Config) -> ProxyGuard {
-    spawn_proxy_server(config, &praxis_ai::build_full_registry(&test_subrequest_client()))
+    let client = configured_subrequest_client(config);
+    let registry = praxis_ai::build_full_registry(&client);
+    spawn_proxy_server(config, &registry, &client)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Centralize shared-client construction in `create_subrequest_client` so startup, `--validate`/`--dump`, and test proxies map `subrequest_pool_size`, `subrequest_max_connections`, and `subrequest_circuit_breaker` through `SubRequestConnector::with_options`. The previous `SubRequestConnector::new` path accepted the YAML and then left `circuit_breakers: None`.
- Spawn idle-circuit eviction on the same 5 min / 10 min cadence as Praxis core when the breaker is configured, and warn on reload that breaker changes require a restart.
- Client-aware callouts inherit the shared connector; isolated `from_config` still builds a dedicated client without a breaker.
- Fixes #695.

## Test plan
- [x] Trip test: YAML `consecutive_failures: 1` → first closed-port `execute` is `Connect`, second is `CircuitOpen`; absent breaker stays `Connect`
- [x] Inherit test: `build_config_with_client` observes the shared connector's `CircuitOpen`; isolated `build_config` does not
- [x] Reload diagnostics warn on add/remove/threshold change; unchanged / both-absent do not
- [x] CLI `--validate` accepts a valid `runtime.subrequest_circuit_breaker` block
- [x] `make test` (`cargo test --workspace`) — 0 failed