### PR TITLE
feat(observability): trace provider backend routes

### DIFF
--- a/docs/architecture/opentelemetry.md
+++ b/docs/architecture/opentelemetry.md
@@ -17,16 +17,50 @@ admission, locality, rank, tier, and overlay revision attributes. It never
 records request or response bodies, prompts, credentials, authorization
 headers, cookies, or session keys.
 
+After `provider_route` validates the edge-selected candidate and resolves it
+to a provider-local backend cluster, the feature emits a short `provider.route`
+child span. The span records the resolved backend cluster the request was
+routed to; it is not proof that a downstream endpoint, pod, or model server
+successfully served the request. It contains:
+
+- `provider.id`: the configured provider-boundary identifier for this
+  listener. This is a configuration value, not necessarily the mTLS peer
+  identity.
+- `provider.backend.cluster`: the configured backend cluster the candidate
+  resolved to.
+- `provider.route.model`: the configured model accepted for the resolved
+  route.
+- `provider.route.candidate_id`: the edge-selected candidate ID that was
+  validated and resolved.
+- `overlay.revision`: present only when the edge supplied a serving overlay
+  revision that passed syntax and trust-boundary validation. It is
+  correlation evidence only, not a provider-local config revision and not an
+  authorization decision.
+
+Like `routing.select`, this span never records request or response bodies,
+prompts, credentials, authorization headers, cookies, session keys, or raw
+request identifiers.
+
 The division of responsibility is intentional:
 
 ```text
-Praxis core request span
+Edge Praxis core request span
   |
-  `-- routing.select        (Praxis AI)
-        |
-        `-- upstream hop    (Praxis core)
+  +-- routing.select          (Praxis AI, intelligent_route)
+  `-- upstream hop            (Praxis core)
+
+Provider Praxis core request span
+  |
+  +-- provider.route          (Praxis AI, provider_route)
+  `-- upstream hop            (Praxis core)
 ```
 
-Praxis core owns the complete HTTP span lifetime and transport boundaries.
-Praxis AI records only the semantic decision it makes. This prevents duplicate
-request roots, conflicting trace propagation, and multiple exporter runtimes.
+Each semantic decision span is short-lived and is a sibling of the later
+transport span within the same request. When trace context is propagated
+between gateways, Praxis core connects the edge provider-hop client span to
+the provider request span.
+
+Praxis core owns the complete HTTP span lifetime and transport boundaries at
+both the edge and the provider-local listener. Praxis AI records only the
+semantic decisions it makes at each hop. This prevents duplicate request
+roots, conflicting trace propagation, and multiple exporter runtimes.

--- a/docs/filters/provider_route.md
+++ b/docs/filters/provider_route.md
@@ -28,4 +28,4 @@ These names are AI-owned rather than Praxis-reserved because Praxis intentionall
 | `routes[].credential.secretRef.namespace` | string | yes | Secret namespace. |
 | `routes[].model` | string | yes | Exact model accepted for this candidate. |
 | `routes[].paths` | string[] | yes | Exact inference paths accepted for this candidate. |
-| `emit_demo_attribution` | bool | no | Add a provider attribution response header for demo evidence. |
+| `emit_demo_attribution` | bool | no | Add provider gateway and selected-backend response attribution headers. |

--- a/filters/src/opentelemetry.rs
+++ b/filters/src/opentelemetry.rs
@@ -5,7 +5,8 @@
 //!
 //! Praxis core owns subscriber installation, OTLP export, propagation,
 //! sampling, request lifecycle spans, and provider-hop client spans. AI owns
-//! only the semantic routing decision made by `intelligent_route`.
+//! only the semantic decisions made by `intelligent_route` (edge routing
+//! selection) and `provider_route` (provider-local backend resolution).
 
 use std::sync::Arc;
 
@@ -60,6 +61,40 @@ impl<'a> RoutingSelection<'a> {
     }
 }
 
+/// Borrowed, validated attributes for a provider-local routing decision span.
+struct ProviderRouteSelection<'a> {
+    /// Configured provider-boundary identifier.
+    provider_id: &'a str,
+    /// Provider-local backend cluster resolved for the candidate.
+    cluster: &'a str,
+    /// Configured model accepted by the resolved route.
+    model: &'a str,
+    /// Validated candidate identifier supplied by the trusted edge hop.
+    candidate_id: &'a str,
+    /// Edge serving-overlay revision, when supplied and validated.
+    revision: Option<&'a str>,
+}
+
+impl<'a> ProviderRouteSelection<'a> {
+    /// Project only bounded provider-route state; request and credential state
+    /// is not accepted by this constructor.
+    fn new(
+        provider_id: &'a Arc<str>,
+        cluster: &'a Arc<str>,
+        model: &'a Arc<str>,
+        candidate_id: &'a str,
+        revision: Option<&'a str>,
+    ) -> Self {
+        Self {
+            provider_id: provider_id.as_ref(),
+            cluster: cluster.as_ref(),
+            model: model.as_ref(),
+            candidate_id,
+            revision,
+        }
+    }
+}
+
 /// Emit a bounded child span for a completed routing decision.
 ///
 /// No prompt, body, credential, authorization header, cookie, session key, or
@@ -96,11 +131,46 @@ pub(crate) fn record_routing_selection(
     let _entered = span.enter();
 }
 
+/// Emit a bounded child span for a completed `provider_route` resolution.
+///
+/// Records the resolved backend cluster the request was routed to; it is not
+/// proof that a downstream endpoint, pod, or model server successfully served
+/// the request. `provider_id` is the configured provider-boundary identifier,
+/// not necessarily the mTLS peer identity. `overlay_revision` is the
+/// edge-supplied serving overlay revision after syntax and trust-boundary
+/// validation; it is correlation evidence, not a provider-local config
+/// revision or an authorization decision.
+///
+/// No prompt, body, credential, authorization header, cookie, session key, or
+/// raw request identifier is recorded. When the feature is disabled this call
+/// site is compiled out entirely.
+pub(crate) fn record_provider_route_selection(
+    provider_id: &Arc<str>,
+    cluster: &Arc<str>,
+    model: &Arc<str>,
+    candidate_id: &str,
+    overlay_revision: Option<&str>,
+) {
+    let selection = ProviderRouteSelection::new(provider_id, cluster, model, candidate_id, overlay_revision);
+    let span = tracing::info_span!(
+        "provider.route",
+        "provider.id" = selection.provider_id,
+        "provider.backend.cluster" = selection.cluster,
+        "provider.route.model" = selection.model,
+        "provider.route.candidate_id" = selection.candidate_id,
+        "overlay.revision" = Empty,
+    );
+    if let Some(revision) = selection.revision {
+        span.record("overlay.revision", revision);
+    }
+    let _entered = span.enter();
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use super::RoutingSelection;
+    use super::{ProviderRouteSelection, RoutingSelection, record_provider_route_selection};
     use crate::routing::descriptor::{AdmissionState, CapabilityKind, RouteCandidate};
 
     #[test]
@@ -144,6 +214,34 @@ mod tests {
         assert_eq!(fields.revision, None, "missing overlay revision must remain absent");
     }
 
+    #[test]
+    fn projects_only_validated_provider_route_attributes() {
+        let provider_id: Arc<str> = Arc::from("provider-a");
+        let cluster: Arc<str> = Arc::from("cluster-a");
+        let model: Arc<str> = Arc::from("model-a");
+        let fields = ProviderRouteSelection::new(&provider_id, &cluster, &model, "candidate-a", Some("revision-a"));
+
+        assert_eq!(fields.provider_id, "provider-a");
+        assert_eq!(fields.cluster, "cluster-a");
+        assert_eq!(fields.model, "model-a");
+        assert_eq!(fields.candidate_id, "candidate-a");
+        assert_eq!(fields.revision, Some("revision-a"));
+
+        // Keep a smoke assertion around the tracing macro in addition to the
+        // projection contract above.
+        record_provider_route_selection(&provider_id, &cluster, &model, "candidate-a", Some("revision-a"));
+    }
+
+    #[test]
+    fn provider_route_optional_revision_remains_absent() {
+        let provider_id: Arc<str> = Arc::from("provider-a");
+        let cluster: Arc<str> = Arc::from("cluster-a");
+        let model: Arc<str> = Arc::from("model-a");
+        let fields = ProviderRouteSelection::new(&provider_id, &cluster, &model, "candidate-a", None);
+
+        assert_eq!(fields.revision, None);
+    }
+
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
@@ -153,6 +251,7 @@ mod tests {
         RouteCandidate {
             admission_state: AdmissionState::NewAndExisting,
             cluster: Arc::from("provider-a"),
+            credential: None,
             fresh: true,
             kind: CapabilityKind::InferenceModel,
             name: Arc::from("model-a"),

--- a/filters/src/routing/metadata.rs
+++ b/filters/src/routing/metadata.rs
@@ -33,6 +33,9 @@ pub(crate) const PROVIDER_OVERLAY_REVISION_HEADER: &str = "x-ai-provider-routing
 /// Demo-only response attribution header.
 pub(crate) const PROVIDER_ATTRIBUTION_RESPONSE_HEADER: &str = "x-ai-demo-provider-gateway";
 
+/// Provider-local inference backend selected by `provider_route`.
+pub(crate) const PROVIDER_INFERENCE_RESPONSE_HEADER: &str = "x-ai-inference-provider";
+
 /// Admission state of the selected route candidate.
 pub(crate) const ROUTE_ADMISSION_STATE: &str = "intelligent_route.admission_state";
 /// Backend cluster selected by `intelligent_route`.

--- a/filters/src/routing/provider_route.rs
+++ b/filters/src/routing/provider_route.rs
@@ -25,10 +25,10 @@ use super::{
     descriptor,
     metadata::{
         CandidateCredential, OVERLAY_REVISION_HEADER, PROVIDER_ATTRIBUTION_HEADER,
-        PROVIDER_ATTRIBUTION_RESPONSE_HEADER, PROVIDER_HOP_REQUEST_ID_HEADER, PROVIDER_OVERLAY_REVISION_HEADER,
-        PROVIDER_REQUEST_ID_HEADER, PROVIDER_ROUTE_CANDIDATE_ID, PROVIDER_ROUTE_CLUSTER, PROVIDER_ROUTE_MODEL,
-        PROVIDER_ROUTE_OVERLAY_REVISION, PROVIDER_ROUTE_PROVIDER_ID, PROVIDER_ROUTE_REQUEST_ID,
-        SELECTED_CANDIDATE_HEADER, set_credential_metadata,
+        PROVIDER_ATTRIBUTION_RESPONSE_HEADER, PROVIDER_HOP_REQUEST_ID_HEADER, PROVIDER_INFERENCE_RESPONSE_HEADER,
+        PROVIDER_OVERLAY_REVISION_HEADER, PROVIDER_REQUEST_ID_HEADER, PROVIDER_ROUTE_CANDIDATE_ID,
+        PROVIDER_ROUTE_CLUSTER, PROVIDER_ROUTE_MODEL, PROVIDER_ROUTE_OVERLAY_REVISION, PROVIDER_ROUTE_PROVIDER_ID,
+        PROVIDER_ROUTE_REQUEST_ID, SELECTED_CANDIDATE_HEADER, set_credential_metadata,
     },
 };
 
@@ -57,7 +57,7 @@ struct ProviderRouteFilterConfig {
     /// Exact provider-local candidate mappings.
     routes: Vec<ProviderRouteConfig>,
 
-    /// Add a provider attribution response header for demo evidence.
+    /// Add provider gateway and selected-backend response attribution headers.
     #[serde(default)]
     emit_demo_attribution: bool,
 }
@@ -121,7 +121,7 @@ struct ProviderRoute {
 /// conditional/fail-open boundary filters, and branch-conditional provider
 /// consumers.
 pub struct ProviderRouteFilter {
-    /// Emit a demo attribution header on responses.
+    /// Emit provider gateway and selected-backend attribution on responses.
     emit_demo_attribution: bool,
     /// Header name containing the requested model.
     model_header: HeaderName,
@@ -151,23 +151,8 @@ impl ProviderRouteFilter {
         if cfg.routes.is_empty() || cfg.routes.len() > MAX_PROVIDER_ROUTES {
             return Err(format!("provider_route: routes must contain 1-{MAX_PROVIDER_ROUTES} entries").into());
         }
-
         let model_header = descriptor::validate_model_header(&cfg.model_header)?;
-        let mut routes = HashMap::with_capacity(cfg.routes.len());
-        for route in cfg.routes {
-            validate_route(&route)?;
-            let candidate_id: Arc<str> = Arc::from(route.candidate_id.as_str());
-            let provider_route = ProviderRoute {
-                cluster: Arc::from(route.cluster.as_str()),
-                credential: route.credential,
-                model: Arc::from(route.model.as_str()),
-                paths: route.paths.into_iter().map(Arc::from).collect(),
-            };
-            if routes.insert(candidate_id, provider_route).is_some() {
-                return Err("provider_route: duplicate candidate_id".into());
-            }
-        }
-
+        let routes = build_routes(cfg.routes, cfg.emit_demo_attribution)?;
         Ok(Box::new(Self {
             emit_demo_attribution: cfg.emit_demo_attribution,
             model_header,
@@ -176,6 +161,41 @@ impl ProviderRouteFilter {
             routes,
         }))
     }
+}
+
+/// Validate and resolve the configured provider-local candidate routes.
+fn build_routes(
+    route_configs: Vec<ProviderRouteConfig>,
+    emit_demo_attribution: bool,
+) -> Result<HashMap<Arc<str>, ProviderRoute>, FilterError> {
+    let mut routes = HashMap::with_capacity(route_configs.len());
+    for route in route_configs {
+        validate_route(&route)?;
+        if emit_demo_attribution {
+            validate_attribution_cluster(&route.cluster)?;
+        }
+        let candidate_id: Arc<str> = Arc::from(route.candidate_id.as_str());
+        let provider_route = ProviderRoute {
+            cluster: Arc::from(route.cluster.as_str()),
+            credential: route.credential,
+            model: Arc::from(route.model.as_str()),
+            paths: route.paths.into_iter().map(Arc::from).collect(),
+        };
+        if routes.insert(candidate_id, provider_route).is_some() {
+            return Err("provider_route: duplicate candidate_id".into());
+        }
+    }
+    Ok(routes)
+}
+
+/// Validate the cluster value before using it in a provider-owned header.
+fn validate_attribution_cluster(cluster: &str) -> Result<(), FilterError> {
+    HeaderValue::from_str(cluster).map_err(|error| {
+        FilterError::from(format!(
+            "provider_route: cluster must be a valid HTTP header value: {error}"
+        ))
+    })?;
+    Ok(())
 }
 
 #[async_trait]
@@ -227,6 +247,15 @@ impl HttpFilter for ProviderRouteFilter {
         set_credential_metadata(ctx, route.credential.as_ref());
         set_provider_headers(ctx, &self.provider_id_header, &request_id, overlay_revision.as_deref())?;
 
+        #[cfg(feature = "opentelemetry")]
+        crate::opentelemetry::record_provider_route_selection(
+            &self.provider_id,
+            &route.cluster,
+            &route.model,
+            &candidate_id,
+            overlay_revision.as_deref(),
+        );
+
         Ok(FilterAction::Continue)
     }
 
@@ -234,6 +263,11 @@ impl HttpFilter for ProviderRouteFilter {
         if !self.emit_demo_attribution {
             return Ok(FilterAction::Continue);
         }
+        let inference_provider = ctx
+            .get_metadata(PROVIDER_ROUTE_CLUSTER)
+            .map(HeaderValue::from_str)
+            .transpose()
+            .map_err(|error| FilterError::from(format!("provider_route: invalid provider cluster header: {error}")))?;
         let Some(response) = ctx.response_header.as_mut() else {
             return Ok(FilterAction::Continue);
         };
@@ -241,6 +275,12 @@ impl HttpFilter for ProviderRouteFilter {
             HeaderName::from_static(PROVIDER_ATTRIBUTION_RESPONSE_HEADER),
             self.provider_id_header.clone(),
         );
+        if let Some(inference_provider) = inference_provider {
+            response.headers.insert(
+                HeaderName::from_static(PROVIDER_INFERENCE_RESPONSE_HEADER),
+                inference_provider,
+            );
+        }
         ctx.response_headers_modified = true;
         Ok(FilterAction::Continue)
     }
@@ -264,6 +304,8 @@ fn strip_edge_headers(ctx: &mut HttpFilterContext<'_>) {
         .push(HeaderName::from_static(PROVIDER_OVERLAY_REVISION_HEADER));
     ctx.request_headers_to_remove
         .push(HeaderName::from_static(PROVIDER_ATTRIBUTION_HEADER));
+    ctx.request_headers_to_remove
+        .push(HeaderName::from_static(PROVIDER_INFERENCE_RESPONSE_HEADER));
     ctx.request_headers_to_remove.push(AUTHORIZATION);
 }
 
@@ -453,6 +495,10 @@ mod tests {
             HeaderName::from_static(PROVIDER_OVERLAY_REVISION_HEADER),
             HeaderValue::from_static("spoofed-revision"),
         );
+        req.headers.insert(
+            HeaderName::from_static(PROVIDER_INFERENCE_RESPONSE_HEADER),
+            HeaderValue::from_static("client-supplied-backend"),
+        );
         let mut ctx = test_utils::make_filter_context(&req);
 
         let action = f.on_request(&mut ctx).await.unwrap();
@@ -460,6 +506,7 @@ mod tests {
         assert!(matches!(action, FilterAction::Continue));
         for name in [
             PROVIDER_ATTRIBUTION_HEADER,
+            PROVIDER_INFERENCE_RESPONSE_HEADER,
             PROVIDER_REQUEST_ID_HEADER,
             PROVIDER_OVERLAY_REVISION_HEADER,
         ] {
@@ -715,6 +762,49 @@ mod tests {
         assert!(ctx.get_metadata(PROVIDER_ROUTE_REQUEST_ID).is_some());
     }
 
+    #[tokio::test]
+    async fn distinct_candidates_resolve_independent_cluster_metadata() {
+        let f = ProviderRouteFilter::from_config(&two_route_config()).unwrap();
+        let req_a = request_with_peer_context("/v1/chat/completions", "abc123", "req-1", "sim-model-v1");
+        let req_b = request_with_peer_context("/v1/chat/completions", "def456", "req-2", "sim-model-v1");
+        let mut ctx_a = test_utils::make_filter_context(&req_a);
+        let mut ctx_b = test_utils::make_filter_context(&req_b);
+
+        let (action_a, action_b) = tokio::join!(f.on_request(&mut ctx_a), f.on_request(&mut ctx_b));
+
+        assert!(matches!(action_a.unwrap(), FilterAction::Continue));
+        assert!(matches!(action_b.unwrap(), FilterAction::Continue));
+        assert_eq!(ctx_a.get_metadata(PROVIDER_ROUTE_CLUSTER), Some("mock-backend"));
+        assert_eq!(ctx_b.get_metadata(PROVIDER_ROUTE_CLUSTER), Some("other-backend"));
+        assert_ne!(
+            ctx_a.get_metadata(PROVIDER_ROUTE_CLUSTER),
+            ctx_b.get_metadata(PROVIDER_ROUTE_CLUSTER),
+            "independent requests against the same filter instance must not leak cluster metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_id_metadata_is_stable_and_distinct_from_cluster() {
+        let f = ProviderRouteFilter::from_config(&two_route_config()).unwrap();
+
+        for (candidate_id, request_id, expected_cluster) in [
+            ("abc123", "req-1", "mock-backend"),
+            ("def456", "req-2", "other-backend"),
+        ] {
+            let req = request_with_peer_context("/v1/chat/completions", candidate_id, request_id, "sim-model-v1");
+            let mut ctx = test_utils::make_filter_context(&req);
+            let action = f.on_request(&mut ctx).await.unwrap();
+            assert!(matches!(action, FilterAction::Continue));
+            assert_eq!(ctx.get_metadata(PROVIDER_ROUTE_PROVIDER_ID), Some("test-provider"));
+            assert_eq!(ctx.get_metadata(PROVIDER_ROUTE_CLUSTER), Some(expected_cluster));
+            assert_ne!(
+                ctx.get_metadata(PROVIDER_ROUTE_PROVIDER_ID),
+                ctx.get_metadata(PROVIDER_ROUTE_CLUSTER),
+                "provider_id must remain distinct from the resolved backend cluster"
+            );
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Provider Attribution
     // -------------------------------------------------------------------------
@@ -736,7 +826,11 @@ mod tests {
     #[tokio::test]
     async fn emits_demo_attribution_response_header() {
         let f = make_filter("abc123");
-        let req = request_with_peer_context("/v1/chat/completions", "abc123", "req-1", "sim-model-v1");
+        let mut req = request_with_peer_context("/v1/chat/completions", "abc123", "req-1", "sim-model-v1");
+        req.headers.insert(
+            HeaderName::from_static(PROVIDER_INFERENCE_RESPONSE_HEADER),
+            HeaderValue::from_static("client-supplied-value"),
+        );
         let mut ctx = test_utils::make_filter_context(&req);
         let _action = f.on_request(&mut ctx).await.unwrap();
         let mut resp = test_utils::make_response();
@@ -748,6 +842,13 @@ mod tests {
             value.map(|v| v.to_str().unwrap()),
             Some("test-provider"),
             "demo attribution response header"
+        );
+        assert_eq!(
+            resp.headers
+                .get(PROVIDER_INFERENCE_RESPONSE_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("mock-backend"),
+            "trusted provider route must override client attribution"
         );
     }
 
@@ -772,6 +873,7 @@ mod tests {
         assert!(matches!(action, FilterAction::Continue));
         assert!(!ctx.response_headers_modified);
         assert!(resp.headers.get(PROVIDER_ATTRIBUTION_RESPONSE_HEADER).is_none());
+        assert!(resp.headers.get(PROVIDER_INFERENCE_RESPONSE_HEADER).is_none());
     }
 
     // -------------------------------------------------------------------------
@@ -887,6 +989,19 @@ mod tests {
     }
 
     #[test]
+    fn invalid_cluster_header_rejected_when_response_attribution_is_enabled() {
+        let yaml = "provider_id: p\nemit_demo_attribution: true\nroutes:\n  - candidate_id: a\n    model: m\n    paths: [/x]\n    cluster: \"bad\\0value\"\n";
+        let val: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let error = ProviderRouteFilter::from_config(&val)
+            .err()
+            .expect("invalid cluster header value must fail construction");
+        assert!(
+            error.to_string().contains("cluster must be a valid HTTP header value"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn duplicate_candidate_id_rejected() {
         let yaml = "provider_id: p\nroutes:\n  - candidate_id: a\n    model: m\n    paths: [/x]\n    cluster: c\n  - candidate_id: a\n    model: m2\n    paths: [/y]\n    cluster: c2\n";
         let val: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
@@ -983,6 +1098,24 @@ mod tests {
     fn make_filter(candidate_id: &str) -> Box<dyn HttpFilter> {
         let config = provider_config(candidate_id, "sim-model-v1", &["/v1/chat/completions"], "mock-backend");
         ProviderRouteFilter::from_config(&config).unwrap()
+    }
+
+    /// Config with two candidates mapped to distinct backend clusters, for
+    /// isolation and attribution tests across independent requests.
+    fn two_route_config() -> serde_yaml::Value {
+        serde_yaml::from_str(
+            "provider_id: test-provider\n\
+             routes:\n\
+             \x20 - candidate_id: abc123\n\
+             \x20   cluster: mock-backend\n\
+             \x20   model: sim-model-v1\n\
+             \x20   paths: [/v1/chat/completions]\n\
+             \x20 - candidate_id: def456\n\
+             \x20   cluster: other-backend\n\
+             \x20   model: sim-model-v1\n\
+             \x20   paths: [/v1/chat/completions]\n",
+        )
+        .unwrap()
     }
 
     fn credential_provider_config() -> serde_yaml::Value {


### PR DESCRIPTION
## Summary

This PR exposes the provider-local backend selected by `provider_route`
through OpenTelemetry and optional response attribution.

It answers:

> As an operator, I want to see which provider-local backend cluster
> `provider_route` resolved for a request, so I can understand where the
> request was routed within the provider boundary.

This records the configured routing decision. It does not claim that the
downstream endpoint successfully completed the request.

## Observability contract

A feature-gated `provider.route` span records:

| Attribute | Meaning |
|---|---|
| `provider.id` | Configured provider-boundary identity |
| `provider.backend.cluster` | Resolved provider-local backend cluster |
| `provider.route.model` | Configured model accepted by the route |
| `provider.route.candidate_id` | Validated candidate identity |
| `overlay.revision` | Optional serving-overlay revision |

Provider and backend identities remain distinct. For example:

```text
provider.id              = provider-west
provider.backend.cluster = qwen-llmd
```

When the existing `emit_demo_attribution` option is enabled, responses also
carry the selected backend as:

```text
x-ai-inference-provider: qwen-llmd
```

The existing provider-gateway response header remains separate. Response
attribution stays disabled by default.

## Trust boundary

Attribution is emitted only after candidate, model, and path validation
succeed and provider forwarding headers are applied. The backend value comes
from trusted, request-local `provider_route.cluster` metadata.

Client-supplied `x-ai-inference-provider` values are removed before forwarding
and cannot override the response. Cluster values are validated for safe header
encoding when response attribution is enabled.

Only bounded configuration-derived values are recorded. Credentials,
authorization headers, prompts, bodies, cookies, session identifiers, and raw
request IDs are excluded.

## Architecture

Praxis AI owns semantic routing attribution:

- `routing.select` describes edge provider selection.
- `provider.route` describes provider-local backend resolution.

Praxis core continues to own request spans, propagation, sampling, transport
spans, and OTLP export. This PR does not install an SDK, exporter, subscriber,
or propagator.

No shared routing state, locks, remote lookups, or request-path control-plane
calls are introduced. Routing, forwarding, authentication, authorization,
affinity, load balancing, and credential behavior are unchanged.

## Coverage

Tests cover:

- required and optional trace attributes;
- distinct provider and backend identities;
- isolated requests resolving different backend clusters;
- trusted response attribution and client-header removal;
- attribution disabled by default;
- invalid attributed cluster values;
- existing candidate, model, and path rejection behavior;
- builds with and without the OpenTelemetry feature.

Generated `provider_route` documentation now describes both optional response
headers.

## Validation

- `make lint`: passed
- `git diff --check`: passed
- `make test`: completed with one unrelated SQLite database-lock failure; all
  relevant provider attribution tests passed
- Earlier default, OpenTelemetry, and all-feature validation passed during
  implementation

## Breaking changes

None expected. OpenTelemetry and response attribution remain optional, and
response attribution remains disabled by default.