### PR TITLE
test(openai): cover vLLM multi-round IRR terminal streaming

### DIFF
--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -803,6 +803,100 @@ class TestAgenticLoopVLLM:
             f"rounds; got: {output_types}"
         )
 
+    def test_mcp_tool_streams_terminal_round_as_one_logical_response(
+        self, agentic_client, agentic_proxy,
+    ):
+        """Streaming sibling of test_mcp_tool_auto_executes_and_returns.
+
+        With stream=True the proxy auto-executes the intermediate MCP
+        tool round internally and buffers it, then streams only the
+        terminal round to the client as ONE logical SSE response
+        (response.created -> ... -> response.completed). The
+        logical-stream finalizer replaces that terminal event's output
+        with the cross-round accumulated trace, so the single
+        response.completed carries the same execution trace the buffered
+        test observes: function_call, mcp_call, and the final message.
+        """
+        _, mcp_port, _ = agentic_proxy
+        mcp_url = f"http://127.0.0.1:{mcp_port}/mcp"
+
+        stream = agentic_client.responses.create(
+            model=VLLM_MODEL,
+            input=(
+                "You MUST call the get_weather function for Paris. "
+                "Do not answer directly. /no_think"
+            ),
+            tools=[
+                {
+                    "type": "mcp",
+                    "server_label": "weather",
+                    "server_url": mcp_url,
+                    "allowed_tools": ["get_weather"],
+                    "require_approval": "never",
+                }
+            ],
+            store=False,
+            stream=True,
+            max_output_tokens=512,
+        )
+
+        event_types = []
+        text_parts = []
+        final_response = None
+
+        for event in stream:
+            event_types.append(event.type)
+            if event.type == "response.output_text.delta":
+                text_parts.append(event.delta)
+            if event.type == "response.completed":
+                final_response = event.response
+
+        # One coherent lifecycle framing, exactly as the single-round
+        # test_streaming_through_irr asserts: created first, completed last.
+        assert event_types[0] == "response.created", event_types
+        assert event_types[-1] == "response.completed", event_types
+        assert final_response is not None, (
+            "stream must terminate with a response.completed event; "
+            f"got: {event_types}"
+        )
+        assert final_response.status in ("completed", "incomplete"), (
+            f"expected completed or incomplete (token limit); got: {final_response.status}"
+        )
+
+        # The terminal event's output is the cross-round accumulated trace,
+        # so it mirrors the buffered test: the auto-executed function_call
+        # and the MCP result (mcp_call) both surface in the one stream.
+        output_types = [item.type for item in final_response.output]
+        assert "function_call" in output_types, (
+            "streamed terminal output should contain the auto-executed "
+            f"function_call; got: {output_types}"
+        )
+        assert "mcp_call" in output_types, (
+            "streamed terminal output should contain the MCP tool result "
+            f"(mcp_call); got: {output_types}"
+        )
+        rounds = sum(
+            1 for t in output_types
+            if t in ("function_call", "message", "reasoning")
+        )
+        assert rounds >= 2, (
+            "streamed terminal output should span at least two inference "
+            f"rounds; got: {output_types}"
+        )
+
+        # MCPHandler returns f"72F and sunny in {city}"; the city argument
+        # is model-chosen, so assert only the stable, non-templated prefix.
+        # The mcp_call output item carries this tool result verbatim, so it
+        # is present whether or not the model echoes it in the streamed text.
+        haystack = (
+            json.dumps(final_response.model_dump(), default=str)
+            + "".join(text_parts)
+        )
+        assert "72F and sunny in" in haystack, (
+            "the MCP get_weather result should be reflected in the "
+            f"accumulated output or streamed text; got: {haystack}"
+        )
+
     def test_client_function_exits_openai(self, agentic_client):
         """Client-side function tools exit the agentic loop without
         auto-execution, even when the IRR is active.


### PR DESCRIPTION
## Summary

Adds one vLLM integration test, `test_mcp_tool_streams_terminal_round_as_one_logical_response`, closing the gap where multi-round IRR terminal streaming was only exercised by the Rust mock suite. It is a `stream=True` sibling of the buffered `test_mcp_tool_auto_executes_and_returns`: it drives an MCP `get_weather` tool round and asserts the proxy auto-executes/buffers the intermediate round, then streams the terminal round to the client as one logical SSE response (`response.created` → … → `response.completed`) whose accumulated output carries the cross-round trace (`function_call` + `mcp_call`, `rounds >= 2`) and reflects the tool result. This is the smallest complete change — a single test method, no production code — since the capability itself already merged in #756.

## Related issue

Follow-up test coverage for the capability merged in #756 (stream Responses across IRR agentic rounds); no separate tracking issue.

Refs #756

## Validation

- [x] Unit tests — n/a (test-only change; no production code touched).
- [x] Integration or functional tests — `uv run tests/integration/sdk/openai/test_openai_responses_vllm.py --co -q` collects the new test (12 tests, was 11). Full end-to-end run needs a live vLLM backend: `PRAXIS_AI_BIN=<path> VLLM_BASE_URL=<url> VLLM_MODEL=<model> uv run tests/integration/sdk/openai/test_openai_responses_vllm.py -v -k test_mcp_tool_streams_terminal_round_as_one_logical_response`.
- [x] `make lint` (and `make build`) — green.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test. — n/a; validates an already-merged capability. `examples/configs/openai/responses/agentic-loop.yaml` already enables `terminal_streaming`.
- [x] User-facing behavior and generated documentation are updated. — n/a; test-only.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence. — n/a.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None — adds test coverage only.
