### PR TITLE
fix(web_search): enforce max_tool_calls and per-continuation cap (#805)

### DIFF
--- a/apis/src/openai/responses/file_search_callout/mod.rs
+++ b/apis/src/openai/responses/file_search_callout/mod.rs
@@ -1312,7 +1312,11 @@ fn unsupported_streaming_rejection(ctx: &HttpFilterContext<'_>) -> Option<Filter
 }
 
 /// Return whether one output item still requires local file-search execution.
-fn is_pending_file_search_call(item: &Value) -> bool {
+///
+/// Shared with `openai_web_search`, which must exclude these pending
+/// placeholders when counting non-web built-in calls against the shared
+/// `max_tool_calls` budget, mirroring [`remaining_file_search_call_budget`].
+pub(crate) fn is_pending_file_search_call(item: &Value) -> bool {
     item.get("type").and_then(Value::as_str) == Some("file_search_call")
         && matches!(
             item.get("status").and_then(Value::as_str),

--- a/apis/src/openai/responses/file_search_callout/mod.rs
+++ b/apis/src/openai/responses/file_search_callout/mod.rs
@@ -1136,7 +1136,10 @@ fn combined_output_fits(state: &ResponsesState, incoming_response: &Value, max_b
 }
 
 /// Return whether an output item is a provider-hosted built-in tool call.
-fn is_builtin_tool_call(item: &Value) -> bool {
+///
+/// Shared with `openai_web_search`, which counts non-web built-in calls against
+/// the same client-declared `max_tool_calls` budget.
+pub(crate) fn is_builtin_tool_call(item: &Value) -> bool {
     matches!(
         item.get("type").and_then(Value::as_str),
         Some(

--- a/apis/src/openai/responses/state.rs
+++ b/apis/src/openai/responses/state.rs
@@ -167,6 +167,18 @@ pub(crate) struct ResponsesState {
     /// one-function-call-per-round limit.
     pub web_search_calls: Vec<serde_json::Value>,
 
+    /// Cumulative web searches dispatched to the provider across all
+    /// agentic-loop iterations.
+    ///
+    /// `openai_web_search` increments this each time it issues a
+    /// provider request so the client-declared `max_tool_calls` budget
+    /// is honored across IRR continuations, not just within one round.
+    /// A dedicated counter is used instead of counting `web_search_call`
+    /// items in [`Self::accumulated_output`] because that field retains
+    /// both the model's echoed call and the executed result, which would
+    /// double-count each search.
+    pub web_search_calls_executed: u32,
+
     /// Tool choice setting. Reset to `"auto"` by `openai_agentic_loop`
     /// after the first iteration; the original value from the
     /// request only applies to the first inference call.
@@ -230,6 +242,7 @@ impl Default for ResponsesState {
             response_object: serde_json::Value::Null,
             tool_calls: Vec::new(),
             web_search_calls: Vec::new(),
+            web_search_calls_executed: 0,
             tool_choice: serde_json::Value::String("auto".to_owned()),
             tools: Vec::new(),
             usage: serde_json::Value::Null,
@@ -649,6 +662,7 @@ mod tests {
         assert!(state.response_object.is_null());
         assert!(state.tool_calls.is_empty());
         assert!(state.web_search_calls.is_empty());
+        assert_eq!(state.web_search_calls_executed, 0);
         assert_eq!(state.tool_choice, json!("auto"));
         assert!(state.tools.is_empty());
         assert!(state.usage.is_null());

--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -34,7 +34,7 @@
 )]
 mod tests;
 
-use std::mem;
+use std::{collections::HashSet, mem};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -396,29 +396,67 @@ struct SearchCallIds<'a> {
 /// type, so the allowance is the declared maximum minus all built-in calls
 /// already consumed — web searches dispatched across prior iterations
 /// ([`ResponsesState::web_search_calls_executed`]) *plus* completed non-web
-/// built-in calls (e.g. file search) accumulated this response. Without the
-/// second term a mixed pipeline could dispatch a full web-search allowance on
-/// top of already-executed file searches and overshoot the client's cap. Web
-/// searches are counted through the dedicated counter rather than by scanning
-/// [`ResponsesState::accumulated_output`] to avoid the echoed-call/result
-/// double count documented on that field; non-web built-in calls have no such
+/// built-in calls (e.g. file search) recorded on the state. Without the second
+/// term a mixed pipeline could dispatch a full web-search allowance on top of
+/// already-executed file searches and overshoot the client's cap. Web searches
+/// are counted through the dedicated counter rather than by scanning the output
+/// collections to avoid the echoed-call/result double count documented on
+/// [`ResponsesState::accumulated_output`]; non-web built-in calls have no such
 /// counter and are counted directly, mirroring
 /// [`remaining_file_search_call_budget`](super::file_search_callout).
 fn remaining_web_search_budget(state: &ResponsesState) -> usize {
     let web_executed = usize::try_from(state.web_search_calls_executed).unwrap_or(usize::MAX);
-    let other_builtin_calls = state
-        .accumulated_output
-        .iter()
-        .filter(|item| {
-            super::file_search_callout::is_builtin_tool_call(item)
-                && item.get("type").and_then(Value::as_str) != Some("web_search_call")
-        })
-        .count();
+    let other_builtin_calls = count_non_web_builtin_calls(state);
     let used = web_executed.saturating_add(other_builtin_calls);
     let client_remaining = state.max_tool_calls.map_or(usize::MAX, |max| {
         usize::try_from(max).unwrap_or(usize::MAX).saturating_sub(used)
     });
     client_remaining.min(MAX_WEB_SEARCH_CALLS_PER_CONTINUATION)
+}
+
+/// Count distinct non-web built-in tool calls already spent against the shared
+/// `max_tool_calls` budget.
+///
+/// A completed file-search call is moved out of the response object into
+/// [`ResponsesState::file_search_output_items`] before the next iterative round,
+/// so scanning only [`ResponsesState::accumulated_output`] would miss it and let
+/// a mixed file-search/web-search pipeline dispatch a full web-search allowance
+/// on top of an already-executed file search, overshooting the client's cap.
+/// Every collection that can retain a built-in call is scanned —
+/// `accumulated_output`, the moved-out `file_search_output_items`, and the live
+/// [`ResponsesState::output_items`] — and results are deduplicated by item `id`,
+/// because a single call can be echoed into more than one collection (e.g.
+/// accumulated during the response phase *and* retained after the move).
+/// Web-search calls are excluded here; they are tracked through
+/// [`ResponsesState::web_search_calls_executed`].
+fn count_non_web_builtin_calls(state: &ResponsesState) -> usize {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut count = 0_usize;
+    let candidates = state
+        .accumulated_output
+        .iter()
+        .chain(&state.file_search_output_items)
+        .chain(state.output_items());
+    for item in candidates {
+        let is_non_web_builtin = super::file_search_callout::is_builtin_tool_call(item)
+            && item.get("type").and_then(Value::as_str) != Some("web_search_call");
+        if !is_non_web_builtin {
+            continue;
+        }
+        match item.get("id").and_then(Value::as_str) {
+            // Distinct calls always carry an id; dedup avoids counting a call
+            // echoed into several collections more than once.
+            Some(id) => {
+                if seen.insert(id) {
+                    count = count.saturating_add(1);
+                }
+            },
+            // An id-less built-in call cannot be deduplicated; count it so the
+            // budget errs toward the client's cap rather than overshooting it.
+            None => count = count.saturating_add(1),
+        }
+    }
+    count
 }
 
 /// Surface an over-budget web search call as incomplete without dispatching.

--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -428,7 +428,12 @@ fn remaining_web_search_budget(state: &ResponsesState) -> usize {
 /// because a single call can be echoed into more than one collection (e.g.
 /// accumulated during the response phase *and* retained after the move).
 /// Web-search calls are excluded here; they are tracked through
-/// [`ResponsesState::web_search_calls_executed`].
+/// [`ResponsesState::web_search_calls_executed`]. Pending file-search
+/// placeholders (`searching`/`in_progress`) are also excluded, mirroring
+/// [`remaining_file_search_call_budget`](super::file_search_callout): they have
+/// not yet consumed a provider call, so counting them would let a mixed pending
+/// file-search/web-search response decline the web search before either call
+/// runs.
 fn count_non_web_builtin_calls(state: &ResponsesState) -> usize {
     let mut seen: HashSet<&str> = HashSet::new();
     let mut count = 0_usize;
@@ -439,7 +444,8 @@ fn count_non_web_builtin_calls(state: &ResponsesState) -> usize {
         .chain(state.output_items());
     for item in candidates {
         let is_non_web_builtin = super::file_search_callout::is_builtin_tool_call(item)
-            && item.get("type").and_then(Value::as_str) != Some("web_search_call");
+            && item.get("type").and_then(Value::as_str) != Some("web_search_call")
+            && !super::file_search_callout::is_pending_file_search_call(item);
         if !is_non_web_builtin {
             continue;
         }

--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -388,14 +388,35 @@ struct SearchCallIds<'a> {
 
 /// Remaining web searches this continuation may dispatch.
 ///
-/// Intersects the client's remaining `max_tool_calls` allowance (the
-/// declared maximum minus searches already dispatched across prior
-/// iterations) with the server-side per-continuation hard cap. When the
-/// client omits `max_tool_calls`, only the server cap applies.
+/// Intersects the client's remaining `max_tool_calls` allowance with the
+/// server-side per-continuation hard cap. When the client omits
+/// `max_tool_calls`, only the server cap applies.
+///
+/// `max_tool_calls` is a single budget shared across *every* built-in tool
+/// type, so the allowance is the declared maximum minus all built-in calls
+/// already consumed — web searches dispatched across prior iterations
+/// ([`ResponsesState::web_search_calls_executed`]) *plus* completed non-web
+/// built-in calls (e.g. file search) accumulated this response. Without the
+/// second term a mixed pipeline could dispatch a full web-search allowance on
+/// top of already-executed file searches and overshoot the client's cap. Web
+/// searches are counted through the dedicated counter rather than by scanning
+/// [`ResponsesState::accumulated_output`] to avoid the echoed-call/result
+/// double count documented on that field; non-web built-in calls have no such
+/// counter and are counted directly, mirroring
+/// [`remaining_file_search_call_budget`](super::file_search_callout).
 fn remaining_web_search_budget(state: &ResponsesState) -> usize {
-    let executed = usize::try_from(state.web_search_calls_executed).unwrap_or(usize::MAX);
+    let web_executed = usize::try_from(state.web_search_calls_executed).unwrap_or(usize::MAX);
+    let other_builtin_calls = state
+        .accumulated_output
+        .iter()
+        .filter(|item| {
+            super::file_search_callout::is_builtin_tool_call(item)
+                && item.get("type").and_then(Value::as_str) != Some("web_search_call")
+        })
+        .count();
+    let used = web_executed.saturating_add(other_builtin_calls);
     let client_remaining = state.max_tool_calls.map_or(usize::MAX, |max| {
-        usize::try_from(max).unwrap_or(usize::MAX).saturating_sub(executed)
+        usize::try_from(max).unwrap_or(usize::MAX).saturating_sub(used)
     });
     client_remaining.min(MAX_WEB_SEARCH_CALLS_PER_CONTINUATION)
 }

--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -67,6 +67,16 @@ const ACTION_DONE: &str = "done";
 /// Include value that gates `action.sources` in the output item.
 const INCLUDE_ACTION_SOURCES: &str = "web_search_call.action.sources";
 
+/// Server-side hard cap on web searches dispatched in one continuation.
+///
+/// Bounds the number of (potentially paid) provider requests issued per
+/// re-entry even when the client omits `max_tool_calls`. Mirrors the
+/// file-search `MAX_PENDING_CALLS` ceiling so the two built-in tools share
+/// the same per-continuation fan-out limit. The enclosing
+/// `iterative_request_router` deadlines and iteration cap bound the total
+/// across continuations.
+const MAX_WEB_SEARCH_CALLS_PER_CONTINUATION: usize = 64;
+
 /// Model-facing result for a malformed call without `action.query`.
 const MISSING_QUERY_OUTPUT: &str = "Web search could not run because the query was missing.";
 
@@ -169,13 +179,18 @@ impl WebSearchFilter {
     /// `index` is the call's position within the pending queue. It keeps the
     /// synthetic bridge `call_id` unique even when the hosted source ids
     /// collide or are absent (issue #808).
+    ///
+    /// Returns `true` when a provider request was dispatched — a `Results` or
+    /// `Failed` outcome, both charged against the call budget — and `false`
+    /// when the call was surfaced as incomplete without issuing a request
+    /// (a missing query).
     async fn execute_single_search(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         call: &Value,
         index: usize,
         context_size: SearchContextSize,
-    ) {
+    ) -> bool {
         let call_id = call.get("id").and_then(Value::as_str).unwrap_or("ws_unknown");
         let query = call.get("action").and_then(|a| a.get("query")).and_then(Value::as_str);
 
@@ -187,7 +202,7 @@ impl WebSearchFilter {
                 bridge: &bridge,
             };
             append_incomplete(ctx, &ids);
-            return;
+            return false;
         };
 
         let bridge = bridge_call_id(call_id, query, index);
@@ -196,7 +211,7 @@ impl WebSearchFilter {
             bridge: &bridge,
         };
         match self.search_client.search(query, Some(context_size)).await {
-            SearchOutcome::Results(results) => append_result(ctx, &ids, query, &results),
+            SearchOutcome::Results(results) => append_result(ctx, &ids, "completed", query, &results),
             SearchOutcome::Failed => {
                 warn!(
                     call_id,
@@ -204,6 +219,42 @@ impl WebSearchFilter {
                 );
                 append_failed(ctx, &ids, query);
             },
+        }
+        true
+    }
+
+    /// Execute pending web search `calls` up to `budget`, then update the
+    /// cumulative execution count and clear the pending queue.
+    ///
+    /// Calls beyond `budget` are surfaced as incomplete without issuing a
+    /// (potentially paid) provider request, honoring the client's
+    /// `max_tool_calls` allowance and the per-continuation server cap. Only
+    /// dispatched calls (a `Results` or `Failed` outcome) are charged against
+    /// the budget; a missing-query call is surfaced as incomplete without a
+    /// provider request and does not consume budget.
+    async fn execute_pending_searches(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        calls: &[Value],
+        budget: usize,
+        context_size: SearchContextSize,
+    ) {
+        let mut dispatched = 0_usize;
+        for (index, call) in calls.iter().enumerate() {
+            if dispatched >= budget {
+                append_excess_incomplete(ctx, call, index);
+                continue;
+            }
+            if self.execute_single_search(ctx, call, index, context_size).await {
+                dispatched = dispatched.saturating_add(1);
+            }
+        }
+
+        if let Some(state) = ctx.extensions.get_mut::<ResponsesState>() {
+            state.web_search_calls_executed = state
+                .web_search_calls_executed
+                .saturating_add(u32::try_from(dispatched).unwrap_or(u32::MAX));
+            state.web_search_calls.clear();
         }
     }
 }
@@ -262,19 +313,22 @@ impl HttpFilter for WebSearchFilter {
             .or_else(|| web_search_context_size_from_state(state))
             .map_or(self.default_context_size, SearchContextSize::from_str_or_default);
 
-        // Move the web search calls out instead of cloning and then removing them from state.
+        // Compute the remaining budget while the shared immutable borrow is
+        // still live, then move the web search calls out instead of cloning
+        // and then removing them from state.
+        let budget = remaining_web_search_budget(state);
         let calls: Vec<Value> = ctx
             .extensions
             .get_mut::<ResponsesState>()
             .map(|state| mem::take(&mut state.web_search_calls))
             .unwrap_or_default();
 
-        debug!(count = calls.len(), "executing pending web search calls");
+        debug!(
+            count = calls.len(),
+            budget, "executing pending web search calls within budget"
+        );
 
-        for (index, call) in calls.iter().enumerate() {
-            self.execute_single_search(ctx, call, index, context_size).await;
-        }
-
+        self.execute_pending_searches(ctx, &calls, budget, context_size).await;
         Ok(FilterAction::Continue)
     }
 
@@ -332,14 +386,60 @@ struct SearchCallIds<'a> {
     bridge: &'a str,
 }
 
+/// Remaining web searches this continuation may dispatch.
+///
+/// Intersects the client's remaining `max_tool_calls` allowance (the
+/// declared maximum minus searches already dispatched across prior
+/// iterations) with the server-side per-continuation hard cap. When the
+/// client omits `max_tool_calls`, only the server cap applies.
+fn remaining_web_search_budget(state: &ResponsesState) -> usize {
+    let executed = usize::try_from(state.web_search_calls_executed).unwrap_or(usize::MAX);
+    let client_remaining = state.max_tool_calls.map_or(usize::MAX, |max| {
+        usize::try_from(max).unwrap_or(usize::MAX).saturating_sub(executed)
+    });
+    client_remaining.min(MAX_WEB_SEARCH_CALLS_PER_CONTINUATION)
+}
+
+/// Surface an over-budget web search call as incomplete without dispatching.
+///
+/// Preserves the requested query in the output item so the model can see which
+/// search was declined, matching the missing-query incomplete shape. No
+/// provider request is issued, so no budget is charged. `index` keeps the
+/// bridge `call_id` unique, mirroring [`WebSearchFilter::execute_single_search`].
+fn append_excess_incomplete(ctx: &mut HttpFilterContext<'_>, call: &Value, index: usize) {
+    let call_id = call.get("id").and_then(Value::as_str).unwrap_or("ws_unknown");
+    let query = call
+        .get("action")
+        .and_then(|a| a.get("query"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let bridge = bridge_call_id(call_id, query, index);
+    let ids = SearchCallIds {
+        public: call_id,
+        bridge: &bridge,
+    };
+    append_result(ctx, &ids, "incomplete", query, &[]);
+}
+
 /// Append a completed search turn to [`ResponsesState`].
 ///
 /// An empty `results` slice is a successful zero-result search: the model
 /// receives `No search results found.` and the public item stays `completed`.
-fn append_result(ctx: &mut HttpFilterContext<'_>, ids: &SearchCallIds<'_>, query: &str, results: &[SearchResult]) {
+/// A non-`completed` status (an over-budget call that was never dispatched)
+/// threads through a truthful `Web search not performed.` bridge, so the
+/// model-facing history never contradicts the client-visible incomplete output
+/// item or pollutes durable rehydration history. A missing-query call uses the
+/// more specific [`append_incomplete`] instead.
+fn append_result(
+    ctx: &mut HttpFilterContext<'_>,
+    ids: &SearchCallIds<'_>,
+    status: &str,
+    query: &str,
+    results: &[SearchResult],
+) {
     let include_sources = include_action_sources(ctx);
-    let output_item = build_output_item(ids.public, "completed", query, results, include_sources);
-    let bridge = build_tool_result_messages(ids.bridge, query, results);
+    let output_item = build_output_item(ids.public, status, query, results, include_sources);
+    let bridge = build_tool_result_messages(ids.bridge, status, query, results);
     push_search_turn(ctx, output_item, bridge);
 }
 
@@ -467,7 +567,7 @@ pub(crate) fn build_output_item(
     })
 }
 
-/// Build the backend-valid continuation for a completed search.
+/// Build the backend-valid continuation for a search.
 ///
 /// A hosted `web_search_call` item is not a valid `OpenResponses` `input`
 /// type (see issue #808), so the model-facing history bridges the result
@@ -476,11 +576,24 @@ pub(crate) fn build_output_item(
 /// public `web_search_call` output item is emitted separately by
 /// [`build_output_item`] and only reaches `accumulated_output`.
 ///
+/// `status` is threaded through so a call that was never dispatched
+/// (over-budget or missing a query, `status != "completed"`) carries a
+/// truthful `Web search not performed.` output instead of a fabricated
+/// `No search results found.` result, keeping the model-facing bridge
+/// consistent with the client-visible incomplete output item.
+///
 /// `call_id` must be a bounded, backend-valid identifier from
 /// [`bridge_call_id`]: the raw hosted id can exceed the `OpenResponses`
 /// 64-character `call_id` limit.
-pub(crate) fn build_tool_result_messages(call_id: &str, query: &str, results: &[SearchResult]) -> [Value; 2] {
-    let content = if results.is_empty() {
+pub(crate) fn build_tool_result_messages(
+    call_id: &str,
+    status: &str,
+    query: &str,
+    results: &[SearchResult],
+) -> [Value; 2] {
+    let content = if status != "completed" {
+        "Web search not performed.".to_owned()
+    } else if results.is_empty() {
         "No search results found.".to_owned()
     } else {
         format_search_results(results)

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -1194,6 +1194,46 @@ fn remaining_budget_saturates_when_exhausted() {
     );
 }
 
+#[test]
+fn remaining_budget_subtracts_non_web_builtin_calls() {
+    // `max_tool_calls` is shared across built-in tools: a completed file search
+    // consumes the single-call budget, leaving nothing for a pending web search.
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 1}));
+    state.accumulated_output = vec![serde_json::json!({
+        "type": "file_search_call",
+        "id": "fs_1",
+        "status": "completed",
+    })];
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        0,
+        "a completed file search must exhaust the shared max_tool_calls budget"
+    );
+}
+
+#[test]
+fn remaining_budget_counts_web_and_non_web_builtin_together() {
+    // A dispatched web search (counter) and a completed file search (output
+    // item) both draw down the same shared allowance.
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 5}));
+    state.web_search_calls_executed = 2;
+    state.accumulated_output = vec![
+        serde_json::json!({"type": "file_search_call", "id": "fs_1", "status": "completed"}),
+        // A prior web_search_call output item must NOT be double counted: web
+        // searches are already tracked by web_search_calls_executed.
+        serde_json::json!({"type": "web_search_call", "id": "ws_1", "status": "completed"}),
+        // A non-built-in item (a message) must not consume budget.
+        serde_json::json!({"type": "message", "id": "msg_1"}),
+    ];
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        2,
+        "5 - (2 web dispatched + 1 file search) = 2; the echoed web_search_call is not double counted"
+    );
+}
+
 #[tokio::test]
 async fn on_request_body_honors_client_max_tool_calls() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -1272,6 +1272,26 @@ fn remaining_budget_dedups_file_search_call_across_collections() {
     );
 }
 
+#[test]
+fn remaining_budget_ignores_pending_file_search_calls() {
+    // A file-search call that is still `searching`/`in_progress` has not yet
+    // consumed a provider call, so it must not draw down the shared budget.
+    // `remaining_file_search_call_budget` already excludes these placeholders;
+    // counting them here would let a mixed pending file-search/web-search
+    // response decline the web search before either call runs.
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 1}));
+    state.accumulated_output = vec![
+        serde_json::json!({"type": "file_search_call", "id": "fs_pending", "status": "searching"}),
+        serde_json::json!({"type": "web_search_call", "id": "ws_pending", "status": "in_progress"}),
+    ];
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        1,
+        "a pending file search must not exhaust the shared max_tool_calls budget"
+    );
+}
+
 #[tokio::test]
 async fn on_request_body_honors_client_max_tool_calls() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -927,7 +927,7 @@ fn build_output_item_with_results() {
 
 #[test]
 fn build_tool_result_messages_empty() {
-    let [call, output] = build_tool_result_messages("ws_123", "rust", &[]);
+    let [call, output] = build_tool_result_messages("ws_123", "completed", "rust", &[]);
     assert_eq!(
         call["type"], "function_call",
         "continuation bridge is a backend-valid function_call/function_call_output pair, never a hosted web_search_call"
@@ -948,7 +948,7 @@ fn build_tool_result_messages_with_results() {
         url: "https://example.com".into(),
         snippet: "A description".into(),
     }];
-    let [call, output] = build_tool_result_messages("ws_123", "example query", &results);
+    let [call, output] = build_tool_result_messages("ws_123", "completed", "example query", &results);
     assert_eq!(call["type"], "function_call");
     assert_eq!(call["arguments"], r#"{"query":"example query"}"#);
     assert_eq!(output["type"], "function_call_output");
@@ -1052,6 +1052,17 @@ fn upsert_output_item_appends_when_no_match() {
 }
 
 #[test]
+fn build_tool_result_messages_incomplete_reports_not_performed() {
+    // A non-dispatched call (over-budget or missing query) must not be
+    // misrepresented to the model as a completed search with no results.
+    let [call, output] = build_tool_result_messages("ws_123", "incomplete", "rust", &[]);
+    assert_eq!(call["type"], "function_call");
+    assert_eq!(call["call_id"], "ws_123");
+    assert_eq!(output["type"], "function_call_output");
+    assert_eq!(output["output"], "Web search not performed.");
+}
+
+#[test]
 fn format_search_results_multiple() {
     let results = vec![
         SearchResult {
@@ -1069,4 +1080,286 @@ fn format_search_results_multiple() {
     assert!(formatted.contains("[1] First"));
     assert!(formatted.contains("[2] Second"));
     assert!(formatted.contains("\n\n"), "results should be separated by blank line");
+}
+
+// -----------------------------------------------------------------------------
+// Call budget: max_tool_calls and the server-side per-continuation cap
+// -----------------------------------------------------------------------------
+
+/// Brave mock that serves every connection and counts dispatched requests.
+fn spawn_counting_brave_mock(listener: std::net::TcpListener) -> std::sync::Arc<std::sync::atomic::AtomicUsize> {
+    use std::{
+        io::{Read as _, Write as _},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+    let counter = Arc::new(AtomicUsize::new(0));
+    let thread_counter = Arc::clone(&counter);
+    let body = serde_json::json!({
+        "web": {
+            "results": [{
+                "title": "Rust Lang",
+                "url": "https://rust-lang.org",
+                "description": "Systems programming language"
+            }]
+        }
+    })
+    .to_string();
+    std::thread::spawn(move || {
+        while let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0_u8; 4096];
+            let _n = stream.read(&mut buf).unwrap_or(0);
+            thread_counter.fetch_add(1, Ordering::SeqCst);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _written = stream.write_all(response.as_bytes());
+        }
+    });
+    counter
+}
+
+fn web_search_call(id: &str, query: &str) -> Value {
+    serde_json::json!({
+        "type": "web_search_call",
+        "id": id,
+        "action": {"type": "search", "query": query}
+    })
+}
+
+/// Find the `function_call_output` bridged for `query` in a message list.
+///
+/// The backend-valid continuation is a `function_call`/`function_call_output`
+/// pair keyed by a bounded hash id (issue #808), so the tool result is located
+/// by the query carried in the `function_call` arguments rather than by the
+/// unbounded public `web_search_call.id`.
+fn find_bridge_output<'a>(messages: &'a [Value], query: &str) -> Option<&'a Value> {
+    let needle = serde_json::json!({ "query": query }).to_string();
+    let call_id = messages.iter().find_map(|m| {
+        (m["type"] == "function_call" && m["arguments"] == needle)
+            .then(|| m["call_id"].as_str())
+            .flatten()
+    })?;
+    messages
+        .iter()
+        .find(|m| m["type"] == "function_call_output" && m["call_id"] == call_id)
+}
+
+#[test]
+fn remaining_budget_uses_server_cap_without_max_tool_calls() {
+    let state = ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x"}));
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        MAX_WEB_SEARCH_CALLS_PER_CONTINUATION,
+        "omitting max_tool_calls falls back to the server hard cap"
+    );
+}
+
+#[test]
+fn remaining_budget_caps_large_max_tool_calls_at_server_cap() {
+    let state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 1000}));
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        MAX_WEB_SEARCH_CALLS_PER_CONTINUATION,
+        "a large client budget is still bounded by the server cap"
+    );
+}
+
+#[test]
+fn remaining_budget_subtracts_prior_executions() {
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 5}));
+    assert_eq!(remaining_web_search_budget(&state), 5);
+    state.web_search_calls_executed = 2;
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        3,
+        "prior dispatches reduce the remaining client allowance"
+    );
+}
+
+#[test]
+fn remaining_budget_saturates_when_exhausted() {
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 2}));
+    state.web_search_calls_executed = 5;
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        0,
+        "an over-budget count saturates to zero remaining searches"
+    );
+}
+
+#[tokio::test]
+async fn on_request_body_honors_client_max_tool_calls() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let count = spawn_counting_brave_mock(listener);
+
+    let yaml = make_filter_yaml_with_base_url("brave", "test-key", &format!("http://{addr}"));
+    let filter = WebSearchFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let body = serde_json::json!({"model": "gpt-4o", "input": "test", "max_tool_calls": 1});
+    let mut state = ResponsesState::from_request_body(body);
+    state.web_search_calls = vec![web_search_call("ws_a", "first"), web_search_call("ws_b", "second")];
+    ctx.extensions.insert(state);
+
+    let action = filter.on_request_body(&mut ctx, &mut None, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    assert_eq!(
+        count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "only one provider request should be dispatched under max_tool_calls=1"
+    );
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.web_search_calls_executed, 1, "one search recorded as executed");
+    assert!(
+        state.web_search_calls.is_empty(),
+        "pending calls cleared after execution"
+    );
+    assert_eq!(state.accumulated_output.len(), 2, "both calls produce an output item");
+    assert_eq!(state.accumulated_output[0]["id"], "ws_a");
+    assert_eq!(state.accumulated_output[0]["status"], "completed");
+    assert_eq!(state.accumulated_output[1]["id"], "ws_b");
+    assert_eq!(
+        state.accumulated_output[1]["status"], "incomplete",
+        "the over-budget call is surfaced as incomplete, not executed"
+    );
+    assert_eq!(
+        state.accumulated_output[1]["action"]["query"], "second",
+        "the declined query is preserved in the incomplete item"
+    );
+
+    // The model-facing bridge (state.messages) and the durable rehydration
+    // history (persisted_messages) must tell the model the truth about the
+    // over-budget call: it was not performed, not a completed empty search.
+    let bridge = find_bridge_output(&state.messages, "second").expect("ws_b bridge present");
+    assert_eq!(
+        bridge["output"], "Web search not performed.",
+        "the over-budget bridge must not fabricate a no-results outcome"
+    );
+    let persisted = find_bridge_output(&state.persisted_messages, "second").expect("ws_b persisted");
+    assert_eq!(
+        persisted["output"], "Web search not performed.",
+        "durable history must not persist a false completed outcome"
+    );
+    // The dispatched call remains a truthful bridge carrying real results.
+    let dispatched = find_bridge_output(&state.messages, "first").expect("ws_a bridge present");
+    assert_ne!(
+        dispatched["output"], "Web search not performed.",
+        "the dispatched call must carry a real search outcome"
+    );
+    assert!(
+        dispatched["output"].as_str().unwrap().contains("Rust Lang"),
+        "the dispatched bridge carries the provider results"
+    );
+}
+
+#[tokio::test]
+async fn on_request_body_budget_spans_iterations() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let count = spawn_counting_brave_mock(listener);
+
+    let yaml = make_filter_yaml_with_base_url("brave", "test-key", &format!("http://{addr}"));
+    let filter = WebSearchFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let body = serde_json::json!({"model": "gpt-4o", "input": "test", "max_tool_calls": 2});
+    let mut state = ResponsesState::from_request_body(body);
+    // Simulate one search already dispatched in a prior IRR iteration.
+    state.web_search_calls_executed = 1;
+    state.web_search_calls = vec![web_search_call("ws_c", "third"), web_search_call("ws_d", "fourth")];
+    ctx.extensions.insert(state);
+
+    let action = filter.on_request_body(&mut ctx, &mut None, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    assert_eq!(
+        count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "only the single remaining budget slot is dispatched this round"
+    );
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(
+        state.web_search_calls_executed, 2,
+        "cumulative executions reach but do not exceed the client budget"
+    );
+    assert_eq!(state.accumulated_output[0]["status"], "completed");
+    assert_eq!(state.accumulated_output[1]["status"], "incomplete");
+}
+
+#[tokio::test]
+async fn on_request_body_exhausted_budget_dispatches_nothing() {
+    // Budget is already spent, so no live provider is contacted.
+    let yaml = make_filter_yaml("brave", "test-key");
+    let filter = WebSearchFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let body = serde_json::json!({"model": "gpt-4o", "input": "test", "max_tool_calls": 2});
+    let mut state = ResponsesState::from_request_body(body);
+    state.web_search_calls_executed = 2;
+    state.web_search_calls = vec![web_search_call("ws_e", "fifth")];
+    ctx.extensions.insert(state);
+
+    let action = filter.on_request_body(&mut ctx, &mut None, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.web_search_calls_executed, 2, "no further searches executed");
+    assert!(state.web_search_calls.is_empty());
+    assert_eq!(state.accumulated_output.len(), 1);
+    assert_eq!(state.accumulated_output[0]["status"], "incomplete");
+    assert_eq!(state.accumulated_output[0]["action"]["query"], "fifth");
+}
+
+#[tokio::test]
+async fn on_request_body_without_max_tool_calls_dispatches_all_under_cap() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let count = spawn_counting_brave_mock(listener);
+
+    let yaml = make_filter_yaml_with_base_url("brave", "test-key", &format!("http://{addr}"));
+    let filter = WebSearchFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let body = serde_json::json!({"model": "gpt-4o", "input": "test"});
+    let mut state = ResponsesState::from_request_body(body);
+    state.web_search_calls = vec![web_search_call("ws_f", "a"), web_search_call("ws_g", "b")];
+    ctx.extensions.insert(state);
+
+    let action = filter.on_request_body(&mut ctx, &mut None, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    assert_eq!(
+        count.load(std::sync::atomic::Ordering::SeqCst),
+        2,
+        "both searches dispatch when the client omits max_tool_calls and the count is under the server cap"
+    );
+
+    let state = ctx.extensions.get::<ResponsesState>().unwrap();
+    assert_eq!(state.web_search_calls_executed, 2);
+    assert!(
+        state
+            .accumulated_output
+            .iter()
+            .all(|item| item["status"] == "completed"),
+        "all searches completed under the server cap"
+    );
 }

--- a/apis/src/openai/responses/web_search/tests.rs
+++ b/apis/src/openai/responses/web_search/tests.rs
@@ -1234,6 +1234,44 @@ fn remaining_budget_counts_web_and_non_web_builtin_together() {
     );
 }
 
+#[test]
+fn remaining_budget_counts_moved_out_file_search_calls() {
+    // A completed file search is moved out of the response object into
+    // `file_search_output_items` before the next iterative round, so it no
+    // longer appears in `accumulated_output`. It must still exhaust the shared
+    // `max_tool_calls` budget, or a later web search would overshoot the cap.
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 1}));
+    state.file_search_output_items = vec![serde_json::json!({
+        "type": "file_search_call",
+        "id": "fs_moved",
+        "status": "completed",
+    })];
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        0,
+        "a moved-out completed file search must exhaust the shared max_tool_calls budget"
+    );
+}
+
+#[test]
+fn remaining_budget_dedups_file_search_call_across_collections() {
+    // The same completed file-search call can be echoed into more than one
+    // collection (accumulated during the response phase and retained after the
+    // move). It must be counted once, not twice, or the budget would decline a
+    // web search that is actually still within the client's cap.
+    let mut state =
+        ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o", "input": "x", "max_tool_calls": 2}));
+    let call = serde_json::json!({"type": "file_search_call", "id": "fs_dup", "status": "completed"});
+    state.accumulated_output = vec![call.clone()];
+    state.file_search_output_items = vec![call];
+    assert_eq!(
+        remaining_web_search_budget(&state),
+        1,
+        "2 - 1 distinct file search = 1; the call echoed into two collections is counted once"
+    );
+}
+
 #[tokio::test]
 async fn on_request_body_honors_client_max_tool_calls() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();

--- a/tests/integration/tests/suite/examples/openai_agentic_loop.rs
+++ b/tests/integration/tests/suite/examples/openai_agentic_loop.rs
@@ -1089,6 +1089,243 @@ fn spawn_failing_search_mock(listener: TcpListener) {
     });
 }
 
+/// Search mock that serves every connection and counts dispatched requests.
+///
+/// Returns a shared counter so a test can assert exactly how many provider
+/// requests the web search filter issued across an agentic-loop continuation.
+fn spawn_counting_search_mock(listener: TcpListener) -> Arc<std::sync::atomic::AtomicUsize> {
+    use std::{
+        io::{Read as _, Write as _},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+    let counter = Arc::new(AtomicUsize::new(0));
+    let thread_counter = Arc::clone(&counter);
+    let body = serde_json::json!({
+        "web": {
+            "results": [{
+                "title": "Rust 2025 Edition",
+                "url": "https://blog.rust-lang.org/2025",
+                "description": "The Rust 2025 edition is here."
+            }]
+        }
+    })
+    .to_string();
+    thread::spawn(move || {
+        while let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0_u8; 4096];
+            let _n = stream.read(&mut buf).unwrap_or(0);
+            thread_counter.fetch_add(1, Ordering::SeqCst);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _written = stream.write_all(response.as_bytes());
+        }
+    });
+    counter
+}
+
+#[test]
+fn web_search_caps_multiple_calls_within_one_round() {
+    // The model requests two searches in a single turn while the client caps
+    // built-in tool calls at one. Exactly one provider request must be
+    // dispatched and the excess call must be surfaced as incomplete.
+    let first_response = serde_json::json!({
+        "id": "resp_ws_cap_1",
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {
+                "type": "web_search_call",
+                "id": "ws_cap_a",
+                "status": "completed",
+                "action": {"type": "search", "query": "Rust 2025 edition"}
+            },
+            {
+                "type": "web_search_call",
+                "id": "ws_cap_b",
+                "status": "completed",
+                "action": {"type": "search", "query": "Rust async runtime"}
+            }
+        ]
+    });
+    let second_response = serde_json::json!({
+        "id": "resp_ws_cap_2",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Here is what I found."}]
+        }]
+    });
+
+    let model = StatefulCapturingBackend::new(vec![
+        (200, serde_json::to_string(&first_response).unwrap()),
+        (200, serde_json::to_string(&second_response).unwrap()),
+    ])
+    .start_with_shutdown();
+
+    let search_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let search_port = search_listener.local_addr().unwrap().port();
+    let search_count = spawn_counting_search_mock(search_listener);
+
+    let proxy_port = free_port();
+    let config = load_web_search_config(proxy_port, model.port(), search_port);
+    let proxy = start_proxy(&config);
+
+    let request_body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "Search for Rust news",
+        "max_tool_calls": 1,
+        "tools": [{"type": "web_search_preview"}]
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&request_body).unwrap()),
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "capped web search round-trip should return 200"
+    );
+
+    assert_eq!(
+        search_count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "only one provider request may be dispatched under max_tool_calls=1"
+    );
+
+    let body = parse_body(&raw);
+    let response: serde_json::Value = serde_json::from_str(&body).expect("response should be JSON");
+    assert_eq!(
+        response["id"], "resp_ws_cap_2",
+        "loop should still complete and return the final model response"
+    );
+
+    let output = response["output"]
+        .as_array()
+        .expect("response output should be an array");
+    let incomplete = output.iter().any(|item| {
+        item["type"] == "web_search_call"
+            && item["status"] == "incomplete"
+            && item["action"]["query"] == "Rust async runtime"
+    });
+    assert!(
+        incomplete,
+        "the over-budget web_search_call must be surfaced as incomplete, not executed"
+    );
+
+    assert_eq!(
+        model.requests().len(),
+        2,
+        "model backend should receive the initial request plus one post-search continuation"
+    );
+}
+
+#[test]
+fn web_search_budget_persists_across_loop_iterations() {
+    // The client caps built-in tool calls at one, but the model requests a
+    // *new* web search in a *later* loop iteration. The executed count lives
+    // in ResponsesState, which survives IRR re-entries, so the second-round
+    // search must be declined even though each individual round contains only
+    // a single call. A per-iteration counter would reset and wrongly dispatch
+    // twice.
+    let first_response = serde_json::json!({
+        "id": "resp_persist_1",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "web_search_call",
+            "id": "ws_persist_a",
+            "status": "completed",
+            "action": {"type": "search", "query": "Rust 2025 edition"}
+        }]
+    });
+    let second_response = serde_json::json!({
+        "id": "resp_persist_2",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "web_search_call",
+            "id": "ws_persist_b",
+            "status": "completed",
+            "action": {"type": "search", "query": "Rust async runtime"}
+        }]
+    });
+    let third_response = serde_json::json!({
+        "id": "resp_persist_3",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Here is what I found."}]
+        }]
+    });
+
+    let model = StatefulCapturingBackend::new(vec![
+        (200, serde_json::to_string(&first_response).unwrap()),
+        (200, serde_json::to_string(&second_response).unwrap()),
+        (200, serde_json::to_string(&third_response).unwrap()),
+    ])
+    .start_with_shutdown();
+
+    let search_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let search_port = search_listener.local_addr().unwrap().port();
+    let search_count = spawn_counting_search_mock(search_listener);
+
+    let proxy_port = free_port();
+    let config = load_web_search_config(proxy_port, model.port(), search_port);
+    let proxy = start_proxy(&config);
+
+    let request_body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "Research Rust news",
+        "max_tool_calls": 1,
+        "tools": [{"type": "web_search_preview"}]
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&request_body).unwrap()),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "multi-round web search should return 200");
+
+    assert_eq!(
+        search_count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the executed budget must persist across iterations: only the first-round search dispatches"
+    );
+
+    let body = parse_body(&raw);
+    let response: serde_json::Value = serde_json::from_str(&body).expect("response should be JSON");
+    assert_eq!(
+        response["id"], "resp_persist_3",
+        "loop should complete and return the final model response"
+    );
+
+    let output = response["output"]
+        .as_array()
+        .expect("response output should be an array");
+    let second_round_incomplete = output.iter().any(|item| {
+        item["type"] == "web_search_call"
+            && item["status"] == "incomplete"
+            && item["action"]["query"] == "Rust async runtime"
+    });
+    assert!(
+        second_round_incomplete,
+        "the second-iteration search must be declined as incomplete once the budget is spent"
+    );
+
+    assert_eq!(
+        model.requests().len(),
+        3,
+        "model backend should receive three requests across the two-search loop"
+    );
+}
+
 /// Encode a typed Responses event as one SSE frame.
 fn sse_event(event_type: &str, mut payload: serde_json::Value) -> String {
     payload


### PR DESCRIPTION
## Summary

`openai_web_search` dispatched every pending `web_search_call` serially, ignoring the client's `max_tool_calls` budget and with no server-side ceiling, so a fast provider could receive many paid requests within a single IRR continuation. This tracks cumulative dispatches in `ResponsesState.web_search_calls_executed` (which survives IRR re-entries) and intersects the remaining `max_tool_calls` allowance with a per-continuation hard cap of 64, surfacing excess and missing-query calls as `incomplete` without issuing a provider request. The tool-result bridge now threads the real status so declined calls are reported truthfully to the model and durable rehydration history instead of a fabricated completed/no-results message.

## Related issue

Closes #805

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis` (11 new tests: `remaining_budget_*`, `on_request_body_*`, `build_tool_result_messages_*`)
- [x] Integration or functional tests — `cargo test -p praxis-tests-integration --test suite web_search` (22 pass, incl. new `web_search_caps_multiple_calls_within_one_round` and `web_search_budget_persists_across_loop_iterations`)
- [x] `make lint` (also `make build` green)

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. Requests without `max_tool_calls` keep today's behavior, now additionally bounded by the 64-call per-continuation server cap.
