### PR TITLE
fix(mcp_dispatch): preserve non-text MCP result content (#807)

### DIFF
--- a/apis/src/openai/responses/mcp_dispatch/mod.rs
+++ b/apis/src/openai/responses/mcp_dispatch/mod.rs
@@ -580,33 +580,32 @@ fn process_call_result(
     match result {
         Ok(r) => {
             let is_error = r.is_error.unwrap_or(false);
-            let non_text = r
-                .content
-                .iter()
-                .filter(|b| !matches!(b, rmcp::model::ContentBlock::Text(_)))
-                .count();
-            if non_text > 0 {
-                warn!(
-                    tool_name,
-                    call_id, non_text, "non-text content blocks discarded from MCP response"
-                );
+            match content_blocks_to_output(&r.content) {
+                Ok(output_text) => {
+                    debug!(
+                        tool_name,
+                        call_id,
+                        is_error,
+                        content_count = r.content.len(),
+                        "MCP tool call completed"
+                    );
+                    build_success_result(
+                        call_id,
+                        server_label,
+                        tool_name,
+                        arguments_string,
+                        &output_text,
+                        is_error,
+                    )
+                },
+                Err(e) => {
+                    warn!(
+                        tool_name, call_id, error = %e,
+                        "failed to serialize MCP content blocks; returning tool error"
+                    );
+                    build_error_result(call_id, server_label, tool_name, arguments_string, &e)
+                },
             }
-            let output_text = content_blocks_to_text(&r.content);
-            debug!(
-                tool_name,
-                call_id,
-                is_error,
-                content_count = r.content.len(),
-                "MCP tool call completed"
-            );
-            build_success_result(
-                call_id,
-                server_label,
-                tool_name,
-                arguments_string,
-                &output_text,
-                is_error,
-            )
         },
         Err(e) => {
             warn!(tool_name, call_id, error = %e, "MCP tool call failed");
@@ -676,17 +675,32 @@ async fn execute_single_call(
 // Result Construction
 // -----------------------------------------------------------------------------
 
-/// Extract text from rmcp `ContentBlock` values, joining
-/// multiple text blocks with newlines.
-fn content_blocks_to_text(blocks: &[rmcp::model::ContentBlock]) -> String {
-    blocks
+/// Serialize rmcp `ContentBlock` values into a lossless string for the
+/// Responses `output` field.
+///
+/// Text-only results keep the simple newline-joined form for readability and
+/// backward compatibility. Any result carrying non-text content (image, audio,
+/// embedded resource, or resource link) is serialized as the compact JSON MCP
+/// content array so that no block is silently dropped.
+///
+/// Returns `Err` when the content cannot be represented, so the caller can
+/// surface an explicit tool error instead of a lossy empty success.
+fn content_blocks_to_output(blocks: &[rmcp::model::ContentBlock]) -> Result<String, String> {
+    if blocks
         .iter()
-        .filter_map(|block| match block {
-            rmcp::model::ContentBlock::Text(text) => Some(text.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+        .all(|block| matches!(block, rmcp::model::ContentBlock::Text(_)))
+    {
+        return Ok(blocks
+            .iter()
+            .filter_map(|block| match block {
+                rmcp::model::ContentBlock::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"));
+    }
+
+    serde_json::to_string(blocks).map_err(|e| format!("failed to serialize MCP content blocks: {e}"))
 }
 
 /// Build result structs for a successful MCP call.

--- a/apis/src/openai/responses/mcp_dispatch/tests.rs
+++ b/apis/src/openai/responses/mcp_dispatch/tests.rs
@@ -561,8 +561,6 @@ fn content_blocks_to_output_empty_is_empty_string() {
 
 #[test]
 fn content_blocks_to_output_preserves_non_text_losslessly() {
-    // A mix of text and non-text blocks must serialize the full MCP content
-    // array as JSON so no block is dropped. See issue #807.
     let blocks = vec![
         rmcp::model::ContentBlock::text("text content"),
         rmcp::model::ContentBlock::image("base64data", "image/png"),
@@ -575,11 +573,12 @@ fn content_blocks_to_output_preserves_non_text_losslessly() {
     ];
     let output = content_blocks_to_output(&blocks).unwrap();
 
-    // Round-trip proves the representation is lossless: every original block
-    // is recoverable from the serialized output.
     let recovered: Vec<rmcp::model::ContentBlock> =
         serde_json::from_str(&output).expect("output must be valid JSON content array");
-    assert_eq!(recovered, blocks, "serialized output must round-trip without loss");
+    assert_eq!(
+        recovered, blocks,
+        "#807: mixed text/non-text output must round-trip losslessly so no MCP content block is dropped"
+    );
 }
 
 // =========================================================================
@@ -923,8 +922,6 @@ fn process_call_result_multi_text_joins_with_newline() {
 
 #[test]
 fn process_call_result_image_content_is_preserved() {
-    // Regression: a tool returning only an image must not become a
-    // successful call with empty output (data loss). See issue #807.
     let call_result =
         rmcp::model::CallToolResult::success(vec![rmcp::model::ContentBlock::image("base64data", "image/png")]);
     let result = process_call_result(Ok(call_result), "c1", "srv", "tool", "{}");
@@ -932,7 +929,7 @@ fn process_call_result_image_content_is_preserved() {
     let model_output = result.message["output"].as_str().unwrap();
     assert!(
         !model_output.is_empty(),
-        "image-only result must not produce empty model output"
+        "#807 regression: image-only result must not produce empty model output (data loss)"
     );
     assert!(model_output.contains("base64data"), "image data must be preserved");
     assert!(model_output.contains("image/png"), "image mime type must be preserved");

--- a/apis/src/openai/responses/mcp_dispatch/tests.rs
+++ b/apis/src/openai/responses/mcp_dispatch/tests.rs
@@ -10,7 +10,7 @@ use praxis_filter::FilterAction;
 use serde_json::json;
 
 use super::{
-    McpDispatchFilter, build_error_result, build_success_result, content_blocks_to_text, encode_function_name,
+    McpDispatchFilter, build_error_result, build_success_result, content_blocks_to_output, encode_function_name,
     execute_mcp_calls, execute_single_call, extract_arguments, extract_call_id, extract_mcp_tool_calls,
     find_approval_required, find_by_encoded_name, is_mcp_tool_call, normalize_arguments, parse_call_arguments,
     process_call_result, resolve_tool_entry,
@@ -537,24 +537,32 @@ fn config_rejects_zero_timeout() {
 // =========================================================================
 
 #[test]
-fn content_blocks_to_text_extracts_text() {
+fn content_blocks_to_output_extracts_text() {
     let blocks = vec![rmcp::model::ContentBlock::text("hello world")];
-    let text = content_blocks_to_text(&blocks);
+    let text = content_blocks_to_output(&blocks).unwrap();
     assert_eq!(text, "hello world");
 }
 
 #[test]
-fn content_blocks_to_text_joins_multiple() {
+fn content_blocks_to_output_joins_multiple_text() {
     let blocks = vec![
         rmcp::model::ContentBlock::text("line 1"),
         rmcp::model::ContentBlock::text("line 2"),
     ];
-    let text = content_blocks_to_text(&blocks);
+    let text = content_blocks_to_output(&blocks).unwrap();
     assert_eq!(text, "line 1\nline 2");
 }
 
 #[test]
-fn content_blocks_to_text_skips_non_text() {
+fn content_blocks_to_output_empty_is_empty_string() {
+    let text = content_blocks_to_output(&[]).unwrap();
+    assert_eq!(text, "", "empty content is genuinely empty, not data loss");
+}
+
+#[test]
+fn content_blocks_to_output_preserves_non_text_losslessly() {
+    // A mix of text and non-text blocks must serialize the full MCP content
+    // array as JSON so no block is dropped. See issue #807.
     let blocks = vec![
         rmcp::model::ContentBlock::text("text content"),
         rmcp::model::ContentBlock::image("base64data", "image/png"),
@@ -565,8 +573,13 @@ fn content_blocks_to_text_skips_non_text() {
             meta: None,
         }),
     ];
-    let text = content_blocks_to_text(&blocks);
-    assert_eq!(text, "text content", "should skip non-text content types");
+    let output = content_blocks_to_output(&blocks).unwrap();
+
+    // Round-trip proves the representation is lossless: every original block
+    // is recoverable from the serialized output.
+    let recovered: Vec<rmcp::model::ContentBlock> =
+        serde_json::from_str(&output).expect("output must be valid JSON content array");
+    assert_eq!(recovered, blocks, "serialized output must round-trip without loss");
 }
 
 // =========================================================================
@@ -906,6 +919,33 @@ fn process_call_result_multi_text_joins_with_newline() {
     ]);
     let result = process_call_result(Ok(call_result), "c1", "srv", "tool", "{}");
     assert_eq!(result.message["output"], "hello\nworld");
+}
+
+#[test]
+fn process_call_result_image_content_is_preserved() {
+    // Regression: a tool returning only an image must not become a
+    // successful call with empty output (data loss). See issue #807.
+    let call_result =
+        rmcp::model::CallToolResult::success(vec![rmcp::model::ContentBlock::image("base64data", "image/png")]);
+    let result = process_call_result(Ok(call_result), "c1", "srv", "tool", "{}");
+
+    let model_output = result.message["output"].as_str().unwrap();
+    assert!(
+        !model_output.is_empty(),
+        "image-only result must not produce empty model output"
+    );
+    assert!(model_output.contains("base64data"), "image data must be preserved");
+    assert!(model_output.contains("image/png"), "image mime type must be preserved");
+
+    let client_output = result.output_item["output"].as_str().unwrap();
+    assert!(
+        !client_output.is_empty(),
+        "image-only result must not produce empty client output"
+    );
+    assert!(
+        result.output_item.get("error").is_none() || result.output_item["error"].is_null(),
+        "preserved content must not be reported as an error"
+    );
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

MCP tool results containing image, audio, embedded resource, or resource-link content were silently dropped: `process_call_result` kept only text blocks and still reported success with empty output, causing irreversible response-data loss. This replaces `content_blocks_to_text` with a lossless `content_blocks_to_output` serializer — text-only results keep the simple newline-joined form, any non-text result is serialized as the compact JSON MCP content array, and unserializable content returns an explicit tool error instead of a lossy empty success. It is the smallest complete change: the common text-only path is unchanged, and behavior differs only where data was previously being lost.

## Related issue

Closes #807

## Validation

- `cargo test -p praxis-ai-apis mcp_dispatch` — 92 passed, including the regression test `process_call_result_image_content_is_preserved` and the lossless round-trip test `content_blocks_to_output_preserves_non_text_losslessly`.
- `make build`
- `make lint`

- [x] Unit tests
- [ ] Integration or functional tests (N/A — the inference-fixture harness rejects the `openai_mcp_dispatch` filter as a non-replay-contained live callout; behavior is fully covered by focused unit tests per the issue's stated minimum scope)
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. (N/A — bug fix, not a new capability)
- [x] User-facing behavior and generated documentation are updated. (generated READMEs verified in sync via `cargo xtask sync-*-readme` / `check-inference`)
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. (N/A — not a hot path; serialization only runs for non-text results)
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. Text-only tool results are byte-for-byte unchanged. Results that previously lost non-text content now carry a compact JSON representation in the string `output` field instead of an empty string.
