### PR TITLE
chore(deps): bump github/codeql-action from 4.37.8 to 4.37.9

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,6 +18,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
+      codeql-action-security:
+        applies-to: security-updates
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: "github-actions"
     directory: ".github/actions/install-nightly-rust"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -56,6 +56,6 @@ jobs:
         run: cargo build --workspace
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: praxis-proxy/conventions/.github/actions/setup-rust@7e1e8d97c2dc820d24b31f9a65b119c4d0e5342c # v0.1.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
 


### PR DESCRIPTION
## Summary

Cherry-picks the Dependabot commits from #865 and #867 onto one branch so `init` and `analyze` stay on the same CodeQL action version (4.37.9 / bundle 2.26.4).

## Related issue

Closes #865
Closes #867

## Validation

- [ ] CodeQL workflow passes on this PR

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. — N/A
- [ ] User-facing behavior and generated documentation are updated. — N/A
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. — N/A
- [x] Commits are signed and include a `Signed-off-by` trailer. (preserved from Dependabot cherry-picks)

## Breaking changes

None.