### PR TITLE
test(responses): cover consecutive tool rounds and accumulated usage

### DIFF
--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -192,7 +192,7 @@ def _wait_for_proxy(port: int, proc: subprocess.Popen, log_path: str, timeout: f
 
 
 class MCPHandler(BaseHTTPRequestHandler):
-    """Streamable HTTP MCP server with a single get_weather tool."""
+    """Streamable HTTP MCP server exposing get_weather and get_time tools."""
 
     def do_POST(self):
         body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
@@ -211,27 +211,41 @@ class MCPHandler(BaseHTTPRequestHandler):
             self.end_headers()
         elif method == "tools/list":
             self._json_rpc(rid, {
-                "tools": [{
-                    "name": "get_weather",
-                    "description": "Get current weather for a city",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {"city": {"type": "string"}},
-                        "required": ["city"],
-                        "additionalProperties": False,
+                "tools": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get current weather for a city",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                            "additionalProperties": False,
+                        },
                     },
-                }]
+                    {
+                        "name": "get_time",
+                        "description": "Get the current local time for a city",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                            "additionalProperties": False,
+                        },
+                    },
+                ]
             })
         elif method == "tools/call":
-            city = (
-                req.get("params", {})
-                .get("arguments", {})
-                .get("city", "unknown")
-            )
+            params = req.get("params", {})
+            tool = params.get("name", "")
+            city = params.get("arguments", {}).get("city", "unknown")
+            # Distinct, tool-keyed results so a two-round loop can be
+            # distinguished in the accumulated output trace.
+            if tool == "get_time":
+                text = f"3:00 PM local time in {city}"
+            else:
+                text = f"72F and sunny in {city}"
             self._json_rpc(rid, {
-                "content": [
-                    {"type": "text", "text": f"72F and sunny in {city}"}
-                ]
+                "content": [{"type": "text", "text": text}]
             })
         elif method == "ping":
             self._json_rpc(rid, {})
@@ -908,6 +922,70 @@ def agentic_client(agentic_proxy):
 # ---------------------------------------------------------------------------
 
 
+def _assert_multi_round_usage_and_trace(response, *, transport):
+    """Assert a terminal agentic response carries a multi-round accumulated
+    output trace and an internally consistent, summed usage object.
+
+    Shared by the buffered and streaming #983 tests so both transports assert
+    exactly the same shape (criterion e: buffered and streaming expose
+    equivalent accumulated terminal output and usage). ``response`` is the
+    buffered ``Response`` or the streamed ``response.completed`` event's
+    ``response`` -- both expose ``.status``, ``.output``, and ``.usage``.
+
+    Deliberately does NOT assert exact per-round token counts: against a real
+    model those are not predictable. The deterministic exact-sum contract is
+    covered by the Rust integration test ``two_tool_rounds_accumulate_*``
+    (tests/integration/tests/suite/examples/openai_agentic_loop.rs) with a
+    StatefulCapturingBackend. Here we assert the accumulation *machinery* end
+    to end over a genuine multi-round loop.
+    """
+    assert response.status in ("completed", "incomplete"), (
+        f"[{transport}] expected completed or incomplete (token limit); "
+        f"got: {response.status}"
+    )
+
+    output_types = [item.type for item in response.output]
+    assert "function_call" in output_types, (
+        f"[{transport}] accumulated output should contain an auto-executed "
+        f"function_call; got: {output_types}"
+    )
+    assert "mcp_call" in output_types, (
+        f"[{transport}] accumulated output should contain an MCP tool result "
+        f"(mcp_call); got: {output_types}"
+    )
+    rounds = sum(
+        1 for t in output_types
+        if t in ("function_call", "message", "reasoning")
+    )
+    assert rounds >= 2, (
+        f"[{transport}] accumulated output should span at least two inference "
+        f"rounds; got: {output_types}"
+    )
+
+    # Usage is summed across every inference round into one terminal object.
+    # We cannot predict the totals, but the summed object must be present,
+    # positive, and internally consistent -- if merge_usage accumulated some
+    # fields but not others, total would drift from input + output.
+    usage = response.usage
+    assert usage is not None, (
+        f"[{transport}] terminal response must carry an accumulated usage "
+        "object"
+    )
+    assert usage.input_tokens > 0, (
+        f"[{transport}] accumulated input_tokens should be positive; "
+        f"got: {usage.input_tokens}"
+    )
+    assert usage.output_tokens > 0, (
+        f"[{transport}] accumulated output_tokens should be positive; "
+        f"got: {usage.output_tokens}"
+    )
+    assert usage.total_tokens == usage.input_tokens + usage.output_tokens, (
+        f"[{transport}] accumulated usage must be internally consistent "
+        f"(total == input + output); got: {usage.input_tokens} + "
+        f"{usage.output_tokens} != {usage.total_tokens}"
+    )
+
+
 class TestAgenticLoopVLLM:
     """Integration tests for the agentic loop against a vLLM backend."""
 
@@ -1101,6 +1179,108 @@ class TestAgenticLoopVLLM:
             f"got output types: {[i.type for i in response.output]}"
         )
         assert function_calls[0].name == "get_weather"
+
+    def test_two_tool_rounds_accumulate_output_and_usage(
+        self, agentic_client, agentic_proxy,
+    ):
+        """Issue #983: consecutive MCP tool rounds accumulate output and usage.
+
+        Buffered variant. Advertising two distinct MCP tools (get_weather,
+        get_time) lets the proxy drive model -> tool -> model -> tool -> model
+        entirely within the IRR loop, executing each tool and feeding its
+        result into the next inference round. The terminal response exposes the
+        cross-round accumulated trace (function_call + mcp_call items and the
+        final message) and a single usage object summed across every round.
+
+        This is the live-vLLM counterpart of the deterministic Rust test
+        ``two_tool_rounds_accumulate_output_and_usage``
+        (tests/integration/tests/suite/examples/openai_agentic_loop.rs), which
+        asserts the *exact* per-round token sum against a StatefulCapturingBackend.
+        A real model's per-round token counts are not predictable, so here we
+        assert the accumulation machinery end to end: a genuine multi-round
+        trace plus a present, positive, internally consistent summed usage.
+        """
+        _, mcp_port, _ = agentic_proxy
+        mcp_url = f"http://127.0.0.1:{mcp_port}/mcp"
+
+        response = agentic_client.responses.create(
+            model=VLLM_MODEL,
+            input=(
+                "You have two tools. First call get_weather for Paris, then "
+                "call get_time for Paris, then answer using both results. "
+                "You MUST call both tools. Do not answer directly. /no_think"
+            ),
+            tools=[
+                {
+                    "type": "mcp",
+                    "server_label": "concierge",
+                    "server_url": mcp_url,
+                    "allowed_tools": ["get_weather", "get_time"],
+                    "require_approval": "never",
+                }
+            ],
+            store=False,
+            max_output_tokens=512,
+        )
+
+        _assert_multi_round_usage_and_trace(response, transport="buffered")
+
+    def test_two_tool_rounds_streaming_matches_buffered(
+        self, agentic_client, agentic_proxy,
+    ):
+        """Issue #983: streaming sibling of
+        test_two_tool_rounds_accumulate_output_and_usage.
+
+        With stream=True the proxy auto-executes the intermediate tool rounds
+        internally and streams only the terminal round to the client as ONE
+        logical SSE response (response.created -> ... -> response.completed).
+        The logical-stream finalizer stamps that terminal event with the
+        cross-round accumulated output and the summed usage, so the single
+        response.completed exposes the same multi-round trace and internally
+        consistent usage the buffered variant observes -- criterion e:
+        buffered and streaming expose equivalent accumulated terminal output
+        and usage.
+        """
+        _, mcp_port, _ = agentic_proxy
+        mcp_url = f"http://127.0.0.1:{mcp_port}/mcp"
+
+        stream = agentic_client.responses.create(
+            model=VLLM_MODEL,
+            input=(
+                "You have two tools. First call get_weather for Paris, then "
+                "call get_time for Paris, then answer using both results. "
+                "You MUST call both tools. Do not answer directly. /no_think"
+            ),
+            tools=[
+                {
+                    "type": "mcp",
+                    "server_label": "concierge",
+                    "server_url": mcp_url,
+                    "allowed_tools": ["get_weather", "get_time"],
+                    "require_approval": "never",
+                }
+            ],
+            store=False,
+            stream=True,
+            max_output_tokens=512,
+        )
+
+        event_types = []
+        final_response = None
+        for event in stream:
+            event_types.append(event.type)
+            if event.type == "response.completed":
+                final_response = event.response
+
+        # One coherent SSE lifecycle framing across the whole multi-round loop.
+        assert event_types[0] == "response.created", event_types
+        assert event_types[-1] == "response.completed", event_types
+        assert final_response is not None, (
+            "stream must terminate with a response.completed event; "
+            f"got: {event_types}"
+        )
+
+        _assert_multi_round_usage_and_trace(final_response, transport="streaming")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -192,7 +192,7 @@ def _wait_for_proxy(port: int, proc: subprocess.Popen, log_path: str, timeout: f
 
 
 class MCPHandler(BaseHTTPRequestHandler):
-    """Streamable HTTP MCP server exposing get_weather and get_time tools."""
+    """Streamable HTTP MCP server with a single get_weather tool."""
 
     def do_POST(self):
         body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
@@ -211,41 +211,27 @@ class MCPHandler(BaseHTTPRequestHandler):
             self.end_headers()
         elif method == "tools/list":
             self._json_rpc(rid, {
-                "tools": [
-                    {
-                        "name": "get_weather",
-                        "description": "Get current weather for a city",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {"city": {"type": "string"}},
-                            "required": ["city"],
-                            "additionalProperties": False,
-                        },
+                "tools": [{
+                    "name": "get_weather",
+                    "description": "Get current weather for a city",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                        "additionalProperties": False,
                     },
-                    {
-                        "name": "get_time",
-                        "description": "Get the current local time for a city",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {"city": {"type": "string"}},
-                            "required": ["city"],
-                            "additionalProperties": False,
-                        },
-                    },
-                ]
+                }]
             })
         elif method == "tools/call":
-            params = req.get("params", {})
-            tool = params.get("name", "")
-            city = params.get("arguments", {}).get("city", "unknown")
-            # Distinct, tool-keyed results so a two-round loop can be
-            # distinguished in the accumulated output trace.
-            if tool == "get_time":
-                text = f"3:00 PM local time in {city}"
-            else:
-                text = f"72F and sunny in {city}"
+            city = (
+                req.get("params", {})
+                .get("arguments", {})
+                .get("city", "unknown")
+            )
             self._json_rpc(rid, {
-                "content": [{"type": "text", "text": text}]
+                "content": [
+                    {"type": "text", "text": f"72F and sunny in {city}"}
+                ]
             })
         elif method == "ping":
             self._json_rpc(rid, {})
@@ -1180,25 +1166,27 @@ class TestAgenticLoopVLLM:
         )
         assert function_calls[0].name == "get_weather"
 
-    def test_two_tool_rounds_accumulate_output_and_usage(
+    def test_agentic_loop_accumulates_usage_across_rounds(
         self, agentic_client, agentic_proxy,
     ):
-        """Issue #983: consecutive MCP tool rounds accumulate output and usage.
+        """Issue #983: usage accumulates across consecutive inference rounds.
 
-        Buffered variant. Advertising two distinct MCP tools (get_weather,
-        get_time) lets the proxy drive model -> tool -> model -> tool -> model
-        entirely within the IRR loop, executing each tool and feeding its
-        result into the next inference round. The terminal response exposes the
-        cross-round accumulated trace (function_call + mcp_call items and the
-        final message) and a single usage object summed across every round.
+        Buffered variant. A single auto-executed MCP tool drives a
+        model -> tool -> model loop; the terminal response exposes the
+        cross-round accumulated output trace (function_call + mcp_call + the
+        final message) and one usage object summed across every inference
+        round.
 
-        This is the live-vLLM counterpart of the deterministic Rust test
-        ``two_tool_rounds_accumulate_output_and_usage``
-        (tests/integration/tests/suite/examples/openai_agentic_loop.rs), which
-        asserts the *exact* per-round token sum against a StatefulCapturingBackend.
-        A real model's per-round token counts are not predictable, so here we
-        assert the accumulation machinery end to end: a genuine multi-round
-        trace plus a present, positive, internally consistent summed usage.
+        The deterministic exact-sum contract over *two sequential tool rounds*
+        lives in the Rust test ``two_tool_rounds_accumulate_output_and_usage``
+        (tests/integration/tests/suite/examples/openai_agentic_loop.rs) with a
+        StatefulCapturingBackend. That scenario is not reproducible live: a
+        small model batches multiple tool calls into one round, which
+        openai_agentic_loop rejects (``exactly one function call per round``),
+        so this live counterpart drives one reliable tool round and asserts the
+        accumulation *machinery* end to end -- a genuine multi-round trace plus
+        a present, positive, internally consistent summed usage -- against a
+        real backend.
         """
         _, mcp_port, _ = agentic_proxy
         mcp_url = f"http://127.0.0.1:{mcp_port}/mcp"
@@ -1206,16 +1194,15 @@ class TestAgenticLoopVLLM:
         response = agentic_client.responses.create(
             model=VLLM_MODEL,
             input=(
-                "You have two tools. First call get_weather for Paris, then "
-                "call get_time for Paris, then answer using both results. "
-                "You MUST call both tools. Do not answer directly. /no_think"
+                "You MUST call the get_weather function for Paris. "
+                "Do not answer directly. /no_think"
             ),
             tools=[
                 {
                     "type": "mcp",
-                    "server_label": "concierge",
+                    "server_label": "weather",
                     "server_url": mcp_url,
-                    "allowed_tools": ["get_weather", "get_time"],
+                    "allowed_tools": ["get_weather"],
                     "require_approval": "never",
                 }
             ],
@@ -1225,13 +1212,13 @@ class TestAgenticLoopVLLM:
 
         _assert_multi_round_usage_and_trace(response, transport="buffered")
 
-    def test_two_tool_rounds_streaming_matches_buffered(
+    def test_agentic_loop_streaming_accumulates_usage_across_rounds(
         self, agentic_client, agentic_proxy,
     ):
         """Issue #983: streaming sibling of
-        test_two_tool_rounds_accumulate_output_and_usage.
+        test_agentic_loop_accumulates_usage_across_rounds.
 
-        With stream=True the proxy auto-executes the intermediate tool rounds
+        With stream=True the proxy auto-executes the intermediate tool round
         internally and streams only the terminal round to the client as ONE
         logical SSE response (response.created -> ... -> response.completed).
         The logical-stream finalizer stamps that terminal event with the
@@ -1247,16 +1234,15 @@ class TestAgenticLoopVLLM:
         stream = agentic_client.responses.create(
             model=VLLM_MODEL,
             input=(
-                "You have two tools. First call get_weather for Paris, then "
-                "call get_time for Paris, then answer using both results. "
-                "You MUST call both tools. Do not answer directly. /no_think"
+                "You MUST call the get_weather function for Paris. "
+                "Do not answer directly. /no_think"
             ),
             tools=[
                 {
                     "type": "mcp",
-                    "server_label": "concierge",
+                    "server_label": "weather",
                     "server_url": mcp_url,
-                    "allowed_tools": ["get_weather", "get_time"],
+                    "allowed_tools": ["get_weather"],
                     "require_approval": "never",
                 }
             ],

--- a/tests/integration/tests/suite/examples/openai_agentic_loop.rs
+++ b/tests/integration/tests/suite/examples/openai_agentic_loop.rs
@@ -619,6 +619,462 @@ fn streaming_mcp_round_trip_uses_one_logical_sse_response() {
 }
 
 // -----------------------------------------------------------------------------
+// Two consecutive tool rounds: accumulated output and usage (issue #983)
+// -----------------------------------------------------------------------------
+//
+// One client Responses request drives model -> tool -> model -> tool -> model
+// final output. Both MCP tools execute exactly once, each result feeds the next
+// inference round, the terminal response lists every function call, server-tool
+// result, and the final assistant message in stable order, and the reported
+// token usage is the exact sum of all three inference rounds. The buffered and
+// streaming variants assert the SAME accumulated output and usage to prove the
+// two transports are equivalent.
+//
+// This flow cannot be an inference fixture: the replay harness binds exactly one
+// upstream exchange per client turn and rejects MCP callout filters as not
+// replay-contained, so a single request that fans out to three upstream rounds
+// must be a functional integration test.
+
+/// Per-round token usage as `(input, output, total)`. Distinct values make the
+/// accumulated sum unambiguous, and each round's total equals input + output so
+/// the summed `total_tokens` (merged as an independent field) also equals the
+/// summed input plus output.
+const ROUND1_USAGE: (u64, u64, u64) = (11, 4, 15);
+const ROUND2_USAGE: (u64, u64, u64) = (22, 5, 27);
+const ROUND3_USAGE: (u64, u64, u64) = (33, 6, 39);
+
+/// Usage accumulated across all three inference rounds.
+const EXPECTED_INPUT_TOKENS: u64 = ROUND1_USAGE.0 + ROUND2_USAGE.0 + ROUND3_USAGE.0;
+const EXPECTED_OUTPUT_TOKENS: u64 = ROUND1_USAGE.1 + ROUND2_USAGE.1 + ROUND3_USAGE.1;
+const EXPECTED_TOTAL_TOKENS: u64 = ROUND1_USAGE.2 + ROUND2_USAGE.2 + ROUND3_USAGE.2;
+
+/// Output item `type` values a two-tool-round terminal response must expose, in
+/// stable chronological order: each tool round contributes a function call then
+/// its server-tool result, followed by the final assistant message.
+const EXPECTED_OUTPUT_TYPES: [&str; 5] = ["function_call", "mcp_call", "function_call", "mcp_call", "message"];
+
+/// Final assistant text emitted by the terminal inference round.
+const FINAL_TEXT: &str = "SF is 72F and it is 3pm PST.";
+
+#[test]
+fn two_tool_rounds_accumulate_output_and_usage() {
+    // Round 1: the model asks to call the weather tool.
+    let first_response = serde_json::json!({
+        "id": "resp_1",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_weather",
+            "name": "weather__get_weather",
+            "arguments": r#"{"location":"SF"}"#,
+            "status": "completed"
+        }],
+        "usage": usage_json(ROUND1_USAGE)
+    });
+    // Round 2: after the weather result, the model asks to call the time tool.
+    let second_response = serde_json::json!({
+        "id": "resp_2",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "function_call",
+            "id": "fc_2",
+            "call_id": "call_time",
+            "name": "weather__get_time",
+            "arguments": r#"{"timezone":"PST"}"#,
+            "status": "completed"
+        }],
+        "usage": usage_json(ROUND2_USAGE)
+    });
+    // Round 3: the model emits the final assistant message and the loop exits.
+    let final_response = serde_json::json!({
+        "id": "resp_3",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": FINAL_TEXT}]
+        }],
+        "usage": usage_json(ROUND3_USAGE)
+    });
+
+    let model = StatefulCapturingBackend::new(vec![
+        (200, serde_json::to_string(&first_response).unwrap()),
+        (200, serde_json::to_string(&second_response).unwrap()),
+        (200, serde_json::to_string(&final_response).unwrap()),
+    ])
+    .start_with_shutdown();
+
+    let mcp = start_mcp_mock_server_with_config(McpMockConfig {
+        tools: vec![
+            McpToolFixture::new("get_weather")
+                .with_description("Get the weather for a location")
+                .with_input_schema(object_schema("location")),
+            McpToolFixture::new("get_time")
+                .with_description("Get the current time for a timezone")
+                .with_input_schema(object_schema("timezone")),
+        ],
+        ..McpMockConfig::default()
+    });
+
+    let proxy_port = free_port();
+    let config = load_loopback_mcp_config(proxy_port, model.port());
+    let proxy = start_proxy(&config);
+
+    let mcp_url = format!("http://127.0.0.1:{}/mcp", mcp.port());
+    let request_body = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "What is the weather and time in SF?",
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "server_url": mcp_url,
+            "allowed_tools": ["get_weather", "get_time"],
+            "require_approval": "never"
+        }]
+    });
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&request_body).unwrap()),
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "two-round agentic request should return 200: {raw}"
+    );
+    let response: serde_json::Value = serde_json::from_str(&parse_body(&raw)).expect("response should be valid JSON");
+
+    // Three inference rounds ran: model -> tool -> model -> tool -> model.
+    let model_reqs = model.requests();
+    assert_eq!(
+        model_reqs.len(),
+        3,
+        "model backend should receive exactly three requests"
+    );
+
+    // Both tools executed exactly once.
+    assert_eq!(mcp.method_count("tools/call"), 2, "exactly two MCP tool calls total");
+    assert_eq!(
+        mcp.tool_call_count("get_weather"),
+        1,
+        "get_weather must execute exactly once"
+    );
+    assert_eq!(mcp.tool_call_count("get_time"), 1, "get_time must execute exactly once");
+
+    // The terminal response lists every function call, server-tool result, and
+    // the final message in stable chronological order.
+    let output = response["output"].as_array().expect("final response output array");
+    let output_types: Vec<&str> = output.iter().map(output_item_type).collect();
+    assert_eq!(
+        output_types, EXPECTED_OUTPUT_TYPES,
+        "terminal output must interleave both tool rounds then the final message: {output:#?}"
+    );
+    let mcp_calls: Vec<&serde_json::Value> = output.iter().filter(|item| item["type"] == "mcp_call").collect();
+    assert!(
+        mcp_calls[0]["output"]
+            .as_str()
+            .is_some_and(|out| out.contains("mock result for get_weather")),
+        "first server-tool result must be the weather call: {:#?}",
+        mcp_calls[0]
+    );
+    assert!(
+        mcp_calls[1]["output"]
+            .as_str()
+            .is_some_and(|out| out.contains("mock result for get_time")),
+        "second server-tool result must be the time call: {:#?}",
+        mcp_calls[1]
+    );
+    let message = output
+        .last()
+        .expect("terminal output should end with the assistant message");
+    assert_eq!(
+        message["content"][0]["text"], FINAL_TEXT,
+        "final message text must survive: {message:#?}"
+    );
+
+    // The buffered terminal keeps the last round's backend response id.
+    assert_eq!(response["id"], "resp_3", "buffered terminal keeps the last round id");
+
+    // Reported usage equals the exact sum of all three inference rounds.
+    assert_eq!(
+        response["usage"]["input_tokens"], EXPECTED_INPUT_TOKENS,
+        "input tokens must sum across rounds"
+    );
+    assert_eq!(
+        response["usage"]["output_tokens"], EXPECTED_OUTPUT_TOKENS,
+        "output tokens must sum across rounds"
+    );
+    assert_eq!(
+        response["usage"]["total_tokens"], EXPECTED_TOTAL_TOKENS,
+        "total tokens must sum across rounds"
+    );
+
+    // Each tool result was supplied to the following inference round.
+    let second_input = request_input(&model_reqs[1].body);
+    assert!(
+        second_input.iter().any(is_weather_result),
+        "round 2 input must carry the weather result: {second_input:#?}"
+    );
+    let third_input = request_input(&model_reqs[2].body);
+    assert!(
+        third_input.iter().any(is_time_result),
+        "round 3 input must carry the time result: {third_input:#?}"
+    );
+}
+
+#[test]
+fn two_tool_rounds_streaming_matches_buffered() {
+    // A streamed function-call turn: created -> item added -> arg deltas -> done
+    // -> completed (carrying the round's usage). Mirrors the buffered rounds so
+    // the streaming and buffered variants accumulate identical output and usage.
+    let fc_turn = |resp_id: &str, item_id: &str, call_id: &str, name: &str, args: &str, usage: (u64, u64, u64)| {
+        vec![
+            sse_event(
+                "response.created",
+                serde_json::json!({
+                    "response": {"id": resp_id, "object": "response", "status": "in_progress", "output": []},
+                    "sequence_number": 0
+                }),
+            ),
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "response_id": resp_id,
+                    "output_index": 0,
+                    "item": {
+                        "type": "function_call",
+                        "id": item_id,
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": "",
+                        "status": "in_progress"
+                    },
+                    "sequence_number": 1
+                }),
+            ),
+            sse_event(
+                "response.function_call_arguments.delta",
+                serde_json::json!({
+                    "response_id": resp_id,
+                    "item_id": item_id,
+                    "output_index": 0,
+                    "delta": args,
+                    "sequence_number": 2
+                }),
+            ),
+            sse_event(
+                "response.function_call_arguments.done",
+                serde_json::json!({
+                    "response_id": resp_id,
+                    "item_id": item_id,
+                    "output_index": 0,
+                    "arguments": args,
+                    "sequence_number": 3
+                }),
+            ),
+            sse_event(
+                "response.completed",
+                serde_json::json!({
+                    "response": {
+                        "id": resp_id,
+                        "object": "response",
+                        "status": "completed",
+                        "output": [{
+                            "type": "function_call",
+                            "id": item_id,
+                            "call_id": call_id,
+                            "name": name,
+                            "arguments": args,
+                            "status": "completed"
+                        }],
+                        "usage": usage_json(usage)
+                    },
+                    "sequence_number": 4
+                }),
+            ),
+        ]
+    };
+    let final_turn = vec![
+        sse_event(
+            "response.created",
+            serde_json::json!({
+                "response": {"id": "resp_stream_3", "object": "response", "status": "in_progress", "output": []},
+                "sequence_number": 0
+            }),
+        ),
+        sse_event(
+            "response.output_item.added",
+            serde_json::json!({
+                "response_id": "resp_stream_3",
+                "output_index": 0,
+                "item": {"type": "message", "id": "msg_stream_3", "role": "assistant", "status": "in_progress", "content": []},
+                "sequence_number": 1
+            }),
+        ),
+        sse_event(
+            "response.output_text.delta",
+            serde_json::json!({
+                "response_id": "resp_stream_3",
+                "item_id": "msg_stream_3",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": FINAL_TEXT,
+                "sequence_number": 2
+            }),
+        ),
+        sse_event(
+            "response.completed",
+            serde_json::json!({
+                "response": {
+                    "id": "resp_stream_3",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [{
+                        "type": "message",
+                        "id": "msg_stream_3",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": FINAL_TEXT}]
+                    }],
+                    "usage": usage_json(ROUND3_USAGE)
+                },
+                "sequence_number": 3
+            }),
+        ),
+    ];
+    let (model_port, model_requests, model_thread) = start_streaming_model(vec![
+        fc_turn(
+            "resp_stream_1",
+            "fc_stream_1",
+            "call_weather",
+            "weather__get_weather",
+            r#"{"location":"SF"}"#,
+            ROUND1_USAGE,
+        ),
+        fc_turn(
+            "resp_stream_2",
+            "fc_stream_2",
+            "call_time",
+            "weather__get_time",
+            r#"{"timezone":"PST"}"#,
+            ROUND2_USAGE,
+        ),
+        final_turn,
+    ]);
+
+    let mcp = start_mcp_mock_server_with_config(McpMockConfig {
+        tools: vec![
+            McpToolFixture::new("get_weather")
+                .with_description("Get the weather for a location")
+                .with_input_schema(object_schema("location")),
+            McpToolFixture::new("get_time")
+                .with_description("Get the current time for a timezone")
+                .with_input_schema(object_schema("timezone")),
+        ],
+        ..McpMockConfig::default()
+    });
+    let proxy_port = free_port();
+    let config = load_loopback_mcp_config(proxy_port, model_port);
+    let proxy = start_proxy(&config);
+    let request = serde_json::json!({
+        "model": "gpt-4.1",
+        "input": "What is the weather and time in SF?",
+        "stream": true,
+        "store": false,
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "server_url": format!("http://127.0.0.1:{}/mcp", mcp.port()),
+            "allowed_tools": ["get_weather", "get_time"],
+            "require_approval": "never"
+        }]
+    });
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&request).unwrap()),
+    );
+    let body = parse_body(&raw);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "streamed two-round request should return 200: {raw}"
+    );
+    assert_eq!(
+        body.matches("event: response.created").count(),
+        1,
+        "the whole loop must expose one logical response.created: {body}"
+    );
+    assert_eq!(
+        body.matches("event: response.completed").count(),
+        1,
+        "intermediate round completions must be suppressed: {body}"
+    );
+    assert!(
+        body.contains(FINAL_TEXT),
+        "the terminal inference text should reach the stream: {body}"
+    );
+    assert!(
+        !body.contains("resp_stream_2") && !body.contains("resp_stream_3"),
+        "resumed rounds must retain the first logical response id: {body}"
+    );
+
+    // Both tools executed exactly once.
+    assert_eq!(mcp.method_count("tools/call"), 2, "exactly two MCP tool calls total");
+    assert_eq!(
+        mcp.tool_call_count("get_weather"),
+        1,
+        "get_weather must execute exactly once"
+    );
+    assert_eq!(mcp.tool_call_count("get_time"), 1, "get_time must execute exactly once");
+
+    // The single terminal response.completed carries the accumulated output and
+    // usage — the same order and sums as the buffered variant.
+    let completed = extract_completed_response(&body);
+    assert_eq!(completed["id"], "resp_stream_1", "streaming keeps the first round id");
+    let output = completed["output"].as_array().expect("terminal streamed output array");
+    let output_types: Vec<&str> = output.iter().map(output_item_type).collect();
+    assert_eq!(
+        output_types, EXPECTED_OUTPUT_TYPES,
+        "streamed terminal output must match the buffered accumulated order: {output:#?}"
+    );
+    assert_eq!(
+        completed["usage"]["input_tokens"], EXPECTED_INPUT_TOKENS,
+        "streamed input tokens must sum across rounds"
+    );
+    assert_eq!(
+        completed["usage"]["output_tokens"], EXPECTED_OUTPUT_TOKENS,
+        "streamed output tokens must sum across rounds"
+    );
+    assert_eq!(
+        completed["usage"]["total_tokens"], EXPECTED_TOTAL_TOKENS,
+        "streamed total tokens must sum across rounds"
+    );
+
+    model_thread.join().expect("streaming model thread should finish");
+    let (second_input, third_input) = {
+        let requests = model_requests
+            .lock()
+            .expect("model request lock should not be poisoned");
+        assert_eq!(requests.len(), 3, "IRR should make three streamed model requests");
+        (request_input(&requests[1]), request_input(&requests[2]))
+    };
+    assert!(
+        second_input.iter().any(is_weather_result),
+        "round 2 input must carry the weather result: {second_input:#?}"
+    );
+    assert!(
+        third_input.iter().any(is_time_result),
+        "round 3 input must carry the time result: {third_input:#?}"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Round-Trip: Web Search via IRR
 // -----------------------------------------------------------------------------
 
@@ -1184,6 +1640,76 @@ fn load_web_search_config(proxy_port: u16, model_port: u16, search_port: u16) ->
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
+
+/// Build an OpenAI Responses `usage` object from `(input, output, total)`.
+fn usage_json((input, output, total): (u64, u64, u64)) -> serde_json::Value {
+    serde_json::json!({
+        "input_tokens": input,
+        "output_tokens": output,
+        "total_tokens": total
+    })
+}
+
+/// A minimal single-string-property MCP tool input schema.
+fn object_schema(property: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {property: {"type": "string"}},
+        "required": [property],
+        "additionalProperties": false
+    })
+}
+
+/// The `type` of a Responses output item, or `""` when absent.
+fn output_item_type(item: &serde_json::Value) -> &str {
+    item["type"].as_str().unwrap_or_default()
+}
+
+/// Parse a captured model request body and return its `input` array.
+fn request_input(body: &str) -> Vec<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_str(body).expect("model request body should be valid JSON");
+    value["input"].as_array().cloned().unwrap_or_default()
+}
+
+/// True when `item` is the `function_call_output` bridge carrying the weather
+/// tool result fed back to the model.
+fn is_weather_result(item: &serde_json::Value) -> bool {
+    item["type"] == "function_call_output"
+        && item["output"]
+            .as_str()
+            .is_some_and(|out| out.contains("mock result for get_weather"))
+}
+
+/// True when `item` is the `function_call_output` bridge carrying the time tool
+/// result fed back to the model.
+fn is_time_result(item: &serde_json::Value) -> bool {
+    item["type"] == "function_call_output"
+        && item["output"]
+            .as_str()
+            .is_some_and(|out| out.contains("mock result for get_time"))
+}
+
+/// Extract the `response` object from the single terminal `response.completed`
+/// SSE frame in a client stream.
+fn extract_completed_response(body: &str) -> serde_json::Value {
+    let mut lines = body.lines();
+    while let Some(line) = lines.next() {
+        if line.trim() != "event: response.completed" {
+            continue;
+        }
+        for data_line in lines.by_ref() {
+            if let Some(payload) = data_line.strip_prefix("data: ") {
+                let event: serde_json::Value =
+                    serde_json::from_str(payload.trim()).expect("response.completed data should be valid JSON");
+                return event["response"].clone();
+            }
+            if data_line.trim().is_empty() {
+                break;
+            }
+        }
+    }
+    panic!("no response.completed event found in stream: {body}");
+}
 
 fn patch_web_search_api_key(yaml: &str) -> String {
     yaml.replace("api_key: ${WEB_SEARCH_API_KEY}", "api_key: test-key")


### PR DESCRIPTION
## Summary

Adds test-only end-to-end coverage for the consecutive-tool-round accumulation path: a deterministic Rust integration test proves that two consecutive MCP tool rounds accumulate output and the *exact* per-round token usage (`StatefulCapturingBackend`, 66/15/81 sum, stable output order) across both the buffered and streaming transports, and a live-vLLM SDK counterpart (a second `get_time` MCP tool plus buffered and streaming tests) asserts the multi-round trace and usage-accumulation integrity (`total == input + output`) against a real backend. No production code changes — the accumulation machinery already existed; this is the smallest change that closes the coverage gap, keeping the exact-sum contract in the deterministic Rust test and real-backend confidence in the SDK test.

## Related issue

Closes #983

## Validation

- `make build` — green
- `make lint` — green (clippy, fmt, deny, docs; inference coverage unchanged at features=21 / scenarios=19 / recordings=24)
- `cargo test -p praxis-tests-integration two_tool_rounds` — 2 passed (`two_tool_rounds_accumulate_output_and_usage`, `two_tool_rounds_streaming_matches_buffered`)
- `uv run tests/integration/sdk/openai/test_openai_responses_vllm.py --collect-only` — 16 collected (was 14); the two new live variants run in the vLLM SDK CI job

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. (N/A — test-only, no new capability)
- [ ] User-facing behavior and generated documentation are updated. (N/A — test-only)
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. (N/A)
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None — test-only change.
