### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-ai-apis"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-ai-build-support"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cargo_metadata",
  "tempfile",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-ai-filters"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2727,7 +2727,7 @@ dependencies = [
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "quixotic-plecostomus-core",
-  "rand 0.10.2",
+ "rand 0.10.2",
  "redis",
  "reqwest",
  "serde",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-ai-llmd-ext-proc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-ai-proxy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "cargo_metadata",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-test-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-tests-environment"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "praxis-ai-proxy",
  "praxis-proxy-core",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-tests-integration"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "praxis-tests-schema"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "praxis-proxy-core",
  "praxis-proxy-filter",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "praxis-ai-apis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Shane Utt <shaneutt@linux.com>"]
@@ -93,13 +93,13 @@ praxis = { version = "0.5.3", package = "praxis-proxy" }
 praxis-test-utils = { path = "tests/utils" }
 
 # AI-owned llm-d ext_proc compatibility layer
-praxis-ai-llmd-ext-proc = { version = "0.2.0", path = "integrations/llmd/ext-proc" }
+praxis-ai-llmd-ext-proc = { version = "0.3.0", path = "integrations/llmd/ext-proc" }
 
 # Praxis AI workspace dependencies
-praxis-ai-proxy = { version = "0.2.0", path = "server" }
-praxis-ai-filters = { version = "0.2.0", path = "filters" }
-praxis-ai-apis = { version = "0.2.0", path = "apis" }
-praxis-ai-build-support = { version = "0.2.0", path = "server/build_support" }
+praxis-ai-proxy = { version = "0.3.0", path = "server" }
+praxis-ai-filters = { version = "0.3.0", path = "filters" }
+praxis-ai-apis = { version = "0.3.0", path = "apis" }
+praxis-ai-build-support = { version = "0.3.0", path = "server/build_support" }
 
 # Pingora (temporary fork)
 pingora-core = { version = "0.8.2", package = "quixotic-plecostomus-core", features = ["rustls"] }


### PR DESCRIPTION
## Summary

Bump the workspace version `0.2.0` → `0.3.0` to prepare the v0.3.0 release.

The release workflow's `validate` job fails unless the pushed tag matches
`Cargo.toml`, so this bump must land on `main` before tagging `v0.3.0`.

## Changes

- `[workspace.package].version`: `0.2.0` → `0.3.0`
- Internal workspace dependency version requirements bumped to `0.3.0`
  (`praxis-ai-proxy`, `praxis-ai-filters`, `praxis-ai-apis`,
  `praxis-ai-build-support`, `praxis-ai-llmd-ext-proc`)
- `Cargo.lock`: all workspace crate versions synced to `0.3.0`
  (regenerated with cargo)

## Verification

- `make lint` passes locally (clippy, nightly rustfmt, dependency, docs,
  and xtask example/inference/link checks)