### PR TITLE
fix(ci): pre-install OGX deps to stop flaky vLLM readiness timeout

### DIFF
--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -48,6 +48,10 @@ env:
   CARGO_TERM_COLOR: always
   VLLM_IMAGE: "quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english@sha256:0212dc82981178033cb71c7477ba8ad1998fb6c0b1ee40646119fb9724ac951b"
   VLLM_MODEL: "Qwen/Qwen3-0.6B"
+  # Pinned + single-sourced so the pre-install and Start OGX specs are provably
+  # identical (uv reuses the same cached environment) and the two jobs can't
+  # drift. Bump this line deliberately to pull a newer OGX.
+  OGX_SPEC: "ogx[starter]==1.3.1"
 
 jobs:
   # ----------------------------------------------------------------------------
@@ -115,6 +119,15 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # Persist uv's wheel/download cache across runs so the pinned OGX
+          # closure and the test's PEP-723 deps are not re-downloaded every run.
+          # Keyed on the files that carry those pins, so the cache invalidates
+          # only when a pin actually changes.
+          enable-cache: true
+          cache-dependency-glob: |
+            .github/workflows/vllm-integration.yaml
+            tests/integration/sdk/openai/test_openai_responses_vllm.py
 
       - name: Pull vLLM CPU image
         run: docker pull "$VLLM_IMAGE"
@@ -133,9 +146,22 @@ jobs:
             --reasoning-parser deepseek_r1 \
             --gpu-memory-utilization 0.5
 
+      - name: Pre-install OGX dependencies
+        run: |
+          # Resolve + download the full OGX dependency closure (torch, CUDA
+          # wheels, faiss, transformers, ...) synchronously and OFF the readiness
+          # clock. Without this the download runs backgrounded inside the
+          # "Wait for OGX readiness" window and loses the race under network
+          # variance, so the server never binds port 8321 in time (exit 124).
+          echo "Pre-installing OGX ($OGX_SPEC)..."
+          uv run --with "$OGX_SPEC" ogx --help > /dev/null
+          echo "OGX environment ready"
+
       - name: Start OGX
         run: |
-          uv run --with 'ogx[starter]' ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          # Same "$OGX_SPEC" as the pre-install above, so uv reuses the already
+          # materialized environment and the server binds within seconds.
+          uv run --with "$OGX_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
           echo $! > /tmp/ogx.pid
 
       - name: Build Praxis
@@ -158,9 +184,30 @@ jobs:
       - name: Wait for OGX readiness
         run: |
           echo "Waiting for OGX server..."
-          timeout 120 bash -c 'until curl -sf http://127.0.0.1:8321/v1/files > /dev/null 2>&1; do
+          # Poll in the current shell (no nested `bash -c`) so we can both bound
+          # the wait and check process liveness: fail fast if the backgrounded
+          # OGX process dies, and dump the log inline so a readiness failure is
+          # diagnosable from this step (mirrors the vLLM liveness check, which
+          # previously produced only an opaque exit 124 here).
+          dump_ogx_log() {
+            echo "----- /tmp/ogx.log (tail -n 200) -----"
+            tail -n 200 /tmp/ogx.log 2>/dev/null || echo "No OGX log found"
+          }
+          OGX_PID="$(cat /tmp/ogx.pid)"
+          deadline=$((SECONDS + 300))
+          until curl -sf http://127.0.0.1:8321/v1/files > /dev/null 2>&1; do
+            if ! kill -0 "$OGX_PID" 2>/dev/null; then
+              echo "::error::OGX process (pid $OGX_PID) exited before binding port 8321"
+              dump_ogx_log
+              exit 1
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::OGX did not become ready within 300s"
+              dump_ogx_log
+              exit 1
+            fi
             sleep 2
-          done'
+          done
           echo "OGX is ready"
 
       - name: Run vLLM integration tests
@@ -226,6 +273,15 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # Persist uv's wheel/download cache across runs so the pinned OGX
+          # closure and the test's PEP-723 deps are not re-downloaded every run.
+          # Keyed on the files that carry those pins, so the cache invalidates
+          # only when a pin actually changes.
+          enable-cache: true
+          cache-dependency-glob: |
+            .github/workflows/vllm-integration.yaml
+            tests/integration/sdk/openai/test_openai_responses_vllm.py
 
       - name: Pull vLLM CPU image
         run: docker pull "$VLLM_IMAGE"
@@ -244,9 +300,22 @@ jobs:
             --reasoning-parser deepseek_r1 \
             --gpu-memory-utilization 0.5
 
+      - name: Pre-install OGX dependencies
+        run: |
+          # Resolve + download the full OGX dependency closure (torch, CUDA
+          # wheels, faiss, transformers, ...) synchronously and OFF the readiness
+          # clock. Without this the download runs backgrounded inside the
+          # "Wait for OGX readiness" window and loses the race under network
+          # variance, so the server never binds port 8321 in time (exit 124).
+          echo "Pre-installing OGX ($OGX_SPEC)..."
+          uv run --with "$OGX_SPEC" ogx --help > /dev/null
+          echo "OGX environment ready"
+
       - name: Start OGX
         run: |
-          uv run --with 'ogx[starter]' ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          # Same "$OGX_SPEC" as the pre-install above, so uv reuses the already
+          # materialized environment and the server binds within seconds.
+          uv run --with "$OGX_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
           echo $! > /tmp/ogx.pid
 
       - name: Build Praxis
@@ -269,9 +338,30 @@ jobs:
       - name: Wait for OGX readiness
         run: |
           echo "Waiting for OGX server..."
-          timeout 120 bash -c 'until curl -sf http://127.0.0.1:8321/v1/files > /dev/null 2>&1; do
+          # Poll in the current shell (no nested `bash -c`) so we can both bound
+          # the wait and check process liveness: fail fast if the backgrounded
+          # OGX process dies, and dump the log inline so a readiness failure is
+          # diagnosable from this step (mirrors the vLLM liveness check, which
+          # previously produced only an opaque exit 124 here).
+          dump_ogx_log() {
+            echo "----- /tmp/ogx.log (tail -n 200) -----"
+            tail -n 200 /tmp/ogx.log 2>/dev/null || echo "No OGX log found"
+          }
+          OGX_PID="$(cat /tmp/ogx.pid)"
+          deadline=$((SECONDS + 300))
+          until curl -sf http://127.0.0.1:8321/v1/files > /dev/null 2>&1; do
+            if ! kill -0 "$OGX_PID" 2>/dev/null; then
+              echo "::error::OGX process (pid $OGX_PID) exited before binding port 8321"
+              dump_ogx_log
+              exit 1
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::OGX did not become ready within 300s"
+              dump_ogx_log
+              exit 1
+            fi
             sleep 2
-          done'
+          done
           echo "OGX is ready"
 
       - name: Run vLLM integration tests (PostgreSQL store)

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -2,9 +2,9 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "httpx>=0.27",
-#     "openai>=2.0",
-#     "pytest>=8.0",
+#     "httpx>=0.27,<1",
+#     "openai>=2.0,<3",
+#     "pytest>=8.0,<9",
 # ]
 # ///
 """


### PR DESCRIPTION
## Summary

The vLLM integration jobs started OGX with `uv run --with 'ogx[starter]'`, which downloaded a large, unpinned, uncached dependency tree (torch, CUDA wheels, faiss, transformers, …) *inside* the 120 s "Wait for OGX readiness" window; under network variance the download lost the race, the server never bound port 8321, and the job died with an opaque exit 124 — ejecting PRs from the merge queue. This moves the download to a synchronous **Pre-install OGX dependencies** step off the readiness clock, pins + single-sources the spec (`OGX_SPEC=ogx[starter]==1.3.1`), enables `setup-uv` caching keyed on the pinned files, and replaces the bare timeout with a current-shell poll that checks process liveness, bounds the wait at 300 s, and dumps the OGX log inline — applied identically to both jobs. It also pins the integration test's PEP-723 deps to compatible majors so an upstream SDK release can't turn CI red on an unchanged commit.

## Related issue

N/A — flaky CI infrastructure fix; no tracking issue.

## Validation

- [ ] Unit tests — N/A (no Rust/source logic changed).
- [x] Integration or functional tests — `actionlint` clean, `yaml.safe_load` parses, `bash -n` passes on the new steps; the vLLM integration workflow itself is exercised end-to-end by this PR's CI run.
- [ ] `make lint` — build/lint run started locally but was interrupted by session teardown; the change touches only the CI workflow YAML and a Python test's PEP-723 comment (no Rust), so `make lint`/`make build` are unaffected. CI on this PR is authoritative.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test. — N/A (CI reliability fix, no new capability).
- [x] User-facing behavior and generated documentation are updated. — N/A.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence. — N/A.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.
