### PR TITLE
fix(openai): return 200 SSE lifecycle on streaming MCP discovery failure

### DIFF
--- a/apis/src/openai/responses/README.md
+++ b/apis/src/openai/responses/README.md
@@ -34,7 +34,7 @@ Body-phase columns show `Access / Mode` when the hook is implemented.
 | `openai_file_resolve` | — | ReadWrite / StreamBuffer | — | — |
 | `openai_file_search_callout` | ✓ | ReadOnly / StreamBuffer | — | ReadWrite / StreamBuffer |
 | `openai_mcp_dispatch` | — | ReadOnly / StreamBuffer | — | ReadWrite / Stream |
-| `openai_mcp_tool_resolve` | — | ReadWrite / StreamBuffer | — | — |
+| `openai_mcp_tool_resolve` | ✓ | ReadWrite / StreamBuffer | — | — |
 | `openai_response_store` | ✓ | ReadOnly / Stream | ✓ | ReadOnly / Stream |
 | `openai_responses_compact` | — | ReadOnly / StreamBuffer | — | — |
 | `openai_responses_format` | — | ReadOnly / StreamBuffer | — | — |

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -48,8 +48,8 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
-    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, body::MAX_JSON_BODY_BYTES,
-    parse_filter_config,
+    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, TerminalResponse,
+    body::MAX_JSON_BODY_BYTES, parse_filter_config,
 };
 use tracing::debug;
 
@@ -75,6 +75,12 @@ const MAX_FUNCTION_NAME_LEN: usize = 64;
 /// Rejects the request with HTTP 400 before any callouts if two or
 /// more resolvable MCP entries share the same `server_label`
 /// (including entries that differ only by credentials).
+///
+/// For streaming requests, a runtime or response-processing failure from
+/// `tools/list` is returned as a successful SSE transport
+/// containing `response.mcp_list_tools.failed` and a terminal
+/// `response.failed` event. Local policy failures such as SSRF blocking
+/// remain HTTP error responses.
 ///
 /// # YAML
 ///
@@ -243,7 +249,10 @@ impl McpToolResolveFilter {
         let is_connector = entry.get("connector_id").is_some();
         mcp_client::validate_mcp_url(server_url, self.timeout, self.allow_loopback)
             .await
-            .map_err(ResolveError::Client)?;
+            .map_err(|source| ResolveError::Client {
+                server_label: label.to_owned(),
+                source,
+            })?;
         if !has_entry_credentials(entry)
             && let Some(cached) =
                 find_cached_listing(previous_tools, label, server_url, cache_allowed_names, is_connector)
@@ -275,7 +284,18 @@ impl HttpFilter for McpToolResolveFilter {
         }
     }
 
-    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        // A streaming `tools/list` runtime failure detected during the
+        // request-body pre-read is emitted here, in the header phase, because a
+        // `TerminalResponse` returned from a body-phase hook is discarded as
+        // `Continue`. Consuming the stash exactly once yields the terminal SSE;
+        // routing it through the response phase lets `openai_stream_events` and
+        // `openai_response_store` observe and persist the failed response.
+        if let Some(pending) = ctx.remove_filter_state::<PendingListToolsFailure>() {
+            return Ok(FilterAction::TerminalResponse(Box::new(
+                build_list_tools_failure_response(ctx, &pending),
+            )));
+        }
         Ok(FilterAction::Continue)
     }
 
@@ -299,9 +319,12 @@ impl HttpFilter for McpToolResolveFilter {
 
         let streaming = is_streaming(ctx);
 
-        match Box::pin(self.resolve_mcp_tools(ctx, body, bytes)).await {
+        // `bytes` is an `Arc`-backed `Bytes`; cloning bumps a refcount rather than
+        // copying the body, so keeping a handle for the failure path (which
+        // captures the size-bounded request options from it) is cheap.
+        match Box::pin(self.resolve_mcp_tools(ctx, body, bytes.clone())).await {
             Ok(action) => Ok(action),
-            Err(e) => Ok(resolve_error_rejection(&e, streaming)),
+            Err(e) => Ok(resolve_error_action(ctx, &e, streaming, &bytes)),
         }
     }
 }
@@ -314,8 +337,15 @@ impl HttpFilter for McpToolResolveFilter {
 #[derive(Debug, thiserror::Error)]
 enum ResolveError {
     /// MCP client call failed.
-    #[error("{0}")]
-    Client(#[from] mcp_client::McpClientError),
+    #[error("MCP tools/list failed for server_label \"{server_label}\": {source}")]
+    Client {
+        /// Client-visible label of the MCP server that failed.
+        server_label: String,
+
+        /// Transport or protocol failure returned by the MCP client.
+        #[source]
+        source: mcp_client::McpClientError,
+    },
 
     /// Generated function names collide after sanitization or
     /// truncation.
@@ -375,6 +405,9 @@ enum ResolveError {
         connector_id: String,
         /// The server label from the request.
         label: String,
+        /// Internal failure retained for classification and diagnostics.
+        #[source]
+        source: mcp_client::McpClientError,
     },
 
     /// A `tool_choice` references a resolved server with zero tools.
@@ -535,22 +568,41 @@ fn redact_connector_client_error(
     entry: &serde_json::Value,
 ) -> Result<Option<Vec<serde_json::Value>>, ResolveError> {
     match result {
-        Err(ResolveError::Client(client_err)) if entry.get("connector_id").is_some() => {
-            debug!(error = %client_err, "connector resolution failed (redacting URL for client)");
+        Err(ResolveError::Client { source, .. }) if entry.get("connector_id").is_some() => {
+            debug!(error = %source, "connector resolution failed (redacting URL for client)");
             let connector_id = entry
                 .get("connector_id")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
                 .to_owned();
             let label = server_label(entry).to_owned();
-            Err(ResolveError::ConnectorClient { connector_id, label })
+            Err(ResolveError::ConnectorClient {
+                connector_id,
+                label,
+                source,
+            })
         },
         other => other,
     }
 }
 
-/// Map a [`ResolveError`] to an appropriate rejection response.
-fn resolve_error_rejection(err: &ResolveError, streaming: bool) -> FilterAction {
+/// Map a [`ResolveError`] to the [`FilterAction`] returned from the
+/// request-body phase.
+///
+/// A streaming `tools/list` runtime failure is *deferred*: a compact
+/// [`PendingListToolsFailure`] descriptor is stashed and `Continue` is
+/// returned, because a `TerminalResponse` produced here (a body-phase hook)
+/// would be swallowed as `Continue` by the pipeline. The header-phase
+/// [`McpToolResolveFilter::on_request`] consumes the stash and emits the
+/// terminal SSE so the response phase can observe and persist it. All other
+/// failures -- and every local request-policy failure such as SSRF -- keep
+/// their immediate [`Rejection`].
+fn resolve_error_action(
+    ctx: &mut HttpFilterContext<'_>,
+    err: &ResolveError,
+    streaming: bool,
+    body: &[u8],
+) -> FilterAction {
     let (status, error_type) = match err {
         ResolveError::DuplicateLabel(_)
         | ResolveError::TooManyServers { .. }
@@ -562,12 +614,508 @@ fn resolve_error_rejection(err: &ResolveError, streaming: bool) -> FilterAction 
         | ResolveError::MissingConnectorLabel(_)
         | ResolveError::EmptyResolvedToolChoice(_) => (400, "invalid_request_error"),
         ResolveError::BodyTooLarge { .. } => (413, "invalid_request_error"),
-        ResolveError::Client(_) | ResolveError::ConnectorClient { .. } => (502, "server_error"),
+        ResolveError::Client { .. } | ResolveError::ConnectorClient { .. } => (502, "server_error"),
         ResolveError::Serialization(_) => (500, "server_error"),
     };
     let msg = err.to_string();
     debug!(error = %msg, "openai_mcp_tool_resolve rejected");
+    if streaming && is_mcp_listing_runtime_failure(err) {
+        ctx.insert_filter_state(PendingListToolsFailure {
+            server_label: failure_server_label(err).to_owned(),
+            error_type,
+            message: msg,
+            options: capture_echoed_options(body),
+        });
+        return FilterAction::Continue;
+    }
     FilterAction::Reject(responses_error_rejection(status, error_type, &msg, streaming))
+}
+
+/// Compact descriptor of a deferred streaming `tools/list` runtime failure.
+///
+/// Stashed as per-filter state during the request-body pre-read and consumed
+/// once in the header phase to build the terminal SSE response. Holds only the
+/// small error-derived strings the lifecycle needs -- never the request or its
+/// body bytes.
+struct PendingListToolsFailure {
+    /// Client-visible label of the MCP server that failed.
+    server_label: String,
+
+    /// OpenAI error `code` (always `server_error` for runtime failures).
+    error_type: &'static str,
+
+    /// Client-safe failure message embedded in the terminal events.
+    message: String,
+
+    /// Size-bounded, credential-free subset of the caller's request options,
+    /// captured from the request body during the pre-read and echoed into the
+    /// synthesized failure snapshot. Captured here -- rather than read from
+    /// `ResponsesState` in the header phase -- so the caller's real options are
+    /// echoed even in a pipeline without
+    /// `openai_responses_validate`/`openai_responses_rehydrate` (which never
+    /// builds that state), and so a large `instructions`/`metadata` cannot be
+    /// amplified across the snapshots. `None` when the body is unparseable,
+    /// carries no echoable field, or the whitelisted subset exceeds
+    /// [`MAX_ECHOED_OPTIONS_BYTES`]; every echoed field then falls back to its
+    /// OpenAI API default.
+    options: Option<serde_json::Value>,
+}
+
+/// Extract the client-visible server label from a resolve error.
+fn failure_server_label(err: &ResolveError) -> &str {
+    match err {
+        ResolveError::Client { server_label, .. }
+        | ResolveError::ConnectorClient {
+            label: server_label, ..
+        } => server_label.as_str(),
+        _ => "unknown",
+    }
+}
+
+/// Return whether an MCP client error represents a discovery attempt that
+/// reached runtime I/O or response processing. Local request-policy failures
+/// such as SSRF blocking and malformed authorization retain their HTTP error.
+fn is_mcp_listing_runtime_failure(err: &ResolveError) -> bool {
+    let (ResolveError::Client { source, .. } | ResolveError::ConnectorClient { source, .. }) = err else {
+        return false;
+    };
+    matches!(
+        source,
+        mcp_client::McpClientError::Connection { .. }
+            | mcp_client::McpClientError::ListTools { .. }
+            | mcp_client::McpClientError::Timeout { .. }
+            | mcp_client::McpClientError::Serialization(_)
+            | mcp_client::McpClientError::TooManyTools { .. }
+    )
+}
+
+/// Request fields echoed into a synthesized discovery-failure snapshot, ordered
+/// by increasing potential size so the small fixed-size options are always
+/// captured and only a large trailing blob (`instructions`/`metadata`) can be
+/// dropped by the size bound. `input` and `tools` are intentionally excluded:
+/// they are not needed to describe the failure, and `tools` may carry per-entry
+/// MCP credentials that must never be persisted.
+const ECHOED_REQUEST_FIELDS: &[&str] = &[
+    "temperature",
+    "top_p",
+    "max_output_tokens",
+    "parallel_tool_calls",
+    "previous_response_id",
+    "tool_choice",
+    "truncation",
+    "model",
+    "reasoning",
+    "text",
+    "metadata",
+    "instructions",
+];
+
+/// Upper bound on the aggregate serialized size of the captured echo options.
+///
+/// The snapshot is embedded in three SSE frames (`response.created`,
+/// `response.in_progress`, `response.failed`) and published to
+/// `ResponsesState.response_object`, so every echoed byte is copied several
+/// times. A valid request may carry a multi-megabyte `instructions` or
+/// `metadata`; echoing it unbounded would amplify a 64 MiB request into hundreds
+/// of MiB. Capping the captured options keeps the synthesized failure bounded
+/// regardless of the request size. A field that would push the running total past
+/// this bound is omitted and falls back to its API default in the snapshot.
+const MAX_ECHOED_OPTIONS_BYTES: usize = 256 * 1024;
+
+/// An [`std::io::Write`] sink that counts bytes and discards them, used to
+/// measure a value's serialized JSON size without allocating a buffer for it.
+struct ByteCounter(usize);
+
+impl std::io::Write for ByteCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 = self.0.saturating_add(buf.len());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Serialized JSON byte length of `value`, computed without materializing the
+/// serialized bytes so that measuring a large field never copies it.
+fn serialized_len(value: &serde_json::Value) -> usize {
+    let mut counter = ByteCounter(0);
+    // Serializing an in-memory `Value` (no non-string map keys, no non-finite
+    // floats) into a counting sink that never errors cannot fail. Should the
+    // impossible happen, report the value as maximally large so the caller skips
+    // (never echoes) it — fail-safe for the size bound rather than panicking.
+    match serde_json::to_writer(&mut counter, value) {
+        Ok(()) => counter.0,
+        Err(_) => usize::MAX,
+    }
+}
+
+/// Extract the size-bounded, credential-free subset of request options echoed
+/// into a streaming discovery-failure snapshot.
+///
+/// Only [`ECHOED_REQUEST_FIELDS`] are copied (never `input`/`tools`), and a field
+/// is skipped once including it would push the aggregate past
+/// [`MAX_ECHOED_OPTIONS_BYTES`], so a large `instructions`/`metadata` cannot be
+/// amplified across the synthesized snapshots. Returns `None` when the body is
+/// unparseable or no whitelisted field survives, in which case the snapshot falls
+/// back to API defaults for every echoed field.
+fn capture_echoed_options(body: &[u8]) -> Option<serde_json::Value> {
+    let parsed: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let obj = parsed.as_object()?;
+    let mut total = 0_usize;
+    let mut captured = serde_json::Map::new();
+    for &field in ECHOED_REQUEST_FIELDS {
+        let Some(value) = obj.get(field) else {
+            continue;
+        };
+        // Measure before cloning so an oversized field is never copied into the
+        // capture, and skip (rather than truncate) any field that would exceed
+        // the aggregate bound so the retained JSON stays well-formed.
+        let len = serialized_len(value);
+        if total.saturating_add(len) > MAX_ECHOED_OPTIONS_BYTES {
+            continue;
+        }
+        total += len;
+        captured.insert(field.to_owned(), value.clone());
+    }
+    (!captured.is_empty()).then_some(serde_json::Value::Object(captured))
+}
+
+/// Build the terminal HTTP 200 SSE response for a deferred MCP discovery
+/// failure.
+///
+/// Consumes the [`PendingListToolsFailure`] stashed during the body pre-read.
+/// A successful HTTP status is required for Responses SDKs to expose SSE events
+/// to callers; the terminal `response.failed` event carries the request failure
+/// instead. Emitting as a `TerminalResponse` (rather than `Reject`) runs the
+/// already-executed request-phase filters on the response path, so
+/// `openai_stream_events` accumulates the failure and `openai_response_store`
+/// persists it for later retrieval when `store` is enabled.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the complete local Responses failure lifecycle is easier to audit in event order"
+)]
+fn build_list_tools_failure_response(
+    ctx: &mut HttpFilterContext<'_>,
+    pending: &PendingListToolsFailure,
+) -> TerminalResponse {
+    let server_label = pending.server_label.as_str();
+    let error_type = pending.error_type;
+    let message = pending.message.as_str();
+    // Effective storage mirrors the store filter's own gate exactly: persist
+    // unless the caller set `store: false`. Explicit-true and omitted both store
+    // (the OpenAI default). `openai_stream_events` accumulates this failure into
+    // `ResponsesState` and `openai_response_store` persists it, so this flag must
+    // match what the caller observes on retrieval.
+    let store = ctx.get_metadata("openai_responses_format.store") != Some("false");
+    let response_id = ctx
+        .get_metadata("responses.response_id")
+        .or_else(|| {
+            ctx.extensions
+                .get::<ResponsesState>()
+                .and_then(|state| state.response_id.as_deref())
+        })
+        .map_or_else(
+            || format!("resp_{}", ctx.id_generator.generate(ctx.time_source)),
+            ToOwned::to_owned,
+        );
+    let item_id = format!("mcpl_{}", ctx.id_generator.generate(ctx.time_source));
+    let created_at = ctx.time_source.now().as_secs();
+    // Size-bounded, credential-free request options captured from the request
+    // body during the pre-read (see `capture_echoed_options`). The failure
+    // resource echoes these parameters (see `discovery_response`) so a persisted
+    // or streamed failure reports the same configuration a real Responses object
+    // would. Sourcing them from the captured descriptor -- rather than
+    // `ResponsesState.request_body` -- keeps fidelity correct even in a pipeline
+    // without `openai_responses_validate`/`openai_responses_rehydrate` (which
+    // never builds that state), and bounds the size so a large
+    // `instructions`/`metadata` is not amplified across the snapshots. `None` (no
+    // echoable field, or over the cap) falls back to API defaults.
+    let options = pending.options.as_ref();
+    // Echo the requested model, matching a real Responses stream. The format
+    // filter promotes it to metadata before this filter runs, so it is present
+    // even when no `ResponsesState` was built (e.g. no validate/rehydrate in the
+    // pipeline); fall back to the captured options, then to an empty string.
+    let model = ctx
+        .get_metadata("openai_responses_format.model")
+        .or_else(|| {
+            options
+                .and_then(|body| body.get("model"))
+                .and_then(serde_json::Value::as_str)
+        })
+        .unwrap_or_default();
+
+    let params = DiscoveryResponseParams {
+        response_id: &response_id,
+        created_at,
+        model,
+        store,
+        request: options,
+    };
+    let response = discovery_response(&params, DiscoveryResponseState::InProgress);
+    let pending_item = serde_json::json!({
+        "id": item_id,
+        "type": "mcp_list_tools",
+        "server_label": server_label,
+        "tools": [],
+        "error": null,
+    });
+    let mut body = Vec::new();
+
+    // Each lifecycle event embeds a response snapshot. `json!` takes `response`
+    // by reference (so the same value is reused across the created/in_progress
+    // frames without a `.clone()` at the call site), but interpolating a `Value`
+    // deep-copies it into each frame via `serde_json::to_value`. This is a cold,
+    // one-shot local failure path, so the extra copies are immaterial. The
+    // snapshot echoes the caller's request parameters (see `discovery_response`);
+    // request `input` and `tools` are intentionally absent, the latter because
+    // MCP entries can carry per-entry credentials that must not be persisted.
+    append_sse_event(
+        "response.created",
+        &serde_json::json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": response,
+        }),
+        &mut body,
+    );
+    append_sse_event(
+        "response.in_progress",
+        &serde_json::json!({
+            "type": "response.in_progress",
+            "sequence_number": 1,
+            "response": response,
+        }),
+        &mut body,
+    );
+    append_sse_event(
+        "response.output_item.added",
+        &serde_json::json!({
+            "type": "response.output_item.added",
+            "sequence_number": 2,
+            "output_index": 0,
+            "item": pending_item,
+        }),
+        &mut body,
+    );
+    append_sse_event(
+        "response.mcp_list_tools.in_progress",
+        &serde_json::json!({
+            "type": "response.mcp_list_tools.in_progress",
+            "sequence_number": 3,
+            "output_index": 0,
+            "item_id": item_id,
+        }),
+        &mut body,
+    );
+
+    append_sse_event(
+        "response.mcp_list_tools.failed",
+        &serde_json::json!({
+            "type": "response.mcp_list_tools.failed",
+            "sequence_number": 4,
+            "output_index": 0,
+            "item_id": item_id,
+        }),
+        &mut body,
+    );
+    let failed_item = serde_json::json!({
+        "id": item_id,
+        "type": "mcp_list_tools",
+        "server_label": server_label,
+        "tools": [],
+        "error": message,
+    });
+    append_sse_event(
+        "response.output_item.done",
+        &serde_json::json!({
+            "type": "response.output_item.done",
+            "sequence_number": 5,
+            "output_index": 0,
+            "item": failed_item,
+        }),
+        &mut body,
+    );
+
+    let response = discovery_response(
+        &params,
+        DiscoveryResponseState::Failed {
+            error_type,
+            message,
+            item: &failed_item,
+        },
+    );
+    append_sse_event(
+        "response.failed",
+        &serde_json::json!({
+            "type": "response.failed",
+            "sequence_number": 6,
+            "response": response,
+        }),
+        &mut body,
+    );
+
+    // Publish the terminal failed resource directly into the shared state so
+    // `openai_response_store` can persist it. Streaming persistence reads
+    // `ResponsesState.response_object`, which is normally populated by
+    // `openai_stream_events` accumulating the terminal frame on the response
+    // phase. But this filter's short-circuiting `TerminalResponse` means any
+    // filter ordered *after* it never runs on the response phase, so persistence
+    // cannot rely on `openai_stream_events` to populate the field:
+    //   * In `agentic-loop.yaml`, `openai_stream_events` is nested in the iterative_request_router that follows this
+    //     filter, so it never runs.
+    //   * A pipeline with `openai_response_store` + this filter but without
+    //     `openai_responses_validate`/`openai_responses_rehydrate` never builds a `ResponsesState` up front, yet still
+    //     persists purely from `response_object` (the store reads only that field, not `request_body`).
+    // `get_or_insert_with` therefore both creates the state when absent and
+    // writes the snapshot, making persistence independent of pipeline ordering
+    // and of which upstream filters ran. When `openai_stream_events` *does* run
+    // on the response phase it overwrites this with the identical snapshot parsed
+    // from the same terminal frame (a full overwrite, not an append), so this
+    // write is a harmless no-op in that ordering. The echoed options borrow
+    // `pending` (not `ctx`) and the `model` metadata borrow of `ctx` both ended
+    // with the final `discovery_response` call above, so the snapshot is moved
+    // into state here without a clone.
+    ctx.extensions
+        .get_or_insert_with(ResponsesState::default)
+        .response_object = response;
+
+    // Emit as a header-phase `TerminalResponse`, not a `Reject`. A terminal
+    // response preserves downstream keepalive (this is a successful 200 transport
+    // of a failure, so it must pool like any normal Responses stream) and runs
+    // the response-phase filters that already executed in the request phase. That
+    // response-phase pass is the point: `openai_stream_events` accumulates the
+    // terminal `response.failed` into `ResponsesState` and `openai_response_store`
+    // persists it, so a caller with `store` enabled can retrieve the failed
+    // response afterwards. The failure was stashed during the body pre-read and
+    // this response is built once here in the header phase, after the full request
+    // body was consumed, so upstream routing and I/O are skipped.
+    let mut headers = http::HeaderMap::new();
+    headers.insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("text/event-stream"),
+    );
+    TerminalResponse::new(200)
+        .with_headers(headers)
+        .with_body(Bytes::from(body))
+}
+
+/// Lifecycle stage a discovery-failure response snapshot represents.
+///
+/// The same locally generated response resource is emitted twice: once while
+/// the MCP listing is in progress and once after it fails.
+#[derive(Clone, Copy)]
+enum DiscoveryResponseState<'a> {
+    /// Listing still in progress; `status: "in_progress"`, no error or output.
+    InProgress,
+
+    /// Listing failed; `status: "failed"` with an error object and the failed
+    /// `mcp_list_tools` output item.
+    Failed {
+        /// OpenAI error `code` (e.g. `server_error`).
+        error_type: &'a str,
+
+        /// Client-safe failure message.
+        message: &'a str,
+
+        /// The failed `mcp_list_tools` output item to place in `output`.
+        item: &'a serde_json::Value,
+    },
+}
+
+/// Fixed inputs shared by every discovery-failure snapshot, independent of the
+/// lifecycle [`DiscoveryResponseState`]. Bundled so the snapshot can be built
+/// twice (in-progress and failed) from a single construction.
+struct DiscoveryResponseParams<'a> {
+    /// Stable response id echoed in every frame.
+    response_id: &'a str,
+
+    /// Response creation timestamp (unix seconds).
+    created_at: u64,
+
+    /// Requested model, echoed to match a real Responses stream.
+    model: &'a str,
+
+    /// Effective storage flag advertised on the snapshot.
+    store: bool,
+
+    /// Size-bounded, credential-free capture of the caller's request options;
+    /// its parameters are echoed into the snapshot. `None` (unparseable body, no
+    /// echoable field, or over the size cap) falls back to the API defaults.
+    request: Option<&'a serde_json::Value>,
+}
+
+/// Construct the minimal schema-complete response shared by the lifecycle
+/// events emitted for local MCP discovery failures.
+#[expect(clippy::too_many_lines, reason = "minimal Responses resource schema")]
+fn discovery_response(params: &DiscoveryResponseParams<'_>, state: DiscoveryResponseState<'_>) -> serde_json::Value {
+    let &DiscoveryResponseParams {
+        response_id,
+        created_at,
+        model,
+        store,
+        request,
+    } = params;
+    let (status, error, output) = match state {
+        DiscoveryResponseState::InProgress => {
+            ("in_progress", serde_json::Value::Null, serde_json::Value::Array(vec![]))
+        },
+        DiscoveryResponseState::Failed {
+            error_type,
+            message,
+            item,
+        } => (
+            "failed",
+            serde_json::json!({"code": error_type, "message": message}),
+            serde_json::json!([item]),
+        ),
+    };
+    // Echo the caller-supplied request parameters so the persisted or streamed
+    // failure reports the same configuration a successful Responses object would;
+    // otherwise a caller who set e.g. `temperature: 0.2` would retrieve a stored
+    // failure claiming the default `1.0`. Absent the field (or the captured
+    // options) each falls back to the OpenAI API default. Request `input` and
+    // `tools` are deliberately omitted -- they are not needed to describe the
+    // failure and `tools` may carry per-entry MCP credentials that must not be
+    // persisted.
+    let echo = |field: &str, default: serde_json::Value| -> serde_json::Value {
+        request.and_then(|body| body.get(field)).cloned().unwrap_or(default)
+    };
+    serde_json::json!({
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "completed_at": null,
+        "status": status,
+        "error": error,
+        "incomplete_details": null,
+        "instructions": echo("instructions", serde_json::Value::Null),
+        "max_output_tokens": echo("max_output_tokens", serde_json::Value::Null),
+        "model": model,
+        "output": output,
+        "parallel_tool_calls": echo("parallel_tool_calls", serde_json::Value::Bool(true)),
+        "previous_response_id": echo("previous_response_id", serde_json::Value::Null),
+        "reasoning": echo("reasoning", serde_json::Value::Null),
+        "store": store,
+        "temperature": echo("temperature", serde_json::json!(1.0)),
+        "text": echo("text", serde_json::json!({"format": {"type": "text"}})),
+        "tool_choice": echo("tool_choice", serde_json::json!("auto")),
+        "tools": [],
+        "top_p": echo("top_p", serde_json::json!(1.0)),
+        "truncation": echo("truncation", serde_json::json!("disabled")),
+        "usage": null,
+        "metadata": echo("metadata", serde_json::json!({})),
+    })
+}
+
+/// Serialize one named SSE frame.
+fn append_sse_event(event_type: &str, payload: &serde_json::Value, output: &mut Vec<u8>) {
+    output.extend_from_slice(b"event: ");
+    output.extend_from_slice(event_type.as_bytes());
+    output.extend_from_slice(b"\ndata: ");
+    output.extend_from_slice(payload.to_string().as_bytes());
+    output.extend_from_slice(b"\n\n");
 }
 
 /// Return the `server_url` if the entry should be eagerly
@@ -701,7 +1249,10 @@ async fn fetch_tools(
         allow_loopback,
     )
     .await
-    .map_err(ResolveError::Client)
+    .map_err(|source| ResolveError::Client {
+        server_label: server_label(entry).to_owned(),
+        source,
+    })
 }
 
 /// Rewrite the request body, replacing resolved `type: "mcp"`

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs
@@ -595,8 +595,8 @@ fn redact_connector_client_error(
 /// would be swallowed as `Continue` by the pipeline. The header-phase
 /// [`McpToolResolveFilter::on_request`] consumes the stash and emits the
 /// terminal SSE so the response phase can observe and persist it. All other
-/// failures -- and every local request-policy failure such as SSRF -- keep
-/// their immediate [`Rejection`].
+/// failures -- and every local request-policy failure such as SSRF -- are
+/// rejected immediately via [`FilterAction::Reject`].
 fn resolve_error_action(
     ctx: &mut HttpFilterContext<'_>,
     err: &ResolveError,

--- a/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
+++ b/apis/src/openai/responses/openai_mcp_tool_resolve/tests.rs
@@ -2657,11 +2657,13 @@ async fn expanded_body_at_exact_limit_continues() {
 /// `BodyTooLarge` maps to HTTP 413 with `invalid_request_error`.
 #[test]
 fn body_too_large_maps_to_413() {
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
     let err = ResolveError::BodyTooLarge {
         actual: 1_000_000,
         limit: 65_536,
     };
-    let action = resolve_error_rejection(&err, false);
+    let action = resolve_error_action(&mut ctx, &err, false, b"{}");
     let rejection = match action {
         FilterAction::Reject(r) => r,
         other => panic!("expected Reject, got {other:?}"),
@@ -3238,7 +3240,10 @@ fn redact_connector_client_error_replaces_url() {
     let client_err = mcp_client::McpClientError::Connection {
         url: mcp_client::McpDisplayUrl::from_uri(&uri),
     };
-    let result: Result<Option<Vec<serde_json::Value>>, ResolveError> = Err(ResolveError::Client(client_err));
+    let result: Result<Option<Vec<serde_json::Value>>, ResolveError> = Err(ResolveError::Client {
+        server_label: "drive".to_owned(),
+        source: client_err,
+    });
 
     let redacted = redact_connector_client_error(result, &entry);
     let err = redacted.unwrap_err();
@@ -3262,12 +3267,15 @@ fn redact_connector_client_error_passes_through_direct_url() {
     let client_err = mcp_client::McpClientError::Connection {
         url: mcp_client::McpDisplayUrl::from_uri(&uri),
     };
-    let result: Result<Option<Vec<serde_json::Value>>, ResolveError> = Err(ResolveError::Client(client_err));
+    let result: Result<Option<Vec<serde_json::Value>>, ResolveError> = Err(ResolveError::Client {
+        server_label: "drive".to_owned(),
+        source: client_err,
+    });
 
     let redacted = redact_connector_client_error(result, &entry);
     let err = redacted.unwrap_err();
     assert!(
-        matches!(err, ResolveError::Client(_)),
+        matches!(err, ResolveError::Client { .. }),
         "direct URL errors should not be redacted"
     );
 }
@@ -3462,4 +3470,666 @@ async fn zero_permitted_tools_does_not_leak_credentials_to_backend() {
         serde_json::json!([]),
         "all tools filtered out → empty tools array"
     );
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "full Responses lifecycle assertions")]
+async fn streaming_list_failure_emits_conformant_mcp_failure_lifecycle() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_url = format!("http://{}/mcp", listener.local_addr().unwrap());
+    drop(listener);
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str("allow_loopback: true\ntimeout_ms: 1000").unwrap();
+    let filter = McpToolResolveFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    // Per-filter state (the deferred-failure stash) is keyed by the filter's
+    // pipeline index, which the real pre-read machinery sets. Emulate it so the
+    // body-phase stash survives into the header phase.
+    ctx.current_filter_id = Some(0);
+    ctx.set_metadata("openai_tool_parse.has_mcp", "true");
+    ctx.set_metadata("openai_responses_format.stream", "true");
+    ctx.set_metadata("responses.response_id", "resp_listing_failure");
+
+    let body_json = serde_json::json!({
+        "model": "gpt-4o-mini",
+        "input": "hello",
+        "stream": true,
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "server_url": server_url,
+        }]
+    });
+    let mut state = ResponsesState::from_request_body(body_json.clone());
+    state.response_id = Some("resp_listing_failure".to_owned());
+    ctx.extensions.insert(state);
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+
+    // The body phase defers: a `TerminalResponse` returned here would be swallowed
+    // as `Continue`, so the runtime failure is stashed and `Continue` returned.
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "a streaming runtime discovery failure defers to the header phase"
+    );
+
+    // The header phase consumes the stash and emits the terminal SSE response.
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let FilterAction::TerminalResponse(terminal) = action else {
+        panic!("failed MCP discovery should terminate locally with a terminal response");
+    };
+
+    assert_eq!(terminal.status, 200, "SSE lifecycle must be visible to SDK clients");
+    assert_eq!(
+        terminal
+            .headers
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/event-stream"),
+        "failure lifecycle must use SSE content type"
+    );
+    let raw = std::str::from_utf8(terminal.body.as_deref().expect("SSE body")).unwrap();
+    let events = parse_named_sse_events(raw);
+    let event_types: Vec<_> = events.iter().map(|(name, _)| name.as_str()).collect();
+    assert_eq!(
+        event_types,
+        [
+            "response.created",
+            "response.in_progress",
+            "response.output_item.added",
+            "response.mcp_list_tools.in_progress",
+            "response.mcp_list_tools.failed",
+            "response.output_item.done",
+            "response.failed",
+        ],
+        "failure stream should form a complete Responses lifecycle"
+    );
+
+    for (expected, (_, payload)) in events.iter().enumerate() {
+        assert_eq!(
+            payload["sequence_number"].as_u64(),
+            Some(expected as u64),
+            "sequence numbers should be monotonic"
+        );
+    }
+    let failed = &events[4].1;
+    assert_eq!(failed["output_index"], 0);
+    assert!(
+        failed["item_id"].as_str().is_some_and(|id| id.starts_with("mcpl_")),
+        "failure event should identify the MCP list item"
+    );
+    assert_eq!(
+        failed.as_object().map(serde_json::Map::len),
+        Some(4),
+        "the standard failure event must not grow non-schema server or error fields"
+    );
+
+    let done_item = &events[5].1["item"];
+    assert_eq!(done_item["server_label"], "weather");
+    assert_eq!(done_item["id"], failed["item_id"]);
+    assert!(
+        done_item["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("server_label \"weather\"") && error.contains(&server_url)),
+        "the output item should carry the server identity and diagnostic"
+    );
+    let failed_response = &events[6].1["response"];
+    assert_eq!(failed_response["id"], "resp_listing_failure");
+    assert_eq!(failed_response["status"], "failed");
+    assert_eq!(failed_response["output"][0], *done_item);
+    assert_eq!(failed_response["error"]["code"], "server_error");
+
+    // The requested model must be echoed in every snapshot. No
+    // `openai_responses_format.model` metadata is set here, so this exercises
+    // the `ResponsesState.request_body` fallback branch.
+    let created_response = &events[0].1["response"];
+    assert_eq!(
+        created_response["model"], "gpt-4o-mini",
+        "created snapshot echoes model"
+    );
+    assert_eq!(failed_response["model"], "gpt-4o-mini", "failed snapshot echoes model");
+
+    // No `openai_responses_format.store` metadata is set, so the effective store
+    // is the OpenAI default (true). The snapshot must advertise that so a caller
+    // who later retrieves the persisted failure sees a consistent resource.
+    assert_eq!(
+        created_response["store"], true,
+        "store defaults to true when omitted, matching the store filter's own gate"
+    );
+    assert_eq!(
+        failed_response["store"], true,
+        "failed snapshot mirrors effective store"
+    );
+
+    // Pin the exact top-level key set of the synthesized response resource so a
+    // future refactor cannot silently drop a required field or add a non-schema
+    // one. The in-progress snapshot shares this shape with the failed one.
+    let mut created_keys: Vec<&str> = created_response
+        .as_object()
+        .expect("response object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    created_keys.sort_unstable();
+    assert_eq!(
+        created_keys,
+        [
+            "completed_at",
+            "created_at",
+            "error",
+            "id",
+            "incomplete_details",
+            "instructions",
+            "max_output_tokens",
+            "metadata",
+            "model",
+            "object",
+            "output",
+            "parallel_tool_calls",
+            "previous_response_id",
+            "reasoning",
+            "status",
+            "store",
+            "temperature",
+            "text",
+            "tool_choice",
+            "tools",
+            "top_p",
+            "truncation",
+            "usage",
+        ],
+        "response snapshot must carry exactly the schema fields"
+    );
+}
+
+#[test]
+fn streaming_failure_classification_includes_runtime_tools_list_failures() {
+    let uri: http::Uri = "https://mcp.example/tools".parse().unwrap();
+    let url = || mcp_client::McpDisplayUrl::from_uri(&uri);
+    let client = |source: mcp_client::McpClientError| ResolveError::Client {
+        server_label: "drive".to_owned(),
+        source,
+    };
+
+    // Every runtime/transport failure of `tools/list` discovery must defer to the
+    // 200 SSE lifecycle. Pinning each arm guards the core feature: a refactor that
+    // drops one would silently return a hard HTTP error for that failure mode.
+    for source in [
+        mcp_client::McpClientError::Connection { url: url() },
+        mcp_client::McpClientError::ListTools { url: url() },
+        mcp_client::McpClientError::Timeout {
+            url: url(),
+            timeout: Duration::from_secs(1),
+        },
+        mcp_client::McpClientError::TooManyTools {
+            url: url(),
+            count: 11,
+            max: 10,
+        },
+        mcp_client::McpClientError::Serialization(serde_json::from_str::<serde_json::Value>("{").unwrap_err()),
+    ] {
+        assert!(
+            is_mcp_listing_runtime_failure(&client(source)),
+            "runtime tools/list failure must defer to the SSE lifecycle"
+        );
+    }
+}
+
+#[test]
+fn streaming_failure_classification_excludes_local_request_policy() {
+    let uri: http::Uri = "https://mcp.example/tools".parse().unwrap();
+    let url = || mcp_client::McpDisplayUrl::from_uri(&uri);
+    let client = |source: mcp_client::McpClientError| ResolveError::Client {
+        server_label: "drive".to_owned(),
+        source,
+    };
+
+    // Local request-policy failures retain their HTTP error. SSRF blocking is the
+    // headline exclusion documented on the filter: it must never be downgraded to
+    // the 200 SSE lifecycle. `CallTool` is a non-listing operation and cannot
+    // arise from the tools/list path.
+    for source in [
+        mcp_client::McpClientError::InvalidAuthorization,
+        mcp_client::McpClientError::SsrfBlocked {
+            url: url(),
+            reason: "resolves to a private address",
+        },
+        mcp_client::McpClientError::CallTool {
+            url: url(),
+            tool_name: "x".to_owned(),
+        },
+    ] {
+        assert!(
+            !is_mcp_listing_runtime_failure(&client(source)),
+            "local policy / non-listing failure must retain its HTTP error"
+        );
+    }
+}
+
+/// A streaming SSRF failure must retain the ordinary HTTP error response (a
+/// single `event: error` frame at the mapped status), not the 200 discovery
+/// lifecycle reserved for runtime `tools/list` failures.
+#[test]
+fn streaming_ssrf_failure_retains_http_error() {
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let uri: http::Uri = "https://mcp.internal/tools".parse().unwrap();
+    let err = ResolveError::Client {
+        server_label: "internal".to_owned(),
+        source: mcp_client::McpClientError::SsrfBlocked {
+            url: mcp_client::McpDisplayUrl::from_uri(&uri),
+            reason: "resolves to a private address",
+        },
+    };
+
+    let FilterAction::Reject(rejection) = resolve_error_action(&mut ctx, &err, true, b"{}") else {
+        panic!("expected Reject");
+    };
+
+    assert_eq!(rejection.status, 502, "SSRF keeps its upstream error status");
+    assert!(
+        !rejection.preserve_keepalive,
+        "a genuine HTTP error closes the connection, unlike the 200 discovery-failure transport"
+    );
+    let raw = std::str::from_utf8(rejection.body.as_deref().expect("SSE body")).unwrap();
+    assert!(
+        raw.starts_with("event: error\n"),
+        "SSRF uses the single error frame: {raw}"
+    );
+    assert!(
+        !raw.contains("response.mcp_list_tools.failed") && !raw.contains("response.failed"),
+        "SSRF must not emit the discovery lifecycle: {raw}"
+    );
+}
+
+/// Drive the deferred-failure path end to end and return the parsed lifecycle
+/// events, so tests can inspect the response snapshots embedded in each frame.
+///
+/// A streaming runtime failure stashes a descriptor and returns `Continue`, and
+/// the header phase consumes it to build the terminal SSE. `body` is the raw
+/// request body the resolver captured its size-bounded echo options from.
+fn failure_lifecycle_events(
+    ctx: &mut HttpFilterContext<'_>,
+    err: &ResolveError,
+    body: &[u8],
+) -> Vec<(String, serde_json::Value)> {
+    ctx.current_filter_id = Some(0);
+    assert!(
+        matches!(resolve_error_action(ctx, err, true, body), FilterAction::Continue),
+        "a streaming runtime discovery failure should defer"
+    );
+    let pending = ctx
+        .remove_filter_state::<PendingListToolsFailure>()
+        .expect("deferred failure descriptor stashed");
+    let terminal = build_list_tools_failure_response(ctx, &pending);
+    let raw = std::str::from_utf8(terminal.body.as_deref().expect("SSE body")).unwrap();
+    parse_named_sse_events(raw)
+}
+
+/// The id from the terminal `response.failed` event of the deferred-failure path.
+fn failed_response_id(ctx: &mut HttpFilterContext<'_>, err: &ResolveError, body: &[u8]) -> String {
+    let events = failure_lifecycle_events(ctx, err, body);
+    events[6].1["response"]["id"].as_str().expect("response id").to_owned()
+}
+
+/// A connection failure descriptor, the canonical runtime `tools/list` failure.
+fn connection_failure() -> ResolveError {
+    let uri: http::Uri = "https://mcp.example/tools".parse().unwrap();
+    ResolveError::Client {
+        server_label: "weather".to_owned(),
+        source: mcp_client::McpClientError::Connection {
+            url: mcp_client::McpDisplayUrl::from_uri(&uri),
+        },
+    }
+}
+
+/// The synthesized failure resource must echo the caller's request parameters in
+/// every snapshot, so a persisted or streamed failure reports the same
+/// configuration a real Responses object would rather than silently substituting
+/// API defaults. `input` and `tools` are intentionally omitted -- the latter so
+/// per-entry MCP credentials are never persisted.
+#[test]
+#[expect(clippy::too_many_lines, reason = "one assertion per echoed request field")]
+fn streaming_failure_snapshot_echoes_request_parameters() {
+    let body_json = serde_json::json!({
+        "model": "gpt-4o-mini",
+        "input": "hello",
+        "stream": true,
+        "temperature": 0.2,
+        "top_p": 0.5,
+        "parallel_tool_calls": false,
+        "max_output_tokens": 256,
+        "instructions": "be terse",
+        "truncation": "auto",
+        "tool_choice": "required",
+        "previous_response_id": "resp_prev",
+        "text": {"format": {"type": "json_object"}},
+        "reasoning": {"effort": "high"},
+        "metadata": {"trace": "abc123"},
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "server_url": "https://mcp.example/tools",
+            "authorization": "secret-token",
+        }],
+    });
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    // Deliberately insert NO `ResponsesState`: the echoed parameters must come
+    // from the size-bounded capture taken from the request body during the
+    // pre-read, so a pipeline without validate/rehydrate still reports the
+    // caller's real configuration.
+    let body = serde_json::to_vec(&body_json).unwrap();
+
+    let events = failure_lifecycle_events(&mut ctx, &connection_failure(), &body);
+    // Every snapshot shares the echoed parameters; assert on the created and
+    // failed frames that bracket the stream.
+    for response in [&events[0].1["response"], &events[6].1["response"]] {
+        assert_eq!(response["temperature"], 0.2, "temperature echoes the request");
+        assert_eq!(response["top_p"], 0.5, "top_p echoes the request");
+        assert_eq!(response["parallel_tool_calls"], false, "parallel_tool_calls echoes");
+        assert_eq!(response["max_output_tokens"], 256, "max_output_tokens echoes");
+        assert_eq!(response["instructions"], "be terse", "instructions echoes");
+        assert_eq!(response["truncation"], "auto", "truncation echoes");
+        assert_eq!(response["tool_choice"], "required", "tool_choice echoes");
+        assert_eq!(
+            response["previous_response_id"], "resp_prev",
+            "previous_response_id echoes"
+        );
+        assert_eq!(
+            response["text"],
+            serde_json::json!({"format": {"type": "json_object"}}),
+            "text echoes"
+        );
+        assert_eq!(
+            response["reasoning"],
+            serde_json::json!({"effort": "high"}),
+            "reasoning echoes"
+        );
+        assert_eq!(
+            response["metadata"],
+            serde_json::json!({"trace": "abc123"}),
+            "metadata echoes"
+        );
+        // Never persist tools (credential leak) or input.
+        assert_eq!(
+            response["tools"],
+            serde_json::json!([]),
+            "tools must not leak credentials"
+        );
+        assert!(response.get("input").is_none(), "request input must not be persisted");
+    }
+}
+
+/// When no request option is captured (a body carrying no echoable field), every
+/// echoed field falls back to its OpenAI API default. Persistence is unaffected:
+/// it depends only on `response_object`, not on the echoed options.
+#[test]
+fn streaming_failure_snapshot_uses_api_defaults_without_captured_options() {
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let events = failure_lifecycle_events(&mut ctx, &connection_failure(), b"{}");
+    let response = &events[6].1["response"];
+    for (field, default) in [
+        ("temperature", serde_json::json!(1.0)),
+        ("top_p", serde_json::json!(1.0)),
+        ("parallel_tool_calls", serde_json::json!(true)),
+        ("tool_choice", serde_json::json!("auto")),
+        ("truncation", serde_json::json!("disabled")),
+        ("previous_response_id", serde_json::Value::Null),
+        ("max_output_tokens", serde_json::Value::Null),
+        ("instructions", serde_json::Value::Null),
+        ("reasoning", serde_json::Value::Null),
+        ("text", serde_json::json!({"format": {"type": "text"}})),
+        ("metadata", serde_json::json!({})),
+    ] {
+        assert_eq!(response[field], default, "{field} falls back to its API default");
+    }
+}
+
+/// `capture_echoed_options` copies only the whitelisted request options -- never
+/// `input` or the credentialed `tools` array -- so nothing that could leak a
+/// secret or bloat the snapshot survives the capture.
+#[test]
+fn capture_echoed_options_whitelists_safe_fields_only() {
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "gpt-4o-mini",
+        "temperature": 0.2,
+        "metadata": {"trace": "abc123"},
+        "input": "secret prompt",
+        "tools": [{
+            "type": "mcp",
+            "server_label": "weather",
+            "authorization": "secret-token",
+        }],
+    }))
+    .unwrap();
+
+    let captured = capture_echoed_options(&body).expect("whitelisted fields are captured");
+    assert_eq!(captured["temperature"], 0.2, "temperature is whitelisted");
+    assert_eq!(
+        captured["metadata"],
+        serde_json::json!({"trace": "abc123"}),
+        "metadata is whitelisted"
+    );
+    assert_eq!(captured["model"], "gpt-4o-mini", "model is whitelisted");
+    assert!(captured.get("input").is_none(), "input must never be captured");
+    assert!(
+        captured.get("tools").is_none(),
+        "tools must never be captured (credential leak)"
+    );
+}
+
+/// `capture_echoed_options` returns `None` when nothing echoable survives -- an
+/// empty object, a body with only non-echoed fields, or an unparseable body --
+/// so the snapshot falls back to API defaults for every field.
+#[test]
+fn capture_echoed_options_none_without_whitelisted_fields() {
+    assert!(
+        capture_echoed_options(br#"{"input":"hi","tools":[]}"#).is_none(),
+        "a body with only non-echoed fields captures nothing"
+    );
+    assert!(
+        capture_echoed_options(b"{}").is_none(),
+        "an empty object captures nothing"
+    );
+    assert!(
+        capture_echoed_options(b"not json").is_none(),
+        "an unparseable body captures nothing"
+    );
+}
+
+/// A single oversized field (`instructions`) is dropped from the capture so it
+/// cannot be amplified across the SSE snapshots, while the smaller fields
+/// captured before it are retained. This bounds a valid-but-large request rather
+/// than rejecting it or losing all fidelity.
+#[test]
+fn capture_echoed_options_drops_oversized_field_keeps_small_ones() {
+    let huge = "x".repeat(MAX_ECHOED_OPTIONS_BYTES + 1);
+    let body = serde_json::to_vec(&serde_json::json!({
+        "temperature": 0.2,
+        "metadata": {"trace": "abc123"},
+        "instructions": huge,
+    }))
+    .unwrap();
+
+    let captured = capture_echoed_options(&body).expect("small fields are still captured");
+    assert_eq!(captured["temperature"], 0.2, "a small field is retained");
+    assert_eq!(
+        captured["metadata"],
+        serde_json::json!({"trace": "abc123"}),
+        "a small field is retained"
+    );
+    assert!(
+        captured.get("instructions").is_none(),
+        "an oversized field is dropped from the capture"
+    );
+}
+
+/// End to end, an oversized `instructions` must not be amplified across the three
+/// SSE snapshots: the terminal failure echoes the default `instructions` (null)
+/// while still echoing the small fields, and the whole SSE body stays far below
+/// the size of the request that produced it.
+#[test]
+fn streaming_failure_snapshot_drops_oversized_options() {
+    let huge = "x".repeat(MAX_ECHOED_OPTIONS_BYTES + 1);
+    let body_json = serde_json::json!({
+        "model": "gpt-4o-mini",
+        "input": "hello",
+        "stream": true,
+        "temperature": 0.2,
+        "instructions": huge,
+    });
+    let body = serde_json::to_vec(&body_json).unwrap();
+    let request_len = body.len();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let events = failure_lifecycle_events(&mut ctx, &connection_failure(), &body);
+
+    let response = &events[6].1["response"];
+    assert_eq!(response["temperature"], 0.2, "the small option still echoes");
+    assert_eq!(
+        response["instructions"],
+        serde_json::Value::Null,
+        "the oversized instructions is dropped to its API default, not amplified"
+    );
+
+    // The SSE body embeds a snapshot in three frames; if the oversized field had
+    // been echoed it would appear ~3x. Assert the whole stream stays a small
+    // fraction of the single request that carried it.
+    let sse_len: usize = events
+        .iter()
+        .map(|(name, payload)| name.len() + payload.to_string().len())
+        .sum();
+    assert!(
+        sse_len < MAX_ECHOED_OPTIONS_BYTES,
+        "oversized options must not amplify the {request_len}-byte request into the SSE body \
+         (got {sse_len} bytes)"
+    );
+}
+
+/// Building the terminal failure must publish the failed snapshot directly into
+/// `ResponsesState.response_object`, the field `openai_response_store` reads to
+/// persist streaming responses. In `agentic-loop.yaml` `openai_stream_events`
+/// runs *after* this filter (nested in the `iterative_request_router`), so the
+/// short-circuiting `TerminalResponse` means `stream_events` never accumulates the
+/// failure -- persistence depends on this direct write. The written snapshot must
+/// be exactly the terminal `response.failed` resource so the store persists the
+/// same object the client received.
+#[test]
+fn build_failure_populates_response_object_state() {
+    let body_json = serde_json::json!({
+        "model": "gpt-4o-mini",
+        "input": "hello",
+        "stream": true,
+    });
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions
+        .insert(ResponsesState::from_request_body(body_json.clone()));
+
+    let body = serde_json::to_vec(&body_json).unwrap();
+    let events = failure_lifecycle_events(&mut ctx, &connection_failure(), &body);
+    let terminal_response = events[6].1["response"].clone();
+
+    let state = ctx.extensions.get::<ResponsesState>().expect("state should exist");
+    assert_eq!(
+        state.response_object, terminal_response,
+        "response_object must hold the terminal response.failed snapshot for the store to persist"
+    );
+    assert_eq!(
+        state.response_object["status"], "failed",
+        "persisted snapshot records the failure"
+    );
+}
+
+/// When no `ResponsesState` exists yet -- a valid pipeline of
+/// `openai_response_store` + this filter *without*
+/// `openai_responses_validate`/`openai_responses_rehydrate` to build state up
+/// front -- the terminal-failure build must still CREATE the state and populate
+/// `response_object`, or the store would have nothing to persist and the failure
+/// would be lost. `get_or_insert_with` (not `get_mut`) is what makes this work.
+#[test]
+fn build_failure_creates_response_object_state_when_absent() {
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    // Deliberately insert NO ResponsesState before building the failure.
+    assert!(
+        ctx.extensions.get::<ResponsesState>().is_none(),
+        "precondition: no state exists yet"
+    );
+
+    let events = failure_lifecycle_events(&mut ctx, &connection_failure(), b"{}");
+    let terminal_response = events[6].1["response"].clone();
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("building the failure must create the state so the store can persist");
+    assert_eq!(
+        state.response_object, terminal_response,
+        "created state must hold the terminal response.failed snapshot"
+    );
+    assert_eq!(
+        state.response_object["status"], "failed",
+        "persisted snapshot records the failure"
+    );
+}
+
+/// `response_id` resolves from metadata first, then `ResponsesState`, then a
+/// generated `resp_` id. The lifecycle test covers the metadata branch; this
+/// covers the state fallback and the generated fallback.
+#[test]
+fn failure_lifecycle_response_id_falls_back_to_state_then_generated() {
+    let uri: http::Uri = "https://mcp.example/tools".parse().unwrap();
+    let make_err = || ResolveError::Client {
+        server_label: "weather".to_owned(),
+        source: mcp_client::McpClientError::Connection {
+            url: mcp_client::McpDisplayUrl::from_uri(&uri),
+        },
+    };
+
+    // No metadata, but ResponsesState carries a response_id → use it.
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut state = ResponsesState::from_request_body(serde_json::json!({"model": "gpt-4o-mini"}));
+    state.response_id = Some("resp_from_state".to_owned());
+    ctx.extensions.insert(state);
+    assert_eq!(
+        failed_response_id(&mut ctx, &make_err(), b"{}"),
+        "resp_from_state",
+        "state fallback used"
+    );
+
+    // No metadata and no ResponsesState → generated resp_ id.
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    assert!(
+        failed_response_id(&mut ctx, &make_err(), b"{}").starts_with("resp_"),
+        "generated fallback should produce a resp_ id"
+    );
+}
+
+fn parse_named_sse_events(body: &str) -> Vec<(String, serde_json::Value)> {
+    body.split("\n\n")
+        .filter(|frame| !frame.is_empty())
+        .map(|frame| {
+            let mut lines = frame.lines();
+            let name = lines
+                .next()
+                .and_then(|line| line.strip_prefix("event: "))
+                .expect("named SSE event")
+                .to_owned();
+            let payload = lines
+                .next()
+                .and_then(|line| line.strip_prefix("data: "))
+                .expect("SSE data line");
+            (name, serde_json::from_str(payload).expect("valid SSE JSON payload"))
+        })
+        .collect()
 }

--- a/docs/filters/openai_mcp_tool_resolve.md
+++ b/docs/filters/openai_mcp_tool_resolve.md
@@ -9,6 +9,8 @@ Resolves MCP tool entries from the Responses API `tools` array into concrete too
 
 Rejects the request with HTTP 400 before any callouts if two or more resolvable MCP entries share the same `server_label` (including entries that differ only by credentials).
 
+For streaming requests, a runtime or response-processing failure from `tools/list` is returned as a successful SSE transport containing `response.mcp_list_tools.failed` and a terminal `response.failed` event. Local policy failures such as SSRF blocking remain HTTP error responses.
+
 ## Configuration
 
 | Field | Type | Required | Description |

--- a/examples/configs/openai/responses/mcp-tool-resolve.yaml
+++ b/examples/configs/openai/responses/mcp-tool-resolve.yaml
@@ -10,6 +10,10 @@
 # buffered request body, checks `previous_tools` for cached
 # listings, calls `tools/list` via the `mcp_client` module, and
 # writes `mcp_tool_map` to `ResponsesState`.
+# For `stream: true`, runtime and response-processing failures are
+# returned as a Responses SSE lifecycle containing
+# `response.mcp_list_tools.failed` and terminal `response.failed` events.
+# Local request-policy failures such as SSRF blocking remain HTTP errors.
 #
 # This is a minimal pipeline focused on MCP tool discovery. For a
 # complete setup with multi-turn conversation support (rehydrate,

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -1104,6 +1104,129 @@ class TestAgenticLoopVLLM:
 
 
 # ---------------------------------------------------------------------------
+# Streaming MCP discovery failure (issue #320)
+# ---------------------------------------------------------------------------
+
+
+def _retrieve_with_retry(client, response_id, attempts=15, delay=0.4):
+    """Retrieve a stored response, tolerating brief post-stream write latency.
+
+    Streaming persistence completes as the proxy finishes serving the response
+    body; a retrieve issued the instant the client's stream iterator returns
+    can race that write. Retry a bounded number of times, treating a 404 as
+    "not persisted yet" rather than a hard failure.
+    """
+    from openai import NotFoundError
+
+    last_exc = None
+    for _ in range(attempts):
+        try:
+            return client.responses.retrieve(response_id)
+        except NotFoundError as exc:
+            last_exc = exc
+            time.sleep(delay)
+    raise AssertionError(
+        f"response {response_id} not retrievable after {attempts} attempts: "
+        f"{last_exc}"
+    )
+
+
+class TestStreamingMcpDiscoveryFailureVLLM:
+    """Issue #320: a streaming Responses request whose MCP ``tools/list``
+    discovery fails at runtime must surface to the official OpenAI SDK as a
+    single, well-formed Responses SSE lifecycle terminating in
+    ``response.failed`` -- never an HTTP error, an exception, or a hung
+    stream -- and, when ``store`` is effective, the failed resource must be
+    retrievable via the SDK.
+
+    The failure is triggered with an MCP ``server_url`` pointing at a dead
+    loopback port. The agentic config sets ``allow_loopback: true`` on
+    ``openai_mcp_tool_resolve``, so the refused connection is classified as a
+    genuine *runtime* discovery failure (-> 200 SSE lifecycle) rather than a
+    local SSRF policy rejection (-> HTTP error). Discovery failures
+    short-circuit in the request phase, so vLLM is never contacted -- this
+    test validates the proxy + SDK streaming contract, not model inference.
+
+    Complements the Rust integration suite, which asserts the raw SSE bytes:
+    here we prove the official OpenAI Python SDK parses those frames into a
+    clean event stream and a retrievable failed resource.
+    """
+
+    def test_streaming_discovery_failure_surfaces_failed_lifecycle(
+        self, agentic_client, agentic_proxy,
+    ):
+        dead_port = _free_port()
+        mcp_url = f"http://127.0.0.1:{dead_port}/mcp"
+
+        stream = agentic_client.responses.create(
+            model=VLLM_MODEL,
+            input="What is the weather in Paris? /no_think",
+            tools=[
+                {
+                    "type": "mcp",
+                    "server_label": "weather",
+                    "server_url": mcp_url,
+                    "allowed_tools": ["get_weather"],
+                    "require_approval": "never",
+                }
+            ],
+            store=True,
+            stream=True,
+            max_output_tokens=128,
+        )
+
+        event_types = []
+        response_id = None
+        failed_response = None
+        for event in stream:
+            event_types.append(event.type)
+            if event.type == "response.created":
+                response_id = event.response.id
+            if event.type == "response.failed":
+                failed_response = event.response.model_dump()
+
+        # One ordered lifecycle: created first, failed last, with the MCP
+        # discovery-failure event in between.
+        assert event_types, "the stream must yield at least one event"
+        assert event_types[0] == "response.created", event_types
+        assert event_types[-1] == "response.failed", event_types
+        assert "response.mcp_list_tools.failed" in event_types, event_types
+
+        # The terminal response carries the failure, not a partial success.
+        assert failed_response is not None, event_types
+        assert failed_response["status"] == "failed", failed_response
+        assert failed_response["error"]["code"] == "server_error", (
+            failed_response
+        )
+
+        mcp_items = [
+            item
+            for item in failed_response.get("output", [])
+            if item.get("type") == "mcp_list_tools"
+        ]
+        assert mcp_items, (
+            "the failed response must include the mcp_list_tools output item; "
+            f"got output types: "
+            f"{[i.get('type') for i in failed_response.get('output', [])]}"
+        )
+        item = mcp_items[0]
+        assert item["server_label"] == "weather", item
+        assert item["tools"] == [], item
+        assert item["error"], "the failed listing item must carry an error"
+
+        # store=True -> the failed resource is persisted and retrievable
+        # through the SDK, echoing the same failed status and error.
+        assert response_id, "response.created must carry an id for retrieval"
+        retrieved = _retrieve_with_retry(agentic_client, response_id)
+        rd = retrieved.model_dump()
+        assert rd["status"] == "failed", rd
+        assert rd["error"]["code"] == "server_error", rd
+        assert any(
+            it.get("type") == "mcp_list_tools" for it in rd.get("output", [])
+        ), rd
+
+
+# ---------------------------------------------------------------------------
 # File search: dedicated proxy config, fixtures, and tests
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
+++ b/tests/integration/tests/suite/openai_mcp_tool_resolve.rs
@@ -5,8 +5,9 @@
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    McpMockConfig, McpToolFixture, free_port, http_send, json_post, parse_body, parse_status,
-    start_backend_with_shutdown, start_echo_backend, start_mcp_mock_server_with_config, start_proxy,
+    McpMockConfig, McpToolFixture, StatefulCapturingBackend, TempSqlite, free_port, http_get, http_send, json_post,
+    parse_body, parse_status, start_backend_with_shutdown, start_echo_backend, start_mcp_mock_server_with_config,
+    start_proxy,
 };
 
 // =============================================================================
@@ -132,6 +133,474 @@ fn mcp_unreachable_server_returns_502() {
     let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
 
     assert_eq!(parse_status(&raw), 502, "unreachable MCP server should produce 502");
+}
+
+#[test]
+fn streaming_mcp_unreachable_server_emits_failed_event() {
+    let backend_guard = start_backend_with_shutdown("inference");
+    let proxy_port = free_port();
+    let dead_port = free_port();
+
+    let yaml = resolve_yaml_with_timeout(proxy_port, backend_guard.port(), 500);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = format!(
+        r#"{{"model":"gpt-4.1","input":"test","stream":true,"tools":[{{"type":"mcp","server_label":"dead","server_url":"http://192.0.2.1:{dead_port}/mcp","allowed_tools":["x"]}}]}}"#
+    );
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "streaming failure should be delivered through the Responses event lifecycle"
+    );
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("event: response.mcp_list_tools.failed"),
+        "stream should expose the MCP listing failure: {response_body}"
+    );
+    assert!(
+        response_body.contains(r#""type":"response.failed""#),
+        "stream should terminate with response.failed: {response_body}"
+    );
+    assert!(
+        response_body.contains(r#""server_label":"dead""#),
+        "failed MCP output item should identify the server: {response_body}"
+    );
+    // The lifecycle snapshots echo the requested model. In the shipped pipeline
+    // the format filter promotes it to `openai_responses_format.model` metadata,
+    // so this exercises the metadata branch (not the ResponsesState fallback the
+    // unit tests cover).
+    assert!(
+        response_body.contains(r#""model":"gpt-4.1""#),
+        "failure lifecycle should echo the requested model: {response_body}"
+    );
+}
+
+// =============================================================================
+// Full-flow: streaming discovery failure persists to the store
+//
+// These exercise the header-phase `TerminalResponse` end to end through the
+// store pipeline (format -> validate -> tool_parse -> store -> stream_events ->
+// mcp_tool_resolve). A streaming `tools/list` runtime failure is emitted as a
+// 200 SSE lifecycle; because it is a `TerminalResponse` (not a `Reject`), the
+// response phase runs `openai_stream_events` (which accumulates the terminal
+// `response.failed`) and `openai_response_store` (which persists it) so a caller
+// can later retrieve the failed response -- all without contacting the backend.
+// =============================================================================
+
+/// Outcome of driving a streaming MCP discovery failure through the store
+/// pipeline: the SSE lifecycle, the failed response id, the follow-up GET
+/// result, and how many times the inference backend was contacted.
+struct FailureRetrieval {
+    /// The SSE body returned to the client for the POST.
+    sse: String,
+    /// The response resource carried by the terminal `response.failed` event.
+    failed_response: serde_json::Value,
+    /// The response id extracted from the terminal `response.failed` event.
+    resp_id: String,
+    /// HTTP status of the follow-up `GET /v1/responses/{id}`.
+    get_status: u16,
+    /// Body of the follow-up GET.
+    get_body: String,
+    /// Number of requests the inference backend received.
+    backend_hits: usize,
+}
+
+/// Extract the response resource carried by the terminal `response.failed`
+/// event.
+fn extract_failed_response(sse: &str) -> serde_json::Value {
+    let mut current_event = None;
+    for line in sse.lines() {
+        if let Some(event) = line.strip_prefix("event: ") {
+            current_event = Some(event.to_owned());
+        } else if let Some(data) = line.strip_prefix("data: ") {
+            if current_event.as_deref() == Some("response.failed") {
+                let value: serde_json::Value =
+                    serde_json::from_str(data).expect("response.failed data should be valid JSON");
+                return value["response"].clone();
+            }
+            current_event = None;
+        }
+    }
+    panic!("no response.failed event found in SSE stream:\n{sse}");
+}
+
+/// Assert a synthesized/persisted failure resource carries the full failure
+/// detail: `status: "failed"`, an error object, and the failed `mcp_list_tools`
+/// output item. `expect_store` pins the effective storage flag on the snapshot.
+fn assert_failed_resource_fidelity(resource: &serde_json::Value, expect_store: bool) {
+    assert_eq!(resource["status"], "failed", "resource records the discovery failure");
+    assert_eq!(
+        resource["store"], expect_store,
+        "snapshot echoes the effective store flag"
+    );
+    assert_eq!(
+        resource["error"]["code"], "server_error",
+        "failed resource carries the runtime error code"
+    );
+    assert!(
+        resource["error"]["message"].is_string(),
+        "failed resource carries an error message: {resource}"
+    );
+    let item = &resource["output"][0];
+    assert_eq!(item["type"], "mcp_list_tools", "output item is the failed listing");
+    assert_eq!(item["server_label"], "weather", "output item identifies the server");
+    assert!(
+        item["tools"].as_array().is_some_and(|tools| tools.is_empty()),
+        "no tools resolved on a failed listing: {item}"
+    );
+    assert!(
+        item["error"].is_string(),
+        "failed listing item carries an error: {item}"
+    );
+}
+
+/// POST a streaming request whose MCP `tools/list` fails against an unreachable
+/// server, then GET the resulting response id. `extra_fields` is spliced into
+/// the request JSON right after `"stream":true` (e.g. `,"store":false` or
+/// `,"temperature":0.2`); pass `""` to add nothing.
+fn run_streaming_mcp_failure(test_name: &str, extra_fields: &str) -> FailureRetrieval {
+    run_streaming_mcp_failure_with_yaml(test_name, extra_fields, resolve_yaml_full_flow_store)
+}
+
+/// Same as [`run_streaming_mcp_failure`] but with the pipeline YAML supplied by
+/// `build_yaml`, so tests can exercise different filter orderings (e.g.
+/// `openai_stream_events` before vs. after `openai_mcp_tool_resolve`).
+fn run_streaming_mcp_failure_with_yaml(
+    test_name: &str,
+    extra_fields: &str,
+    build_yaml: fn(u16, u16, &str, u64) -> String,
+) -> FailureRetrieval {
+    // A capturing backend lets us prove the inference cluster is never contacted:
+    // the failure terminates in the request phase before the router runs.
+    let backend = StatefulCapturingBackend::new(vec![(200, "inference".to_owned())]).start_with_shutdown();
+    let proxy_port = free_port();
+    let dead_port = free_port();
+    let db = TempSqlite::new(test_name);
+
+    let yaml = build_yaml(proxy_port, backend.port(), db.url(), 500);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    // 192.0.2.0/24 is TEST-NET-1 (RFC 5737): guaranteed unreachable, so the
+    // discovery attempt reaches runtime I/O and fails (a runtime failure), not a
+    // local request-policy failure like SSRF.
+    let body = format!(
+        r#"{{"model":"gpt-4.1","input":"test","stream":true{extra_fields},"tools":[{{"type":"mcp","server_label":"weather","server_url":"http://192.0.2.1:{dead_port}/mcp","allowed_tools":["x"]}}]}}"#
+    );
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "streaming MCP failure must surface as a 200 SSE lifecycle"
+    );
+    let sse = parse_body(&raw);
+    let failed_response = extract_failed_response(&sse);
+    let resp_id = failed_response["id"]
+        .as_str()
+        .expect("response.failed should carry a response id")
+        .to_owned();
+
+    let (get_status, get_body) = http_get(proxy.addr(), &format!("/v1/responses/{resp_id}"), None);
+    let backend_hits = backend.requests().len();
+
+    drop(proxy);
+    FailureRetrieval {
+        sse,
+        failed_response,
+        resp_id,
+        get_status,
+        get_body,
+        backend_hits,
+    }
+}
+
+/// Assert the SSE lifecycle carries the failure, the terminal snapshot has full
+/// fidelity (with the expected store flag), and the backend stayed cold.
+fn assert_failed_lifecycle(outcome: &FailureRetrieval, expect_store: bool) {
+    assert!(
+        outcome.sse.contains("event: response.mcp_list_tools.failed"),
+        "stream should expose the MCP listing failure: {}",
+        outcome.sse
+    );
+    assert!(
+        outcome.sse.contains(r#""type":"response.failed""#),
+        "stream should terminate with response.failed: {}",
+        outcome.sse
+    );
+    assert!(
+        outcome.resp_id.starts_with("resp_"),
+        "failure lifecycle should carry a response id: {}",
+        outcome.resp_id
+    );
+    // The terminal snapshot delivered over the wire pins the failure detail and
+    // the effective store flag, independent of what the store later persists.
+    assert_failed_resource_fidelity(&outcome.failed_response, expect_store);
+    assert_eq!(
+        outcome.backend_hits, 0,
+        "the inference backend must never be contacted for a local discovery failure"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_is_retrievable_when_store_omitted() {
+    let outcome = run_streaming_mcp_failure("mcp_fail_store_omitted", "");
+    assert_failed_lifecycle(&outcome, true);
+
+    assert_eq!(
+        outcome.get_status, 200,
+        "an omitted store defaults to persisted, so the failed response is retrievable"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+    assert_eq!(parsed["id"], outcome.resp_id, "retrieved id should match the stream's");
+    // The persisted resource must round-trip the full failure detail, not just a
+    // `status: "failed"` marker, so a caller can inspect what went wrong.
+    assert_failed_resource_fidelity(&parsed, true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_is_retrievable_when_store_true() {
+    let outcome = run_streaming_mcp_failure("mcp_fail_store_true", r#","store":true"#);
+    assert_failed_lifecycle(&outcome, true);
+
+    assert_eq!(
+        outcome.get_status, 200,
+        "an explicit store:true persists the failed response for retrieval"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+    assert_eq!(parsed["id"], outcome.resp_id, "retrieved id should match the stream's");
+    assert_failed_resource_fidelity(&parsed, true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_not_retrievable_when_store_false() {
+    let outcome = run_streaming_mcp_failure("mcp_fail_store_false", r#","store":false"#);
+    // The over-the-wire snapshot still carries full failure detail, but with
+    // `store: false` so a caller knows it was not persisted.
+    assert_failed_lifecycle(&outcome, false);
+
+    assert_eq!(
+        outcome.get_status, 404,
+        "store:false must not persist the failed response, so retrieval is a miss"
+    );
+}
+
+/// Assert a resource echoes the non-default request options spliced by
+/// [`streaming_list_failure_persists_non_default_request_options`].
+fn assert_non_default_options_echoed(resource: &serde_json::Value) {
+    assert_eq!(resource["temperature"], 0.2, "temperature echoed: {resource}");
+    assert_eq!(resource["top_p"], 0.5, "top_p echoed: {resource}");
+    assert_eq!(
+        resource["parallel_tool_calls"], false,
+        "parallel_tool_calls echoed: {resource}"
+    );
+    assert_eq!(
+        resource["max_output_tokens"], 256,
+        "max_output_tokens echoed: {resource}"
+    );
+    assert_eq!(resource["instructions"], "be terse", "instructions echoed: {resource}");
+    assert_eq!(resource["truncation"], "auto", "truncation echoed: {resource}");
+    assert_eq!(resource["tool_choice"], "required", "tool_choice echoed: {resource}");
+    assert_eq!(
+        resource["metadata"],
+        serde_json::json!({"trace": "abc123"}),
+        "metadata echoed: {resource}"
+    );
+}
+
+/// Non-default request parameters (temperature, top_p, metadata, tool_choice,
+/// ...) must survive into both the streamed failure snapshot and the persisted
+/// resource, so a caller who set them does not retrieve a failure that silently
+/// claims the API defaults.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_persists_non_default_request_options() {
+    let outcome = run_streaming_mcp_failure(
+        "mcp_fail_non_default_opts",
+        r#","temperature":0.2,"top_p":0.5,"parallel_tool_calls":false,"max_output_tokens":256,"instructions":"be terse","truncation":"auto","tool_choice":"required","metadata":{"trace":"abc123"}"#,
+    );
+    assert_failed_lifecycle(&outcome, true);
+
+    assert_eq!(
+        outcome.get_status, 200,
+        "an omitted store defaults to persisted, so the failed response is retrievable"
+    );
+    let persisted: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+
+    // Both the over-the-wire snapshot and the persisted resource must echo the
+    // caller's parameters verbatim, not substitute API defaults.
+    assert_non_default_options_echoed(&outcome.failed_response);
+    assert_non_default_options_echoed(&persisted);
+}
+
+/// Regression for the pipeline-ordering persistence gap in `agentic-loop.yaml`,
+/// where `openai_stream_events` runs *after* `openai_mcp_tool_resolve` (nested in
+/// the iterative_request_router). The resolver's short-circuiting
+/// `TerminalResponse` means stream_events never runs on the response phase, so it
+/// never accumulates the failure into `ResponsesState.response_object`. Unless the
+/// resolver writes that state directly when building the terminal failure, the
+/// store sees a null `response_object` and skips persistence -- and this GET would
+/// 404 despite `store` defaulting to enabled. Proves the failed response is
+/// retrievable regardless of where `openai_stream_events` sits relative to the
+/// resolver.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_persists_when_stream_events_after_resolve() {
+    let outcome = run_streaming_mcp_failure_with_yaml(
+        "mcp_fail_stream_events_after",
+        "",
+        resolve_yaml_store_stream_events_after_resolve,
+    );
+    assert_failed_lifecycle(&outcome, true);
+
+    assert_eq!(
+        outcome.get_status, 200,
+        "the failed response must persist even when openai_stream_events runs after the resolver"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+    assert_eq!(parsed["id"], outcome.resp_id, "retrieved id should match the stream's");
+    assert_failed_resource_fidelity(&parsed, true);
+}
+
+/// Regression for a persistence gap in the store-without-validate/rehydrate
+/// configuration: when no filter builds a `ResponsesState` before the resolver,
+/// the terminal-failure build must CREATE the state (not just mutate an existing
+/// one) so `openai_response_store` has a `response_object` to persist. With a
+/// `get_mut`-only write this GET would 404 despite `store` defaulting to enabled;
+/// `get_or_insert_with` makes the failed response retrievable regardless of which
+/// upstream filters ran.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_persists_without_validate_or_rehydrate() {
+    let outcome = run_streaming_mcp_failure_with_yaml(
+        "mcp_fail_no_validate_rehydrate",
+        "",
+        resolve_yaml_store_no_validate_rehydrate,
+    );
+    assert_failed_lifecycle(&outcome, true);
+
+    assert_eq!(
+        outcome.get_status, 200,
+        "the failed response must persist even without validate/rehydrate to pre-build state"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+    assert_eq!(parsed["id"], outcome.resp_id, "retrieved id should match the stream's");
+    assert_failed_resource_fidelity(&parsed, true);
+}
+
+/// The no-validate/rehydrate configuration must still echo the caller's real,
+/// non-default request options into both the streamed and persisted failure
+/// resource. Because nothing builds a `ResponsesState.request_body` up front, the
+/// options can only come from the size-bounded capture the resolver takes from
+/// the request body during the pre-read; without it the failure would silently
+/// claim API defaults even though the caller set otherwise.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_persists_non_default_options_without_validate_or_rehydrate() {
+    let outcome = run_streaming_mcp_failure_with_yaml(
+        "mcp_fail_non_default_no_validate",
+        r#","temperature":0.2,"top_p":0.5,"parallel_tool_calls":false,"max_output_tokens":256,"instructions":"be terse","truncation":"auto","tool_choice":"required","metadata":{"trace":"abc123"}"#,
+        resolve_yaml_store_no_validate_rehydrate,
+    );
+    assert_failed_lifecycle(&outcome, true);
+
+    assert_eq!(
+        outcome.get_status, 200,
+        "the failed response must persist without validate/rehydrate to pre-build state"
+    );
+    let persisted: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+
+    // Both the over-the-wire snapshot and the persisted resource echo the
+    // caller's options -- captured from the body, not defaulted -- even though no
+    // filter built a `ResponsesState.request_body`.
+    assert_non_default_options_echoed(&outcome.failed_response);
+    assert_non_default_options_echoed(&persisted);
+}
+
+/// An oversized-but-valid request (a multi-hundred-KB `instructions`) must not be
+/// amplified across the three SSE snapshots and the persisted resource. The
+/// resolver's size-bounded capture drops the oversized `instructions` (echoing
+/// the API default) while retaining the small options, so the whole SSE stream
+/// stays a small fraction of the request that produced it -- a 64 MiB request
+/// cannot be turned into hundreds of MiB of synthesized response.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_list_failure_bounds_oversized_request_options() {
+    let huge_instructions = "x".repeat(300 * 1024);
+    let extra_fields = format!(r#","temperature":0.2,"instructions":"{huge_instructions}""#);
+    let outcome = run_streaming_mcp_failure_with_yaml(
+        "mcp_fail_oversized_opts",
+        &extra_fields,
+        resolve_yaml_store_no_validate_rehydrate,
+    );
+    assert_failed_lifecycle(&outcome, true);
+
+    // The small option still echoes; the oversized one is dropped to its default.
+    assert_eq!(outcome.failed_response["temperature"], 0.2, "small option echoes");
+    assert_eq!(
+        outcome.failed_response["instructions"],
+        serde_json::Value::Null,
+        "oversized instructions is dropped, not echoed"
+    );
+    // If the oversized field had been echoed it would appear ~3x in the stream;
+    // assert the whole SSE body stays far below the single request's size.
+    assert!(
+        outcome.sse.len() < 100 * 1024,
+        "oversized options must not amplify into the SSE body (got {} bytes)",
+        outcome.sse.len()
+    );
+
+    assert_eq!(outcome.get_status, 200, "the bounded failure still persists");
+    let persisted: serde_json::Value =
+        serde_json::from_str(&outcome.get_body).expect("retrieved response should be valid JSON");
+    assert_eq!(persisted["temperature"], 0.2, "persisted small option echoes");
+    assert_eq!(
+        persisted["instructions"],
+        serde_json::Value::Null,
+        "persisted oversized instructions is dropped, not echoed"
+    );
+}
+
+/// A streaming request whose MCP `server_url` is blocked by SSRF policy must
+/// retain a genuine HTTP error -- never the 200 SSE lifecycle reserved for
+/// runtime `tools/list` failures against a validated-safe target. This guards
+/// the security-critical direction end to end through the store pipeline: a
+/// pipeline-ordering or classification regression that leaked a policy failure
+/// as a fake 200 success would be caught here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_local_policy_failure_retains_http_error() {
+    let backend = StatefulCapturingBackend::new(vec![(200, "inference".to_owned())]).start_with_shutdown();
+    let proxy_port = free_port();
+    let db = TempSqlite::new("mcp_stream_ssrf");
+
+    // The MCP filter's own `allow_loopback` defaults to false (independent of the
+    // global allow_private_endpoints the loopback inference upstream needs), so a
+    // loopback MCP URL is blocked as SSRF before any runtime I/O -- a local policy
+    // failure, not a runtime one.
+    let yaml = resolve_yaml_full_flow_store(proxy_port, backend.port(), db.url(), 500);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","stream":true,"tools":[{"type":"mcp","server_label":"evil","server_url":"http://127.0.0.1/mcp","allowed_tools":["x"]}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(
+        parse_status(&raw),
+        502,
+        "a streaming SSRF failure must stay a hard HTTP error, not a 200 SSE lifecycle"
+    );
+    let sse = parse_body(&raw);
+    assert!(
+        !sse.contains("event: response.mcp_list_tools.failed") && !sse.contains(r#""type":"response.failed""#),
+        "SSRF must not emit the discovery lifecycle: {sse}"
+    );
+    assert!(
+        backend.requests().is_empty(),
+        "SSRF rejection must not contact the inference backend"
+    );
 }
 
 // =============================================================================
@@ -687,6 +1156,147 @@ fn direct_url_alongside_connector_both_resolved() {
 
 fn resolve_yaml(proxy_port: u16, backend_port: u16) -> String {
     resolve_yaml_with_timeout(proxy_port, backend_port, 5000)
+}
+
+/// Pipeline mirroring the relevant `full-flow.yaml` ordering for store
+/// retrieval: `openai_response_store` and `openai_stream_events` run before
+/// `openai_mcp_tool_resolve`, so the header-phase `TerminalResponse` triggers
+/// their response-phase persistence of the synthesized failure.
+fn resolve_yaml_full_flow_store(proxy_port: u16, backend_port: u16, db_url: &str, timeout_ms: u64) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: openai_responses_format
+        on_invalid: reject
+      - filter: openai_responses_validate
+      - filter: openai_tool_parse
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "{db_url}"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+      - filter: openai_stream_events
+      - filter: openai_mcp_tool_resolve
+        timeout_ms: {timeout_ms}
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
+"#
+    )
+}
+
+/// Pipeline mirroring `agentic-loop.yaml`'s ordering, where `openai_stream_events`
+/// runs *after* `openai_mcp_tool_resolve` (there, nested inside the
+/// iterative_request_router that follows the resolver). The resolver's
+/// header-phase `TerminalResponse` short-circuits before `openai_stream_events`
+/// ever runs, so stream_events never accumulates the failure into
+/// `ResponsesState.response_object`. Persistence must therefore come from the
+/// resolver writing that state directly when it builds the terminal failure;
+/// otherwise the store sees a null `response_object` and skips persistence.
+fn resolve_yaml_store_stream_events_after_resolve(
+    proxy_port: u16,
+    backend_port: u16,
+    db_url: &str,
+    timeout_ms: u64,
+) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: openai_responses_format
+        on_invalid: reject
+      - filter: openai_responses_validate
+      - filter: openai_tool_parse
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "{db_url}"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+      - filter: openai_responses_rehydrate
+      - filter: openai_mcp_tool_resolve
+        timeout_ms: {timeout_ms}
+      - filter: openai_stream_events
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
+"#
+    )
+}
+
+/// Minimal store pipeline with `openai_response_store` + `openai_mcp_tool_resolve`
+/// but WITHOUT `openai_responses_validate`/`openai_responses_rehydrate` (and no
+/// `openai_stream_events`). Nothing builds a `ResponsesState` before the resolver,
+/// so persistence depends entirely on the resolver *creating* the state when it
+/// writes the terminal snapshot (`get_or_insert_with`, not `get_mut`). The store
+/// still triggers streaming persistence -- its gating reads only
+/// `openai_responses_format.*` metadata, which `openai_responses_format`
+/// (always first) supplies -- and `build_record_from_state` reads only
+/// `response_object`, so a default state carrying just that field suffices.
+fn resolve_yaml_store_no_validate_rehydrate(
+    proxy_port: u16,
+    backend_port: u16,
+    db_url: &str,
+    timeout_ms: u64,
+) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: openai_responses_format
+        on_invalid: reject
+      - filter: openai_tool_parse
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "{db_url}"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+      - filter: openai_mcp_tool_resolve
+        timeout_ms: {timeout_ms}
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+insecure_options:
+  allow_private_endpoints: true
+"#
+    )
 }
 
 fn resolve_yaml_with_timeout(proxy_port: u16, backend_port: u16, timeout_ms: u64) -> String {


### PR DESCRIPTION
## Summary

Streaming (`stream:true`) OpenAI Responses requests whose MCP `tools/list` discovery fails at runtime now return HTTP 200 with a complete Responses SSE lifecycle (`response.created` → `response.in_progress` → `output_item.added` → `mcp_list_tools.in_progress` → `mcp_list_tools.failed` → `output_item.done` → `response.failed`) instead of an opaque non-200 error, so SDKs surface the failure as stream events. The synthetic failure resource is emitted from `openai_mcp_tool_resolve` as a header-phase `TerminalResponse`, so it flows through the response pipeline and `openai_response_store` persists it (retrievable via GET when store is effective), while local policy failures (SSRF, `InvalidAuthorization`, `CallTool`) keep their genuine HTTP errors. Echoed request parameters are sourced from a size-bounded, credential-free whitelist captured during the body phase, with `input`/`tools` excluded so per-entry MCP credentials never persist. This is the smallest complete change: it reuses the existing store/stream pipeline rather than adding a new streaming path.

## Related issue

Closes #320 and https://github.com/praxis-proxy/ai/issues/984

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis -- openai::responses::openai_mcp_tool_resolve` (177 passed)
- [x] Integration or functional tests — `cargo test -p praxis-tests-integration --test suite -- openai_mcp_tool_resolve` (36 passed); live OpenAI-SDK test `TestStreamingMcpDiscoveryFailureVLLM` (drives the real binary via the `openai` client against a dead MCP port; passed)
- [x] `make lint` (also `make build`), all green on the rebased state

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence — N/A; the failure path short-circuits before any backend request.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.
