### PR TITLE
perf(web-search): take pending Responses calls instead of cloning

### DIFF
--- a/apis/src/openai/responses/web_search/mod.rs
+++ b/apis/src/openai/responses/web_search/mod.rs
@@ -34,6 +34,8 @@
 )]
 mod tests;
 
+use std::mem;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
@@ -260,15 +262,17 @@ impl HttpFilter for WebSearchFilter {
             .or_else(|| web_search_context_size_from_state(state))
             .map_or(self.default_context_size, SearchContextSize::from_str_or_default);
 
-        let calls: Vec<Value> = state.web_search_calls.clone();
+        // Move the web search calls out instead of cloning and then removing them from state.
+        let calls: Vec<Value> = ctx
+            .extensions
+            .get_mut::<ResponsesState>()
+            .map(|state| mem::take(&mut state.web_search_calls))
+            .unwrap_or_default();
+
         debug!(count = calls.len(), "executing pending web search calls");
 
         for (index, call) in calls.iter().enumerate() {
             self.execute_single_search(ctx, call, index, context_size).await;
-        }
-
-        if let Some(state) = ctx.extensions.get_mut::<ResponsesState>() {
-            state.web_search_calls.clear();
         }
 
         Ok(FilterAction::Continue)


### PR DESCRIPTION
## Summary

Move the pending web_search_calls queue out of `ResponsesState` with `mem::take` instead of deep-cloning it and clearing state after the loop. Execution order and per-call state updates are unchanged.

Closes #903 

## Validation

- [x] cargo test -p praxis-ai-apis
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.
