### PR TITLE
perf(translation): avoid copying tool input and message content

### DIFF
--- a/apis/src/anthropic/to_openai/request.rs
+++ b/apis/src/anthropic/to_openai/request.rs
@@ -201,8 +201,10 @@ fn append_text_content(text: &str, text_parts: &mut Vec<String>, content_parts: 
 fn convert_tool_use_block(block: &Value, tool_calls: &mut Vec<Value>) {
     let id = block.get("id").and_then(Value::as_str).unwrap_or("");
     let name = block.get("name").and_then(Value::as_str).unwrap_or("");
-    let input = block.get("input").cloned().unwrap_or_else(|| Value::Object(Map::new()));
-    let args = serde_json::to_string(&input).unwrap_or_default();
+
+    let empty = Value::Object(Map::new());
+    let input = block.get("input").unwrap_or(&empty);
+    let args = serde_json::to_string(input).unwrap_or_default();
 
     tool_calls.push(json!({
         "id": id,

--- a/apis/src/openai/translation/chat_completions.rs
+++ b/apis/src/openai/translation/chat_completions.rs
@@ -1001,7 +1001,7 @@ fn append_message_output(
         return;
     }
 
-    output.push(message_output_item(context, status, &content_items));
+    output.push(message_output_item(context, status, content_items));
 }
 
 /// Build a stable assistant message output item id.
@@ -1010,13 +1010,13 @@ fn message_item_id(context: &ResponseContext<'_>) -> String {
 }
 
 /// Build a schema-complete `Responses` assistant message item.
-fn message_output_item(context: &ResponseContext<'_>, status: &str, content: &[Value]) -> Value {
+fn message_output_item(context: &ResponseContext<'_>, status: &str, content: Vec<Value>) -> Value {
     json!({
         "id": message_item_id(context),
         "type": "message",
         "status": status,
         "role": "assistant",
-        "content": Value::Array(content.to_vec())
+        "content": Value::Array(content)
     })
 }
 


### PR DESCRIPTION
## Summary

Serialize the borrowed Anthropic `tool_use` input instead of cloning it, and let the Chat Completions message-output helper consume its owned content vector instead of calling `to_vec()`.

Closes #904 

## Validation

- [X] `cargo test -p praxis-ai-apis`
- [X] `make lint`

## Checklist

- [X] I reviewed every changed line and can explain the change.
- [X] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.
