### PR TITLE
refactor(streaming): adopt shared Praxis SSE codec for Responses framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,46 +147,18 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
 ]
 
 [[package]]
@@ -512,11 +484,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -639,7 +611,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -979,19 +951,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1030,25 +989,11 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1063,17 +1008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,7 +1015,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1525,7 +1458,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1537,12 +1470,6 @@ name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1917,16 +1844,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2005,7 +1922,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.20",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -2364,11 +2281,11 @@ checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
  "evmap",
- "indexmap 2.14.0",
+ "indexmap",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -2380,7 +2297,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "metrics",
  "ordered-float",
  "quanta",
@@ -2619,20 +2536,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2756,7 +2664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2767,7 +2675,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2846,7 +2754,7 @@ dependencies = [
  "axum",
  "base64 0.23.1",
  "bytes",
- "dashmap 6.2.1",
+ "dashmap",
  "futures",
  "http 1.5.0",
  "jsonschema",
@@ -2862,7 +2770,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror",
  "tiktoken-rs",
  "tokio",
  "tokio-util",
@@ -2891,7 +2799,7 @@ dependencies = [
  "base64 0.23.1",
  "bytes",
  "chrono",
- "dashmap 6.2.1",
+ "dashmap",
  "http 1.5.0",
  "metrics",
  "metrics-util",
@@ -2908,7 +2816,7 @@ dependencies = [
  "serde_json_path",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2936,7 +2844,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sync_wrapper",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2978,8 +2886,7 @@ dependencies = [
 [[package]]
 name = "praxis-proxy"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aceb4ee3eff4f5c73d528f8803bffe9f979bc49e56b62cbdfacf090f9fe354"
+source = "git+https://github.com/praxis-proxy/praxis?rev=c4cab7966e3a707cad1ab274ffca180970f9e1dd#c4cab7966e3a707cad1ab274ffca180970f9e1dd"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -2999,12 +2906,11 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-core"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40057cbaa0e3d0e91e77173560532408117b95570a405fd12f445431f5be8cdc"
+source = "git+https://github.com/praxis-proxy/praxis?rev=c4cab7966e3a707cad1ab274ffca180970f9e1dd#c4cab7966e3a707cad1ab274ffca180970f9e1dd"
 dependencies = [
  "bytes",
  "chrono",
- "dashmap 6.2.1",
+ "dashmap",
  "http 1.5.0",
  "metrics",
  "percent-encoding",
@@ -3014,7 +2920,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "serde",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -3025,13 +2931,12 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-filter"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c84f1ccd01894ba939685446f0a433303eefb691cacd746b38513821408ccc"
+source = "git+https://github.com/praxis-proxy/praxis?rev=c4cab7966e3a707cad1ab274ffca180970f9e1dd#c4cab7966e3a707cad1ab274ffca180970f9e1dd"
 dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
- "dashmap 6.2.1",
+ "dashmap",
  "http 1.5.0",
  "metrics",
  "percent-encoding",
@@ -3044,7 +2949,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "yaml_serde",
@@ -3054,8 +2959,7 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-protocol"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e415a81a87c52f6d7dafae7723c1ef35d8a80f17a7aef2d7baff909a65abb1"
+source = "git+https://github.com/praxis-proxy/praxis?rev=c4cab7966e3a707cad1ab274ffca180970f9e1dd#c4cab7966e3a707cad1ab274ffca180970f9e1dd"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3081,14 +2985,13 @@ dependencies = [
 [[package]]
 name = "praxis-proxy-tls"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f85b8155a01acb3a85ca9f6809bd51de81889484c9a62123fdbaa07dd2612f"
+source = "git+https://github.com/praxis-proxy/praxis?rev=c4cab7966e3a707cad1ab274ffca180970f9e1dd#c4cab7966e3a707cad1ab274ffca180970f9e1dd"
 dependencies = [
  "arc-swap",
  "notify",
  "rustls",
  "serde",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "zeroize",
@@ -3124,7 +3027,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -3336,7 +3239,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -3348,7 +3251,7 @@ dependencies = [
  "logos 0.15.1",
  "miette",
  "prost-types",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -3400,7 +3303,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3423,7 +3326,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.20",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3445,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-cache"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a820a1a3e59644b38bc03606b638b41f1c5a474215efcec37f94b15871a7e1c"
+checksum = "2170cdcd123450231d0828912839eef227bb1d0055f005cccbc8c4879c505fda"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3458,7 +3361,7 @@ dependencies = [
  "http 1.5.0",
  "httparse",
  "httpdate",
- "indexmap 1.9.3",
+ "indexmap",
  "log",
  "lru",
  "once_cell",
@@ -3469,7 +3372,7 @@ dependencies = [
  "quixotic-plecostomus-http",
  "quixotic-plecostomus-lru",
  "quixotic-plecostomus-timeout",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "rmp",
  "rmp-serde",
@@ -3480,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-core"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d6d9e04414ba6819c51ec210eddf17865c505431a492c86c6356338c2b4f60"
+checksum = "10afcc507d2cb09b581d71f2ed501bbd9f68117d3e5dcdb280bb486049f019e1"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3493,7 +3396,6 @@ dependencies = [
  "clap",
  "daemonix",
  "daggy",
- "derivative",
  "flate2",
  "flurry",
  "futures",
@@ -3515,10 +3417,9 @@ dependencies = [
  "quixotic-plecostomus-runtime",
  "quixotic-plecostomus-rustls",
  "quixotic-plecostomus-timeout",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "serde",
- "serde_yaml",
  "sfv",
  "socket2",
  "strum 0.26.3",
@@ -3528,21 +3429,22 @@ dependencies = [
  "tokio-test",
  "unicase",
  "windows-sys 0.59.0",
- "x509-parser 0.16.0",
+ "x509-parser",
+ "yaml_serde",
  "zstd",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-error"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af30024450d6dc4785ccadf33e7cfd91f837bc6a226f133f9e77b397b4206c5"
+checksum = "babdfdca7e2daabbef281e3d0a6b9eac958afcdb28c4c4c4a882384690c7d3cc"
 
 [[package]]
 name = "quixotic-plecostomus-header-serde"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fe7db0e7899a6b2d2cf06e71adacfad4c1bcfe3b5f238494dd3b3eafb2c1b1"
+checksum = "c18c8ab3e8b558bfd8fb7c9953869fedc07b5a0acf4a9fc547f4dbfb21bcd286"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -3556,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-http"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f337131150ff271246df2584da8bdb0280b8424646d2c76e3926faa70409dc9"
+checksum = "3f9a488e14da09575fa4b108cc8ee31385692c5f73700ec88ddd0438dc2cf092"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -3567,24 +3469,24 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-lru"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec55d3bcbd56e52b3424bc62739a237d43c14df8ed04aaf294ae187b60da348a"
+checksum = "ace25e7acff2509609f603331204eaf416a62d92233785e7a0ad58d91a328dba"
 dependencies = [
  "arrayvec",
  "hashbrown 0.17.1",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-pool"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6383d2998b2298a0f34bb8a7330f5fea4bb0fb55671db2dc788b5f703c2009f"
+checksum = "0c3a8ab05fe009d7ef2cc7236dee12904bd60efa2a5a2cb5a8b0955b08f3baa4"
 dependencies = [
  "crossbeam-queue",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "log",
  "lru",
@@ -3595,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-proxy"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953dcda74a2c196497ddc7892e571cdaa0bdb8acc8f7afb6d7b97339b28c658"
+checksum = "4e9987508338ed682178a703bfc9ce6c050112fae1eb6687d2b3f38544f77d35"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3611,20 +3513,20 @@ dependencies = [
  "quixotic-plecostomus-core",
  "quixotic-plecostomus-error",
  "quixotic-plecostomus-http",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "tokio",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-runtime"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51621ff504cfde18409889d6d5b8773e0b0de0e4defa610006a36c27adc06a10"
+checksum = "8b2906b043f5511fff32636a80ff45624a68675f3cc42ffd5b5b7acb691ca29a"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.7",
+ "rand 0.10.2",
  "serde",
  "thread_local",
  "tokio",
@@ -3632,9 +3534,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-rustls"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ba2674ecab001d9ebdc6dc9944326857c07f9c65e7c0779f25db17f96ee84"
+checksum = "a2359930255ece5446d6f62246f4781870d8f2230df3e5abfb764f1fd69490ec"
 dependencies = [
  "log",
  "no_debug",
@@ -3649,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-timeout"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f76d183bcbdae3c0f4b0547e0fb7afdc658853a5e7421bbae1b59e48c25e667"
+checksum = "7ef2ccca7162912fc19e1e1aa4902793c084995bc0bc0acd3fed1e89d17dd0ad"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3683,22 +3585,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3715,31 +3606,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3803,7 +3675,7 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.18.1",
+ "x509-parser",
  "yasna",
 ]
 
@@ -3974,7 +3846,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rand 0.10.2",
@@ -3984,7 +3856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4354,7 +4226,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4386,7 +4258,7 @@ dependencies = [
  "serde_json",
  "serde_json_path_core",
  "serde_json_path_macros",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -4398,7 +4270,7 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -4424,26 +4296,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sfv"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa1f336066b758b7c9df34ed049c0e693a426afe2b27ff7d5b14f410ab1a132"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap",
  "rust_decimal",
 ]
 
@@ -4598,7 +4457,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "percent-encoding",
@@ -4607,7 +4466,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4682,7 +4541,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.20",
+ "thiserror",
  "tracing",
  "whoami",
 ]
@@ -4706,7 +4565,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror 2.0.20",
+ "thiserror",
  "tracing",
  "url",
 ]
@@ -4810,17 +4669,6 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -4876,31 +4724,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.20",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5183,7 +5011,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5244,7 +5072,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -5331,7 +5159,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -5416,12 +5244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5457,7 +5279,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -5957,36 +5779,19 @@ checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs 0.6.2",
- "data-encoding",
- "der-parser 9.0.0",
- "lazy_static",
- "nom",
- "oid-registry 0.7.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
+ "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
 ]
 
@@ -6024,7 +5829,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "libyaml-rs",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,11 +86,15 @@ tokio-stream = "0.1.19"
 zeroize = "1.9.0"
 
 # Praxis core dependencies
-praxis-core = { version = "0.5.4", package = "praxis-proxy-core" }
-praxis-filter = { version = "0.5.4", package = "praxis-proxy-filter" }
-praxis-protocol = { version = "0.5.4", package = "praxis-proxy-protocol" }
-praxis-tls = { version = "0.5.4", package = "praxis-proxy-tls" }
-praxis = { version = "0.5.4", package = "praxis-proxy" }
+#
+# Pinned to praxis main (no release yet) at the merge commit of
+# praxis-proxy/praxis#1060, which adds the shared `praxis_filter::sse` codec that
+# issue #842 migrates onto. Bump the rev once a release carrying the codec ships.
+praxis-core = { git = "https://github.com/praxis-proxy/praxis", rev = "c4cab7966e3a707cad1ab274ffca180970f9e1dd", package = "praxis-proxy-core" }
+praxis-filter = { git = "https://github.com/praxis-proxy/praxis", rev = "c4cab7966e3a707cad1ab274ffca180970f9e1dd", package = "praxis-proxy-filter" }
+praxis-protocol = { git = "https://github.com/praxis-proxy/praxis", rev = "c4cab7966e3a707cad1ab274ffca180970f9e1dd", package = "praxis-proxy-protocol" }
+praxis-tls = { git = "https://github.com/praxis-proxy/praxis", rev = "c4cab7966e3a707cad1ab274ffca180970f9e1dd", package = "praxis-proxy-tls" }
+praxis = { git = "https://github.com/praxis-proxy/praxis", rev = "c4cab7966e3a707cad1ab274ffca180970f9e1dd", package = "praxis-proxy" }
 praxis-test-utils = { path = "tests/utils" }
 
 # AI-owned llm-d ext_proc compatibility layer
@@ -103,9 +107,12 @@ praxis-ai-apis = { version = "0.3.0", path = "apis" }
 praxis-ai-build-support = { version = "0.3.0", path = "server/build_support" }
 
 # Pingora (temporary fork)
-pingora-core = { version = "0.8.2", package = "quixotic-plecostomus-core", features = ["rustls"] }
-pingora-http = { version = "0.8.2", package = "quixotic-plecostomus-http" }
-pingora-proxy = { version = "0.8.2", package = "quixotic-plecostomus-proxy", features = ["rustls"] }
+#
+# Kept in lockstep with praxis core: praxis main depends on the 0.8.4 fork, and
+# the proxy links the same Pingora types across both, so the versions must match.
+pingora-core = { version = "0.8.4", package = "quixotic-plecostomus-core", features = ["rustls"] }
+pingora-http = { version = "0.8.4", package = "quixotic-plecostomus-http" }
+pingora-proxy = { version = "0.8.4", package = "quixotic-plecostomus-proxy", features = ["rustls"] }
 arc-swap = "1.9.2"
 metrics = "0.24.6"
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -82,6 +82,7 @@ pub(crate) mod test_utils {
             request_headers_to_set: Vec::new(),
             filter_metadata: std::collections::HashMap::new(),
             pre_read_mutations: Vec::new(),
+            prior_pre_read_mutations: Vec::new(),
             structured_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             filter_state: std::collections::HashMap::new(),

--- a/apis/src/openai/sse/frame.rs
+++ b/apis/src/openai/sse/frame.rs
@@ -1,14 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Praxis Contributors
 
-//! Byte-level SSE frame reassembly.
+//! SSE frame reassembly, adapted onto the shared Praxis SSE codec.
+//!
+//! This module keeps the OpenAI-facing [`SseFrame`] / [`SseFrameParser`] /
+//! [`SseParseError`] surface stable while delegating the byte-level record
+//! framing to [`praxis_filter::sse::SseDecoder`]. Provider JSON typing, the
+//! `[DONE]` sentinel, the event-count budget, timeouts, and lifecycle rules
+//! stay in the OpenAI consumers (see `responses::parser` and the
+//! `responses::stream_events` filter) — this layer only turns a byte stream
+//! into data-bearing [`SseFrame`] values.
 
 use std::{fmt, time::Duration};
+
+use bytes::Bytes;
+use praxis_filter::sse::{SseDecodeError, SseDecoder, SseLimits, SseRecord};
 
 /// A completed SSE frame: one event boundary's worth of data.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct SseFrame {
-    /// Value from the `event:` field, if present.
+    /// Value from the last `event:` field, if present (lossily UTF-8 decoded).
     pub event_type: Option<String>,
     /// Joined `data:` field values, separated by `\n`.
     pub data: Vec<u8>,
@@ -16,48 +27,57 @@ pub(crate) struct SseFrame {
 
 /// Incremental SSE frame parser.
 ///
-/// Buffers partial lines across chunk boundaries and yields
-/// complete [`SseFrame`] values on each blank-line event boundary.
+/// Feeds each body chunk to a request-scoped [`SseDecoder`] and yields the
+/// data-bearing records it completed as [`SseFrame`] values on each blank-line
+/// event boundary. Comment-only, `event`-only, and `id`/`retry`-only blocks are
+/// framed by the decoder but carry no `data`, so they never surface as frames —
+/// matching the pre-codec parser, which only dispatched blocks with at least one
+/// `data:` field.
 pub(crate) struct SseFrameParser {
-    /// Accumulates the current line being parsed.
-    line_buf: Vec<u8>,
-    /// The `event:` value for the current frame, if any.
-    event_type: Option<String>,
-    /// Joined `data:` field values for the current frame.
-    data_buf: Vec<u8>,
-    /// Whether at least one `data:` field has been seen.
-    has_data: bool,
-    /// Whether the previous chunk ended with a bare `\r`.
-    prev_cr: bool,
-    /// Current total buffered bytes retained across chunks.
-    scratch_bytes: usize,
-    /// Maximum allowed buffered bytes.
-    max_buffer_bytes: usize,
+    /// Shared-codec decoder holding the cross-chunk line/record state.
+    decoder: SseDecoder,
 }
 
 impl SseFrameParser {
     /// Create a new parser with the given buffer byte limit.
+    ///
+    /// The single OpenAI `max_buffer_bytes` budget is applied to *both* shared-codec
+    /// framing bounds — `max_line_bytes` (one partial line held across chunks) and
+    /// `max_record_bytes` (the committed fields of one in-progress record) — and
+    /// either overflow surfaces as [`SseParseError::BufferOverflow`].
+    ///
+    /// For the blocks the Responses API emits — a single `data:` line each — the
+    /// record *is* that one line, so both the overflow trip point and the peak
+    /// retained bytes (`max_buffer_bytes`) match the pre-codec parser. The two
+    /// accountings do differ for a *multi-line* record, which the Responses API
+    /// never produces: the old parser summed its carried line and joined data into
+    /// one budget, whereas the codec bounds the carried line and the committed
+    /// record separately, so such a record can retain up to two budgets transiently
+    /// and is accepted slightly past the old combined trip point. This only ever
+    /// loosens the bound — no stream the old parser accepted is now rejected.
+    ///
+    /// The codec's default `max_fields_per_record` is left in place: it never trips
+    /// on Responses events and bounds an otherwise unbounded field vector (e.g. many
+    /// empty `data:` lines), so it strengthens rather than weakens backpressure.
     pub fn new(max_buffer_bytes: usize) -> Self {
         Self {
-            line_buf: Vec::new(),
-            event_type: None,
-            data_buf: Vec::new(),
-            has_data: false,
-            prev_cr: false,
-            scratch_bytes: 0,
-            max_buffer_bytes,
+            decoder: SseDecoder::with_limits(SseLimits {
+                max_line_bytes: max_buffer_bytes,
+                max_record_bytes: max_buffer_bytes,
+                ..SseLimits::default()
+            }),
         }
     }
 
     /// Feed a chunk of bytes, returning any complete SSE frames.
-    pub fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<SseFrame>, SseParseError> {
-        self.parse_chunk_inner(chunk, None, |_| true)
+    pub fn parse_chunk(&mut self, chunk: &Bytes) -> Result<Vec<SseFrame>, SseParseError> {
+        self.parse_chunk_with_counted_event_limit(chunk, 0, usize::MAX, |_| true)
     }
 
     /// Feed a chunk and stop before emitting more frames than the event budget allows.
     pub fn parse_chunk_with_event_limit(
         &mut self,
-        chunk: &[u8],
+        chunk: &Bytes,
         current_events: usize,
         max_events: usize,
     ) -> Result<Vec<SseFrame>, SseParseError> {
@@ -65,153 +85,95 @@ impl SseFrameParser {
     }
 
     /// Feed a chunk and count only selected frames against the event budget.
+    ///
+    /// Frames complete by this chunk are built in order; a frame for which
+    /// `count_frame` returns `true` is checked against the budget *before* it is
+    /// emitted, so exceeding the budget returns [`SseParseError::EventLimitExceeded`]
+    /// and discards the whole chunk's frames — the pre-codec behavior. A framing
+    /// limit violation likewise discards the chunk's frames and surfaces as
+    /// [`SseParseError::BufferOverflow`].
     pub fn parse_chunk_with_counted_event_limit(
         &mut self,
-        chunk: &[u8],
+        chunk: &Bytes,
         current_events: usize,
         max_events: usize,
-        count_frame: impl FnMut(&SseFrame) -> bool,
-    ) -> Result<Vec<SseFrame>, SseParseError> {
-        self.parse_chunk_inner(chunk, Some((current_events, max_events)), count_frame)
-    }
-
-    /// Feed a chunk with optional event-budget enforcement.
-    #[expect(clippy::too_many_lines, reason = "linear byte-processing loop")]
-    fn parse_chunk_inner(
-        &mut self,
-        chunk: &[u8],
-        event_limit: Option<(usize, usize)>,
         mut count_frame: impl FnMut(&SseFrame) -> bool,
     ) -> Result<Vec<SseFrame>, SseParseError> {
-        if chunk.is_empty() {
-            self.scratch_bytes = self.buffered_bytes();
-            return Ok(Vec::new());
-        }
+        // Inspect only: `push` reads the chunk (a cheap `Bytes` refcount bump for
+        // Pingora), never the forwarded body, which the filter leaves untouched.
+        let batch = self.decoder.push(chunk);
 
         let mut frames = Vec::new();
         let mut counted_in_chunk = 0;
-        let mut i = 0;
 
-        if self.prev_cr && chunk.first() == Some(&b'\n') {
-            i = 1;
-        }
-        self.prev_cr = false;
-
-        while let Some(&b) = chunk.get(i) {
-            if b == b'\n' || b == b'\r' {
-                if let Some(frame) = self.process_line() {
-                    if count_frame(&frame) {
-                        Self::check_event_limit(event_limit, counted_in_chunk)?;
-                        counted_in_chunk = counted_in_chunk.saturating_add(1);
-                    }
-                    frames.push(frame);
-                }
-                self.line_buf.clear();
-                self.scratch_bytes = self.buffered_bytes();
-
-                if b == b'\r' {
-                    if let Some(&next) = chunk.get(i + 1) {
-                        if next == b'\n' {
-                            i += 1;
-                        }
-                    } else {
-                        self.prev_cr = true;
-                    }
-                }
-            } else {
-                self.line_buf.push(b);
-                self.scratch_bytes = self.scratch_bytes.saturating_add(1);
+        for record in &batch.records {
+            // The decoder frames every blank-line-terminated block; only blocks
+            // with a `data:` field are dispatchable events (WHATWG), matching the
+            // old parser's `has_data` gate.
+            if !record.is_event() {
+                continue;
             }
 
-            self.check_buffer_limit()?;
-
-            i += 1;
+            let frame = frame_from_record(record);
+            if count_frame(&frame) {
+                check_event_limit(current_events, counted_in_chunk, max_events)?;
+                counted_in_chunk = counted_in_chunk.saturating_add(1);
+            }
+            frames.push(frame);
         }
 
-        self.scratch_bytes = self.buffered_bytes();
+        // A framing-limit violation poisons the decoder; report it (and drop this
+        // chunk's frames) only after the event budget, preserving the byte-order
+        // precedence of the pre-codec parser. An unterminated final block is
+        // never salvaged: `finish` is intentionally not called, so a trailing
+        // partial record stays buffered and is discarded (WHATWG), which the
+        // consumers observe as a missing terminal event.
+        if let Some(err) = batch.error {
+            return Err(map_decode_error(err));
+        }
+
         Ok(frames)
     }
+}
 
-    /// Return the number of bytes currently retained by the parser.
-    fn buffered_bytes(&self) -> usize {
-        self.line_buf
-            .len()
-            .saturating_add(self.data_buf.len())
-            .saturating_add(self.event_type.as_ref().map_or(0, String::len))
+/// Build an [`SseFrame`] from a data-bearing decoder record.
+///
+/// The owned copy mirrors the pre-codec `SseFrame`: it is an internal inspection
+/// view, distinct from the response body, which the filter forwards byte-exact.
+fn frame_from_record(record: &SseRecord) -> SseFrame {
+    SseFrame {
+        event_type: record.event().map(|bytes| String::from_utf8_lossy(bytes).into_owned()),
+        data: record.data().to_vec(),
+    }
+}
+
+/// Check whether another counted frame would exceed the event budget.
+fn check_event_limit(current_events: usize, counted_in_chunk: usize, max_events: usize) -> Result<(), SseParseError> {
+    let count = current_events.saturating_add(counted_in_chunk).saturating_add(1);
+    if count > max_events {
+        return Err(SseParseError::EventLimitExceeded {
+            count,
+            limit: max_events,
+        });
     }
 
-    /// Check whether the current retained byte count exceeds the buffer limit.
-    fn check_buffer_limit(&self) -> Result<(), SseParseError> {
-        if self.scratch_bytes > self.max_buffer_bytes {
-            return Err(SseParseError::BufferOverflow {
-                buffered_bytes: self.scratch_bytes,
-                limit: self.max_buffer_bytes,
-            });
-        }
+    Ok(())
+}
 
-        Ok(())
-    }
-
-    /// Check whether another completed frame would exceed the event budget.
-    fn check_event_limit(event_limit: Option<(usize, usize)>, parsed_in_chunk: usize) -> Result<(), SseParseError> {
-        let Some((current_events, max_events)) = event_limit else {
-            return Ok(());
-        };
-
-        let count = current_events.saturating_add(parsed_in_chunk).saturating_add(1);
-        if count > max_events {
-            return Err(SseParseError::EventLimitExceeded {
-                count,
-                limit: max_events,
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Process a completed line, emitting a frame on blank lines.
-    #[expect(clippy::indexing_slicing, reason = "colon_pos from position() guarantees bounds")]
-    #[expect(clippy::too_many_lines, reason = "linear SSE field processing")]
-    fn process_line(&mut self) -> Option<SseFrame> {
-        if self.line_buf.is_empty() {
-            let frame = self.has_data.then(|| {
-                self.has_data = false;
-                SseFrame {
-                    event_type: self.event_type.take(),
-                    data: std::mem::take(&mut self.data_buf),
-                }
-            });
-
-            self.event_type = None;
-            return frame;
-        }
-
-        if self.line_buf.first() == Some(&b':') {
-            return None;
-        }
-
-        let colon_pos = self.line_buf.iter().position(|&b| b == b':')?;
-
-        let field = &self.line_buf[..colon_pos];
-        let value_start = if self.line_buf.get(colon_pos + 1) == Some(&b' ') {
-            colon_pos + 2
-        } else {
-            colon_pos + 1
-        };
-        let value = self.line_buf.get(value_start..).unwrap_or_default();
-
-        if field == b"data" {
-            if self.has_data {
-                self.data_buf.push(b'\n');
-            }
-            self.has_data = true;
-            self.data_buf.extend_from_slice(value);
-        } else if field == b"event" {
-            self.event_type = Some(String::from_utf8_lossy(value).into_owned());
-        }
-
-        None
-    }
+/// Map a shared-codec framing error onto the OpenAI-facing [`SseParseError`].
+///
+/// Every retained-memory bound the codec enforces (line, record, or field count)
+/// is a framing overflow from this layer's perspective, so all three collapse to
+/// [`SseParseError::BufferOverflow`], preserving the pre-codec error surface.
+/// `Finished` is unreachable: this adapter only ever calls `push`, never
+/// `finish`, so the decoder never enters the finished state.
+fn map_decode_error(err: SseDecodeError) -> SseParseError {
+    let (buffered_bytes, limit) = match err {
+        SseDecodeError::LineTooLong { size, limit } | SseDecodeError::RecordTooLarge { size, limit } => (size, limit),
+        SseDecodeError::TooManyFields { count, limit } => (count, limit),
+        SseDecodeError::Finished => (0, 0),
+    };
+    SseParseError::BufferOverflow { buffered_bytes, limit }
 }
 
 /// Errors from SSE parsing, shared across frame and event layers.
@@ -317,21 +279,38 @@ mod tests {
 
     const MAX_BUF: usize = 65_536;
 
+    /// Wrap a byte slice as the `Bytes` the parser (and Pingora) hand around.
+    fn chunk(bytes: &'static [u8]) -> Bytes {
+        Bytes::from_static(bytes)
+    }
+
+    // These are adapter tests: they cover this layer's contract with the shared
+    // codec — mapping a data-bearing `SseRecord` to an `SseFrame`, skipping
+    // non-event records, translating framing-limit errors, enforcing the
+    // consumer event budget, and never salvaging an unterminated tail. Byte-level
+    // framing (CR/CRLF/LF handling, BOM stripping, cross-chunk line reassembly,
+    // optional-space and colon-less field parsing) belongs to the codec and is
+    // exercised by its own conformance tests, not duplicated here.
+
+    // -------------------------------------------------------------------------
+    // Record -> SseFrame mapping
+    // -------------------------------------------------------------------------
+
     #[test]
-    fn single_frame_yields_one_result() {
+    fn data_record_maps_to_frame() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: hello\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
+        let frames = parser.parse_chunk(&chunk(b"data: hello\n\n")).unwrap();
         assert_eq!(frames.len(), 1, "single complete frame should dispatch");
         assert_eq!(frames[0].data, b"hello", "frame data should match");
         assert_eq!(frames[0].event_type, None, "frame should not have event type");
     }
 
     #[test]
-    fn event_type_captured() {
+    fn event_field_maps_to_frame_event_type() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"event: response.created\ndata: {\"id\":\"r1\"}\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
+        let frames = parser
+            .parse_chunk(&chunk(b"event: response.created\ndata: {\"id\":\"r1\"}\n\n"))
+            .unwrap();
         assert_eq!(frames.len(), 1, "single event frame should dispatch");
         assert_eq!(
             frames[0].event_type.as_deref(),
@@ -342,249 +321,201 @@ mod tests {
     }
 
     #[test]
-    fn event_type_resets_between_frames() {
+    fn every_record_in_chunk_maps_to_a_frame() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"event: first\ndata: a\n\ndata: b\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 2, "two frames should dispatch");
-        assert_eq!(
-            frames[0].event_type.as_deref(),
-            Some("first"),
-            "first event type should be captured"
-        );
-        assert_eq!(frames[1].event_type, None, "event type should reset between frames");
-    }
-
-    #[test]
-    fn multiple_frames_in_one_chunk() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: first\n\ndata: second\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 2, "two frames should dispatch from one chunk");
+        let frames = parser.parse_chunk(&chunk(b"data: first\n\ndata: second\n\n")).unwrap();
+        assert_eq!(frames.len(), 2, "both records in the chunk should map to frames");
         assert_eq!(frames[0].data, b"first", "first frame data should match");
         assert_eq!(frames[1].data, b"second", "second frame data should match");
     }
 
     #[test]
-    fn frame_split_across_chunks() {
+    fn multiline_data_is_joined_into_frame() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let frames1 = parser.parse_chunk(b"data: hel").unwrap();
+        let frames = parser
+            .parse_chunk(&chunk(b"data: line1\ndata: line2\ndata: line3\n\n"))
+            .unwrap();
+        assert_eq!(frames.len(), 1, "multiline data should dispatch one frame");
+        assert_eq!(
+            frames[0].data, b"line1\nline2\nline3",
+            "the record's joined data should surface in the frame"
+        );
+    }
+
+    #[test]
+    fn decoder_state_persists_across_chunks() {
+        // The adapter owns the request-scoped decoder, so a record split across
+        // two `parse_chunk` calls must still complete.
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let frames1 = parser.parse_chunk(&chunk(b"data: hel")).unwrap();
         assert!(frames1.is_empty(), "partial frame should not dispatch");
-        let frames2 = parser.parse_chunk(b"lo\n\n").unwrap();
+        let frames2 = parser.parse_chunk(&chunk(b"lo\n\n")).unwrap();
         assert_eq!(frames2.len(), 1, "completed split frame should dispatch");
         assert_eq!(frames2[0].data, b"hello", "joined frame data should match");
     }
 
     #[test]
-    fn blank_line_split_across_chunks() {
+    fn lossy_event_type_from_invalid_utf8() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let frames1 = parser.parse_chunk(b"data: hello\n").unwrap();
-        assert!(frames1.is_empty(), "line ending alone should not dispatch");
-        let frames2 = parser.parse_chunk(b"\n").unwrap();
-        assert_eq!(frames2.len(), 1, "blank line should dispatch frame");
-        assert_eq!(frames2[0].data, b"hello", "frame data should match");
+        let frames = parser.parse_chunk(&chunk(b"event: \xFF\xFF\ndata: x\n\n")).unwrap();
+        assert_eq!(
+            frames.len(),
+            1,
+            "invalid-UTF-8 event type should still dispatch its data frame"
+        );
+        assert_eq!(
+            frames[0].event_type.as_deref(),
+            Some("\u{FFFD}\u{FFFD}"),
+            "invalid UTF-8 in the event type should be replaced lossily"
+        );
+        assert_eq!(
+            frames[0].data, b"x",
+            "data should be preserved alongside the lossy event type"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-event records are skipped (is_event filtering)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn comment_only_record_is_not_a_frame() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let frames = parser.parse_chunk(&chunk(b": keepalive\n\ndata: hello\n\n")).unwrap();
+        assert_eq!(frames.len(), 1, "a comment-only block is not a dispatchable event");
+        assert_eq!(frames[0].data, b"hello", "only the data-bearing frame dispatches");
     }
 
     #[test]
-    fn multiline_data_joined_with_newline() {
+    fn event_only_record_is_not_a_frame() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: line1\ndata: line2\ndata: line3\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "multiline data should dispatch one frame");
+        let frames = parser.parse_chunk(&chunk(b"event: ping\n\ndata: hello\n\n")).unwrap();
         assert_eq!(
-            frames[0].data, b"line1\nline2\nline3",
-            "data lines should be joined with newlines"
+            frames.len(),
+            1,
+            "an event-only block carries no data and does not dispatch"
+        );
+        assert_eq!(frames[0].data, b"hello", "only the data-bearing frame dispatches");
+        assert_eq!(
+            frames[0].event_type, None,
+            "the discarded event: does not leak into the next frame"
         );
     }
 
     #[test]
-    fn crlf_line_endings() {
+    fn unterminated_final_block_is_discarded() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: hello\r\n\r\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "CRLF frame should dispatch");
-        assert_eq!(frames[0].data, b"hello", "frame data should match");
-    }
-
-    #[test]
-    fn crlf_split_across_chunks() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let frames1 = parser.parse_chunk(b"data: hello\r").unwrap();
-        assert!(frames1.is_empty(), "CR at chunk boundary should wait for LF");
-        let frames2 = parser.parse_chunk(b"\n\r\n").unwrap();
-        assert_eq!(frames2.len(), 1, "CRLF split across chunks should dispatch");
-        assert_eq!(frames2[0].data, b"hello", "frame data should match");
-    }
-
-    #[test]
-    fn crlf_split_by_empty_chunk_preserves_event_type() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-
-        let frames1 = parser.parse_chunk(b"event: response.completed\r").unwrap();
-        assert!(frames1.is_empty(), "event line alone should not dispatch");
-
-        let frames2 = parser.parse_chunk(b"").unwrap();
-        assert!(frames2.is_empty(), "empty chunk should not dispatch");
-
-        let frames3 = parser.parse_chunk(b"\ndata: {}\r\n\r\n").unwrap();
-        assert_eq!(frames3.len(), 1, "data frame should dispatch after split CRLF");
-        assert_eq!(
-            frames3[0].event_type.as_deref(),
-            Some("response.completed"),
-            "empty chunk should preserve pending CRLF state"
-        );
-    }
-
-    #[test]
-    fn bare_cr_line_ending() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: hello\r\r";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "bare CR frame should dispatch");
-        assert_eq!(frames[0].data, b"hello", "frame data should match");
-    }
-
-    #[test]
-    fn comments_ignored() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b": this is a comment\ndata: hello\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "comment should be ignored");
-        assert_eq!(frames[0].data, b"hello", "frame data should match");
-    }
-
-    #[test]
-    fn unknown_fields_ignored() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"id: 42\nretry: 1000\ndata: hello\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "unknown fields should be ignored");
-        assert_eq!(frames[0].data, b"hello", "frame data should match");
-    }
-
-    #[test]
-    fn empty_frames_ignored() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"\n\ndata: hello\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "empty frames should be ignored");
-        assert_eq!(frames[0].data, b"hello", "non-empty frame data should match");
-    }
-
-    #[test]
-    fn data_without_space_after_colon() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data:nospace\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "data without optional space should dispatch");
-        assert_eq!(frames[0].data, b"nospace", "frame data should match");
-    }
-
-    #[test]
-    fn data_with_empty_value() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data:\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "empty data value should dispatch");
-        assert!(frames[0].data.is_empty(), "empty data value should remain empty");
-    }
-
-    #[test]
-    fn line_without_colon_ignored() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"justtext\ndata: hello\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(frames.len(), 1, "line without colon should be ignored");
-        assert_eq!(frames[0].data, b"hello", "frame data should match");
-    }
-
-    #[test]
-    fn buffer_overflow_returns_error() {
-        let mut parser = SseFrameParser::new(10);
-        let result = parser.parse_chunk(b"data: this line is way too long for the limit\n\n");
-        assert!(result.is_err(), "oversized line should return an error");
-    }
-
-    #[test]
-    fn overflow_after_completed_frame() {
-        let mut parser = SseFrameParser::new(15);
-        let chunk = b"data: ok\n\ndata: this-is-way-too-long\n\n";
-        let result = parser.parse_chunk(chunk);
+        let frames = parser.parse_chunk(&chunk(b"data: no terminator")).unwrap();
         assert!(
-            result.is_err(),
-            "overflow after a completed frame should return an error"
+            frames.is_empty(),
+            "an unterminated final block is never dispatched (finish is not called; WHATWG discard)"
         );
     }
 
+    // -------------------------------------------------------------------------
+    // Framing-limit -> BufferOverflow mapping
+    // -------------------------------------------------------------------------
+
     #[test]
-    fn event_type_counts_toward_buffer_limit() {
-        let mut parser = SseFrameParser::new(20);
-        let result = parser.parse_chunk(b"event: 1234567890123\ndata: 12345678\n\n");
+    fn line_overflow_maps_to_buffer_overflow() {
+        let mut parser = SseFrameParser::new(10);
+        let result = parser.parse_chunk(&chunk(b"data: this line is way too long for the limit\n\n"));
         assert!(
             matches!(result, Err(SseParseError::BufferOverflow { .. })),
-            "retained event type bytes should count toward the buffer limit"
+            "an over-long line should map to a buffer overflow error"
         );
     }
 
     #[test]
-    fn lossy_event_type_expansion_counts_after_line_processing() {
-        let mut parser = SseFrameParser::new(11);
-        let result = parser.parse_chunk(b"event: \xFF\xFF\xFF\xFF\n");
+    fn record_overflow_maps_to_buffer_overflow() {
+        let mut parser = SseFrameParser::new(20);
+        let result = parser.parse_chunk(&chunk(b"event: 1234567890123\ndata: 12345678\n\n"));
         assert!(
-            matches!(
-                result,
-                Err(SseParseError::BufferOverflow {
-                    buffered_bytes: 12,
-                    limit: 11
-                })
-            ),
-            "lossy UTF-8 expansion in event type should be checked after line processing"
+            matches!(result, Err(SseParseError::BufferOverflow { .. })),
+            "retained record bytes over the limit should map to a buffer overflow error"
         );
     }
 
     #[test]
-    fn event_limit_returns_error_before_extra_frame() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: one\n\ndata: two\n\n";
-        let result = parser.parse_chunk_with_event_limit(chunk, 1, 1);
+    fn overflow_after_a_frame_discards_the_chunk_frames() {
+        let mut parser = SseFrameParser::new(15);
+        let result = parser.parse_chunk(&chunk(b"data: ok\n\ndata: this-is-way-too-long\n\n"));
         assert!(
-            matches!(result, Err(SseParseError::EventLimitExceeded { count: 2, limit: 1 })),
-            "event limit should stop before emitting another frame"
+            matches!(result, Err(SseParseError::BufferOverflow { .. })),
+            "an overflow after a completed frame should still return an error, discarding the chunk's frames"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Event budget (a consumer limit layered above framing)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn event_limit_allows_frames_within_budget() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let frames = parser
+            .parse_chunk_with_event_limit(&chunk(b"data: one\n\ndata: two\n\n"), 0, 5)
+            .unwrap();
+        assert_eq!(frames.len(), 2, "both frames should be emitted within budget");
+    }
+
+    #[test]
+    fn event_limit_exact_boundary_succeeds() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let frames = parser
+            .parse_chunk_with_event_limit(&chunk(b"data: one\n\ndata: two\n\n"), 0, 2)
+            .unwrap();
+        assert_eq!(frames.len(), 2, "exactly at limit should succeed");
+    }
+
+    #[test]
+    fn event_limit_exceeded_returns_error_before_extra_frame() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let result = parser.parse_chunk_with_event_limit(&chunk(b"data: one\n\ndata: two\n\ndata: three\n\n"), 0, 2);
+        assert!(
+            matches!(result, Err(SseParseError::EventLimitExceeded { count: 3, limit: 2 })),
+            "third frame should exceed limit of 2"
         );
     }
 
     #[test]
-    fn event_type_with_space_after_colon() {
+    fn event_limit_accounts_for_current_events() {
         let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"event: response.completed\ndata: {}\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
+        let result = parser.parse_chunk_with_event_limit(&chunk(b"data: one\n\n"), 5, 5);
+        assert!(
+            matches!(result, Err(SseParseError::EventLimitExceeded { count: 6, limit: 5 })),
+            "current_events at limit should reject the next frame"
+        );
+    }
+
+    #[test]
+    fn event_limit_no_frames_always_succeeds() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        let frames = parser
+            .parse_chunk_with_event_limit(&chunk(b"data: partial"), 100, 100)
+            .unwrap();
+        assert!(
+            frames.is_empty(),
+            "no complete frames should succeed regardless of current count"
+        );
+    }
+
+    #[test]
+    fn counted_event_limit_skips_uncounted_frames() {
+        let mut parser = SseFrameParser::new(MAX_BUF);
+        // The `[DONE]` sentinel is not counted against the budget but is still
+        // emitted, mirroring the OpenAI consumers' `count_frame` predicate.
+        let frames = parser
+            .parse_chunk_with_counted_event_limit(&chunk(b"data: one\n\ndata: [DONE]\n\n"), 0, 1, |frame| {
+                frame.data != b"[DONE]"
+            })
+            .unwrap();
         assert_eq!(
-            frames[0].event_type.as_deref(),
-            Some("response.completed"),
-            "event type with space should be captured"
+            frames.len(),
+            2,
+            "the uncounted sentinel frame is still emitted within budget"
         );
-    }
-
-    #[test]
-    fn event_type_without_space_after_colon() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"event:response.completed\ndata: {}\n\n";
-        let frames = parser.parse_chunk(chunk).unwrap();
-        assert_eq!(
-            frames[0].event_type.as_deref(),
-            Some("response.completed"),
-            "event type without space should be captured"
-        );
-    }
-
-    #[test]
-    fn multiline_data_split_across_chunks() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let frames1 = parser.parse_chunk(b"data: line1\n").unwrap();
-        assert!(frames1.is_empty(), "first data line should not dispatch");
-        let frames2 = parser.parse_chunk(b"data: line2\n\n").unwrap();
-        assert_eq!(frames2.len(), 1, "second data line with blank line should dispatch");
-        assert_eq!(frames2[0].data, b"line1\nline2", "split multiline data should match");
+        assert_eq!(frames[1].data, b"[DONE]", "sentinel frame preserved");
     }
 
     // -------------------------------------------------------------------------
@@ -678,58 +609,5 @@ mod tests {
             "should mention the event type"
         );
         assert!(msg.contains("terminal"), "should mention terminal context");
-    }
-
-    // -------------------------------------------------------------------------
-    // parse_chunk_with_event_limit
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn event_limit_allows_frames_within_budget() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: one\n\ndata: two\n\n";
-        let frames = parser.parse_chunk_with_event_limit(chunk, 0, 5).unwrap();
-        assert_eq!(frames.len(), 2, "both frames should be emitted within budget");
-    }
-
-    #[test]
-    fn event_limit_exact_boundary_succeeds() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: one\n\ndata: two\n\n";
-        let frames = parser.parse_chunk_with_event_limit(chunk, 0, 2).unwrap();
-        assert_eq!(frames.len(), 2, "exactly at limit should succeed");
-    }
-
-    #[test]
-    fn event_limit_exceeded_at_boundary() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: one\n\ndata: two\n\ndata: three\n\n";
-        let result = parser.parse_chunk_with_event_limit(chunk, 0, 2);
-        assert!(
-            matches!(result, Err(SseParseError::EventLimitExceeded { count: 3, limit: 2 })),
-            "third frame should exceed limit of 2"
-        );
-    }
-
-    #[test]
-    fn event_limit_accounts_for_current_events() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: one\n\n";
-        let result = parser.parse_chunk_with_event_limit(chunk, 5, 5);
-        assert!(
-            matches!(result, Err(SseParseError::EventLimitExceeded { count: 6, limit: 5 })),
-            "current_events at limit should reject the next frame"
-        );
-    }
-
-    #[test]
-    fn event_limit_no_frames_always_succeeds() {
-        let mut parser = SseFrameParser::new(MAX_BUF);
-        let chunk = b"data: partial";
-        let frames = parser.parse_chunk_with_event_limit(chunk, 100, 100).unwrap();
-        assert!(
-            frames.is_empty(),
-            "no complete frames should succeed regardless of current count"
-        );
     }
 }

--- a/apis/src/openai/sse/responses/parser.rs
+++ b/apis/src/openai/sse/responses/parser.rs
@@ -5,6 +5,8 @@
 
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
+
 use super::{
     super::{SseFrameParser, SseParseError, SseParserConfig},
     event::ResponsesEvent,
@@ -55,7 +57,7 @@ impl ResponsesSseParser {
     }
 
     /// Feed a raw chunk, returning typed events.
-    pub fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<ResponsesEvent>, SseParseError> {
+    pub fn parse_chunk(&mut self, chunk: &Bytes) -> Result<Vec<ResponsesEvent>, SseParseError> {
         let now = Instant::now();
         self.started_at.get_or_insert(now);
         self.check_timeout(now)?;
@@ -166,15 +168,15 @@ mod tests {
         }
     }
 
-    fn sse_bytes(event_type: &str, data: &Value) -> Vec<u8> {
+    fn sse_bytes(event_type: &str, data: &Value) -> Bytes {
         let mut data = data.clone();
         if let Value::Object(obj) = &mut data {
             obj.insert("type".to_owned(), Value::String(event_type.to_owned()));
         }
-        format!("event: {event_type}\ndata: {data}\n\n").into_bytes()
+        Bytes::from(format!("event: {event_type}\ndata: {data}\n\n"))
     }
 
-    fn full_lifecycle_chunks() -> Vec<Vec<u8>> {
+    fn full_lifecycle_chunks() -> Vec<Bytes> {
         vec![
             sse_bytes("response.created", &json!({"id": "resp_1"})),
             sse_bytes("response.in_progress", &json!({"id": "resp_1"})),
@@ -247,12 +249,15 @@ mod tests {
             ..config()
         };
         let mut parser = ResponsesSseParser::new(&cfg);
-        let chunk = [
+        let mut chunk = Vec::new();
+        for event in [
             sse_bytes("response.created", &json!({})),
             sse_bytes("response.in_progress", &json!({})),
             sse_bytes("response.output_text.delta", &json!({})),
-        ]
-        .concat();
+        ] {
+            chunk.extend_from_slice(&event);
+        }
+        let chunk = Bytes::from(chunk);
 
         let result = parser.parse_chunk(&chunk);
         assert!(
@@ -275,7 +280,7 @@ mod tests {
     #[test]
     fn done_sentinel_is_ignored() {
         let mut parser = ResponsesSseParser::new(&config());
-        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+        let events = parser.parse_chunk(&Bytes::from_static(b"data: [DONE]\n\n")).unwrap();
         assert!(events.is_empty(), "[DONE] should not dispatch as a typed event");
     }
 
@@ -286,7 +291,7 @@ mod tests {
             .parse_chunk(&sse_bytes("response.completed", &json!({"id": "resp_1"})))
             .unwrap();
 
-        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+        let events = parser.parse_chunk(&Bytes::from_static(b"data: [DONE]\n\n")).unwrap();
 
         assert!(events.is_empty(), "[DONE] should not dispatch as a typed event");
         assert!(
@@ -306,7 +311,7 @@ mod tests {
             .parse_chunk(&sse_bytes("response.completed", &json!({"id": "resp_1"})))
             .unwrap();
 
-        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+        let events = parser.parse_chunk(&Bytes::from_static(b"data: [DONE]\n\n")).unwrap();
 
         assert!(events.is_empty(), "[DONE] should not count against max_events");
         assert!(
@@ -385,7 +390,7 @@ mod tests {
     #[test]
     fn malformed_terminal_event_does_not_validate_complete() {
         let mut parser = ResponsesSseParser::new(&config());
-        let result = parser.parse_chunk(b"event: response.completed\ndata: {}\n\n");
+        let result = parser.parse_chunk(&Bytes::from_static(b"event: response.completed\ndata: {}\n\n"));
         assert!(
             matches!(result, Err(SseParseError::MissingEventType { field: "data.type", .. })),
             "terminal-looking SSE event must still contain data.type"
@@ -464,8 +469,8 @@ mod tests {
     #[test]
     fn malformed_json_propagated() {
         let mut parser = ResponsesSseParser::new(&config());
-        let chunk = b"event: response.created\ndata: not-json\n\n";
-        let result = parser.parse_chunk(chunk);
+        let chunk = Bytes::from_static(b"event: response.created\ndata: not-json\n\n");
+        let result = parser.parse_chunk(&chunk);
         assert!(
             matches!(result, Err(SseParseError::MalformedJson { .. })),
             "malformed event data should propagate MalformedJson"
@@ -476,12 +481,14 @@ mod tests {
     fn split_chunk_assembles_correctly() {
         let mut parser = ResponsesSseParser::new(&config());
         let full = sse_bytes("response.created", &json!({"id": "resp_1"}));
-        let (a, b) = full.split_at(full.len() / 2);
+        let mid = full.len() / 2;
+        let a = full.slice(..mid);
+        let b = full.slice(mid..);
 
-        let events1 = parser.parse_chunk(a).unwrap();
+        let events1 = parser.parse_chunk(&a).unwrap();
         assert!(events1.is_empty(), "partial event should not dispatch");
 
-        let events2 = parser.parse_chunk(b).unwrap();
+        let events2 = parser.parse_chunk(&b).unwrap();
         assert_eq!(events2.len(), 1, "completed split event should dispatch");
         assert!(
             matches!(events2[0], ResponsesEvent::ResponseCreated(_)),

--- a/filters/src/agentic/a2a/sse.rs
+++ b/filters/src/agentic/a2a/sse.rs
@@ -10,6 +10,28 @@
 //!
 //! The scanner never modifies response bytes. It inspects chunks and
 //! yields completed payloads; the caller passes bytes through unchanged.
+//!
+//! # Why this is not the shared `praxis_filter::sse` codec
+//!
+//! Issue #842 (epic praxis#985) migrates AI's SSE record framing onto the
+//! shared `praxis_filter::sse` codec. This scanner is intentionally left in
+//! place because its framing does **not** match the shared codec's contract:
+//! on an oversized record the shared [`SseDecoder`] poisons permanently and
+//! stops yielding, whereas this scanner is **fail-open and recoverable** — it
+//! discards the oversized event's bytes without buffering them (see
+//! [`SkipPhase`]) and resumes at the next blank-line boundary, so a terminal
+//! usage/summary event arriving after an oversized one is still captured.
+//! Both this A2A route capture and the token-usage counter
+//! (`crate::token_usage::count`, via `use crate::agentic::a2a::sse`) depend on
+//! that recover-and-continue behavior, so neither can adopt the poison-on-
+//! overflow decoder without a functional regression.
+//!
+//! Adopting the shared codec here requires refining praxis#986 to add a
+//! recoverable / resync-on-overflow mode (drop the current record, clear
+//! poison, resume framing) rather than adding another AI-local parser. Until
+//! that lands, this scanner stays; revisit when the codec gains that mode.
+//!
+//! [`SseDecoder`]: praxis_filter::sse::SseDecoder
 
 // -----------------------------------------------------------------------------
 // SseScanState

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -94,6 +94,7 @@ pub(crate) mod test_utils {
             request_headers_to_set: Vec::new(),
             filter_metadata: std::collections::HashMap::new(),
             pre_read_mutations: Vec::new(),
+            prior_pre_read_mutations: Vec::new(),
             structured_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             filter_state: std::collections::HashMap::new(),

--- a/filters/src/token_usage/count.rs
+++ b/filters/src/token_usage/count.rs
@@ -41,6 +41,10 @@ use super::{
     providers::{parse_anthropic, parse_bedrock, parse_google, parse_openai},
     set_cache_token_usage, set_token_status_overflow, set_token_usage, streaming,
 };
+// Reuses the A2A fail-open recoverable SSE scanner. This consumer relies on the
+// same drop-oversized-event-and-continue behavior, so it is intentionally not
+// migrated onto the shared `praxis_filter::sse` codec by issue #842; see the
+// module docs on [`sse`] for the codec gap and praxis#986 refinement path.
 use crate::agentic::a2a::sse;
 
 // -----------------------------------------------------------------------------

--- a/integrations/llmd/ext-proc/src/tests.rs
+++ b/integrations/llmd/ext-proc/src/tests.rs
@@ -2471,6 +2471,7 @@ fn make_ctx(req: &praxis_filter::Request) -> HttpFilterContext<'_> {
         filter_metadata: HashMap::new(),
         structured_metadata: HashMap::new(),
         pre_read_mutations: Vec::new(),
+        prior_pre_read_mutations: Vec::new(),
         filter_results: HashMap::new(),
         filter_state: HashMap::new(),
         health_registry: None,


### PR DESCRIPTION
## What

Migrate the OpenAI Responses provider-neutral SSE **record framing** onto the shared `praxis_filter::sse` codec introduced by praxis-proxy/praxis#1060 (epic praxis#985). `SseFrameParser` now delegates byte-level line/record framing to `SseDecoder` while keeping the OpenAI-facing `SseFrame` / `SseParseError` surface, the `[DONE]` sentinel, the event-count budget, timeouts, and lifecycle rules in the Responses consumers unchanged.

Praxis has no release carrying the codec yet, so the praxis core crates are pinned to `main` at the #1060 merge commit (`c4cab79`) and Pingora moves to the `0.8.4` fork in lockstep with core.

## Scope — migrate only where framing matches the shared contract

- **OpenAI Responses** (`openai_stream_events`, `responses::parser`) → migrated onto the codec. `parse_chunk` now takes `&Bytes` and threads it into the decoder without copying.
- **A2A route-capture scanner + the token-usage counter that reuses it** → intentionally **not** migrated. They are fail-open and *recoverable* on an oversized record (drop it, resync at the next blank-line boundary), whereas the shared decoder poisons permanently. Adopting the codec there requires a recoverable/resync-on-overflow mode in praxis#986, not another AI-local parser. The gap is documented in the A2A `sse` module and referenced from the token-usage consumer.
- **Anthropic `anthropic_stream_events`** → deferred to a follow-up PR.

## Behavior preservation

`max_buffer_bytes` maps onto both codec framing bounds (`max_line_bytes` and `max_record_bytes`). For the single-`data:`-line blocks the Responses API emits, the overflow trip point and peak retained bytes match the pre-codec parser; the `new()` doc describes the mapping truthfully (including how a multi-line record — which the Responses API never emits — is accounted differently). No full-body buffering is introduced and backpressure is not weakened for real traffic.

Duplicate pure-codec framing tests are removed in favor of adapter-focused tests plus the codec's own conformance suite.

## Testing

- `make lint` ✓
- `make test` ✓
- `make doc` ✓ (verifies the new intra-doc links)

Refs #842