### PR TITLE
fix(compact): validate compact_threshold is at least 1000 (#838)

### DIFF
--- a/apis/src/openai/responses/compact/mod.rs
+++ b/apis/src/openai/responses/compact/mod.rs
@@ -58,6 +58,9 @@ use crate::{
 /// Maximum response body size for summarization callouts (1 MiB).
 const MAX_SUMMARIZATION_RESPONSE_BYTES: usize = 1_048_576;
 
+/// Minimum allowed `compact_threshold` for compaction (1,000 tokens).
+const MIN_COMPACT_THRESHOLD: u64 = 1_000; // 1,000 tokens
+
 /// System prompt for the summarization call.
 const SUMMARIZATION_SYSTEM_PROMPT: &str = "\
 Summarize the following conversation concisely. \
@@ -71,6 +74,7 @@ capture everything needed to continue coherently.";
 // -----------------------------------------------------------------------------
 
 /// Parsed compaction parameters from the request's `context_management`.
+#[derive(Debug, Eq, PartialEq)]
 struct CompactionParams {
     /// Token threshold above which compaction triggers.
     compact_threshold: u64,
@@ -85,9 +89,9 @@ struct CompactionParams {
 /// Summarizes conversation history when the token count exceeds a
 /// configured threshold.
 ///
-/// `compact_threshold` in `context_management` must be an integer.
-/// Floating-point values (e.g. `0.9`) are ignored and compaction
-/// is skipped.
+/// `compact_threshold` in `context_management` must be an integer
+/// of at least 1000. Invalid or missing `compact_threshold` values
+/// produce an `invalid_request_error`.
 ///
 /// Compaction only applies to multi-turn requests where
 /// `openai_responses_rehydrate` has loaded stored conversation
@@ -216,6 +220,36 @@ impl CompactFilter {
             ))),
         }
     }
+
+    /// Execute compaction callout and update `ResponsesState` with summary.
+    async fn run_compaction_callout(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        params: &CompactionParams,
+        streaming: bool,
+        conversation_text: &str,
+    ) -> Result<FilterAction, FilterError> {
+        let summary = {
+            let Some(state) = ctx.extensions.get::<ResponsesState>() else {
+                return Ok(FilterAction::Release);
+            };
+            match self
+                .execute_compaction(state, params, streaming, conversation_text)
+                .await
+            {
+                Ok(Some(s)) => s,
+                Ok(None) | Err(FilterAction::Release) => return Ok(FilterAction::Release),
+                Err(action) => return Ok(action),
+            }
+        };
+        let Some(state) = ctx.extensions.get_mut::<ResponsesState>() else {
+            return Ok(FilterAction::Release);
+        };
+        let compaction_id = format!("compact_{}", ctx.id_generator.generate(ctx.time_source));
+        replace_messages(state, build_compaction_item(&compaction_id, &summary));
+        ctx.set_metadata("responses.compacted", "true");
+        Ok(FilterAction::Release)
+    }
 }
 
 #[async_trait]
@@ -251,46 +285,60 @@ impl HttpFilter for CompactFilter {
             return Ok(FilterAction::Release);
         }
         let streaming = is_streaming(ctx);
-        let Some(state) = ctx.extensions.get::<ResponsesState>() else {
-            return Ok(FilterAction::Release);
-        };
-        if !state.history_rehydrated {
-            return Ok(FilterAction::Release);
-        }
-        let Some((params, conversation_text)) = should_compact(state, &self.config.tiktoken_encoding) else {
-            return Ok(FilterAction::Release);
-        };
-        let compaction = self.execute_compaction(state, &params, streaming, &conversation_text);
-        let summary = match compaction.await {
-            Ok(Some(s)) => s,
-            Ok(None) | Err(FilterAction::Release) => return Ok(FilterAction::Release),
-            Err(action) => return Ok(action),
-        };
-        let Some(state) = ctx.extensions.get_mut::<ResponsesState>() else {
-            return Ok(FilterAction::Release);
-        };
-        let compaction_id = format!("compact_{}", ctx.id_generator.generate(ctx.time_source));
-        replace_messages(state, build_compaction_item(&compaction_id, &summary));
-        ctx.set_metadata("responses.compacted", "true");
-        Ok(FilterAction::Release)
+        let (params, conversation_text) =
+            match prepare_compaction_params(ctx, &self.config.tiktoken_encoding, streaming) {
+                Ok(Some(pair)) => pair,
+                Ok(None) => return Ok(FilterAction::Release),
+                Err(action) => return Ok(action),
+            };
+
+        self.run_compaction_callout(ctx, &params, streaming, &conversation_text)
+            .await
     }
+}
+
+/// Extract compaction parameters and build conversation text if threshold is exceeded.
+fn prepare_compaction_params(
+    ctx: &HttpFilterContext<'_>,
+    tiktoken_encoding: &str,
+    streaming: bool,
+) -> Result<Option<(CompactionParams, String)>, FilterAction> {
+    let Some(state) = ctx.extensions.get::<ResponsesState>() else {
+        return Ok(None);
+    };
+
+    let params = match extract_compaction_config(&state.context_management) {
+        Ok(Some(p)) => p,
+        Ok(None) => return Ok(None),
+        Err(msg) => {
+            let rej = responses_error_rejection(400, "invalid_request_error", &msg, streaming);
+            return Err(FilterAction::Reject(rej));
+        },
+    };
+
+    if !state.history_rehydrated {
+        return Ok(None);
+    }
+
+    let Some(text) = should_compact(state, &params, tiktoken_encoding) else {
+        return Ok(None);
+    };
+
+    Ok(Some((params, text)))
 }
 
 // -----------------------------------------------------------------------------
 // Compaction Logic
 // -----------------------------------------------------------------------------
 
-/// Check whether compaction should run and return the params + text.
+/// Check whether compaction should run and return the conversation text.
 ///
-/// Returns `None` if there is no compaction config, the encoding is
-/// unknown, or the token count is below the threshold.
+/// Returns `None` if the encoding is unknown or the token count is below the threshold.
 ///
 /// The token estimate includes instructions and tool definitions in
 /// addition to conversation messages, since all three contribute to
 /// the rendered context sent to the model.
-fn should_compact(state: &ResponsesState, tiktoken_encoding: &str) -> Option<(CompactionParams, String)> {
-    let params = extract_compaction_config(&state.context_management)?;
-
+fn should_compact(state: &ResponsesState, params: &CompactionParams, tiktoken_encoding: &str) -> Option<String> {
     let conversation_text = build_conversation_text(&state.messages);
     let message_tokens = get_token_count(&conversation_text, tiktoken_encoding)?;
 
@@ -319,7 +367,7 @@ fn should_compact(state: &ResponsesState, tiktoken_encoding: &str) -> Option<(Co
         threshold = params.compact_threshold,
         "threshold exceeded, compacting"
     );
-    Some((params, conversation_text))
+    Some(conversation_text)
 }
 
 /// Build the text for instructions and tool definitions that live
@@ -349,39 +397,49 @@ fn is_streaming(ctx: &HttpFilterContext<'_>) -> bool {
         .is_some_and(|v| v == "true")
 }
 
+/// Parse fields from a compaction entry in `context_management`.
+fn parse_compaction_entry(entry: &Value) -> Result<CompactionParams, String> {
+    let err_msg = || "compact_threshold must be an integer of at least 1000".to_owned();
+    let raw_threshold = entry.get("compact_threshold").ok_or_else(err_msg)?;
+    let compact_threshold = raw_threshold.as_u64().ok_or_else(err_msg)?;
+    if compact_threshold < MIN_COMPACT_THRESHOLD {
+        return Err(err_msg());
+    }
+    let compaction_model = match entry.get("compaction_model") {
+        Some(m) => Some(
+            m.as_str()
+                .ok_or_else(|| "compaction_model must be a string".to_owned())?
+                .to_owned(),
+        ),
+        None => None,
+    };
+    Ok(CompactionParams {
+        compact_threshold,
+        compaction_model,
+    })
+}
+
 /// Parse the `context_management` JSON to find a compaction config.
 ///
 /// The `context_management` field is an array like:
 /// `[{"type": "compaction", "compact_threshold": 50000}]`
 ///
-/// Returns `None` if no compaction entry is found.
-fn extract_compaction_config(context_management: &Option<Value>) -> Option<CompactionParams> {
-    let array = context_management.as_ref()?.as_array()?;
+/// Returns:
+/// - `Ok(None)` if no compaction entry is present.
+/// - `Ok(Some(params))` if a valid compaction entry is present.
+/// - `Err(msg)` if a compaction entry is present but has an invalid `compact_threshold` or `compaction_model`.
+fn extract_compaction_config(context_management: &Option<Value>) -> Result<Option<CompactionParams>, String> {
+    let Some(array) = context_management.as_ref().and_then(Value::as_array) else {
+        return Ok(None);
+    };
 
     for entry in array {
-        let Some(entry_type) = entry.get("type").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        if entry_type != "compaction" {
-            continue;
+        if entry.get("type").and_then(Value::as_str) == Some("compaction") {
+            return parse_compaction_entry(entry).map(Some);
         }
-        let Some(raw_threshold) = entry.get("compact_threshold") else {
-            continue;
-        };
-        let Some(compact_threshold) = raw_threshold.as_u64() else {
-            warn!(value = %raw_threshold, "compact_threshold is not a valid integer, skipping compaction");
-            continue;
-        };
-        let compaction_model = entry
-            .get("compaction_model")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
-        return Some(CompactionParams {
-            compact_threshold,
-            compaction_model,
-        });
     }
-    None
+
+    Ok(None)
 }
 
 /// Resolve the tiktoken singleton for the given encoding name.

--- a/apis/src/openai/responses/compact/tests.rs
+++ b/apis/src/openai/responses/compact/tests.rs
@@ -87,9 +87,7 @@ fn build_config_custom_values() {
 #[test]
 fn extract_compaction_config_with_compaction_entry() {
     let cm = Some(json!([{"type": "compaction", "compact_threshold": 50_000}]));
-    let params = extract_compaction_config(&cm);
-    assert!(params.is_some());
-    let params = params.unwrap();
+    let params = extract_compaction_config(&cm).unwrap().unwrap();
     assert_eq!(params.compact_threshold, 50_000);
     assert!(params.compaction_model.is_none());
 }
@@ -101,7 +99,7 @@ fn extract_compaction_config_with_model_override() {
         "compact_threshold": 100_000,
         "compaction_model": "gpt-4o"
     }]));
-    let params = extract_compaction_config(&cm).unwrap();
+    let params = extract_compaction_config(&cm).unwrap().unwrap();
     assert_eq!(params.compact_threshold, 100_000);
     assert_eq!(params.compaction_model.as_deref(), Some("gpt-4o"));
 }
@@ -109,43 +107,60 @@ fn extract_compaction_config_with_model_override() {
 #[test]
 fn extract_compaction_config_no_compaction_entry() {
     let cm = Some(json!([{"type": "truncation", "max_tokens": 4096}]));
-    assert!(extract_compaction_config(&cm).is_none());
+    assert!(extract_compaction_config(&cm).unwrap().is_none());
 }
 
 #[test]
 fn extract_compaction_config_none() {
-    assert!(extract_compaction_config(&None).is_none());
+    assert!(extract_compaction_config(&None).unwrap().is_none());
 }
 
 #[test]
 fn extract_compaction_config_empty_array() {
     let cm = Some(json!([]));
-    assert!(extract_compaction_config(&cm).is_none());
+    assert!(extract_compaction_config(&cm).unwrap().is_none());
 }
 
 #[test]
-fn extract_compaction_config_missing_threshold_skips_compaction() {
+fn extract_compaction_config_missing_threshold_returns_error() {
     let cm = Some(json!([{"type": "compaction"}]));
-    assert!(
-        extract_compaction_config(&cm).is_none(),
-        "missing threshold should skip compaction"
-    );
+    let err = extract_compaction_config(&cm).unwrap_err();
+    assert!(err.contains("compact_threshold"));
 }
 
 #[test]
-fn extract_compaction_config_null_threshold_skips_compaction() {
+fn extract_compaction_config_null_threshold_returns_error() {
     let cm = Some(json!([{"type": "compaction", "compact_threshold": null}]));
-    assert!(
-        extract_compaction_config(&cm).is_none(),
-        "null threshold should skip compaction"
-    );
+    let err = extract_compaction_config(&cm).unwrap_err();
+    assert!(err.contains("compact_threshold"));
 }
 
 #[test]
-fn extract_compaction_config_zero_threshold_compacts_immediately() {
-    let cm = Some(json!([{"type": "compaction", "compact_threshold": 0}]));
-    let params = extract_compaction_config(&cm).unwrap();
-    assert_eq!(params.compact_threshold, 0, "explicit zero should still compact");
+fn extract_compaction_config_float_threshold_returns_error() {
+    let cm = Some(json!([{"type": "compaction", "compact_threshold": 0.9}]));
+    let err = extract_compaction_config(&cm).unwrap_err();
+    assert!(err.contains("compact_threshold"));
+}
+
+#[test]
+fn extract_compaction_config_string_threshold_returns_error() {
+    let cm = Some(json!([{"type": "compaction", "compact_threshold": "1000"}]));
+    let err = extract_compaction_config(&cm).unwrap_err();
+    assert!(err.contains("compact_threshold"));
+}
+
+#[test]
+fn extract_compaction_config_threshold_below_minimum_returns_error() {
+    let cm = Some(json!([{"type": "compaction", "compact_threshold": 999}]));
+    let err = extract_compaction_config(&cm).unwrap_err();
+    assert!(err.contains("at least 1000"));
+}
+
+#[test]
+fn extract_compaction_config_minimum_threshold_succeeds() {
+    let cm = Some(json!([{"type": "compaction", "compact_threshold": 1000}]));
+    let params = extract_compaction_config(&cm).unwrap().unwrap();
+    assert_eq!(params.compact_threshold, 1000);
 }
 
 // =============================================================================
@@ -582,15 +597,16 @@ fn overhead_tokens_count_with_get_token_count() {
 
 #[test]
 fn should_compact_accounts_for_overhead() {
-    let long_instructions = "x".repeat(5000);
+    let long_instructions = "word ".repeat(1500);
     let mut state = ResponsesState::from_request_body(json!({
         "model": "gpt-4o",
         "input": "Hello",
         "instructions": long_instructions,
-        "context_management": [{"type": "compaction", "compact_threshold": 50}]
+        "context_management": [{"type": "compaction", "compact_threshold": 1000}]
     }));
     state.messages = vec![json!({"role": "user", "content": "Hi"})];
-    let result = should_compact(&state, "cl100k_base");
+    let params = extract_compaction_config(&state.context_management).unwrap().unwrap();
+    let result = should_compact(&state, &params, "cl100k_base");
     assert!(
         result.is_some(),
         "overhead from long instructions should push total above threshold"

--- a/docs/filters/openai_responses_compact.md
+++ b/docs/filters/openai_responses_compact.md
@@ -7,7 +7,7 @@ Summarizes conversation history when the token count exceeds a configured thresh
 
 ## Configuration Notes
 
-`compact_threshold` in `context_management` must be an integer. Floating-point values (e.g. `0.9`) are ignored and compaction is skipped.
+`compact_threshold` in `context_management` must be an integer of at least 1000. Invalid or missing `compact_threshold` values produce an `invalid_request_error`.
 
 Compaction only applies to multi-turn requests where `openai_responses_rehydrate` has loaded stored conversation history. Single-turn requests are released without compaction.
 

--- a/examples/configs/openai/responses/compact.yaml
+++ b/examples/configs/openai/responses/compact.yaml
@@ -15,10 +15,10 @@
 #     -d '{"model":"llama3.2:1b","input":"Explain TCP vs UDP in detail"}' \
 #     | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
 #
-#   # Step 2 — follow up with compaction (threshold=200 tokens)
+#   # Step 2 — follow up with compaction (threshold=1000 tokens)
 #   curl -s -X POST http://localhost:8080/v1/responses \
 #     -H "Content-Type: application/json" \
-#     -d "{\"model\":\"llama3.2:1b\",\"input\":\"Compare with QUIC\",\"previous_response_id\":\"$RESP_ID\",\"context_management\":[{\"type\":\"compaction\",\"compact_threshold\":200}],\"store\":false}"
+#     -d "{\"model\":\"llama3.2:1b\",\"input\":\"Compare with QUIC\",\"previous_response_id\":\"$RESP_ID\",\"context_management\":[{\"type\":\"compaction\",\"compact_threshold\":1000}],\"store\":false}"
 
 listeners:
   - name: ai-gateway

--- a/tests/integration/tests/suite/examples/compact.rs
+++ b/tests/integration/tests/suite/examples/compact.rs
@@ -24,8 +24,8 @@ use praxis_test_utils::{
 // -----------------------------------------------------------------------------
 
 /// Backend response for the first turn — stored by response_store.
-/// The output text is long enough to exceed a low compact_threshold.
-const FIRST_RESPONSE_JSON: &str = r#"{"id":"resp_compact","created_at":1000,"model":"gpt-4.1","object":"response","status":"completed","input":"Explain TCP vs UDP","output":[{"type":"message","content":[{"type":"output_text","text":"TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability."}]}]}"#;
+/// The output text is long enough to exceed a 1000 token compact_threshold.
+const FIRST_RESPONSE_JSON: &str = r#"{"id":"resp_compact","created_at":1000,"model":"gpt-4.1","object":"response","status":"completed","input":"Explain TCP vs UDP","output":[{"type":"message","content":[{"type":"output_text","text":"TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability. TCP is a connection-oriented protocol that provides reliable, ordered delivery of data. It establishes a connection through a three-way handshake before transmitting data. UDP is a connectionless protocol that sends data without establishing a connection first. TCP guarantees delivery through acknowledgments and retransmissions while UDP does not. TCP is used for applications requiring reliability like web browsing and email while UDP is used for real-time applications like video streaming and gaming where speed matters more than reliability."}]}]}"#;
 
 /// Chat Completions response used for the summarization callout.
 const CHAT_COMPLETIONS_RESPONSE: &str = r#"{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Summary of the conversation."},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":10,"total_tokens":60}}"#;
@@ -185,7 +185,7 @@ async fn compact_multi_turn_compaction() {
         proxy2.addr(),
         &json_post(
             "/v1/responses",
-            r#"{"model":"gpt-4.1","input":"Compare with QUIC","previous_response_id":"resp_compact","context_management":[{"type":"compaction","compact_threshold":50}]}"#,
+            r#"{"model":"gpt-4.1","input":"Compare with QUIC","previous_response_id":"resp_compact","context_management":[{"type":"compaction","compact_threshold":1000}]}"#,
         ),
     );
     let status2 = parse_status(&raw2);
@@ -230,7 +230,7 @@ async fn compact_verifies_summarization_call_and_compacted_state() {
         proxy2.addr(),
         &json_post(
             "/v1/responses",
-            r#"{"model":"gpt-4.1","input":"Compare with QUIC","previous_response_id":"resp_compact","context_management":[{"type":"compaction","compact_threshold":50}]}"#,
+            r#"{"model":"gpt-4.1","input":"Compare with QUIC","previous_response_id":"resp_compact","context_management":[{"type":"compaction","compact_threshold":1000}]}"#,
         ),
     );
     assert_eq!(parse_status(&raw2), 200, "second request should succeed");
@@ -273,5 +273,36 @@ async fn compact_verifies_summarization_call_and_compacted_state() {
     assert!(
         second.contains("Compare with QUIC"),
         "second item should be the current user input"
+    );
+}
+
+#[test]
+fn compact_rejects_invalid_compact_threshold() {
+    let backend_guard = Backend::fixed(FIRST_RESPONSE_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("openai/responses/compact.yaml"))
+        .expect("example config should exist");
+    let config = load_compact_config(&yaml, "sqlite::memory:", proxy_port, backend_guard.port());
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/responses",
+            r#"{"model":"gpt-4.1","input":"Compare with QUIC","context_management":[{"type":"compaction","compact_threshold":50}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 400, "threshold below 1000 should return 400");
+    assert!(
+        raw.contains("invalid_request_error"),
+        "response should be invalid_request_error: {raw}"
+    );
+    assert!(
+        raw.contains("at least 1000"),
+        "response should explain threshold requirement: {raw}"
     );
 }


### PR DESCRIPTION
## Summary

Validate `compact_threshold` as at least 1000 when parsing the compaction entry in `context_management`. Invalid or missing proxy-consumed values produce an `invalid_request_error` rather than silently skipping or executing compaction.

## Related issue

Closes https://github.com/praxis-proxy/ai/issues/838

## Validation

- [x] Unit tests (`cargo test -p praxis-ai-apis -- compact`)
- [x] Integration or functional tests (`cargo test -p praxis-tests-integration -- compact`)
- [x] `make lint`

### Verification Proof

To test the rejection for an invalid threshold (< 1000), send a value below 1000 (e.g. 50):

```bash
curl -i -X POST http://localhost:8080/v1/responses \
  -H "Content-Type: application/json" \
  -d '{"model":"llama3.2:1b","input":"Hello","context_management":[{"type":"compaction","compact_threshold":50}]}'
```

The proxy will intercept it and return HTTP 400 Bad Request directly:

```json
HTTP/1.1 400 Bad Request
Content-Type: application/json

{"error":{"code":"invalid_request_error","message":"compact_threshold must be an integer of at least 1000","param":null,"type":"invalid_request_error"}}
```

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.