### PR TITLE
fix(conversations): resolve remaining OpenAI conformance drifts (8/8)

### DIFF
--- a/apis/src/openai/conversations/contracts.rs
+++ b/apis/src/openai/conversations/contracts.rs
@@ -8,11 +8,16 @@
     reason = "utoipa macro-generated schema builders allocate large temporary values"
 )]
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use utoipa::{
-    ToSchema,
-    openapi::schema::{AnyOfBuilder, ArrayBuilder, Object, ObjectBuilder, Ref, Schema, Type},
+    PartialSchema, ToSchema,
+    openapi::{
+        RefOr,
+        schema::{AnyOfBuilder, ArrayBuilder, Object, ObjectBuilder, Ref, Schema, SchemaType, Type},
+    },
 };
 
 use super::item_schema::validate_input_item;
@@ -44,12 +49,60 @@ pub(super) struct UpdateConversationRequest {
 }
 
 /// Request body accepted by `POST /conversations/{conversation_id}/items`.
-#[derive(Debug, Deserialize, ToSchema)]
+///
+/// The `OpenAPI` schema is hand-built by the [`PartialSchema`] impl below so the
+/// emitted component omits the top-level `type: object`, matching OpenAI's inline
+/// `createConversationItems` request body (`properties.items` + `required:
+/// [items]` only).
+#[derive(Debug, Deserialize)]
 pub(super) struct CreateConversationItemsRequest {
     /// Items to create.
     #[serde(default)]
-    #[schema(value_type = Vec<InputItem>, required = true, max_items = 20)]
     pub(super) items: Option<Vec<InputItem>>,
+}
+
+impl PartialSchema for CreateConversationItemsRequest {
+    /// Emit the append-items body schema without a top-level `type: object`.
+    ///
+    /// utoipa's `ObjectBuilder` defaults `schema_type` to [`Type::Object`], so a
+    /// derived schema would add `type: object` at the top level. The pinned
+    /// OpenAI `createConversationItems` body has no top-level type — only
+    /// `properties.items` and `required: [items]` — so the type is cleared with
+    /// [`SchemaType::AnyValue`], which utoipa omits from the serialized schema.
+    fn schema() -> RefOr<Schema> {
+        RefOr::T(Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::AnyValue)
+                .description(Some(
+                    "Request body accepted by `POST /conversations/{conversation_id}/items`.",
+                ))
+                .property(
+                    "items",
+                    ArrayBuilder::new()
+                        .items(Ref::from_schema_name("InputItem"))
+                        .description(Some("Items to create."))
+                        .max_items(Some(MAX_ITEMS_PER_REQUEST)),
+                )
+                .required("items")
+                .build(),
+        ))
+    }
+}
+
+impl ToSchema for CreateConversationItemsRequest {
+    /// Preserve the derived component name referenced by the request body.
+    fn name() -> Cow<'static, str> {
+        Cow::Borrowed("CreateConversationItemsRequest")
+    }
+
+    /// Forward the referenced `InputItem` union exactly as the derive did.
+    fn schemas(schemas: &mut Vec<(String, RefOr<Schema>)>) {
+        schemas.push((
+            <InputItem as ToSchema>::name().into_owned(),
+            <InputItem as PartialSchema>::schema(),
+        ));
+        <InputItem as ToSchema>::schemas(schemas);
+    }
 }
 
 /// Metadata supplied with a conversation.

--- a/apis/src/openai/conversations/openapi.rs
+++ b/apis/src/openai/conversations/openapi.rs
@@ -167,6 +167,61 @@ mod tests {
     }
 
     #[test]
+    fn generated_append_items_body_omits_top_level_type() {
+        let document = implementation_openapi_value().unwrap();
+        let base = "/components/schemas/CreateConversationItemsRequest";
+
+        assert!(
+            document.pointer(&format!("{base}/type")).is_none(),
+            "the append-items body omits the top-level type to match the official inline schema"
+        );
+        assert_eq!(
+            document.pointer(&format!("{base}/required/0")),
+            Some(&Value::String("items".to_owned())),
+            "the append-items body requires the items property"
+        );
+        assert_eq!(
+            document.pointer(&format!("{base}/properties/items/items/$ref")),
+            Some(&Value::String("#/components/schemas/InputItem".to_owned())),
+            "the append-items array references the InputItem union"
+        );
+    }
+
+    #[test]
+    fn generated_list_items_limit_matches_reference_schema() {
+        let document = serde_json::to_value(implementation_openapi()).unwrap();
+        let parameters = document
+            .pointer("/paths/~1conversations~1{conversation_id}~1items/get/parameters")
+            .and_then(Value::as_array)
+            .unwrap();
+        let limit = parameters
+            .iter()
+            .find(|parameter| parameter.get("name") == Some(&Value::String("limit".to_owned())))
+            .unwrap();
+
+        assert_eq!(limit["in"], "query");
+        assert_eq!(limit["required"], false);
+        assert_eq!(
+            limit.pointer("/schema/type"),
+            Some(&Value::String("integer".to_owned())),
+            "limit schema should be an integer"
+        );
+        assert_eq!(
+            limit.pointer("/schema/default"),
+            Some(&Value::Number(serde_json::Number::from(20_u64))),
+            "limit schema should carry the reference default of 20"
+        );
+        assert!(
+            limit.pointer("/schema/format").is_none(),
+            "limit schema must not add the int32 format the reference omits"
+        );
+        assert!(
+            limit.pointer("/schema/minimum").is_none(),
+            "limit schema must not add the minimum the reference omits"
+        );
+    }
+
+    #[test]
     fn generated_create_request_contract_matches_runtime() {
         let document = serde_json::to_value(implementation_openapi()).unwrap();
 

--- a/apis/src/openai/conversations/routes.rs
+++ b/apis/src/openai/conversations/routes.rs
@@ -5,7 +5,14 @@
 
 use std::ops::Deref;
 
-use utoipa::PartialSchema;
+use serde_json::Value;
+use utoipa::{
+    PartialSchema,
+    openapi::{
+        RefOr,
+        schema::{ObjectBuilder, Schema, Type},
+    },
+};
 
 use super::contracts::{
     ConversationItem, ConversationItemList, ConversationResource, CreateConversationItemsRequest,
@@ -18,6 +25,7 @@ use crate::openai::{
         OpenAiTransport, OperationEntry, OwnedOperationContract, ParameterLocation, ParameterSpec, RequestBodySpec,
         ResponseSpec, RouteParams, match_operation, schema_binding,
     },
+    responses::store::DEFAULT_PAGE_LIMIT,
 };
 
 /// JSON media type used by all Conversations bodies.
@@ -140,6 +148,10 @@ macro_rules! path_parameter {
 }
 
 /// Declare an optional typed query parameter.
+///
+/// The `$schema:ty` form derives the schema from a type's [`PartialSchema`]
+/// impl. The `schema_fn = $path` form takes an explicit schema constructor for
+/// parameters whose emitted contract must match the official reference exactly.
 macro_rules! query_parameter {
     ($name:literal, $schema:ty, $description:literal) => {
         ParameterSpec::new(
@@ -150,6 +162,25 @@ macro_rules! query_parameter {
             <$schema as PartialSchema>::schema,
         )
     };
+    ($name:literal,schema_fn = $schema_fn:path, $description:literal) => {
+        ParameterSpec::new($name, ParameterLocation::Query, false, $description, $schema_fn)
+    };
+}
+
+/// Emit the `listConversationItems` `limit` query schema mandated by the
+/// official reference: `{type: integer, default: 20}`.
+///
+/// The derived `<u32 as PartialSchema>::schema` would add `format: int32` and
+/// `minimum: 0` and omit the default, so the schema is hand-built to match the
+/// pinned OpenAI contract exactly. The default mirrors the runtime page size in
+/// [`DEFAULT_PAGE_LIMIT`], keeping the contract and handler in lockstep.
+fn list_items_limit_schema() -> RefOr<Schema> {
+    RefOr::T(Schema::Object(
+        ObjectBuilder::new()
+            .schema_type(Type::Integer)
+            .default(Some(Value::from(DEFAULT_PAGE_LIMIT)))
+            .build(),
+    ))
 }
 
 /// Declare each operation once and derive both runtime and `OpenAPI` metadata.
@@ -282,7 +313,7 @@ conversation_operations! {
                     "conversation_id",
                     "The ID of the conversation to list items for."
                 ),
-                query_parameter!("limit", u32, "Maximum number of items to return."),
+                query_parameter!("limit", schema_fn = list_items_limit_schema, "Maximum number of items to return."),
                 query_parameter!("order", ItemOrder, "Sort order for returned items."),
                 query_parameter!("after", String, "Item ID to list after."),
                 query_parameter!(

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -49,9 +49,11 @@ against `api.openai.com` on 2026-07-27.
 | Update with object `metadata` | `200` |
 
 The pinned and current upstream OpenAPI documents omit `requestBody.required`
-for update even though the live endpoint requires the body. The implementation
-document follows the verified runtime contract, so that upstream discrepancy
-remains visible instead of declaring behavior Praxis does not implement.
+for update and mark `metadata` nullable even though the live endpoint requires
+the body and rejects null metadata. The implementation document follows the
+verified runtime contract, and both discrepancies are recorded as explicit
+`upstream_spec_exceptions` on `POST /conversations/{conversation_id}` rather
+than declaring behavior Praxis does not implement.
 
 ## Code Map
 
@@ -206,6 +208,14 @@ OpenAI Conversations responses were checked against `api.openai.com` on
 populated string map round-tripped unchanged. Praxis therefore retains its
 string-map response schema and records the 12 missing upstream metadata
 constraints as explicit exceptions.
+
+The same probe covered the update request body. An absent body returned `400
+missing_required_parameter` and null metadata returned `400 invalid_type`, so
+the pinned upstream is incomplete: it omits `requestBody.required` and marks
+`metadata` nullable. Praxis follows the verified runtime contract — a required
+body with non-null string-map metadata — and records the seven resulting
+`POST /conversations/{conversation_id}` request drift fingerprints as explicit
+exceptions.
 
 ## CI Enforcement
 

--- a/docs/conformance/openai-conformance-report.json
+++ b/docs/conformance/openai-conformance-report.json
@@ -253,72 +253,15 @@
         "implementation_source": "generated:praxis-ai-apis/openai/conversations",
         "operation_contracts": {
           "total": 8,
-          "exact": 5,
+          "exact": 8,
           "missing": 0,
-          "drifted": 3,
-          "request_drifted": 3,
+          "drifted": 0,
+          "request_drifted": 0,
           "response_drifted": 0,
           "other_drifted": 0,
-          "exact_percent": 62.5,
+          "exact_percent": 100.0,
           "missing_operations": [],
-          "drifted_operations": [
-            {
-              "operation": {
-                "method": "GET",
-                "path": "/conversations/{conversation_id}/items",
-                "operation": "GET /conversations/{conversation_id}/items"
-              },
-              "has_request_drift": true,
-              "has_response_drift": false,
-              "has_other_drift": false,
-              "request_details": [
-                "parameters.query.limit.schema.format.from",
-                "parameters.query.limit.schema.format.to",
-                "parameters.query.limit.schema.default.from",
-                "parameters.query.limit.schema.default.to",
-                "parameters.query.limit.schema.min.from",
-                "parameters.query.limit.schema.min.to"
-              ],
-              "response_details": [],
-              "other_details": []
-            },
-            {
-              "operation": {
-                "method": "POST",
-                "path": "/conversations/{conversation_id}",
-                "operation": "POST /conversations/{conversation_id}"
-              },
-              "has_request_drift": true,
-              "has_response_drift": false,
-              "has_other_drift": false,
-              "request_details": [
-                "requestBody.required.from",
-                "requestBody.required.to",
-                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted",
-                "requestBody.content.application/json.schema.properties.metadata.type.added",
-                "requestBody.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "requestBody.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
-                "requestBody.content.application/json.schema.properties.metadata.listOfTypes.deleted"
-              ],
-              "response_details": [],
-              "other_details": []
-            },
-            {
-              "operation": {
-                "method": "POST",
-                "path": "/conversations/{conversation_id}/items",
-                "operation": "POST /conversations/{conversation_id}/items"
-              },
-              "has_request_drift": true,
-              "has_response_drift": false,
-              "has_other_drift": false,
-              "request_details": [
-                "requestBody.content.application/json.schema.type.added"
-              ],
-              "response_details": [],
-              "other_details": []
-            }
-          ]
+          "drifted_operations": []
         },
         "inherited_contract": {
           "exact": true,
@@ -456,31 +399,108 @@
             "detail": "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
             "rationale": "OpenAI returns metadata as a string map, while the upstream response property has no schema",
             "evidence": "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.required.from",
+            "rationale": "OpenAI's live update endpoint requires the request body, while the pinned upstream omits requestBody.required",
+            "evidence": "api.openai.com probe on 2026-07-27: update with no body or {} returned 400 missing_required_parameter for metadata"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.required.to",
+            "rationale": "OpenAI's live update endpoint requires the request body, while the pinned upstream omits requestBody.required",
+            "evidence": "api.openai.com probe on 2026-07-27: update with no body or {} returned 400 missing_required_parameter for metadata"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted",
+            "rationale": "OpenAI's live update endpoint rejects null metadata, while the pinned upstream Metadata schema is nullable",
+            "evidence": "api.openai.com probe on 2026-07-27: update with null metadata returned 400 invalid_type, update with object metadata returned 200"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.content.application/json.schema.properties.metadata.type.added",
+            "rationale": "OpenAI's live update endpoint rejects null metadata, while the pinned upstream Metadata schema is nullable",
+            "evidence": "api.openai.com probe on 2026-07-27: update with null metadata returned 400 invalid_type, update with object metadata returned 200"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+            "rationale": "OpenAI's live update endpoint rejects null metadata, while the pinned upstream Metadata schema is nullable",
+            "evidence": "api.openai.com probe on 2026-07-27: update with null metadata returned 400 invalid_type, update with object metadata returned 200"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+            "rationale": "OpenAI's live update endpoint rejects null metadata, while the pinned upstream Metadata schema is nullable",
+            "evidence": "api.openai.com probe on 2026-07-27: update with null metadata returned 400 invalid_type, update with object metadata returned 200"
+          },
+          {
+            "kind": "request",
+            "operation": {
+              "method": "POST",
+              "path": "/conversations/{conversation_id}",
+              "operation": "POST /conversations/{conversation_id}"
+            },
+            "detail": "requestBody.content.application/json.schema.properties.metadata.listOfTypes.deleted",
+            "rationale": "OpenAI's live update endpoint rejects null metadata, while the pinned upstream Metadata schema is nullable",
+            "evidence": "api.openai.com probe on 2026-07-27: update with null metadata returned 400 invalid_type, update with object metadata returned 200"
           }
         ],
-        "all_exact": false
+        "all_exact": true
       }
     ],
     "operation_contracts": {
       "total": 8,
-      "exact": 5,
+      "exact": 8,
       "missing": 0,
-      "drifted": 3,
-      "request_drifted": 3,
+      "drifted": 0,
+      "request_drifted": 0,
       "response_drifted": 0,
       "other_drifted": 0,
-      "exact_percent": 62.5,
+      "exact_percent": 100.0,
       "by_area": [
         {
           "area": "Conversations",
           "total": 8,
-          "conformant": 5,
+          "conformant": 8,
           "missing": 0,
-          "drifted": 3,
-          "request_drifted": 3,
+          "drifted": 0,
+          "request_drifted": 0,
           "response_drifted": 0,
           "other_drifted": 0,
-          "conformance_percent": 62.5
+          "conformance_percent": 100.0
         }
       ]
     },
@@ -491,80 +511,17 @@
         "details": []
       }
     ],
-    "all_exact": false,
+    "all_exact": true,
     "fixes_required": {
       "summary": {
-        "operations_to_fix": 3,
+        "operations_to_fix": 0,
         "area_contracts_to_fix": 0,
         "missing_operations": 0,
-        "request_drift_operations": 3,
+        "request_drift_operations": 0,
         "response_drift_operations": 0,
         "other_drift_operations": 0
       },
-      "by_operation": [
-        {
-          "operation": {
-            "method": "GET",
-            "path": "/conversations/{conversation_id}/items",
-            "operation": "GET /conversations/{conversation_id}/items"
-          },
-          "fixes": [
-            {
-              "area": "request",
-              "kind": "request_parameters",
-              "summary": "Add or align OpenAI request parameters in the implementation spec and handler behavior.",
-              "detail_paths": [
-                "parameters.query.limit.schema.format.from",
-                "parameters.query.limit.schema.format.to",
-                "parameters.query.limit.schema.default.from",
-                "parameters.query.limit.schema.default.to",
-                "parameters.query.limit.schema.min.from",
-                "parameters.query.limit.schema.min.to"
-              ]
-            }
-          ]
-        },
-        {
-          "operation": {
-            "method": "POST",
-            "path": "/conversations/{conversation_id}",
-            "operation": "POST /conversations/{conversation_id}"
-          },
-          "fixes": [
-            {
-              "area": "request",
-              "kind": "request_body_schema",
-              "summary": "Align the request body schema with the OpenAI spec.",
-              "detail_paths": [
-                "requestBody.required.from",
-                "requestBody.required.to",
-                "requestBody.content.application/json.schema.properties.metadata.anyOf.deleted",
-                "requestBody.content.application/json.schema.properties.metadata.type.added",
-                "requestBody.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
-                "requestBody.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
-                "requestBody.content.application/json.schema.properties.metadata.listOfTypes.deleted"
-              ]
-            }
-          ]
-        },
-        {
-          "operation": {
-            "method": "POST",
-            "path": "/conversations/{conversation_id}/items",
-            "operation": "POST /conversations/{conversation_id}/items"
-          },
-          "fixes": [
-            {
-              "area": "request",
-              "kind": "request_body_schema",
-              "summary": "Align the request body schema with the OpenAI spec.",
-              "detail_paths": [
-                "requestBody.content.application/json.schema.type.added"
-              ]
-            }
-          ]
-        }
-      ],
+      "by_operation": [],
       "by_area": []
     }
   },

--- a/xtask/src/openai_conformance/area.rs
+++ b/xtask/src/openai_conformance/area.rs
@@ -36,7 +36,14 @@ const CONVERSATIONS_RUNTIME_CHECKS: &[RuntimeVerificationCheck] = &[
     },
 ];
 
-/// Response metadata discrepancies caused by the incomplete upstream property.
+/// Evidence-backed discrepancies where the pinned upstream schema is incomplete
+/// and the implementation follows the verified live OpenAI behavior instead.
+///
+/// The response-metadata entries record the string-map response Praxis returns
+/// for an upstream property that carries no schema. The request entries on
+/// `POST /conversations/{conversation_id}` record the update body Praxis
+/// requires and its non-null object metadata, both of which the pinned upstream
+/// omits or leaves nullable but the live endpoint enforces.
 const CONVERSATIONS_CONTRACT_EXCEPTIONS: &[ContractException] = &[
     metadata_response_exception(
         "POST",
@@ -98,6 +105,19 @@ const CONVERSATIONS_CONTRACT_EXCEPTIONS: &[ContractException] = &[
         "/conversations/{conversation_id}/items/{item_id}",
         "responses.200.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
     ),
+    update_body_required_exception("requestBody.required.from"),
+    update_body_required_exception("requestBody.required.to"),
+    update_metadata_request_exception("requestBody.content.application/json.schema.properties.metadata.anyOf.deleted"),
+    update_metadata_request_exception("requestBody.content.application/json.schema.properties.metadata.type.added"),
+    update_metadata_request_exception(
+        "requestBody.content.application/json.schema.properties.metadata.additionalProperties.schemaAdded",
+    ),
+    update_metadata_request_exception(
+        "requestBody.content.application/json.schema.properties.metadata.propertyNames.schemaAdded",
+    ),
+    update_metadata_request_exception(
+        "requestBody.content.application/json.schema.properties.metadata.listOfTypes.deleted",
+    ),
 ];
 
 /// One conformance area checked by `cargo xtask openai-conformance`.
@@ -140,6 +160,37 @@ const fn metadata_response_exception(
         detail,
         rationale: "OpenAI returns metadata as a string map, while the upstream response property has no schema",
         evidence: "api.openai.com probe on 2026-07-27: omitted and null metadata returned {}, populated metadata returned the supplied string map",
+    }
+}
+
+/// Declare one live-verified `updateConversation` required-body exception.
+///
+/// The pinned upstream omits `requestBody.required`, but the live endpoint
+/// rejects an absent update body, so the implementation marks the body required.
+const fn update_body_required_exception(detail: &'static str) -> ContractException {
+    ContractException {
+        kind: super::model::ContractDriftKind::Request,
+        method: Some("POST"),
+        path: Some("/conversations/{conversation_id}"),
+        detail,
+        rationale: "OpenAI's live update endpoint requires the request body, while the pinned upstream omits requestBody.required",
+        evidence: "api.openai.com probe on 2026-07-27: update with no body or {} returned 400 missing_required_parameter for metadata",
+    }
+}
+
+/// Declare one live-verified `updateConversation` metadata request exception.
+///
+/// The pinned upstream `Metadata` schema is nullable, but the live update
+/// endpoint rejects null metadata, so the implementation emits a non-null
+/// string-map object that matches the verified runtime contract.
+const fn update_metadata_request_exception(detail: &'static str) -> ContractException {
+    ContractException {
+        kind: super::model::ContractDriftKind::Request,
+        method: Some("POST"),
+        path: Some("/conversations/{conversation_id}"),
+        detail,
+        rationale: "OpenAI's live update endpoint rejects null metadata, while the pinned upstream Metadata schema is nullable",
+        evidence: "api.openai.com probe on 2026-07-27: update with null metadata returned 400 invalid_type, update with object metadata returned 200",
     }
 }
 


### PR DESCRIPTION
## What

Resolves the three remaining request-side owned-contract drifts on the OpenAI
Conversations area, bringing oasdiff owned-contract conformance from **5/8
(62.5%)** to **8/8 (100%)** exact operations. The strict conformance gate now
passes without `conformance-failure-acknowledged`.

Closes #934. Refs #565.

## The three drifts

### 1. `GET /conversations/{conversation_id}/items` — `limit` param (code fix)

The `limit` query schema was derived from the runtime `u32`, so utoipa emitted
`format: int32` and `minimum: 0` and dropped the reference's `default: 20`. A new
`schema_fn =` arm on the `query_parameter!` macro lets the `limit` parameter emit
`{type: integer, default: 20}` explicitly. The default is sourced from
`DEFAULT_PAGE_LIMIT`, so the documented and runtime defaults cannot drift apart.

### 2. `POST /conversations/{conversation_id}/items` — append body (code fix)

The append-items request body emitted a top-level `type: object` the reference
omits. A hand-built `PartialSchema` impl for `CreateConversationItemsRequest`
clears the top-level type (via `SchemaType::AnyValue`, which utoipa omits from
the serialized schema), matching OpenAI's inline `createConversationItems` body
(`properties.items` + `required: [items]`).

### 3. `POST /conversations/{conversation_id}` — update body (documented exception)

This is an intentional, evidence-backed divergence — matching the reference would
misrepresent live OpenAI behavior. The seven fingerprints are recorded as
`upstream_spec_exceptions` (option (a) from #934):

- **Required body** (`requestBody.required.from/.to`): the implementation marks
  the update body required; the pinned upstream marks it optional. Live OpenAI
  returns `400 missing_required_parameter` for an absent body.
- **Non-null metadata** (5 `metadata.*` fingerprints): the implementation models
  `metadata` as a non-null string map and rejects `null`
  (`deserialize_metadata_object`, guarded by `update_request_requires_non_null_metadata`),
  while the pinned upstream `Metadata` is nullable. Live OpenAI returns
  `400 invalid_type` for null metadata.

Both are backed by the `api.openai.com` probe on 2026-07-27 already documented in
`docs/conformance/README.md`, symmetric with the 12 existing response-metadata
exceptions. This applies the already-sanctioned exception mechanism to the
request side rather than leaving the divergence in the actionable backlog.

## Truthfulness

No runtime behavior changed. The generated implementation document still follows
the verified runtime contract; the exceptions only reclassify a documented
upstream-incompleteness discrepancy out of the actionable drift backlog, and the
README prose is updated to say so. Every exception fingerprint is exact-string
and fail-closed: generation fails if a declared fingerprint no longer appears.

## Tests

- `apis/src/openai/conversations/openapi.rs`: new `generated_list_items_limit_matches_reference_schema`
  (type/default present, no format/minimum) and `generated_append_items_body_omits_top_level_type`
  (no top-level type, `required: [items]`, InputItem ref).
- `xtask` conformance + gate tests pass; report regenerates byte-identically.
- `make lint` and `make test` green. Report regenerated with pinned `oasdiff 1.23.0`.