### PR TITLE
fix(web_search): truthful continuation for missing-query calls (#670)

### DIFF
--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -65,6 +65,9 @@ const ACTION_DONE: &str = "done";
 /// Include value that gates `action.sources` in the output item.
 const INCLUDE_ACTION_SOURCES: &str = "web_search_call.action.sources";
 
+/// Model-facing result for a malformed call without `action.query`.
+const MISSING_QUERY_OUTPUT: &str = "Web search could not run because the query was missing.";
+
 // -----------------------------------------------------------------------------
 // WebSearchFilter
 // -----------------------------------------------------------------------------
@@ -181,7 +184,7 @@ impl WebSearchFilter {
                 public: call_id,
                 bridge: &bridge,
             };
-            append_result(ctx, &ids, "incomplete", "", &[]);
+            append_incomplete(ctx, &ids);
             return;
         };
 
@@ -191,7 +194,7 @@ impl WebSearchFilter {
             bridge: &bridge,
         };
         match self.search_client.search(query, Some(context_size)).await {
-            SearchOutcome::Results(results) => append_result(ctx, &ids, "completed", query, &results),
+            SearchOutcome::Results(results) => append_result(ctx, &ids, query, &results),
             SearchOutcome::Failed => {
                 warn!(
                     call_id,
@@ -321,16 +324,23 @@ struct SearchCallIds<'a> {
 ///
 /// An empty `results` slice is a successful zero-result search: the model
 /// receives `No search results found.` and the public item stays `completed`.
-fn append_result(
-    ctx: &mut HttpFilterContext<'_>,
-    ids: &SearchCallIds<'_>,
-    status: &str,
-    query: &str,
-    results: &[SearchResult],
-) {
+fn append_result(ctx: &mut HttpFilterContext<'_>, ids: &SearchCallIds<'_>, query: &str, results: &[SearchResult]) {
     let include_sources = include_action_sources(ctx);
-    let output_item = build_output_item(ids.public, status, query, results, include_sources);
+    let output_item = build_output_item(ids.public, "completed", query, results, include_sources);
     let bridge = build_tool_result_messages(ids.bridge, query, results);
+    push_search_turn(ctx, output_item, bridge);
+}
+
+/// Append a malformed search turn to [`ResponsesState`].
+///
+/// The public item remains `incomplete`, while the backend-valid bridge carries
+/// the missing arguments and an explicit failure message. This prevents the
+/// next inference iteration and persisted replay from treating a missing query
+/// as a successful search with zero results.
+fn append_incomplete(ctx: &mut HttpFilterContext<'_>, ids: &SearchCallIds<'_>) {
+    let include_sources = include_action_sources(ctx);
+    let output_item = build_output_item(ids.public, "incomplete", "", &[], include_sources);
+    let bridge = build_incomplete_tool_result_messages(ids.bridge);
     push_search_turn(ctx, output_item, bridge);
 }
 
@@ -477,6 +487,28 @@ pub(crate) fn build_tool_result_messages(call_id: &str, query: &str, results: &[
             "type": "function_call_output",
             "call_id": call_id,
             "output": content,
+        }),
+    ]
+}
+
+/// Build the backend-valid continuation for a call missing `action.query`.
+///
+/// The synthetic function call is fully generated, so its status is
+/// `completed`; the empty arguments and explicit output truthfully describe
+/// the incomplete hosted-tool execution.
+pub(crate) fn build_incomplete_tool_result_messages(call_id: &str) -> [Value; 2] {
+    [
+        serde_json::json!({
+            "type": "function_call",
+            "call_id": call_id,
+            "name": "web_search",
+            "arguments": "{}",
+            "status": "completed",
+        }),
+        serde_json::json!({
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": MISSING_QUERY_OUTPUT,
         }),
     ]
 }

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -504,6 +504,27 @@ async fn on_request_body_missing_query_produces_incomplete_status() {
         output["status"], "incomplete",
         "missing query should produce incomplete status"
     );
+
+    // The model-facing and persisted continuation must describe the malformed
+    // call truthfully, rather than fabricating a successful zero-result search.
+    let bridge_call = &state.messages[state.messages.len() - 2];
+    assert_eq!(bridge_call["type"], "function_call");
+    assert_eq!(bridge_call["arguments"], r#"{}"#);
+    assert_eq!(
+        bridge_call["status"], "completed",
+        "the synthetic function call was fully generated; its output carries the incomplete execution result"
+    );
+    let bridge_output = state.messages.last().unwrap();
+    assert_eq!(bridge_output["type"], "function_call_output");
+    assert_eq!(
+        bridge_output["output"],
+        "Web search could not run because the query was missing."
+    );
+    assert_eq!(
+        state.persisted_messages.last(),
+        Some(bridge_output),
+        "persisted history must contain the truthful model continuation"
+    );
 }
 
 #[tokio::test]

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -505,8 +505,6 @@ async fn on_request_body_missing_query_produces_incomplete_status() {
         "missing query should produce incomplete status"
     );
 
-    // The model-facing and persisted continuation must describe the malformed
-    // call truthfully, rather than fabricating a successful zero-result search.
     let bridge_call = &state.messages[state.messages.len() - 2];
     assert_eq!(bridge_call["type"], "function_call");
     assert_eq!(bridge_call["arguments"], r#"{}"#);


### PR DESCRIPTION
## Summary

When a hosted `web_search` call arrived without `action.query`, the public output item was correctly marked `incomplete`, but the bridge message appended to both `messages` and `persisted_messages` was built by a helper that hardcoded `completed` with "No search results found." — so the next inference iteration and any future rehydration saw a fabricated successful zero-result search that contradicted the incomplete public item. This adds a dedicated `append_incomplete` path (`build_incomplete_tool_result_messages`) that emits an empty-argument function call plus an explicit "Web search could not run because the query was missing." output, keeping the model-facing and persisted continuation truthful. It is the smallest change that fixes the inconsistency without altering behavior for valid or zero-result searches.

## Related issue

Closes #670

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis` (2653 passed, 0 failed, 27 ignored); extended `on_request_body_missing_query_produces_incomplete_status` to assert the truthful bridge function call/output and the persisted continuation.
- [x] Integration or functional tests — covered by the apis suite above.
- [x] `make lint`
- Also ran `make build` (clean).

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. (N/A — bug fix, no new capability or config surface.)
- [ ] User-facing behavior and generated documentation are updated. (N/A — internal continuation/persistence semantics only.)
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. (N/A — no hot-path or allocation change.)
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. Valid searches and successful zero-result searches are unaffected; only malformed missing-query calls change from a fabricated `completed` / "No search results found." bridge to a truthful `incomplete` continuation.
