### PR TITLE
fix(mcp_client): enforce overall timeout for list_tools pagination (#836)

### DIFF
--- a/apis/src/mcp_client/mod.rs
+++ b/apis/src/mcp_client/mod.rs
@@ -240,16 +240,12 @@ pub(crate) async fn list_tools(
             build_transport_config(server_url, headers, authorization)?,
         );
         let display_url = resolved.display_url;
-        let client = tokio::time::timeout(timeout, Box::pin(().serve(transport)))
+        let client = Box::pin(().serve(transport))
             .await
-            .map_err(|_elapsed| McpClientError::Timeout {
-                url: display_url.clone(),
-                timeout,
-            })?
             .map_err(|_source| McpClientError::Connection {
                 url: display_url.clone(),
             })?;
-        let tools = paginate_tools(&client, timeout, max_tools, &display_url).await?;
+        let tools = Box::pin(paginate_tools(&client, max_tools, &display_url)).await?;
         tools_to_json(tools)
     };
 
@@ -293,12 +289,8 @@ pub(crate) async fn call_tool(
         );
         let display_url = resolved.display_url;
 
-        let client = tokio::time::timeout(timeout, Box::pin(().serve(transport)))
+        let client = Box::pin(().serve(transport))
             .await
-            .map_err(|_elapsed| McpClientError::Timeout {
-                url: display_url.clone(),
-                timeout,
-            })?
             .map_err(|_source| McpClientError::Connection {
                 url: display_url.clone(),
             })?;
@@ -313,12 +305,8 @@ pub(crate) async fn call_tool(
             params = params.with_arguments(args_obj);
         }
 
-        tokio::time::timeout(timeout, Box::pin(client.call_tool(params)))
+        Box::pin(client.call_tool(params))
             .await
-            .map_err(|_elapsed| McpClientError::Timeout {
-                url: display_url.clone(),
-                timeout,
-            })?
             .map_err(|_source| McpClientError::CallTool {
                 url: display_url.clone(),
                 tool_name: tool_name.to_owned(),
@@ -339,10 +327,8 @@ const MAX_PAGES: usize = 100;
 
 /// Paginate `tools/list`, bounded by both `max_tools` and
 /// [`MAX_PAGES`].
-#[expect(clippy::too_many_lines, reason = "pagination loop with error branches")]
 async fn paginate_tools(
     client: &Peer<RoleClient>,
-    timeout: Duration,
     max_tools: usize,
     url: &McpDisplayUrl,
 ) -> Result<Vec<rmcp::model::Tool>, McpClientError> {
@@ -350,12 +336,8 @@ async fn paginate_tools(
     let mut cursor = None;
     for _ in 0..MAX_PAGES {
         let params = PaginatedRequestParams::default().with_cursor(cursor);
-        let page = tokio::time::timeout(timeout, Box::pin(client.list_tools(Some(params))))
+        let page = Box::pin(client.list_tools(Some(params)))
             .await
-            .map_err(|_elapsed| McpClientError::Timeout {
-                url: url.clone(),
-                timeout,
-            })?
             .map_err(|_source| McpClientError::ListTools { url: url.clone() })?;
         all_tools.extend(page.tools);
         if all_tools.len() > max_tools {

--- a/apis/src/mcp_client/mod.rs
+++ b/apis/src/mcp_client/mod.rs
@@ -200,6 +200,13 @@ pub(crate) enum McpClientError {
     InvalidAuthorization,
 }
 
+/// Parse a server URL into a safe display URL, or return invalid fallback.
+fn parse_display_url(server_url: &str) -> McpDisplayUrl {
+    server_url
+        .parse::<http::Uri>()
+        .map_or_else(|_| McpDisplayUrl::invalid(), |uri| McpDisplayUrl::from_uri(&uri))
+}
+
 // -----------------------------------------------------------------------------
 // Public API
 // -----------------------------------------------------------------------------
@@ -224,23 +231,34 @@ pub(crate) async fn list_tools(
     max_tools: usize,
     allow_loopback: bool,
 ) -> Result<Vec<serde_json::Value>, McpClientError> {
-    let resolved = resolve_and_validate(server_url, timeout, allow_loopback).await?;
-    let transport = StreamableHttpClientTransport::with_client(
-        build_pinned_client(&resolved)?,
-        build_transport_config(server_url, headers, authorization)?,
-    );
-    let display_url = resolved.display_url;
-    let client = tokio::time::timeout(timeout, Box::pin(().serve(transport)))
+    let display_url = parse_display_url(server_url);
+
+    let work = async {
+        let resolved = resolve_and_validate(server_url, timeout, allow_loopback).await?;
+        let transport = StreamableHttpClientTransport::with_client(
+            build_pinned_client(&resolved)?,
+            build_transport_config(server_url, headers, authorization)?,
+        );
+        let display_url = resolved.display_url;
+        let client = tokio::time::timeout(timeout, Box::pin(().serve(transport)))
+            .await
+            .map_err(|_elapsed| McpClientError::Timeout {
+                url: display_url.clone(),
+                timeout,
+            })?
+            .map_err(|_source| McpClientError::Connection {
+                url: display_url.clone(),
+            })?;
+        let tools = paginate_tools(&client, timeout, max_tools, &display_url).await?;
+        tools_to_json(tools)
+    };
+
+    tokio::time::timeout(timeout, Box::pin(work))
         .await
         .map_err(|_elapsed| McpClientError::Timeout {
-            url: display_url.clone(),
+            url: display_url,
             timeout,
         })?
-        .map_err(|_source| McpClientError::Connection {
-            url: display_url.clone(),
-        })?;
-    let tools = paginate_tools(&client, timeout, max_tools, &display_url).await?;
-    tools_to_json(tools)
 }
 
 /// Call `tools/call` on an MCP server and return the result.
@@ -265,43 +283,54 @@ pub(crate) async fn call_tool(
     timeout: Duration,
     allow_loopback: bool,
 ) -> Result<rmcp::model::CallToolResult, McpClientError> {
-    let resolved = resolve_and_validate(server_url, timeout, allow_loopback).await?;
-    let transport = StreamableHttpClientTransport::with_client(
-        build_pinned_client(&resolved)?,
-        build_transport_config(server_url, headers, authorization)?,
-    );
-    let display_url = resolved.display_url;
+    let display_url = parse_display_url(server_url);
 
-    let client = tokio::time::timeout(timeout, Box::pin(().serve(transport)))
-        .await
-        .map_err(|_elapsed| McpClientError::Timeout {
-            url: display_url.clone(),
-            timeout,
-        })?
-        .map_err(|_source| McpClientError::Connection {
-            url: display_url.clone(),
-        })?;
+    let work = async {
+        let resolved = resolve_and_validate(server_url, timeout, allow_loopback).await?;
+        let transport = StreamableHttpClientTransport::with_client(
+            build_pinned_client(&resolved)?,
+            build_transport_config(server_url, headers, authorization)?,
+        );
+        let display_url = resolved.display_url;
 
-    let parsed_args = match &arguments {
-        serde_json::Value::Object(obj) => Some(obj.clone()),
-        serde_json::Value::String(s) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(s).ok(),
-        _ => None,
+        let client = tokio::time::timeout(timeout, Box::pin(().serve(transport)))
+            .await
+            .map_err(|_elapsed| McpClientError::Timeout {
+                url: display_url.clone(),
+                timeout,
+            })?
+            .map_err(|_source| McpClientError::Connection {
+                url: display_url.clone(),
+            })?;
+
+        let parsed_args = match &arguments {
+            serde_json::Value::Object(obj) => Some(obj.clone()),
+            serde_json::Value::String(s) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(s).ok(),
+            _ => None,
+        };
+        let mut params = CallToolRequestParams::new(tool_name.to_owned());
+        if let Some(args_obj) = parsed_args {
+            params = params.with_arguments(args_obj);
+        }
+
+        tokio::time::timeout(timeout, Box::pin(client.call_tool(params)))
+            .await
+            .map_err(|_elapsed| McpClientError::Timeout {
+                url: display_url.clone(),
+                timeout,
+            })?
+            .map_err(|_source| McpClientError::CallTool {
+                url: display_url.clone(),
+                tool_name: tool_name.to_owned(),
+            })
     };
-    let mut params = CallToolRequestParams::new(tool_name.to_owned());
-    if let Some(args_obj) = parsed_args {
-        params = params.with_arguments(args_obj);
-    }
 
-    tokio::time::timeout(timeout, Box::pin(client.call_tool(params)))
+    tokio::time::timeout(timeout, Box::pin(work))
         .await
         .map_err(|_elapsed| McpClientError::Timeout {
-            url: display_url.clone(),
+            url: display_url,
             timeout,
         })?
-        .map_err(|_source| McpClientError::CallTool {
-            url: display_url.clone(),
-            tool_name: tool_name.to_owned(),
-        })
 }
 
 /// Cap on pagination rounds to prevent infinite loops from

--- a/apis/src/mcp_client/tests.rs
+++ b/apis/src/mcp_client/tests.rs
@@ -972,3 +972,78 @@ async fn call_tool_timeout() {
     let msg = err.to_string();
     assert!(msg.contains("timed out"), "error should mention timeout: {msg}");
 }
+
+#[derive(Debug, Clone)]
+struct SlowListToolsMcpServer {
+    delay_per_page: Duration,
+}
+
+impl ServerHandler for SlowListToolsMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::ListToolsResult, rmcp::ErrorData> {
+        tokio::time::sleep(self.delay_per_page).await;
+        let cursor = request.and_then(|p| p.cursor);
+        let next_cursor = match cursor.as_deref() {
+            None => Some("page2".to_owned()),
+            Some("page2") => Some("page3".to_owned()),
+            _ => None,
+        };
+        let tool = rmcp::model::Tool::new(
+            "dummy".to_owned(),
+            "dummy tool".to_owned(),
+            std::sync::Arc::new(serde_json::Map::new()),
+        );
+        let mut res = rmcp::model::ListToolsResult::with_all_items(vec![tool]);
+        res.next_cursor = next_cursor;
+        Ok(res)
+    }
+}
+
+async fn start_slow_list_mcp_server(delay_per_page: Duration) -> (String, tokio_util::sync::CancellationToken) {
+    let ct = tokio_util::sync::CancellationToken::new();
+    let config = StreamableHttpServerConfig::default()
+        .with_legacy_session_mode(false)
+        .with_json_response(true)
+        .with_sse_keep_alive(None)
+        .with_cancellation_token(ct.child_token());
+
+    let service: StreamableHttpService<SlowListToolsMcpServer, LocalSessionManager> = StreamableHttpService::new(
+        move || Ok(SlowListToolsMcpServer { delay_per_page }),
+        std::sync::Arc::default(),
+        config,
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let shutdown = ct.clone();
+    tokio::spawn(async move {
+        drop(
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move { shutdown.cancelled_owned().await })
+                .await,
+        );
+    });
+
+    (format!("http://{addr}/mcp"), ct)
+}
+
+#[tokio::test]
+async fn list_tools_cumulative_pagination_timeout() {
+    let (url, ct) = start_slow_list_mcp_server(Duration::from_millis(150)).await;
+    let short_timeout = Duration::from_millis(200);
+    let result = list_tools(&url, None, None, short_timeout, 128, true).await;
+    ct.cancel();
+
+    let err = result.expect_err("cumulative pagination time exceeding timeout should time out");
+    let msg = err.to_string();
+    assert!(msg.contains("timed out"), "error should mention timeout: {msg}");
+}


### PR DESCRIPTION
## Summary

Enforces a top-level `tokio::time::timeout` wrapper across the complete `list_tools` and `call_tool` client lifecycle (DNS resolution, transport connection/handshake, and multi-page tools listing pagination), and removes inner timers shadowed by the top-level timeout.

Previously, each individual tools/list page request had its own timeout check inside `paginate_tools`. A degraded or malicious MCP server returning paginated tools (up to 100 pages) could delay every page request by slightly under the timeout duration, causing `list_tools` to execute for up to ~100x the configured timeout.

The top-level timeout replaces inner handshake, per-page pagination, and tool call timers in `list_tools` and `call_tool`, while preserving the standalone DNS timeout in `resolve_hostname_ssrf` used by `validate_mcp_url`.

## Related issue

Closes https://github.com/praxis-proxy/ai/issues/836

## Validation

- [x] Unit tests (`cargo test -p praxis-ai-apis -- mcp_client`)
- [x] Integration or functional tests (added `list_tools_cumulative_pagination_timeout` with mock slow paginated MCP server)
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.