### PR TITLE
fix(callouts): restrict status_on_error to HTTP error statuses

### DIFF
--- a/apis/src/callout_policy.rs
+++ b/apis/src/callout_policy.rs
@@ -95,16 +95,16 @@ pub fn validate_timeout_ms(filter: &str, raw: Option<u64>, default: u64) -> Resu
 }
 
 /// Validate `status_on_error`, applying a default and rejecting
-/// values outside the HTTP status range.
+/// values that are not HTTP error status codes (`400..=599`).
 ///
 /// # Errors
 ///
 /// Returns [`FilterError`] when the resolved value is not in
-/// `100..=599`.
+/// `400..=599`.
 pub fn validate_status_on_error(filter: &str, raw: Option<u16>, default: u16) -> Result<u16, FilterError> {
     let value = raw.unwrap_or(default);
-    if !(100..=599).contains(&value) {
-        return Err(format!("{filter}: status_on_error must be between 100 and 599, got {value}").into());
+    if !(400..=599).contains(&value) {
+        return Err(format!("{filter}: status_on_error must be between 400 and 599, got {value}").into());
     }
     Ok(value)
 }
@@ -157,7 +157,7 @@ mod tests {
     fn status_below_range_rejected() {
         let err = validate_status_on_error("test", Some(99), 502).unwrap_err();
         assert!(
-            err.to_string().contains("between 100 and 599"),
+            err.to_string().contains("between 400 and 599"),
             "below range should be rejected, got: {err}"
         );
     }
@@ -166,14 +166,25 @@ mod tests {
     fn status_above_range_rejected() {
         let err = validate_status_on_error("test", Some(600), 502).unwrap_err();
         assert!(
-            err.to_string().contains("between 100 and 599"),
+            err.to_string().contains("between 400 and 599"),
             "above range should be rejected, got: {err}"
         );
     }
 
     #[test]
+    fn status_non_error_classes_rejected() {
+        for status in [100, 101, 200, 204, 301, 399] {
+            let err = validate_status_on_error("test", Some(status), 502).unwrap_err();
+            assert!(
+                err.to_string().contains("between 400 and 599"),
+                "non-error status {status} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn status_boundaries_accepted() {
-        validate_status_on_error("test", Some(100), 502).expect("100 should be accepted");
+        validate_status_on_error("test", Some(400), 502).expect("400 should be accepted");
         validate_status_on_error("test", Some(599), 502).expect("599 should be accepted");
     }
 

--- a/apis/src/openai/responses/compact/config.rs
+++ b/apis/src/openai/responses/compact/config.rs
@@ -53,7 +53,7 @@ pub(super) struct CompactFilterConfig {
     #[serde(default)]
     pub on_failure: Option<OnFailure>,
 
-    /// HTTP status code to return when rejecting on error.
+    /// HTTP error status code (`400..=599`) to return when rejecting on error.
     #[serde(default)]
     pub status_on_error: Option<u16>,
 }

--- a/docs/filters/http_callout.md
+++ b/docs/filters/http_callout.md
@@ -33,7 +33,7 @@ Makes an outbound HTTP request during request processing, optionally forwarding 
 | `response.extract[].result_key` | string | yes | Key to write the result under in [`FilterResultSet`]. |
 | `response.inject_headers` | string[] | no | Callout response headers to inject into the upstream request on success. |
 | `on_failure` | `closed` \| `open` | no | Behavior when the callout itself fails (DNS, connect, timeout, I/O): `open` continues the request, `closed` rejects it. Note: this is distinct from the pipeline entry's own `failure_mode` key, which governs how the pipeline reacts when a filter returns an error. Core strips `failure_mode` as a structural key before this config is parsed, so it cannot be used as an alias here. |
-| `status_on_error` | integer | no | HTTP status code returned when rejecting on failure. |
+| `status_on_error` | integer | no | HTTP error status code (`400..=599`) to return when rejecting on error. |
 | `circuit_breaker` | CircuitBreakerConfig | no | Circuit breaker configuration. |
 | `circuit_breaker.failure_threshold` | integer | yes | Consecutive failures to trip the breaker. |
 | `circuit_breaker.recovery_timeout` | Duration | yes | Recovery window (e.g. `"30s"`). |

--- a/docs/filters/openai_responses_compact.md
+++ b/docs/filters/openai_responses_compact.md
@@ -23,7 +23,7 @@ Praxis runs `StreamBuffer` body hooks before header-phase request filters. This 
 | `tiktoken_encoding` | string | no | Tiktoken encoding name for local token estimation of the conversation text. |
 | `timeout_ms` | integer | no | Callout timeout in milliseconds. |
 | `on_failure` | `closed` \| `open` | no | Failure mode for the inference callout. |
-| `status_on_error` | integer | no | HTTP status code to return when rejecting on error. |
+| `status_on_error` | integer | no | HTTP error status code (`400..=599`) to return when rejecting on error. |
 
 ## Examples
 

--- a/filters/src/callout/config.rs
+++ b/filters/src/callout/config.rs
@@ -40,7 +40,7 @@ pub(crate) struct HttpCalloutConfig {
     #[serde(default)]
     pub on_failure: OnFailure,
 
-    /// HTTP status code returned when rejecting on failure.
+    /// HTTP error status code (`400..=599`) to return when rejecting on error.
     pub status_on_error: Option<u16>,
 
     /// Circuit breaker configuration.

--- a/filters/src/callout/tests.rs
+++ b/filters/src/callout/tests.rs
@@ -222,7 +222,7 @@ mod filter_tests {
 
     #[test]
     fn config_rejects_status_on_error_out_of_range() {
-        for bad in ["0", "99", "600", "65535"] {
+        for bad in ["0", "99", "100", "200", "204", "302", "399", "600", "65535"] {
             let yaml = serde_yaml::from_str::<serde_yaml::Value>(&format!(
                 r#"
                 target:


### PR DESCRIPTION
## Summary

`validate_status_on_error` accepted 100..=599, but the value becomes the status of a rejection carrying an error body: `status_on_error: 200 `made a failed closed-mode callout look successful.

Narrow the range to 400..=599. Covers both consumers of the shared validator: `http_callout` and `openai_responses_compact`. Existing configs are all 4xx/5xx, so nothing breaks.

Closes #672 

## Validation

- [x] `cargo test -p praxis-ai-apis`
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking changes.
