### PR TITLE
perf(mcp): consume owned argument maps without cloning

### DIFF
--- a/apis/src/mcp_client/mod.rs
+++ b/apis/src/mcp_client/mod.rs
@@ -294,9 +294,9 @@ pub(crate) async fn call_tool(
                 url: display_url.clone(),
             })?;
 
-        let parsed_args = match &arguments {
-            serde_json::Value::Object(obj) => Some(obj.clone()),
-            serde_json::Value::String(s) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(s).ok(),
+        let parsed_args = match arguments {
+            serde_json::Value::Object(obj) => Some(obj),
+            serde_json::Value::String(s) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&s).ok(),
             _ => None,
         };
         let mut params = CallToolRequestParams::new(tool_name.to_owned());


### PR DESCRIPTION
## Summary

`call_tool` already takes arguments by value but matched it by reference, deep-cloning the JSON map for `CallToolRequestParams`. Match by value so object arguments move their map into the request. String arguments are still parsed only for execution, so the wire representation is unchanged.

Closes #905 

## Validation

- [X] cargo test -p praxis-ai-apis
- [X] `make lint`

## Checklist

- [X] I reviewed every changed line and can explain the change.
- [X] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking changes.
