### PR TITLE
fix(classifier): treat invalid system values as non-signals (#948)

### DIFF
--- a/apis/src/classifier/mod.rs
+++ b/apis/src/classifier/mod.rs
@@ -240,7 +240,10 @@ fn classify_format(obj: &serde_json::Map<String, serde_json::Value>) -> AiReques
 /// - Any message in `messages` has typed content blocks (array of objects with a `type` key, e.g. `[{"type": "text",
 ///   ...}]`)
 fn has_anthropic_signals(obj: &serde_json::Map<String, serde_json::Value>) -> bool {
-    if obj.contains_key("system") {
+    if matches!(
+        obj.get("system"),
+        Some(serde_json::Value::String(_) | serde_json::Value::Array(_))
+    ) {
         return true;
     }
 
@@ -484,6 +487,18 @@ mod tests {
             result.format,
             AiRequestFormat::ChatCompletions,
             "max_tokens + string content + no system should be chat_completions — header override disambiguates in the filter layer"
+        );
+    }
+
+    #[test]
+    fn chat_completions_with_null_system_not_misclassified() {
+        let body = br#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"max_tokens":100,"system":null}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::ChatCompletions,
+            "system: null should not be treated as an Anthropic signal"
         );
     }
 


### PR DESCRIPTION
## Description
Fixes #948.

The request classifier previously checked `obj.contains_key("system")` when looking for Anthropic-specific request signals. When automated clients or SDKs submit a Chat Completions request containing `"max_tokens"` and `"system": null`, `contains_key("system")` returned `true`, misclassifying the request as `AnthropicMessages`.

This change updates `has_anthropic_signals()` to check that `system` is actually a string or array value (as expected by Anthropic's schema) before using it as a classification signal.

## Testing
- Added unit test `chat_completions_with_null_system_not_misclassified` in `apis/src/classifier/mod.rs`.
- Verified all classifier tests pass (`cargo test -p praxis-ai-apis -- classifier`).