### PR TITLE
fix(stream_events): cap tool-call arguments on done and after overflow

### DIFF
--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -184,19 +184,7 @@ fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut
     if filter_state.rejected_tool_call_args.contains(&key) {
         return;
     }
-
-    if payload
-        .get("arguments")
-        .and_then(Value::as_str)
-        .is_some_and(|arguments| arguments.len() > filter_state.max_tool_call_argument_bytes)
-    {
-        warn!(
-            key,
-            limit = filter_state.max_tool_call_argument_bytes,
-            "completed tool-call arguments exceed max_tool_call_argument_bytes, dropping"
-        );
-        filter_state.tool_call_args.remove(&key);
-        filter_state.rejected_tool_call_args.insert(key);
+    if reject_oversized_done(filter_state, &key, payload) {
         return;
     }
 
@@ -208,6 +196,32 @@ fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut
         .or(accumulated)
         .unwrap_or_default();
 
+    finalize_function_call(ctx, &key, payload, &arguments);
+}
+
+/// Reject a completed function call whose `arguments` already exceed the cap.
+///
+/// Returns `true` when the call was rejected and finalization must stop.
+fn reject_oversized_done(filter_state: &mut StreamEventsState, key: &str, payload: &Value) -> bool {
+    let oversized = payload
+        .get("arguments")
+        .and_then(Value::as_str)
+        .is_some_and(|arguments| arguments.len() > filter_state.max_tool_call_argument_bytes);
+    if !oversized {
+        return false;
+    }
+    warn!(
+        key,
+        limit = filter_state.max_tool_call_argument_bytes,
+        "completed tool-call arguments exceed max_tool_call_argument_bytes, dropping"
+    );
+    filter_state.tool_call_args.remove(key);
+    filter_state.rejected_tool_call_args.insert(key.to_owned());
+    true
+}
+
+/// Apply finalized arguments to the matching output item and store the tool call.
+fn finalize_function_call(ctx: &mut HttpFilterContext<'_>, key: &str, payload: &Value, arguments: &str) {
     let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
     let tool_call = {
         let Some(item) = find_output_item_mut(state.output_items_mut(), payload) else {
@@ -218,7 +232,7 @@ fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut
             return;
         };
 
-        let Some(tool_call) = complete_function_call_item(item, &arguments) else {
+        let Some(tool_call) = complete_function_call_item(item, arguments) else {
             warn!(
                 key,
                 "dropping function-call arguments.done for non-function output item"

--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -158,6 +158,9 @@ fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Va
     let Some(delta) = payload.get("delta").and_then(Value::as_str) else {
         return;
     };
+    if filter_state.rejected_tool_call_args.contains(&key) {
+        return;
+    }
 
     let buf = filter_state.tool_call_args.entry(key.clone()).or_default();
     if buf.len().saturating_add(delta.len()) > filter_state.max_tool_call_argument_bytes {
@@ -167,6 +170,7 @@ fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Va
             "accumulated tool-call arguments exceed max_tool_call_argument_bytes, dropping"
         );
         filter_state.tool_call_args.remove(&key);
+        filter_state.rejected_tool_call_args.insert(key);
         return;
     }
     buf.push_str(delta);
@@ -174,11 +178,27 @@ fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Va
 
 /// Finalize a function call from the done event's payload and push to `tool_calls`.
 fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut StreamEventsState, payload: &Value) {
-    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
-
     let Some(key) = tool_call_key(payload) else {
         return;
     };
+    if filter_state.rejected_tool_call_args.contains(&key) {
+        return;
+    }
+
+    if payload
+        .get("arguments")
+        .and_then(Value::as_str)
+        .is_some_and(|arguments| arguments.len() > filter_state.max_tool_call_argument_bytes)
+    {
+        warn!(
+            key,
+            limit = filter_state.max_tool_call_argument_bytes,
+            "completed tool-call arguments exceed max_tool_call_argument_bytes, dropping"
+        );
+        filter_state.tool_call_args.remove(&key);
+        filter_state.rejected_tool_call_args.insert(key);
+        return;
+    }
 
     let accumulated = filter_state.tool_call_args.remove(&key);
     let arguments = payload
@@ -188,6 +208,7 @@ fn handle_function_call_done(ctx: &mut HttpFilterContext<'_>, filter_state: &mut
         .or(accumulated)
         .unwrap_or_default();
 
+    let state = ctx.extensions.get_or_insert_with(ResponsesState::default);
     let tool_call = {
         let Some(item) = find_output_item_mut(state.output_items_mut(), payload) else {
             warn!(

--- a/apis/src/openai/responses/stream_events/config.rs
+++ b/apis/src/openai/responses/stream_events/config.rs
@@ -32,8 +32,9 @@ pub(crate) struct StreamEventsConfig {
     #[serde(default)]
     pub timeout_secs: Option<u64>,
 
-    /// Maximum bytes accumulated per function-call argument string
-    /// from `function_call_arguments.delta` events. Default: 1 MiB.
+    /// Maximum bytes accepted per function-call argument string from
+    /// `function_call_arguments.delta` or `function_call_arguments.done` events.
+    /// Default: 1 MiB.
     #[serde(default)]
     pub max_tool_call_argument_bytes: Option<usize>,
 }

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -60,6 +60,8 @@ pub(super) struct StreamEventsState {
     completion_state: CompletionState,
     /// Accumulated function-call argument deltas, keyed by item id or output index.
     tool_call_args: std::collections::HashMap<String, String>,
+    /// Tool-call keys whose arguments exceeded the configured byte cap.
+    rejected_tool_call_args: std::collections::HashSet<String>,
     /// Cap on accumulated bytes per tool-call argument string.
     max_tool_call_argument_bytes: usize,
 }
@@ -142,6 +144,7 @@ impl HttpFilter for OpenaiStreamEventsFilter {
                 completed_at: None,
                 completion_state: CompletionState::Open,
                 tool_call_args: std::collections::HashMap::new(),
+                rejected_tool_call_args: std::collections::HashSet::new(),
                 max_tool_call_argument_bytes: self.max_tool_call_argument_bytes,
             });
         }

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -434,6 +434,7 @@ fn body_passes_through_unchanged() {
         completed_at: None,
         completion_state: CompletionState::Open,
         tool_call_args: std::collections::HashMap::new(),
+        rejected_tool_call_args: std::collections::HashSet::new(),
         max_tool_call_argument_bytes: 1024 * 1024,
     });
 
@@ -460,6 +461,7 @@ fn parse_error_sets_metadata() {
         completed_at: None,
         completion_state: CompletionState::Open,
         tool_call_args: std::collections::HashMap::new(),
+        rejected_tool_call_args: std::collections::HashSet::new(),
         max_tool_call_argument_bytes: 1024 * 1024,
     });
 
@@ -789,6 +791,106 @@ async fn tool_call_argument_bytes_cap_enforced() {
         !state.tool_call_args.contains_key("item:fc_big"),
         "exceeding max_tool_call_argument_bytes should drop the accumulator entry"
     );
+    assert!(
+        state.rejected_tool_call_args.contains("item:fc_big"),
+        "an overflowing tool call should remain rejected"
+    );
+}
+
+#[tokio::test]
+async fn tool_call_argument_bytes_cap_rejects_restart_after_overflow() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_tool_call_argument_bytes: 20").unwrap();
+    let filter = OpenaiStreamEventsFilter::from_config(&yaml).unwrap();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+    ctx.current_filter_id = Some(0);
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_restart",
+            "call_id": "call_restart",
+            "name": "restart_fn",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut added = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut added, false).unwrap();
+
+    let oversized = json!({"item_id": "fc_restart", "output_index": 0, "delta": "012345678901234567890"});
+    let mut delta = Some(make_sse_chunk("response.function_call_arguments.delta", &oversized));
+    filter.on_response_body(&mut ctx, &mut delta, false).unwrap();
+
+    let restart = json!({"item_id": "fc_restart", "output_index": 0, "delta": "{\"x\":1}"});
+    let mut delta = Some(make_sse_chunk("response.function_call_arguments.delta", &restart));
+    filter.on_response_body(&mut ctx, &mut delta, false).unwrap();
+
+    let done = json!({"item_id": "fc_restart", "output_index": 0});
+    let mut done_body = Some(make_sse_chunk("response.function_call_arguments.done", &done));
+    filter.on_response_body(&mut ctx, &mut done_body, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert!(
+        state.tool_calls.is_empty(),
+        "a rejected tool call should not be finalized"
+    );
+    assert_eq!(state.output_items()[0]["arguments"], "");
+    assert_eq!(state.output_items()[0]["status"], "in_progress");
+}
+
+#[tokio::test]
+async fn tool_call_argument_bytes_cap_rejects_oversized_done_payload() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_tool_call_argument_bytes: 20").unwrap();
+    let filter = OpenaiStreamEventsFilter::from_config(&yaml).unwrap();
+    let req = make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = make_filter_context(Box::leak(Box::new(req)));
+    ctx.set_metadata("openai_responses_format.format", "openai_responses".to_owned());
+    ctx.set_metadata("openai_responses_format.stream", "true".to_owned());
+    ctx.current_filter_id = Some(0);
+    filter.on_request(&mut ctx).await.unwrap();
+
+    let item = json!({
+        "item": {
+            "type": "function_call",
+            "id": "fc_done_big",
+            "call_id": "call_done_big",
+            "name": "done_fn",
+            "arguments": "",
+            "status": "in_progress"
+        },
+        "output_index": 0
+    });
+    let mut added = Some(make_sse_chunk("response.output_item.added", &item));
+    filter.on_response_body(&mut ctx, &mut added, false).unwrap();
+
+    let done = json!({
+        "item_id": "fc_done_big",
+        "output_index": 0,
+        "arguments": "012345678901234567890"
+    });
+    let mut done_body = Some(make_sse_chunk("response.function_call_arguments.done", &done));
+    filter.on_response_body(&mut ctx, &mut done_body, false).unwrap();
+
+    let retry = json!({
+        "item_id": "fc_done_big",
+        "output_index": 0,
+        "arguments": "{\"x\":1}"
+    });
+    let mut retry_body = Some(make_sse_chunk("response.function_call_arguments.done", &retry));
+    filter.on_response_body(&mut ctx, &mut retry_body, false).unwrap();
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert!(
+        state.tool_calls.is_empty(),
+        "an oversized done payload should keep the tool call rejected"
+    );
+    assert_eq!(state.output_items()[0]["arguments"], "");
+    assert_eq!(state.output_items()[0]["status"], "in_progress");
 }
 
 #[tokio::test]

--- a/docs/filters/openai_stream_events.md
+++ b/docs/filters/openai_stream_events.md
@@ -16,7 +16,7 @@ All fields are optional; omitted values fall back to [`SseParserConfig`] default
 | `max_buffer_bytes` | integer | no | Maximum bytes buffered for incomplete SSE lines/data across chunk boundaries. Default: 10 MiB. |
 | `max_events` | integer | no | Maximum number of SSE events before the parser errors. Default: 100,000. |
 | `timeout_secs` | integer | no | Maximum seconds from first chunk to stream completion. Default: 300 (5 minutes). |
-| `max_tool_call_argument_bytes` | integer | no | Maximum bytes accumulated per function-call argument string from `function_call_arguments.delta` events. Default: 1 MiB. |
+| `max_tool_call_argument_bytes` | integer | no | Maximum bytes accepted per function-call argument string from `function_call_arguments.delta` or `function_call_arguments.done` events. Default: 1 MiB. |
 
 ## Example
 


### PR DESCRIPTION
## Summary

The `openai_stream_events` filter capped accumulated function-call arguments from `function_call_arguments.delta` events, but two paths bypassed the limit: an oversized `function_call_arguments.done` payload skipped the cap entirely, and after a rejected delta the accumulator could restart from an empty buffer on later chunks. This change tracks rejected tool-call keys in `StreamEventsState`, validates the `done` payload against the same `max_tool_call_argument_bytes` cap, and permanently ignores further delta/done events for a rejected call — keeping oversized arguments out of the stored response and tool-call state.

## Related issue

Closes #559

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis stream_events` (82 passed), including new `tool_call_argument_bytes_cap_rejects_oversized_done_payload` and `tool_call_argument_bytes_cap_rejects_restart_after_overflow`
- [ ] Integration or functional tests — n/a (filter-state hardening; covered by unit tests above)
- [x] `make lint`
- [x] `make build`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. — n/a (hardening of an existing filter, no new capability)
- [x] User-facing behavior and generated documentation are updated (`docs/filters/openai_stream_events.md`).
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. — n/a
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. The cap already applied to `delta` events (default 1 MiB); this closes the bypasses so the documented limit is enforced consistently.
