### PR TITLE
fix(token_count): preserve OpenAI Responses cache writes and parse once

### DIFF
--- a/filters/src/token_usage/count/tests.rs
+++ b/filters/src/token_usage/count/tests.rs
@@ -206,6 +206,18 @@ async fn json_openai_extracts_tokens() {
 }
 
 #[tokio::test]
+async fn json_openai_responses_extracts_tokens() {
+    let json =
+        br#"{"id":"resp_123","object":"response","usage":{"input_tokens":15,"output_tokens":42,"total_tokens":57}}"#;
+
+    let (input, output, total) = run_json_extraction(ProviderKind::OpenAi, json).await;
+
+    assert_eq!(input.as_deref(), Some("15"), "Responses API input tokens");
+    assert_eq!(output.as_deref(), Some("42"), "Responses API output tokens");
+    assert_eq!(total.as_deref(), Some("57"), "Responses API total tokens");
+}
+
+#[tokio::test]
 async fn json_anthropic_extracts_tokens() {
     let json = br#"{"usage":{"input_tokens":15,"output_tokens":42}}"#;
 
@@ -377,6 +389,20 @@ async fn sse_openai_final_usage_event() {
     assert_eq!(input.as_deref(), Some("10"), "OpenAI SSE input tokens");
     assert_eq!(output.as_deref(), Some("20"), "OpenAI SSE output tokens");
     assert_eq!(total.as_deref(), Some("30"), "OpenAI SSE total tokens");
+}
+
+#[tokio::test]
+async fn sse_openai_responses_final_usage_event() {
+    let events = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hi\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":20,\"total_tokens\":30}}}\n\n",
+    );
+
+    let (input, output, total) = run_sse_extraction(ProviderKind::OpenAi, events.as_bytes()).await;
+
+    assert_eq!(input.as_deref(), Some("10"), "Responses API SSE input tokens");
+    assert_eq!(output.as_deref(), Some("20"), "Responses API SSE output tokens");
+    assert_eq!(total.as_deref(), Some("30"), "Responses API SSE total tokens");
 }
 
 #[tokio::test]
@@ -1067,6 +1093,16 @@ async fn json_openai_records_cached_tokens() {
 }
 
 #[tokio::test]
+async fn json_openai_responses_records_cache_breakdown() {
+    let json = br#"{"id":"resp_123","object":"response","usage":{"input_tokens":1000,"output_tokens":50,"input_tokens_details":{"cached_tokens":900,"cache_write_tokens":80}}}"#;
+
+    let (cache_read, cache_write) = run_cache_extraction(ProviderKind::OpenAi, "application/json", json).await;
+
+    assert_eq!(cache_read.as_deref(), Some("900"), "Responses API cache reads");
+    assert_eq!(cache_write.as_deref(), Some("80"), "Responses API cache writes");
+}
+
+#[tokio::test]
 async fn json_google_records_cached_content_tokens() {
     let json =
         br#"{"usageMetadata":{"promptTokenCount":1200,"candidatesTokenCount":40,"cachedContentTokenCount":1100}}"#;
@@ -1163,6 +1199,20 @@ async fn sse_openai_final_usage_records_cached_tokens() {
         cache_write, None,
         "OpenAI has no cache write field, so no cache write metadata is written"
     );
+}
+
+#[tokio::test]
+async fn sse_openai_responses_records_cache_breakdown() {
+    let events = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hi\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1000,\"output_tokens\":20,\"input_tokens_details\":{\"cached_tokens\":900,\"cache_write_tokens\":80}}}}\n\n",
+    );
+
+    let (cache_read, cache_write) =
+        run_cache_extraction(ProviderKind::OpenAi, "text/event-stream", events.as_bytes()).await;
+
+    assert_eq!(cache_read.as_deref(), Some("900"), "Responses API SSE cache reads");
+    assert_eq!(cache_write.as_deref(), Some("80"), "Responses API SSE cache writes");
 }
 
 #[tokio::test]

--- a/filters/src/token_usage/providers.rs
+++ b/filters/src/token_usage/providers.rs
@@ -9,25 +9,39 @@ use super::TokenUsage;
 
 /// Cache write counts are not reported by every provider.
 ///
-/// `OpenAI` and Google expose how much of the prompt was *read* from their cache
-/// but not how much was written to it, so those parsers leave the cache write
-/// count absent rather than claiming a zero the provider never reported.
+/// `OpenAI` Chat Completions and Google expose how much of the prompt was *read*
+/// from their cache but not how much was written to it, so those parsers leave
+/// the cache write count absent rather than claiming a zero the provider never
+/// reported.
 const NO_CACHE_WRITE: Option<u64> = None;
 
 // -----------------------------------------------------------------------------
 // OpenAI / Azure
 // -----------------------------------------------------------------------------
 
-/// `OpenAI` / Azure `OpenAI` response format.
+/// Fields needed from an `OpenAI` / Azure JSON response or SSE payload.
 #[derive(Deserialize)]
-struct OpenAiResponse {
-    /// Token usage statistics.
-    usage: Option<OpenAiUsage>,
+struct OpenAiEnvelope {
+    /// Top-level usage from Chat Completions or a non-streaming Responses API response.
+    usage: Option<OpenAiTopLevelUsage>,
+
+    /// Nested response from a Responses API streaming event.
+    response: Option<ResponsesApiResponse>,
 }
 
-/// `OpenAI` usage object.
+/// Top-level usage formats accepted by the `OpenAI` provider.
 #[derive(Deserialize)]
-struct OpenAiUsage {
+#[serde(untagged)]
+enum OpenAiTopLevelUsage {
+    /// Chat Completions usage.
+    ChatCompletions(ChatCompletionsUsage),
+    /// Non-streaming Responses API usage.
+    Responses(ResponsesApiUsage),
+}
+
+/// `OpenAI` Chat Completions usage object.
+#[derive(Deserialize)]
+struct ChatCompletionsUsage {
     /// Tokens in the prompt.
     prompt_tokens: u64,
 
@@ -53,65 +67,44 @@ struct OpenAiPromptTokensDetails {
 /// Supports both Chat Completions format (`usage.prompt_tokens`) and
 /// Responses API format (`response.usage.input_tokens`). The Responses
 /// API nests usage under a `response` wrapper and uses different field
-/// names. Cached input is already counted in the input total for both
-/// formats, so it is recorded as a breakdown rather than added to it.
+/// names. Cached input is already counted in the input total for both formats,
+/// so cache reads and writes are recorded as breakdowns rather than added to
+/// it.
 pub(super) fn parse_openai(body: &[u8]) -> Option<TokenUsage> {
-    // Chat Completions format (top-level usage).
-    if let Ok(response) = serde_json::from_slice::<OpenAiResponse>(body)
-        && let Some(usage) = response.usage
-    {
-        let cache_read = usage.prompt_tokens_details.and_then(|details| details.cached_tokens);
-        return Some(
-            TokenUsage::new(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens)
-                .with_cache(cache_read, NO_CACHE_WRITE),
-        );
+    let envelope: OpenAiEnvelope = serde_json::from_slice(body).ok()?;
+
+    if let Some(usage) = envelope.usage {
+        return Some(match usage {
+            OpenAiTopLevelUsage::ChatCompletions(usage) => chat_completions_usage(usage),
+            OpenAiTopLevelUsage::Responses(usage) => responses_api_usage(usage),
+        });
     }
 
-    // Responses API streaming (usage nested under response wrapper).
-    if let Ok(wrapper) = serde_json::from_slice::<ResponsesApiEvent>(body)
-        && let Some(inner) = wrapper.response
-        && let Some(usage) = inner.usage
-    {
-        return Some(responses_api_usage(usage));
-    }
-
-    // Responses API non-streaming (top-level usage with input_tokens/output_tokens).
-    if let Ok(resp) = serde_json::from_slice::<ResponsesApiDirectResponse>(body)
-        && let Some(usage) = resp.usage
-    {
-        return Some(responses_api_usage(usage));
-    }
-
-    None
+    envelope.response?.usage.map(responses_api_usage)
 }
 
-/// Converts a Responses API usage object, keeping the cached-input
-/// breakdown out of the totals.
+/// Converts a Chat Completions usage object.
+fn chat_completions_usage(usage: ChatCompletionsUsage) -> TokenUsage {
+    let cache_read = usage.prompt_tokens_details.and_then(|details| details.cached_tokens);
+    TokenUsage::new(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens)
+        .with_cache(cache_read, NO_CACHE_WRITE)
+}
+
+/// Converts a Responses API usage object, keeping cache breakdowns out of the
+/// totals.
 fn responses_api_usage(usage: ResponsesApiUsage) -> TokenUsage {
-    // `input_tokens` already includes any cached tokens, so the cache read
-    // count is recorded as a breakdown of the input rather than added to it.
-    let cache_read = usage.input_tokens_details.and_then(|details| details.cached_tokens);
-    TokenUsage::new(usage.input_tokens, usage.output_tokens, usage.total_tokens).with_cache(cache_read, NO_CACHE_WRITE)
-}
-
-/// Wrapper for OpenAI Responses API `response.completed` SSE events.
-#[derive(Deserialize)]
-struct ResponsesApiEvent {
-    /// The nested response object.
-    response: Option<ResponsesApiResponse>,
+    // `input_tokens` already includes cached reads and writes, so both counts
+    // are recorded as breakdowns of the input rather than added to it.
+    let (cache_read, cache_write) = usage.input_tokens_details.map_or((None, None), |details| {
+        (details.cached_tokens, details.cache_write_tokens)
+    });
+    TokenUsage::new(usage.input_tokens, usage.output_tokens, usage.total_tokens).with_cache(cache_read, cache_write)
 }
 
 /// Inner response object in Responses API events.
 #[derive(Deserialize)]
 struct ResponsesApiResponse {
     /// Token usage statistics.
-    usage: Option<ResponsesApiUsage>,
-}
-
-/// Non-streaming Responses API response with top-level usage.
-#[derive(Deserialize)]
-struct ResponsesApiDirectResponse {
-    /// Token usage (same format as streaming, at top level).
     usage: Option<ResponsesApiUsage>,
 }
 
@@ -133,6 +126,8 @@ struct ResponsesApiUsage {
 struct ResponsesApiInputTokensDetails {
     /// Tokens read from cache, already counted in `input_tokens`.
     cached_tokens: Option<u64>,
+    /// Tokens written to cache, already counted in `input_tokens`.
+    cache_write_tokens: Option<u64>,
 }
 
 // -----------------------------------------------------------------------------
@@ -337,7 +332,7 @@ mod tests {
 
     #[test]
     fn openai_responses_api_cached_tokens() {
-        let json = br#"{"type":"response.completed","response":{"id":"resp_123","usage":{"input_tokens":150,"output_tokens":42,"total_tokens":192,"input_tokens_details":{"cached_tokens":120}}}}"#;
+        let json = br#"{"type":"response.completed","response":{"id":"resp_123","usage":{"input_tokens":150,"output_tokens":42,"total_tokens":192,"input_tokens_details":{"cached_tokens":120,"cache_write_tokens":30}}}}"#;
         let usage = parse_openai(json).unwrap();
         assert_eq!(usage.input_tokens(), 150, "cached input stays part of the input total");
         assert_eq!(usage.output_tokens(), 42);
@@ -347,7 +342,11 @@ mod tests {
             Some(120),
             "cached input should be reported as a cache-read breakdown"
         );
-        assert_eq!(usage.cache_write_tokens(), None, "OpenAI reports no cache-write count");
+        assert_eq!(
+            usage.cache_write_tokens(),
+            Some(30),
+            "cache writes should be reported as a breakdown of Responses API input"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #714 fixing two issues in the newly added OpenAI Responses token-usage parsing. The Responses parser discarded `cache_write_tokens` (always emitting no `token.cache_write` metadata), which could undercount billable cache activity, and it deserialized each payload up to three times, so most SSE events were parsed three times. The parser now reads each payload once into a single envelope with an untagged top-level usage enum—classifying it as Chat Completions, non-streaming Responses, or nested streaming Responses usage—and preserves both Responses cache reads and writes. The OpenAI projection types stay beside the parser because they are intentionally partial, filter-specific wire types, not reusable canonical OpenAI models.

## Related issue

Follow-up to #714, addressing the code-review findings on the newly merged OpenAI Responses token extraction. No separate tracking issue.

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-filters token_usage` (JSON + SSE token totals and both cache-metadata fields, incl. a nonzero cache-write count); full `make test` (17 suites, 0 failures)
- [x] Integration or functional tests — covered by the workspace `make test` run
- [x] `make lint` — clippy, rustfmt, dependency, docs, and example/README-sync checks all pass

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test. — N/A: bug fix to an existing parser, no new capability or config.
- [x] User-facing behavior and generated documentation are updated. — `token.cache_write` is now reported for OpenAI Responses; generated READMEs verified in sync.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence. — Removes two redundant deserializations per payload; behavior covered by tests, no separate benchmark.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. Metering now reports `token.cache_write` for OpenAI Responses where it previously reported nothing; token totals are unchanged.
