### PR TITLE
ci: close pull requests not opened from a fork

### DIFF
--- a/.github/workflows/pull-request-conventions.yaml
+++ b/.github/workflows/pull-request-conventions.yaml
@@ -59,6 +59,44 @@ jobs:
           done
 
   # ----------------------------------------------------------------------------
+  # Close Non-Fork PRs
+  # ----------------------------------------------------------------------------
+
+  close-non-fork-prs:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PRAXIS_BOT_APP_ID }}
+          private-key: ${{ secrets.PRAXIS_BOT_APP_PRIVATE_KEY }}
+
+      - name: Close PRs not opened from a fork
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Contributions must come from a fork. A PR whose head branch lives in
+          # this repository (isCrossRepository == false) is closed, except for
+          # bot-authored PRs such as Dependabot, which legitimately push branches
+          # to this repository, and PRs carrying the skip/non-fork-close label.
+          prs=$(gh pr list --base main --state open --limit 100 \
+            --json number,isCrossRepository,author,labels \
+            --jq '[.[]
+              | select(.isCrossRepository == false)
+              | select(.author.is_bot == false)
+              | select(.labels | map(.name) | any(. == "skip/non-fork-close") | not)
+            ] | .[].number')
+
+          for number in $prs; do
+            gh pr close "$number" --comment "Closed: pull requests must be opened from a fork, not from a branch in this repository. Please push your branch to your fork and open a new pull request from there."
+          done
+
+  # ----------------------------------------------------------------------------
   # Close Stale Draft PRs
   # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a `close-non-fork-prs` job to the Pull Request Conventions workflow that closes any open PR whose head branch lives in this repository (`isCrossRepository == false`), enforcing the fork-based contribution workflow with a comment asking the author to re-open from their fork. Bot-authored PRs — notably Dependabot, which pushes update branches directly into this repository — and PRs carrying the `skip/non-fork-close` label are exempt. The job reuses the file's existing conventions (the `praxis-bot-app` token, `pull-requests: write` scope, and the `workflow_dispatch` trigger).

## Related issue

N/A — CI/contribution-workflow hardening.

## Validation

- [ ] Unit tests — N/A (GitHub Actions workflow change, no Rust code).
- [x] Integration or functional tests — dry-ran the exact `--jq` filter against live `praxis-proxy/ai` PR data: across 40 historical non-fork PRs it selects the 12 human-authored ones and spares all 28 `app/dependabot` PRs; 0 currently-open PRs would be closed.
- [x] `make lint` — green (also `make build` green).

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test — N/A.
- [ ] User-facing behavior and generated documentation are updated — N/A.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence — N/A.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.
