### PR TITLE
refactor(conversations): drive on_request dispatch from request-body metadata

### DIFF
--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -264,6 +264,83 @@ impl OpenaiConversationsFilter {
         }
     }
 
+    /// Arm request-body buffering for a body-carrying operation and, when an
+    /// earlier filter has already pre-read the body, dispatch it immediately.
+    async fn begin_body_operation(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        route: &MatchedConversationRoute<'_>,
+    ) -> Result<FilterAction, FilterError> {
+        ctx.set_request_body_mode(BodyMode::StreamBuffer {
+            max_bytes: Some(MAX_JSON_BODY_BYTES),
+        });
+        let Some(body) = Self::mark_request_filters_ran(ctx) else {
+            return Ok(FilterAction::Continue);
+        };
+        let Some(store) = self.get_or_init_store().await else {
+            return Ok(FilterAction::Reject(reject_store_unavailable()));
+        };
+        Box::pin(Self::handle_post_route(ctx, store.as_ref(), route, &body)).await
+    }
+
+    /// Dispatch a bodyless conversation operation to its local handler.
+    #[expect(clippy::too_many_lines, reason = "one arm per bodyless endpoint")]
+    async fn dispatch_read_operation(
+        &self,
+        ctx: &HttpFilterContext<'_>,
+        route: &MatchedConversationRoute<'_>,
+    ) -> Result<FilterAction, FilterError> {
+        match route.spec.operation {
+            ConversationOperation::GetConversation => {
+                let id = route
+                    .conversation_id()
+                    .ok_or_else(|| FilterError::from("openai_conversations: matched get route missing id"))?;
+                let store = self.require_store().await?;
+                handlers::handle_get_conversation(ctx, store.as_ref(), id).await
+            },
+            ConversationOperation::ListConversationItems => {
+                let id = route
+                    .conversation_id()
+                    .ok_or_else(|| FilterError::from("openai_conversations: matched list route missing id"))?;
+                let store = self.require_store().await?;
+                handlers::handle_list_items(ctx, store.as_ref(), id).await
+            },
+            ConversationOperation::GetConversationItem => {
+                let id = route
+                    .conversation_id()
+                    .ok_or_else(|| FilterError::from("openai_conversations: matched get item route missing id"))?;
+                let item_id = route
+                    .item_id()
+                    .ok_or_else(|| FilterError::from("openai_conversations: matched get item route missing item id"))?;
+                let store = self.require_store().await?;
+                handlers::handle_get_item(ctx, store.as_ref(), id, item_id).await
+            },
+            ConversationOperation::DeleteConversation => {
+                let id = route
+                    .conversation_id()
+                    .ok_or_else(|| FilterError::from("openai_conversations: matched delete route missing id"))?;
+                let store = self.require_store().await?;
+                handlers::handle_delete_conversation(ctx, store.as_ref(), id).await
+            },
+            ConversationOperation::DeleteConversationItem => {
+                let id = route
+                    .conversation_id()
+                    .ok_or_else(|| FilterError::from("openai_conversations: matched delete item route missing id"))?;
+                let item_id = route.item_id().ok_or_else(|| {
+                    FilterError::from("openai_conversations: matched delete item route missing item id")
+                })?;
+                let store = self.require_store().await?;
+                handlers::handle_delete_item(ctx, store.as_ref(), id, item_id).await
+            },
+            ConversationOperation::CreateConversation
+            | ConversationOperation::UpdateConversation
+            | ConversationOperation::CreateConversationItems => Err(FilterError::from(format!(
+                "openai_conversations: dispatch_read_operation called for body operation {:?}",
+                route.spec.operation
+            ))),
+        }
+    }
+
     /// Persist conversation items synchronously using `block_in_place`.
     fn append_items_blocking(
         &self,
@@ -317,7 +394,6 @@ impl HttpFilter for OpenaiConversationsFilter {
         true
     }
 
-    #[expect(clippy::too_many_lines, reason = "dispatcher with one arm per endpoint")]
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
         let Some(route) = routes::match_route(ctx.request.method.as_str(), ctx.request.uri.path()) else {
             if should_append_back(ctx) {
@@ -326,64 +402,14 @@ impl HttpFilter for OpenaiConversationsFilter {
             return Ok(FilterAction::Continue);
         };
 
-        match route.spec.operation {
-            ConversationOperation::GetConversation => {
-                let id = route
-                    .conversation_id()
-                    .ok_or_else(|| FilterError::from("openai_conversations: matched get route missing id"))?;
-                let store = self.require_store().await?;
-                handlers::handle_get_conversation(ctx, store.as_ref(), id).await
-            },
-            ConversationOperation::ListConversationItems => {
-                let id = route
-                    .conversation_id()
-                    .ok_or_else(|| FilterError::from("openai_conversations: matched list route missing id"))?;
-                let store = self.require_store().await?;
-                handlers::handle_list_items(ctx, store.as_ref(), id).await
-            },
-            ConversationOperation::GetConversationItem => {
-                let id = route
-                    .conversation_id()
-                    .ok_or_else(|| FilterError::from("openai_conversations: matched get item route missing id"))?;
-                let item_id = route
-                    .item_id()
-                    .ok_or_else(|| FilterError::from("openai_conversations: matched get item route missing item id"))?;
-                let store = self.require_store().await?;
-                handlers::handle_get_item(ctx, store.as_ref(), id, item_id).await
-            },
-            ConversationOperation::DeleteConversation => {
-                let id = route
-                    .conversation_id()
-                    .ok_or_else(|| FilterError::from("openai_conversations: matched delete route missing id"))?;
-                let store = self.require_store().await?;
-                handlers::handle_delete_conversation(ctx, store.as_ref(), id).await
-            },
-            ConversationOperation::DeleteConversationItem => {
-                let id = route
-                    .conversation_id()
-                    .ok_or_else(|| FilterError::from("openai_conversations: matched delete item route missing id"))?;
-                let item_id = route.item_id().ok_or_else(|| {
-                    FilterError::from("openai_conversations: matched delete item route missing item id")
-                })?;
-                let store = self.require_store().await?;
-                handlers::handle_delete_item(ctx, store.as_ref(), id, item_id).await
-            },
-            ConversationOperation::CreateConversation
-            | ConversationOperation::UpdateConversation
-            | ConversationOperation::CreateConversationItems => {
-                ctx.set_request_body_mode(BodyMode::StreamBuffer {
-                    max_bytes: Some(MAX_JSON_BODY_BYTES),
-                });
-                let deferred_body = Self::mark_request_filters_ran(ctx);
-                let Some(body) = deferred_body else {
-                    return Ok(FilterAction::Continue);
-                };
-                let Some(store) = self.get_or_init_store().await else {
-                    return Ok(FilterAction::Reject(reject_store_unavailable()));
-                };
-                Box::pin(Self::handle_post_route(ctx, store.as_ref(), &route, &body)).await
-            },
+        // The shared operation registry is the single source of truth for
+        // whether this operation carries a request body: body-carrying
+        // operations arm buffering, everything else dispatches from the head.
+        // Both dispatch paths are boxed so this hook's own frame stays small.
+        if route.spec.has_request_body() {
+            return Box::pin(self.begin_body_operation(ctx, &route)).await;
         }
+        Box::pin(self.dispatch_read_operation(ctx, &route)).await
     }
 
     async fn on_request_body(


### PR DESCRIPTION
## Summary

Branch the Conversations `on_request` hook on the shared operation registry's `has_request_body()` metadata instead of enumerating the body-carrying operations (`Create`/`Update`/`CreateItems`) inline, so the registry is the single source of truth for request-body handling. Header-phase dispatch is split into two boxed helpers — `begin_body_operation` (arms `StreamBuffer` buffering, then dispatches a pre-read body) and `dispatch_read_operation` (the bodyless read handlers) — so `on_request` keeps a small stack frame. This is the increment of #742 unblocked today on top of the shared `match_operation` delegation landed by #772; full consumption of an `openai_operation` classifier (the issue headline) still depends on #744, which has not landed.

## Related issue

<!-- Contributors must be assigned to the issue before opening a PR. -->

Refs #742 (partial — headline blocked on #744)

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis` (2586 passed, 0 failed, 27 ignored; +2 doctests)
- [ ] Integration or functional tests — N/A: behavior-preserving refactor, no new capability; covered by the existing crate suite
- [x] `make lint` — passes (clippy, nightly fmt, deps, docs, example checks)

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. — N/A (internal refactor, no new capability)
- [ ] User-facing behavior and generated documentation are updated. — N/A (no user-facing or documented behavior change)
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. — N/A: neutral-to-positive; shrinks `on_request`'s stack frame (previously tripped the `large_stack_frames = deny` clippy gate) via boxed dispatch
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. The change is behavior-preserving: the same operations arm body buffering and the same read operations dispatch from the header phase; only the decision source (registry metadata vs. an inline operation list) changed.
