### PR TITLE
fix(mcp_tool_resolve): strip credentials and honor tool_choice on empty resolve

### DIFF
--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -703,10 +703,16 @@ async fn fetch_tools(
 /// entries with `type: "function"` entries and translating any
 /// MCP `tool_choice` references.
 ///
-/// Returns `None` when no rewrite is needed (unparseable body,
-/// empty tools array, or no resolved entries). The caller is
-/// responsible for checking the serialized size against
+/// Returns `None` only when the body cannot be rewritten at all
+/// (unparseable body, non-object root, or missing `tools` array).
+/// The caller is responsible for checking the serialized size against
 /// `max_body_bytes` before committing.
+///
+/// A resolved MCP entry is always dropped from the outgoing tools
+/// array, even when it produced zero permitted tools; otherwise the
+/// entry's `authorization`/`headers` credentials would leak to the
+/// inference backend. When every tool resolves away this yields an
+/// empty `tools` array rather than the original (credentialed) body.
 ///
 /// MCP entries that were not resolved (no `server_url` or deferred)
 /// are left unchanged for upstream to handle.
@@ -726,10 +732,12 @@ fn rewrite_request_body(
         return Ok(None);
     };
 
+    // An empty `rewritten` array here means every tool in the request
+    // was a resolved MCP entry that produced zero permitted tools.
+    // Commit the emptied array anyway: returning `None` would make the
+    // caller forward the *original* body, leaking those entries'
+    // `authorization`/`headers` credentials to the inference backend.
     let (rewritten, generated_names) = rewrite_tools_array(tools, per_entry);
-    if rewritten.is_empty() {
-        return Ok(None);
-    }
     detect_name_collisions(&rewritten, &generated_names)?;
 
     let rewritten_count = rewritten.len();
@@ -824,10 +832,7 @@ fn rewrite_tool_choice(
 
     match choice_type {
         Some("mcp") => rewrite_mcp_tool_choice(obj, &choice_obj, tool_map, resolved_labels),
-        Some("allowed_tools") => {
-            rewrite_allowed_tools_choice(obj, &choice_obj, tool_map);
-            Ok(())
-        },
+        Some("allowed_tools") => rewrite_allowed_tools_choice(obj, &choice_obj, tool_map, resolved_labels),
         _ => Ok(()),
     }
 }
@@ -874,17 +879,76 @@ fn rewrite_mcp_tool_choice(
 
 /// Rewrite MCP selectors inside an `allowed_tools`-typed
 /// `tool_choice`.
+///
+/// Resolved selectors expand to their generated function refs. A
+/// selector whose `server_label` was resolved locally but yields no
+/// eligible tool is dropped, so a locally consumed MCP reference never
+/// reaches the backend. Genuinely unresolved selectors (deferred,
+/// connector-only, or unknown labels) are preserved for upstream.
+///
+/// If dropping locally consumed selectors leaves the list empty,
+/// emitting `tools: []` would be a schema-invalid `allowed_tools`
+/// choice. A `mode: "required"` choice is then rejected as unsatisfiable
+/// with [`ResolveError::EmptyResolvedToolChoice`] (matching the
+/// server-level MCP `tool_choice` behavior); any other mode is
+/// normalized to `"none"`, because the restriction now permits no tool
+/// and the model must not fall back to any other tool still supplied in
+/// the request.
 fn rewrite_allowed_tools_choice(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     choice_obj: &serde_json::Map<String, serde_json::Value>,
     tool_map: &HashMap<(String, String), serde_json::Value>,
-) {
+    resolved_labels: &HashSet<String>,
+) -> Result<(), ResolveError> {
     let Some(tools_arr) = choice_obj.get("tools").and_then(serde_json::Value::as_array) else {
-        return;
+        return Ok(());
     };
 
+    let (new_tools, changed, dropped_label) = rebuild_allowed_tools_selectors(tools_arr, tool_map, resolved_labels);
+
+    if !changed {
+        return Ok(());
+    }
+
+    if new_tools.is_empty() {
+        // Every selector was a locally resolved server that produced no
+        // eligible tool, so the restricted set is now empty. An empty
+        // `allowed_tools` is invalid, so resolve it by mode.
+        if choice_obj.get("mode").and_then(serde_json::Value::as_str) == Some("required") {
+            // `required` over an empty set is unsatisfiable: reject.
+            return Err(ResolveError::EmptyResolvedToolChoice(
+                dropped_label.unwrap_or_else(|| "unknown".to_owned()),
+            ));
+        }
+        // `auto` restricted the model to this now-empty set. Normalize to
+        // `"none"` rather than removing `tool_choice`: removal would let
+        // the model call any other tool left in the request, which the
+        // original choice deliberately excluded.
+        obj.insert("tool_choice".to_owned(), serde_json::Value::String("none".to_owned()));
+        return Ok(());
+    }
+
+    let mut new_choice = choice_obj.clone();
+    new_choice.insert("tools".to_owned(), serde_json::Value::Array(new_tools));
+    obj.insert("tool_choice".to_owned(), serde_json::Value::Object(new_choice));
+    Ok(())
+}
+
+/// Rebuild an `allowed_tools` selector list: expand resolved MCP
+/// selectors to their function refs, drop locally consumed
+/// resolved-empty selectors, and preserve unresolved ones.
+///
+/// Returns the rebuilt selector list, whether it differs from the
+/// input, and the first dropped `server_label` (used for error
+/// reporting when the list collapses to empty).
+fn rebuild_allowed_tools_selectors(
+    tools_arr: &[serde_json::Value],
+    tool_map: &HashMap<(String, String), serde_json::Value>,
+    resolved_labels: &HashSet<String>,
+) -> (Vec<serde_json::Value>, bool, Option<String>) {
     let mut new_tools = Vec::with_capacity(tools_arr.len());
     let mut changed = false;
+    let mut dropped_label: Option<String> = None;
 
     for tool_ref in tools_arr {
         if tool_ref.get("type").and_then(serde_json::Value::as_str) != Some("mcp") {
@@ -895,16 +959,36 @@ fn rewrite_allowed_tools_choice(
         expand_mcp_selector(tool_ref, tool_map, &mut new_tools);
         if new_tools.len() > before {
             changed = true;
+        } else if selector_label_resolved(tool_ref, resolved_labels) {
+            // The server was resolved locally but exposes no matching
+            // tool; the selector is locally consumed. Drop it so the
+            // MCP reference never reaches the inference backend.
+            changed = true;
+            if dropped_label.is_none() {
+                dropped_label = tool_ref
+                    .get("server_label")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+            }
         } else {
+            // Unresolved (deferred / connector-only / unknown) selector:
+            // preserve it for the backend to handle.
             new_tools.push(tool_ref.clone());
         }
     }
 
-    if changed {
-        let mut new_choice = choice_obj.clone();
-        new_choice.insert("tools".to_owned(), serde_json::Value::Array(new_tools));
-        obj.insert("tool_choice".to_owned(), serde_json::Value::Object(new_choice));
-    }
+    (new_tools, changed, dropped_label)
+}
+
+/// Whether an MCP `tool_choice` selector targets a `server_label`
+/// that was resolved locally. Such a selector is locally consumed and
+/// must not survive into the backend request even when it produced
+/// zero eligible tools.
+fn selector_label_resolved(selector: &serde_json::Value, resolved_labels: &HashSet<String>) -> bool {
+    selector
+        .get("server_label")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|label| resolved_labels.contains(label))
 }
 
 /// Expand a single MCP selector into function tool references.

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -1323,6 +1323,175 @@ fn rewrite_tools_array_expands_resolved_nonempty() {
 }
 
 // =========================================================================
+// Credential isolation: entries resolving to zero permitted tools
+// =========================================================================
+
+/// A request whose only MCP entry resolves to zero permitted tools
+/// must still be rewritten: the original `type: "mcp"` entry — and
+/// its `authorization`/`headers` credentials — must never survive
+/// into the body handed to the inference backend.
+///
+/// Regression test for the credential-isolation leak where
+/// `rewrite_request_body` returned `None` for an empty rewritten
+/// tools array, causing the caller to forward the original body
+/// (credentials included) verbatim.
+#[test]
+#[expect(clippy::too_many_lines, reason = "comprehensive credential-isolation assertions")]
+fn rewrite_request_body_strips_credentials_when_all_entries_resolve_empty() {
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "hi",
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "server_url": "https://mcp.example.test/mcp",
+            "authorization": "Bearer super-secret-token",
+            "headers": {"x-api-key": "another-secret"}
+        }]
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+
+    let per_entry = vec![EntryResolution::Resolved(Vec::new())];
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["weather".to_owned()]);
+
+    let serialized = rewrite_request_body(&body_bytes, per_entry, &tool_map, &resolved_labels)
+        .expect("rewrite must not error")
+        .expect("a resolved-empty entry must trigger a rewrite, not forward the original body");
+
+    let rewritten: serde_json::Value = serde_json::from_slice(serialized.as_bytes()).unwrap();
+    assert_eq!(
+        rewritten["tools"],
+        serde_json::json!([]),
+        "the resolved-empty MCP entry must be dropped, leaving an empty tools array"
+    );
+
+    let raw = String::from_utf8(serialized.as_bytes().to_vec()).unwrap();
+    assert!(
+        !raw.contains("super-secret-token"),
+        "authorization credential must not survive into the backend request: {raw}"
+    );
+    assert!(
+        !raw.contains("another-secret"),
+        "custom header credential must not survive into the backend request: {raw}"
+    );
+    assert!(
+        !raw.contains("\"mcp\""),
+        "no type:mcp entry may survive into the backend request: {raw}"
+    );
+}
+
+/// A mixed request where one MCP entry resolves to concrete tools and
+/// a second resolves to zero must drop only the empty entry's
+/// credentials while keeping the resolved function tools.
+#[test]
+#[expect(clippy::too_many_lines, reason = "comprehensive credential-isolation assertions")]
+fn rewrite_request_body_strips_only_empty_entry_credentials_in_mixed_request() {
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "hi",
+        "tools": [
+            {
+                "type": "mcp",
+                "server_label": "weather",
+                "server_url": "https://weather.example.test/mcp"
+            },
+            {
+                "type": "mcp",
+                "server_label": "empty",
+                "server_url": "https://empty.example.test/mcp",
+                "authorization": "Bearer empty-secret-token"
+            }
+        ]
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+
+    let per_entry = vec![
+        EntryResolution::Resolved(vec![mcp_tool_to_function_tool(
+            "weather",
+            &serde_json::json!({"name": "get_weather", "description": "A"}),
+        )]),
+        EntryResolution::Resolved(Vec::new()),
+    ];
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["weather".to_owned(), "empty".to_owned()]);
+
+    let serialized = rewrite_request_body(&body_bytes, per_entry, &tool_map, &resolved_labels)
+        .expect("rewrite must not error")
+        .expect("mixed request must be rewritten");
+
+    let rewritten: serde_json::Value = serde_json::from_slice(serialized.as_bytes()).unwrap();
+    let tools = rewritten["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 1, "only the resolved-nonempty entry survives: {tools:?}");
+    assert_eq!(tools[0]["name"], "weather__get_weather", "resolved tool preserved");
+
+    let raw = String::from_utf8(serialized.as_bytes().to_vec()).unwrap();
+    assert!(
+        !raw.contains("empty-secret-token"),
+        "empty entry credential must not leak: {raw}"
+    );
+}
+
+/// Regression: an `allowed_tools` choice restricting the model to an MCP
+/// server that resolves to zero tools, while an unrelated top-level
+/// function tool survives. The emptied choice must normalize to `"none"`,
+/// never be removed — removing it would let the model call the unrelated
+/// function that the original choice deliberately excluded.
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "request fixture plus tool_choice normalization and survival assertions"
+)]
+fn rewrite_request_body_normalizes_to_none_keeping_unrelated_tool_when_allowed_tools_empties() {
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "hi",
+        "tools": [
+            {
+                "type": "mcp",
+                "server_label": "weather",
+                "server_url": "https://weather.example.test/mcp",
+                "authorization": "Bearer super-secret-token"
+            },
+            {"type": "function", "name": "unrelated_local_tool"}
+        ],
+        "tool_choice": {
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [{"type": "mcp", "server_label": "weather"}]
+        }
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+
+    // The single MCP entry resolves to zero permitted tools.
+    let per_entry = vec![EntryResolution::Resolved(Vec::new())];
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["weather".to_owned()]);
+
+    let serialized = rewrite_request_body(&body_bytes, per_entry, &tool_map, &resolved_labels)
+        .expect("rewrite must not error")
+        .expect("resolved-empty entry must trigger a rewrite");
+
+    let rewritten: serde_json::Value = serde_json::from_slice(serialized.as_bytes()).unwrap();
+    assert_eq!(
+        rewritten["tool_choice"], "none",
+        "emptied auto allowed_tools must normalize to \"none\", not be removed: {rewritten}"
+    );
+    let tools = rewritten["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 1, "the unrelated function tool must survive: {tools:?}");
+    assert_eq!(
+        tools[0]["name"], "unrelated_local_tool",
+        "unrelated top-level tool preserved"
+    );
+
+    let raw = String::from_utf8(serialized.as_bytes().to_vec()).unwrap();
+    assert!(
+        !raw.contains("super-secret-token"),
+        "empty entry credential must not leak: {raw}"
+    );
+}
+
+// =========================================================================
 // Body Rewrite: MCP to Function
 // =========================================================================
 
@@ -1913,6 +2082,126 @@ fn rewrite_tool_choice_mixed_resolved_and_unresolved_selectors() {
         .iter()
         .any(|t| t["type"] == "mcp" && t["server_label"] == "deferred_server");
     assert!(has_preserved, "unresolved MCP selector should be preserved");
+}
+
+/// A server-level MCP selector for a label that resolved to zero
+/// tools must be dropped from an `allowed_tools` `tool_choice`,
+/// mirroring the top-level MCP `tool_choice` handling. The native
+/// selector must not reach the backend.
+#[test]
+fn rewrite_tool_choice_drops_resolved_empty_server_selector_in_allowed_tools() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["empty_server".to_owned()]);
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [
+                {"type": "mcp", "server_label": "empty_server"},
+                {"type": "function", "name": "calc"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap();
+
+    let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
+    assert!(
+        tool_refs.iter().all(|t| t["type"] != "mcp"),
+        "resolved-empty MCP selector must be dropped, not preserved: {tool_refs:?}"
+    );
+    assert!(
+        tool_refs.iter().any(|t| t["name"] == "calc"),
+        "unrelated function selector must be preserved"
+    );
+}
+
+/// A named MCP selector whose server resolved but whose tool is not
+/// in the resolved set is dropped, while a genuinely unresolved
+/// (deferred) selector on another label is preserved.
+#[test]
+fn rewrite_tool_choice_drops_resolved_empty_named_selector_keeps_unresolved() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["empty_server".to_owned()]);
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [
+                {"type": "mcp", "server_label": "empty_server", "name": "gone"},
+                {"type": "mcp", "server_label": "deferred_server"}
+            ]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap();
+
+    let tool_refs = obj["tool_choice"]["tools"].as_array().expect("tools array");
+    assert_eq!(
+        tool_refs.len(),
+        1,
+        "only the unresolved selector should remain: {tool_refs:?}"
+    );
+    assert_eq!(tool_refs[0]["type"], "mcp", "deferred selector preserved");
+    assert_eq!(
+        tool_refs[0]["server_label"], "deferred_server",
+        "the preserved selector must be the unresolved one"
+    );
+}
+
+/// When every selector in an `allowed_tools` choice targets a locally
+/// resolved server that produced zero eligible tools, a
+/// `mode: "required"` choice is unsatisfiable. It must be rejected
+/// rather than rewritten to an empty (schema-invalid) `allowed_tools`.
+#[test]
+fn rewrite_tool_choice_rejects_allowed_tools_when_all_selectors_resolved_empty_required() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["empty_server".to_owned()]);
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "mcp", "server_label": "empty_server"}]
+        }),
+    );
+
+    let err = rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap_err();
+    assert!(
+        matches!(err, ResolveError::EmptyResolvedToolChoice(_)),
+        "an all-empty required allowed_tools choice must be rejected, not emitted as empty: {err}"
+    );
+}
+
+/// When every selector in a non-required `allowed_tools` choice
+/// resolves to zero eligible tools, the restricted set is empty. It must
+/// normalize to `"none"` — never to an empty (schema-invalid)
+/// `allowed_tools`, and never removed (which would broaden access to any
+/// other tool still supplied in the request).
+#[test]
+fn rewrite_tool_choice_normalizes_empty_auto_allowed_tools_to_none() {
+    let tool_map = HashMap::new();
+    let resolved_labels = HashSet::from(["empty_server".to_owned()]);
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "tool_choice".to_owned(),
+        serde_json::json!({
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [{"type": "mcp", "server_label": "empty_server"}]
+        }),
+    );
+
+    rewrite_tool_choice(&mut obj, &tool_map, &resolved_labels).unwrap();
+    assert_eq!(
+        obj["tool_choice"], "none",
+        "a vacuous auto allowed_tools choice must normalize to \"none\", not be emptied or removed: {obj:?}"
+    );
 }
 
 // =========================================================================
@@ -2954,5 +3243,142 @@ fn rewrite_tool_choice_passes_unresolved_label_zero_tools() {
     assert_eq!(
         obj["tool_choice"]["type"], "mcp",
         "unresolved label should be left unchanged"
+    );
+}
+
+// =========================================================================
+// Credential isolation end-to-end (real rmcp MCP server)
+// =========================================================================
+
+use rmcp::{
+    ServerHandler,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    },
+};
+
+/// Request payload for the single-tool server's `get_weather` tool.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct WeatherRequest {
+    /// City to look up the weather for.
+    #[schemars(description = "City to look up")]
+    city: String,
+}
+
+/// Minimal MCP server exposing a single, non-read-only tool.
+#[derive(Debug, Clone)]
+struct SingleToolMcpServer {
+    /// Router holding the server's generated tool handlers.
+    tool_router: ToolRouter<Self>,
+}
+
+#[expect(clippy::unused_self, reason = "rmcp macro-generated code")]
+#[tool_router]
+impl SingleToolMcpServer {
+    /// Construct the server with its generated tool router.
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// The single non-read-only tool the server advertises.
+    #[tool(description = "Get current weather for a city")]
+    fn get_weather(&self, Parameters(req): Parameters<WeatherRequest>) -> String {
+        format!("weather in {}", req.city)
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for SingleToolMcpServer {
+    /// Advertise tool support so `tools/list` returns `get_weather`.
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("Single-tool MCP server for credential-isolation tests")
+    }
+}
+
+/// Start the single-tool MCP server on an ephemeral loopback port.
+///
+/// Returns the server URL and a `CancellationToken` that shuts the
+/// server down when cancelled or dropped.
+async fn start_single_tool_mcp_server() -> (String, tokio_util::sync::CancellationToken) {
+    let ct = tokio_util::sync::CancellationToken::new();
+    let config = StreamableHttpServerConfig::default()
+        .with_legacy_session_mode(false)
+        .with_json_response(true)
+        .with_sse_keep_alive(None)
+        .with_cancellation_token(ct.child_token());
+    let service: StreamableHttpService<SingleToolMcpServer, LocalSessionManager> =
+        StreamableHttpService::new(|| Ok(SingleToolMcpServer::new()), std::sync::Arc::default(), config);
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shutdown = ct.clone();
+    tokio::spawn(async move {
+        drop(
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move { shutdown.cancelled_owned().await })
+                .await,
+        );
+    });
+    (format!("http://{addr}/mcp"), ct)
+}
+
+/// End-to-end regression: a credentialed MCP entry whose permitted
+/// tool set filters down to zero must not forward its credentials to
+/// the inference backend. `tools/list` succeeds (returning one
+/// non-read-only tool), but `allowed_tools.read_only = true` removes
+/// it, so the entry resolves to zero permitted tools. The resolved
+/// MCP entry — and its `authorization` — must be stripped from the
+/// body handed downstream.
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "e2e setup plus credential-isolation assertions")]
+async fn zero_permitted_tools_does_not_leak_credentials_to_backend() {
+    let (server_url, ct) = start_single_tool_mcp_server().await;
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str("allow_loopback: true").unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "hi",
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "server_url": server_url,
+            "authorization": "Bearer super-secret-token",
+            "allowed_tools": {"tool_names": ["get_weather"], "read_only": true}
+        }]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    ct.cancel();
+
+    assert!(matches!(action, FilterAction::Continue), "should continue");
+
+    let committed = body.as_ref().expect("body present");
+    let raw = String::from_utf8(committed.to_vec()).unwrap();
+    assert!(
+        !raw.contains("super-secret-token"),
+        "credential leaked to backend request body: {raw}"
+    );
+    assert!(
+        !raw.contains("\"mcp\""),
+        "resolved MCP entry leaked to backend request body: {raw}"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(committed).unwrap();
+    assert_eq!(
+        parsed["tools"],
+        serde_json::json!([]),
+        "all tools filtered out → empty tools array"
     );
 }


### PR DESCRIPTION
## Summary

When an MCP tool entry in an OpenAI Responses request resolves to zero permitted tools, the original `type: "mcp"` entry (including its `authorization`/`headers` credentials) was forwarded to the inference backend, leaking credentials across the isolation boundary. This strips those entries from the `tools` array, and for an `allowed_tools` `tool_choice` that restricts the model to servers which all resolve empty, rejects a `required` choice as unsatisfiable (HTTP 400) and normalizes an `auto`/mode-less choice to `"none"` instead of removing it (removal would broaden access to unrelated tools the client left in the request). The change is confined to the `openai_mcp_tool_resolve` body and `tool_choice` rewrite, plus matching unit and integration tests.

## Related issue

Closes #667

## Validation

- `cargo test -p praxis-ai-apis` — 2553 passed, 2 doctests passed
- `make build` — clean
- `make lint` — clean (clippy feature sets, nightly rustfmt, `cargo machete`, xtask doc/example/inference checks)

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. (N/A: bug fix to an existing filter; no new capability or config surface.)
- [ ] User-facing behavior and generated documentation are updated. (No doc changes required; generated filter docs remain in sync, verified by `make lint`.)
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. (N/A: no hot-path change.)
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

Not a breaking API change. Behavior correction only: a `required` `allowed_tools` choice whose MCP servers all resolve to zero tools now returns a `400 invalid_request_error` instead of forwarding an invalid, credential-bearing request; an equivalent `auto` choice collapses to `tool_choice: "none"`.
