### PR TITLE
test(vllm): raise CI IRR deadlines for flaky file-search chat flow

### DIFF
--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -1122,6 +1122,15 @@ def _write_file_search_chat_config(praxis_port: int) -> str:
     Exercises the real example config (per repo test requirements) while
     retargeting the vector-store callout at OGX and the model backend at
     vLLM's /v1/chat/completions endpoint.
+
+    The shipped example carries production-facing iterative_request_router
+    deadlines (120s overall / 60s per step) sized for a real GPU backend.
+    This test drives a CPU-only vLLM under heavy co-located CI load (postgres
+    + vLLM + OGX on one runner), where a single inference round -- especially
+    the second, whose prompt now carries the file_search results -- can exceed
+    the 60s step budget and get aborted by the IRR with a 504 (a load-driven
+    flake, seen only in the postgres variant). Raise the CI-only budgets to
+    match TestFileSearchVLLM without changing the shipped example's defaults.
     """
     with open(FILE_SEARCH_CHAT_CONFIG_PATH) as f:
         config = f.read()
@@ -1129,6 +1138,24 @@ def _write_file_search_chat_config(praxis_port: int) -> str:
     config = config.replace("127.0.0.1:8080", f"127.0.0.1:{praxis_port}")
     config = config.replace("127.0.0.1:3001", _vllm_endpoint())
     config = config.replace("127.0.0.1:8001", _ogx_endpoint())
+
+    # Generous CI deadlines for CPU-only vLLM (mirror TestFileSearchVLLM).
+    # Both the overall and per-step IRR budgets must rise together: bumping
+    # only the step budget would leave the 120s overall deadline to fire
+    # first on a slow multi-round flow.
+    config = config.replace("timeout_ms: 120000", "timeout_ms: 300000")
+    config = config.replace("step_timeout_ms: 60000", "step_timeout_ms: 300000")
+    # Give the vector-store search callout the same headroom the sibling uses
+    # so a slow OGX search under load is not the next flake source.
+    config = config.replace("timeout_ms: 5000", "timeout_ms: 30000")
+    # Once the step budget is 300s, keep the upstream read timeout from
+    # becoming the new binding limit (it defaults to None; set >= step budget).
+    config = config.replace(
+        '- name: "chat-completions-backend"\n                    endpoints:',
+        '- name: "chat-completions-backend"\n'
+        "                    read_timeout_ms: 300000\n"
+        "                    endpoints:",
+    )
 
     fd, path = tempfile.mkstemp(suffix=".yaml")
     with os.fdopen(fd, "w") as f:


### PR DESCRIPTION
## Summary

The `TestFileSearchChatCompletionsVLLM` integration test patches only the
endpoints of the shipped `file-search-chat-completions.yaml`, keeping its
production `iterative_request_router` budgets (120s overall / 60s per step).
On CPU-only vLLM under heavy co-located CI load (postgres + vLLM + OGX on one
runner) the second inference round — whose prompt now carries the file_search
results — can exceed the 60s step budget, so the router aborts the sub-request
with a 504 (`IRR buffered transport failure … sub-request deadline exceeded`).
This is a load-driven flake observed only in the `vllm-responses-postgres` job
while the non-postgres job passes on the same commit (e.g. run
[34113553552](https://github.com/praxis-proxy/ai/actions/runs/34113553552/job/101715064152),
which aborted iteration 1 at exactly 60.001s). This raises the CI-only budgets
to 300s (overall and per step), gives the OGX search callout 30s of headroom,
and pins the upstream read timeout at 300s — mirroring `TestFileSearchVLLM`
while leaving the shipped example's production defaults untouched.

## Related issue

<!-- No tracking issue exists for this CI flake; surfaced from run 34113553552. -->

N/A — CI flake fix.

## Validation

- [x] Unit tests — N/A (CI-only integration-test config patcher; no product code changed).
- [x] Integration or functional tests — patch prototyped and the edited
  `_write_file_search_chat_config` invoked offline; it produces valid YAML with
  `timeout_ms`/`step_timeout_ms: 300000`, OGX callout `timeout_ms: 30000`, and
  cluster `read_timeout_ms: 300000`. The live path exercises in the `vLLM
  Integration` workflow.
- [ ] `make lint` — not run locally; the change is confined to a Python
  integration-test file, so the Rust `clippy`/`fmt`/build gates are unaffected.
  CI runs the `vLLM Integration` workflow against the real stack.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test. — N/A (no new capability; existing test hardened).
- [x] User-facing behavior and generated documentation are updated. — N/A (test-only; shipped example unchanged).
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence. — N/A.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. The change is confined to the CI integration test's config generator;
the shipped `file-search-chat-completions.yaml` production defaults are
unchanged.
