### PR TITLE
fix(responses): resume translated streaming web search through agentic loop

### DIFF
--- a/apis/src/openai/responses/README.md
+++ b/apis/src/openai/responses/README.md
@@ -32,7 +32,7 @@ Body-phase columns show `Access / Mode` when the hook is implemented.
 | `openai_agentic_loop` | ✓ | ReadOnly / StreamBuffer | — | ReadWrite / Stream |
 | `openai_doc_extract` | — | ReadWrite / StreamBuffer | — | — |
 | `openai_file_resolve` | — | ReadWrite / StreamBuffer | — | — |
-| `openai_file_search_callout` | ✓ | ReadOnly / StreamBuffer | — | ReadWrite / StreamBuffer |
+| `openai_file_search_callout` | ✓ | ReadOnly / StreamBuffer | — | ReadWrite / Stream |
 | `openai_mcp_dispatch` | — | ReadOnly / StreamBuffer | — | ReadWrite / Stream |
 | `openai_mcp_tool_resolve` | — | ReadWrite / StreamBuffer | — | — |
 | `openai_response_store` | ✓ | ReadOnly / Stream | ✓ | ReadOnly / Stream |

--- a/apis/src/openai/responses/file_search_callout/mod.rs
+++ b/apis/src/openai/responses/file_search_callout/mod.rs
@@ -458,12 +458,27 @@ impl HttpFilter for FileSearchCalloutFilter {
     }
 
     fn response_body_mode(&self) -> BodyMode {
-        BodyMode::StreamBuffer {
-            max_bytes: Some(MAX_JSON_BODY_BYTES),
-        }
+        // Declared `Stream` so this filter can share an iterative-router step with
+        // `responses_to_chat_completions`, which always advertises the streaming
+        // subrequest capability. A statically declared `StreamBuffer` would trip
+        // the per-step build check that rejects a streaming-capable step whose
+        // merged response body mode is `StreamBuffer`. This filter still needs the
+        // complete response to run `capture_response`, so `on_request` ratchets the
+        // runtime body mode back up to `StreamBuffer` (mirroring
+        // `openai_response_store`); a file-search request always rejects
+        // `stream: true`, so the runtime response is never actually streamed.
+        BodyMode::Stream
     }
 
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        // A file-search pipeline never streams (`stream: true` is rejected), so
+        // buffer the complete response for `capture_response`. Declared statically
+        // as `Stream` to stay build-compatible with a streaming-capable step;
+        // ratcheting the runtime mode up to `StreamBuffer` here restores buffering
+        // without reintroducing a static `StreamBuffer` that would trip the check.
+        ctx.set_response_body_mode(BodyMode::StreamBuffer {
+            max_bytes: Some(MAX_JSON_BODY_BYTES),
+        });
         let action = self.execute_pending(ctx).await?;
         if matches!(action, FilterAction::Continue) {
             preserve_original_request_headers(ctx);

--- a/apis/src/openai/responses/responses_to_chat_completions/mod.rs
+++ b/apis/src/openai/responses/responses_to_chat_completions/mod.rs
@@ -26,9 +26,10 @@ mod tests;
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_filter::{
-    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, body::MAX_JSON_BODY_BYTES,
-    parse_filter_config,
+    BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext, SubRequestResponseMode,
+    body::MAX_JSON_BODY_BYTES, parse_filter_config,
 };
+use serde::Deserialize;
 use tracing::{debug, trace, warn};
 
 use self::{
@@ -105,6 +106,24 @@ const RESPONSE_TRANSFORM_STREAM: &str = "stream";
 /// `openai_response_store` are compatible because they persist streamed turns
 /// from the accumulator, not a buffered body, whereas any other response-body
 /// rewriter needing the complete buffered body would instead receive fragments.
+///
+/// # Streaming through the agentic loop
+///
+/// Because this filter runs inside the iterative router, it always declares the
+/// streaming subrequest capability and selects the transport per request from
+/// the effective `stream` bit: an effective `"stream": true` request uses
+/// Praxis's typed streaming transport, and a buffered request uses the buffered
+/// transport. Selecting streaming keeps each translated per-round stream internal
+/// to the router instead of delivering the whole upstream SSE body to
+/// `openai_agentic_loop` as one buffered blob — a blob is not a Responses
+/// resource, so the loop could not detect a returned `web_search_call` and would
+/// terminate before any search dispatches. With streaming, `openai_web_search`
+/// dispatches the search, inference resumes, and `openai_stream_events` (with
+/// `logical_stream: true`, placed first in the step) composes one client-facing
+/// Responses SSE lifecycle across the model, search, and resumed model output.
+/// Every response filter co-located in a step with this one must therefore use
+/// `BodyMode::Stream`; a static `StreamBuffer` filter in the same step must
+/// instead buffer dynamically (see `openai_file_search_callout`).
 ///
 /// # YAML
 ///
@@ -336,6 +355,18 @@ impl HttpFilter for ResponsesToChatCompletionsFilter {
         BodyAccess::ReadWrite
     }
 
+    fn may_select_streaming_subrequest_response(&self) -> bool {
+        // This filter runs inside the iterative router and always advertises the
+        // streaming subrequest capability. The transport is chosen per request in
+        // `on_request_body` from the effective `stream` bit: an effective
+        // `"stream": true` request streams so each translated per-round stream
+        // stays internal to the router (letting `openai_agentic_loop` parse it and
+        // dispatch tools), and a buffered request buffers. A build-time flag would
+        // make a `stream: true` request silently buffer — and so fail to dispatch
+        // the search — by default, so the capability is declared unconditionally.
+        true
+    }
+
     async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
         Ok(FilterAction::Continue)
     }
@@ -420,6 +451,7 @@ impl HttpFilter for ResponsesToChatCompletionsFilter {
         ctx.request_headers_to_remove.push(http::header::ACCEPT_ENCODING);
         *body = Some(Bytes::from(serialized));
         ctx.set_metadata(ARMED_KEY, "true");
+        select_terminal_response_mode(ctx, body);
         let now = ctx.time_source.now().as_secs();
         let created_at = ctx
             .extensions
@@ -429,6 +461,40 @@ impl HttpFilter for ResponsesToChatCompletionsFilter {
 
         Ok(FilterAction::Continue)
     }
+}
+
+/// Narrow deserialization target for the provider-visible stream bit.
+///
+/// Only `stream` participates in transport selection; every other translated
+/// request field is intentionally ignored.
+#[derive(Deserialize)]
+struct EffectiveResponseMode {
+    /// Whether the translated outbound Chat Completions request asks for SSE.
+    #[serde(default)]
+    stream: bool,
+}
+
+/// Align the typed Praxis response transport with the translated outbound body.
+///
+/// The translated Chat Completions body carries the effective `stream` bit
+/// copied from the client Responses request, so this selects the transport
+/// matching the bytes it leaves for the backend: incremental typed streaming for
+/// an SSE request, buffered otherwise. Selecting streaming is what keeps each
+/// translated per-round stream internal to the iterative router — buffering it
+/// would deliver the whole SSE body to `openai_agentic_loop` as an opaque blob
+/// it cannot parse as a Responses resource, so the loop would terminate before
+/// `openai_web_search` ever dispatches.
+fn select_terminal_response_mode(ctx: &mut HttpFilterContext<'_>, body: &Option<Bytes>) {
+    let mode = if body
+        .as_deref()
+        .and_then(|bytes| serde_json::from_slice::<EffectiveResponseMode>(bytes).ok())
+        .is_some_and(|selection| selection.stream)
+    {
+        SubRequestResponseMode::Streaming
+    } else {
+        SubRequestResponseMode::Buffered
+    };
+    ctx.set_subrequest_response_mode(mode);
 }
 
 /// Decide whether the current request should translate, release, or fail closed.

--- a/apis/src/openai/responses/responses_to_chat_completions/tests.rs
+++ b/apis/src/openai/responses/responses_to_chat_completions/tests.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use http::StatusCode;
 use praxis_core::time::FixedTimeSource;
-use praxis_filter::{BodyAccess, BodyMode, FilterAction};
+use praxis_filter::{BodyAccess, BodyMode, FilterAction, SubRequestResponseMode};
 use serde_json::json;
 
 use super::{
@@ -503,6 +503,76 @@ async fn canonical_state_is_translated_and_arms_response() {
             .get::<ResponsesState>()
             .and_then(|state| state.response_created_at),
         Some(1_700_000_000)
+    );
+}
+
+#[test]
+fn always_advertises_streaming_subrequest_capability() {
+    // Running inside the iterative router, the filter always declares the
+    // streaming subrequest capability. The transport is chosen per request from
+    // the effective `stream` bit, never a build-time flag — a flag would make a
+    // `stream: true` request silently buffer, and so never dispatch the search.
+    let filter = ResponsesToChatCompletionsFilter::from_config(&serde_yaml::Value::Null).unwrap();
+    assert!(
+        filter.may_select_streaming_subrequest_response(),
+        "the filter must always advertise the build-time streaming-subrequest contract"
+    );
+}
+
+/// Drive one create request through `on_request_body` with the given config and
+/// return the transport the filter selected for the translated subrequest.
+async fn selected_subrequest_mode(config_yaml: &str, request_body: serde_json::Value) -> SubRequestResponseMode {
+    let config = serde_yaml::from_str(config_yaml).unwrap();
+    let filter = ResponsesToChatCompletionsFilter::from_config(&config).unwrap();
+    let request = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut context = crate::test_utils::make_filter_context(&request);
+    context.set_metadata("openai_responses_format.format", "openai_responses");
+    context
+        .extensions
+        .insert(ResponsesState::from_request_body(request_body.clone()));
+    let mut body = Some(Bytes::from(serde_json::to_vec(&request_body).unwrap()));
+
+    let action = filter.on_request_body(&mut context, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "translation should continue");
+    assert_eq!(context.get_metadata(ARMED_KEY), Some("true"), "translation should arm");
+    context.subrequest_response_mode()
+}
+
+#[tokio::test]
+async fn selects_streaming_transport_for_streaming_request() {
+    // An effective stream:true request must keep each translated per-round stream
+    // internal to the router so `openai_agentic_loop` can parse it and dispatch.
+    let mode = selected_subrequest_mode("{}", json!({"model": "gpt-4.1-mini", "input": "hello", "stream": true})).await;
+    assert_eq!(
+        mode,
+        SubRequestResponseMode::Streaming,
+        "an effective stream:true request must keep each translated round internal to the router"
+    );
+}
+
+#[tokio::test]
+async fn selects_buffered_transport_for_non_streaming_request() {
+    let mode = selected_subrequest_mode(
+        "{}",
+        json!({"model": "gpt-4.1-mini", "input": "hello", "stream": false}),
+    )
+    .await;
+    assert_eq!(
+        mode,
+        SubRequestResponseMode::Buffered,
+        "a non-streaming request must not select the streaming subrequest transport"
+    );
+}
+
+#[tokio::test]
+async fn selects_buffered_transport_when_stream_is_absent() {
+    // A request that omits `stream` entirely buffers, matching a `stream: false`
+    // request: only an explicit effective stream:true selects the streaming path.
+    let mode = selected_subrequest_mode("{}", json!({"model": "gpt-4.1-mini", "input": "hello"})).await;
+    assert_eq!(
+        mode,
+        SubRequestResponseMode::Buffered,
+        "an absent stream bit must leave the subrequest transport at its buffered default"
     );
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -99,7 +99,7 @@ before sending requests.
 | [vector-stores-routing.yaml](configs/openai/responses/vector-stores-routing.yaml) | Routes /v1/vector_stores traffic and all its subresources to a dedicated backend (any server compatible with the OpenAI Files / Vector Stores API), while sending everything else to a default backend |
 | [vllm-agentic-api.yaml](configs/openai/responses/vllm-agentic-api.yaml) | vLLM Agentic API: https://github.com/vllm-project/agentic-api |
 | [web-search-chat-completions-fixture.yaml](configs/openai/responses/web-search-chat-completions-fixture.yaml) | Single-upstream fixture configuration for recording the private Chat Completions function representation of a Responses web_search tool |
-| [web-search-chat-completions.yaml](configs/openai/responses/web-search-chat-completions.yaml) | Accepts finite OpenAI Responses requests with hosted web search while targeting a backend that only implements /v1/chat/completions |
+| [web-search-chat-completions.yaml](configs/openai/responses/web-search-chat-completions.yaml) | Accepts OpenAI Responses requests with hosted web search while targeting a backend that only implements /v1/chat/completions |
 | [web-search.yaml](configs/openai/responses/web-search.yaml) | Demonstrates the `openai_web_search` filter configuration |
 
 ### Payload Processing

--- a/examples/configs/openai/responses/web-search-chat-completions.yaml
+++ b/examples/configs/openai/responses/web-search-chat-completions.yaml
@@ -59,6 +59,12 @@ filter_chains:
       - filter: iterative_request_router
         initial_step: inference
         max_iterations: 11
+        # Terminal streaming rounds resume real inference after the web-search
+        # dispatch, so allow generous per-request and per-step deadlines for
+        # slower backends (mirrors full-flow-agentic.yaml). The default step
+        # deadline is too tight for a full translated streaming generation.
+        timeout_ms: 120000
+        step_timeout_ms: 60000
         max_stream_response_bytes: 67108864
         steps:
           - name: inference

--- a/examples/configs/openai/responses/web-search-chat-completions.yaml
+++ b/examples/configs/openai/responses/web-search-chat-completions.yaml
@@ -1,22 +1,41 @@
 # Responses Web Search with a Chat Completions Backend
 #
-# Accepts finite OpenAI Responses requests with hosted web search while
-# targeting a backend that only implements /v1/chat/completions. The
-# compatibility filter privately exposes web_search to that backend as a
-# strict function tool. The existing openai_web_search executor handles the
-# returned call and IRR drives the second inference round.
+# Accepts OpenAI Responses requests with hosted web search while targeting a
+# backend that only implements /v1/chat/completions. Serves both finite
+# (`"stream": false`) and streaming (`"stream": true`) requests from one
+# pipeline. The compatibility filter privately exposes web_search to that
+# backend as a strict function tool. The existing openai_web_search executor
+# handles the returned call and IRR drives the second inference round.
+#
+# responses_to_chat_completions runs inside the iterative router and selects its
+# transport from the effective request: a `"stream": true` request streams, so
+# each translated per-round stream stays internal to the router; a finite request
+# buffers. openai_stream_events (logical_stream: true) accumulates each translated
+# per-round Responses SSE stream and withholds per-round terminal events until the
+# IRR transition is known, exposing one coherent client-facing Responses SSE
+# lifecycle across the model round, the web search, and the resumed model output.
+# On a finite request openai_stream_events never arms (the response is not SSE),
+# so it is a no-op and the finite round-trip is unaffected.
 #
 # Request order inside IRR:
-#   openai_web_search -> openai_agentic_loop
+#   openai_stream_events -> openai_web_search -> openai_agentic_loop
 #     -> responses_to_chat_completions -> path_rewrite -> router
 #
-# Response filters run in reverse. Each Chat Completions response is therefore
-# converted into a Responses resource before openai_agentic_loop sees it. A
-# private function_call(name="web_search") becomes a canonical web_search_call,
-# which openai_web_search executes on the next iteration.
+# Response filters run in reverse. Each Chat Completions response (finite JSON or
+# streamed SSE) is therefore converted into a Responses resource before
+# openai_agentic_loop and openai_web_search see it, and openai_stream_events
+# (client-facing) composes the logical stream last. A private
+# function_call(name="web_search") becomes a canonical web_search_call, which
+# openai_web_search executes on the next iteration.
 #
-# This pipeline is finite only. Streaming composition depends on the separate
-# Chat SSE conversion and streaming-across-IRR work.
+#   curl -N http://localhost:8080/v1/responses \
+#     -H "Content-Type: application/json" \
+#     -d '{
+#       "model": "gpt-4.1",
+#       "input": "What is the weather in SF?",
+#       "stream": true,
+#       "tools": [{"type": "web_search"}]
+#     }'
 
 listeners:
   - name: responses-web-search-chat-gateway
@@ -40,9 +59,18 @@ filter_chains:
       - filter: iterative_request_router
         initial_step: inference
         max_iterations: 11
+        max_stream_response_bytes: 67108864
         steps:
           - name: inference
             filters:
+              # Parses every translated inference SSE stream, preserves one
+              # logical response identity across rounds, and withholds per-round
+              # terminal events until the IRR transition is known. Runs last in
+              # the response phase so it observes the translated Responses SSE. A
+              # no-op on finite (non-SSE) responses.
+              - filter: openai_stream_events
+                logical_stream: true
+
               - filter: openai_web_search
                 provider: brave
                 api_key: ${WEB_SEARCH_API_KEY}

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -56,6 +56,9 @@ CHAT_STREAMING_CONFIG_PATH = (
     "examples/configs/openai/responses/responses-to-chat-completions.yaml"
 )
 COMPACT_CONFIG_PATH = "examples/configs/openai/responses/compact.yaml"
+WEB_SEARCH_CHAT_STREAMING_CONFIG_PATH = (
+    "examples/configs/openai/responses/web-search-chat-completions.yaml"
+)
 
 TERMINAL_RESPONSE_EVENTS = {
     "response.cancelled",
@@ -260,6 +263,40 @@ def _write_compact_config(
     return path
 
 
+def _write_web_search_chat_streaming_config(
+    praxis_port: int, search_port: int,
+) -> str:
+    """Patch the streaming web-search-through-Chat example for live vLLM.
+
+    Points the loop at the live vLLM backend and swaps the Brave provider's
+    ``${WEB_SEARCH_API_KEY}`` placeholder for the in-process mock search server.
+    """
+    with open(WEB_SEARCH_CHAT_STREAMING_CONFIG_PATH) as f:
+        config = f.read()
+
+    config = config.replace("127.0.0.1:8080", f"127.0.0.1:{praxis_port}")
+    config = config.replace(
+        '- "127.0.0.1:3001"',
+        f'- "{_vllm_endpoint()}"\n'
+        "                    read_timeout_ms: 300000",
+    )
+    config = config.replace(
+        "- filter: openai_web_search\n"
+        "                provider: brave\n"
+        "                api_key: ${WEB_SEARCH_API_KEY}",
+        "- filter: openai_web_search\n"
+        "                provider: brave\n"
+        "                api_key: test-key\n"
+        f"                base_url: http://127.0.0.1:{search_port}\n"
+        "                allow_private_base_url: true",
+    )
+
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    with os.fdopen(fd, "w") as f:
+        f.write(config)
+    return path
+
+
 def _wait_for_proxy(
     port: int, proc: subprocess.Popen, log_path: str, timeout: float = 30.0
 ) -> None:
@@ -366,12 +403,24 @@ class MCPHandler(BaseHTTPRequestHandler):
 
 
 class BraveSearchHandler(BaseHTTPRequestHandler):
-    """Mock Brave Search API returning canned results."""
+    """Mock Brave Search API returning canned results.
+
+    Counts every dispatched query so tests can assert the web-search
+    provider is invoked exactly once per agentic round.
+    """
+
+    #: Total queries served across all instances since the last reset.
+    request_count = 0
+
+    @classmethod
+    def reset(cls):
+        cls.request_count = 0
 
     request_paths: ClassVar[list[str]] = []
 
     def do_GET(self):
         type(self).request_paths.append(self.path)
+        BraveSearchHandler.request_count += 1
         payload = json.dumps(
             {
                 "web": {
@@ -711,6 +760,56 @@ def compact_client(compact_proxy):
     """Return an SDK client using the compact filter example."""
     return OpenAI(
         base_url=f"http://127.0.0.1:{compact_proxy}/v1",
+        api_key="test",
+        max_retries=0,
+        timeout=300,
+    )
+
+
+@pytest.fixture(scope="session")
+def web_search_chat_streaming_proxy(tmp_path_factory, request, search_server):
+    """Start the streaming web-search-through-Chat example against live vLLM."""
+    port = _free_port()
+    db_dir = tmp_path_factory.mktemp("web-search-chat-streaming")
+    config_path = _write_web_search_chat_streaming_config(port, search_server)
+    binary = _find_binary()
+
+    log_path = str(db_dir / "praxis.log")
+    log_file = open(log_path, "w")
+    started = False
+
+    proc = subprocess.Popen(
+        [binary, "-c", config_path],
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        _wait_for_proxy(port, proc, log_path)
+        started = True
+        yield port, search_server
+    finally:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        log_file.close()
+        if not started or request.session.testsfailed > 0:
+            with open(log_path) as f:
+                print(
+                    f"\n=== Web search chat streaming Praxis logs ===\n{f.read()}",
+                    file=sys.stderr,
+                )
+        os.unlink(config_path)
+
+
+@pytest.fixture(scope="session")
+def web_search_chat_streaming_client(web_search_chat_streaming_proxy):
+    """Return an SDK client using streaming web-search-through-Chat translation."""
+    proxy_port, _ = web_search_chat_streaming_proxy
+    return OpenAI(
+        base_url=f"http://127.0.0.1:{proxy_port}/v1",
         api_key="test",
         max_retries=0,
         timeout=300,
@@ -1648,6 +1747,83 @@ class TestResponsesToChatCompletionsVLLM:
                 store=False,
             )
         assert exc_info.value.status_code == 404
+
+    def test_web_search_streams_terminal_round_as_one_logical_response(
+        self, web_search_chat_streaming_client, web_search_chat_streaming_proxy,
+    ):
+        """Streaming web search resumes through the agentic loop (#986).
+
+        A streaming Responses request is translated to Chat Completions,
+        the returned private ``web_search`` tool call is restored to a
+        canonical ``web_search_call``, ``openai_web_search`` dispatches the
+        query, and inference resumes — all exposed to the client as ONE
+        logical Responses SSE lifecycle. The terminal event carries the
+        completed web-search item and the final assistant message.
+        """
+        BraveSearchHandler.reset()
+
+        stream = web_search_chat_streaming_client.responses.create(
+            model=VLLM_MODEL,
+            input=(
+                "You MUST call the web_search tool to look up the latest "
+                "Praxis Proxy release, then answer. Do not answer directly. "
+                "/no_think"
+            ),
+            tools=[{"type": "web_search"}],
+            store=False,
+            stream=True,
+            max_output_tokens=512,
+        )
+
+        event_types = []
+        text_parts = []
+        final_response = None
+
+        for event in stream:
+            event_types.append(event.type)
+            if event.type == "response.output_text.delta":
+                text_parts.append(event.delta)
+            if event.type == "response.completed":
+                final_response = event.response
+
+        # AC: one coherent lifecycle framing — created first, completed last,
+        # with no intermediate terminal exposed for the internal search round.
+        assert event_types[0] == "response.created", event_types
+        assert event_types[-1] == "response.completed", event_types
+        assert event_types.count("response.created") == 1, event_types
+        assert event_types.count("response.completed") == 1, event_types
+        assert final_response is not None, (
+            "stream must terminate with a response.completed event; "
+            f"got: {event_types}"
+        )
+        assert final_response.status in ("completed", "incomplete"), (
+            f"expected completed or incomplete (token limit); got: {final_response.status}"
+        )
+
+        # AC: the configured web-search provider is dispatched exactly once.
+        assert BraveSearchHandler.request_count == 1, (
+            "web search must be dispatched exactly once through the agentic "
+            f"loop; got {BraveSearchHandler.request_count} dispatches"
+        )
+
+        # AC: the terminal output carries the completed web-search item plus a
+        # resumed assistant message — the search round and the final round both
+        # surface in the single logical stream.
+        output_types = [item.type for item in final_response.output]
+        assert "web_search_call" in output_types, (
+            "streamed terminal output should contain the completed "
+            f"web_search_call; got: {output_types}"
+        )
+        search_calls = [
+            item for item in final_response.output if item.type == "web_search_call"
+        ]
+        assert all(item.status == "completed" for item in search_calls), (
+            f"web_search_call items should be completed; got: {search_calls}"
+        )
+        assert "message" in output_types, (
+            "streamed terminal output should contain the final assistant "
+            f"message; got: {output_types}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/tests/suite/examples/web_search_chat_completions.rs
+++ b/tests/integration/tests/suite/examples/web_search_chat_completions.rs
@@ -2,8 +2,25 @@
 // Copyright (c) 2026 Praxis Contributors
 
 //! Functional tests for Responses web search through a Chat Completions backend.
+//!
+//! The single `web-search-chat-completions.yaml` example serves both finite
+//! (`"stream": false`) and streaming (`"stream": true`) requests. These tests
+//! exercise the finite round-trip, the streaming round-trip (translated Chat
+//! Completions SSE, restored `web_search_call`, dispatched search, resumed
+//! inference, one coherent Responses SSE lifecycle), and the fail-closed guard
+//! when the logical-stream finalizer is absent from a streaming pipeline.
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    io::{Read as _, Write as _},
+    net::{TcpListener, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+    time::Duration,
+};
 
 use praxis_test_utils::{
     StatefulCapturingBackend, build_pipeline, example_config_path, free_port, http_send, json_post, parse_body,
@@ -13,15 +30,42 @@ use serde_json::{Value, json};
 
 const EXAMPLE: &str = "openai/responses/web-search-chat-completions.yaml";
 
-fn load_test_config(listener_port: u16, model_port: u16, search_port: u16) -> praxis_core::config::Config {
+/// Read the example config and point its model backend and search provider at
+/// the given local mock ports.
+fn patched_yaml(listener_port: u16, model_port: u16, search_port: u16) -> String {
     let yaml = std::fs::read_to_string(example_config_path(EXAMPLE)).expect("example config should exist");
     let yaml = patch_yaml(&yaml, listener_port, &HashMap::from([("127.0.0.1:3001", model_port)]));
-    let yaml = yaml.replace(
+    yaml.replace(
         "api_key: ${WEB_SEARCH_API_KEY}",
         &format!(
             "api_key: test-key\n                base_url: http://127.0.0.1:{search_port}\n                allow_private_base_url: true"
         ),
+    )
+}
+
+fn load_test_config(listener_port: u16, model_port: u16, search_port: u16) -> praxis_core::config::Config {
+    praxis_core::config::Config::from_yaml(&patched_yaml(listener_port, model_port, search_port))
+        .expect("patched config should parse")
+}
+
+/// Load the example with the logical-stream finalizer disabled, modelling a
+/// streaming-capable pipeline that is missing `openai_stream_events`'s
+/// `logical_stream: true`.
+fn load_test_config_without_logical_stream(
+    listener_port: u16,
+    model_port: u16,
+    search_port: u16,
+) -> praxis_core::config::Config {
+    // Match the `- filter:`/`logical_stream:` pair so the header doc comment,
+    // which also contains the literal `logical_stream: true`, is left untouched.
+    let enabled = "- filter: openai_stream_events\n                logical_stream: true";
+    let disabled = "- filter: openai_stream_events\n                logical_stream: false";
+    let yaml = patched_yaml(listener_port, model_port, search_port);
+    assert!(
+        yaml.contains(enabled),
+        "expected the openai_stream_events logical_stream toggle in the example; its block may have changed"
     );
+    let yaml = yaml.replace(enabled, disabled);
     praxis_core::config::Config::from_yaml(&yaml).expect("patched config should parse")
 }
 
@@ -166,6 +210,214 @@ fn web_search_chat_completions_completes_model_search_model_round_trip() {
 }
 
 #[test]
+fn web_search_chat_completions_streams_dispatch_once_as_one_logical_response() {
+    // Round 1: the Chat backend streams a private `web_search` tool call.
+    let first_response = vec![
+        chat_chunk(
+            r#"{"id":"chatcmpl_ws","object":"chat.completion.chunk","model":"chat-only-model","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_ws_1","type":"function","function":{"name":"web_search","arguments":""}}]}}]}"#,
+        ),
+        chat_chunk(
+            r#"{"id":"chatcmpl_ws","object":"chat.completion.chunk","model":"chat-only-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"Praxis Proxy latest release\"}"}}]}}]}"#,
+        ),
+        chat_chunk(
+            r#"{"id":"chatcmpl_ws","object":"chat.completion.chunk","model":"chat-only-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        ),
+        "data: [DONE]\n\n".to_owned(),
+    ];
+    // Round 2: after the search result is bridged in, the model streams the
+    // final assistant answer.
+    let second_response = vec![
+        chat_chunk(
+            r#"{"id":"chatcmpl_ans","object":"chat.completion.chunk","model":"chat-only-model","choices":[{"index":0,"delta":{"role":"assistant","content":"Praxis Proxy shipped a new release."}}]}"#,
+        ),
+        chat_chunk(
+            r#"{"id":"chatcmpl_ans","object":"chat.completion.chunk","model":"chat-only-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+        ),
+        "data: [DONE]\n\n".to_owned(),
+    ];
+    let (model_port, model_requests, model_thread) = start_streaming_model(vec![first_response, second_response]);
+
+    let search_listener = TcpListener::bind("127.0.0.1:0").expect("search mock should bind");
+    let search_port = search_listener.local_addr().expect("search mock address").port();
+    let search_hits = spawn_counting_search_mock(search_listener);
+
+    let proxy_port = free_port();
+    let config = load_test_config(proxy_port, model_port, search_port);
+    let proxy = start_proxy(&config);
+    let request = json!({
+        "model": "chat-only-model",
+        "input": "Find the latest Praxis Proxy release.",
+        "stream": true,
+        "store": false,
+        "tools": [{"type": "web_search"}]
+    });
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", &serde_json::to_string(&request).unwrap()),
+    );
+    let body = parse_body(&raw);
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "streaming web-search round-trip should return 200 (model requests: {}, search hits: {}): {raw}",
+        model_requests
+            .lock()
+            .expect("model request lock should not be poisoned")
+            .len(),
+        search_hits.load(Ordering::SeqCst),
+    );
+
+    // AC1: the configured web-search provider is dispatched exactly once.
+    assert_eq!(
+        search_hits.load(Ordering::SeqCst),
+        1,
+        "the search provider must be dispatched exactly once: {body}"
+    );
+
+    // AC3: the client observes ONE coherent Responses SSE lifecycle across the
+    // model round, the search, and the resumed model output.
+    assert_eq!(
+        body.matches("event: response.created").count(),
+        1,
+        "one logical stream must expose exactly one response.created event: {body}"
+    );
+    assert_eq!(
+        body.matches("event: response.completed").count(),
+        1,
+        "the intermediate per-round completion must be suppressed: {body}"
+    );
+    // None of the upstream Chat Completions framing leaks to the client.
+    assert!(
+        !body.contains("chat.completion.chunk"),
+        "raw Chat framing leaked to a Responses client: {body}"
+    );
+    assert!(!body.contains("[DONE]"), "raw Chat sentinel leaked: {body}");
+    // The resumed inference text reaches the same stream.
+    assert!(
+        body.contains("Praxis Proxy shipped a new release."),
+        "resumed inference text should reach the client stream: {body}"
+    );
+
+    // AC4: the terminal response.completed carries the completed web_search_call
+    // and the final assistant message.
+    let completed = body
+        .split("\n\n")
+        .find(|frame| frame.starts_with("event: response.completed\n"))
+        .expect("stream should contain a terminal response.completed event");
+    let data = completed
+        .lines()
+        .nth(1)
+        .and_then(|line| line.strip_prefix("data: "))
+        .expect("terminal event should carry a data line");
+    let terminal: Value = serde_json::from_str(data).expect("terminal event data should be JSON");
+    assert_eq!(terminal["response"]["status"], "completed");
+    let output = terminal["response"]["output"]
+        .as_array()
+        .expect("terminal response should carry an output array");
+    let search_calls: Vec<&Value> = output.iter().filter(|item| item["type"] == "web_search_call").collect();
+    assert_eq!(
+        search_calls.len(),
+        1,
+        "terminal output must contain exactly one web_search_call: {output:#?}"
+    );
+    assert_eq!(search_calls[0]["status"], "completed");
+    assert!(
+        output.iter().any(|item| {
+            item["type"] == "message" && item["content"][0]["text"] == "Praxis Proxy shipped a new release."
+        }),
+        "terminal output must contain the final assistant message: {output:#?}"
+    );
+
+    // AC2: the search result is bridged into the resumed inference request.
+    model_thread.join().expect("streaming model thread should finish");
+    // The model thread has joined, so take the captured bodies out of the shared
+    // log; the lock guard is released with the statement instead of being held
+    // across the request assertions below.
+    let requests = std::mem::take(
+        &mut *model_requests
+            .lock()
+            .expect("model request lock should not be poisoned"),
+    );
+    assert_eq!(
+        requests.len(),
+        2,
+        "web search should drive exactly two streamed model requests"
+    );
+    let first: Value = serde_json::from_str(&requests[0]).expect("first request should be JSON");
+    assert_eq!(
+        first["stream"], true,
+        "the translated request must ask the backend to stream"
+    );
+    assert_eq!(
+        first["tools"][0]["function"]["name"], "web_search",
+        "web_search must be exposed to the Chat backend as a private function tool"
+    );
+
+    let second: Value = serde_json::from_str(&requests[1]).expect("second request should be JSON");
+    let messages = second["messages"].as_array().expect("second request messages array");
+    // #808: a hosted web_search_call is not a valid Chat input, so the
+    // continuation bridges it as a function_call / tool result pair instead.
+    assert!(
+        messages.iter().any(|message| {
+            message["tool_calls"][0]["function"]["name"] == "web_search"
+                && message["tool_calls"][0]["function"]["arguments"] == "{\"query\":\"Praxis Proxy latest release\"}"
+        }),
+        "second inference should carry the bridged web_search function_call: {messages:#?}"
+    );
+    assert!(
+        messages.iter().any(|message| {
+            message["role"] == "tool"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("Praxis Proxy releases"))
+        }),
+        "second inference should carry the search result as a tool message: {messages:#?}"
+    );
+}
+
+#[test]
+fn web_search_chat_completions_streaming_fails_closed_without_logical_stream() {
+    // responses_to_chat_completions always advertises the streaming subrequest
+    // capability and selects the streaming transport for an effective
+    // `"stream": true` request. Without `openai_stream_events`'s
+    // `logical_stream: true` finalizer, typed streaming would commit
+    // `response.completed` to the client as it arrives, so a loop-terminal error
+    // detected later by `openai_agentic_loop` could not reach the client. The
+    // loop must therefore fail closed before any backend dispatch rather than
+    // forward a truncatable typed stream.
+    let model = StatefulCapturingBackend::new(vec![(200, "unexpected".to_owned())]).start_with_shutdown();
+    let proxy_port = free_port();
+    let config = load_test_config_without_logical_stream(proxy_port, model.port(), free_port());
+    let proxy = start_proxy(&config);
+    let request = json!({
+        "model": "chat-only-model",
+        "input": "Find the latest Praxis Proxy release.",
+        "stream": true,
+        "store": false,
+        "tools": [{"type": "web_search"}]
+    });
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &request.to_string()));
+
+    assert_eq!(
+        parse_status(&raw),
+        500,
+        "a streaming request without a logical-stream finalizer must fail closed before dispatch: {raw}"
+    );
+    assert!(
+        parse_body(&raw).contains("server_error"),
+        "the rejection must carry the server_error code: {}",
+        parse_body(&raw)
+    );
+    assert!(
+        model.requests().is_empty(),
+        "an unsafe streaming request must not reach the model backend"
+    );
+}
+
+#[test]
 fn web_search_chat_completions_rejects_function_name_collision_before_forwarding() {
     let model = StatefulCapturingBackend::new(vec![(200, "unexpected".to_owned())]).start_with_shutdown();
     let proxy_port = free_port();
@@ -192,4 +444,112 @@ fn web_search_chat_completions_rejects_function_name_collision_before_forwarding
         model.requests().is_empty(),
         "collision must not reach the model backend"
     );
+}
+
+/// Encode one Chat Completions SSE frame (no `event:` line, `data:` payload).
+fn chat_chunk(payload: &str) -> String {
+    format!("data: {payload}\n\n")
+}
+
+/// Handle returned by the synthetic streaming model backend.
+type StreamingModel = (u16, Arc<Mutex<Vec<String>>>, thread::JoinHandle<()>);
+
+/// Start a two-turn Chat Completions backend that emits each SSE frame as a
+/// separate chunk and records the request body it received each round.
+fn start_streaming_model(responses: Vec<Vec<String>>) -> StreamingModel {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("streaming model should bind");
+    let port = listener
+        .local_addr()
+        .expect("streaming model should have an address")
+        .port();
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&requests);
+    let handle = thread::spawn(move || {
+        for response in responses {
+            let (mut stream, _) = listener.accept().expect("streaming model should accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("streaming model should set read timeout");
+            let request = read_json_request(&mut stream);
+            captured
+                .lock()
+                .expect("model request lock should not be poisoned")
+                .push(request);
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+                )
+                .expect("streaming model should write response headers");
+            for frame in response {
+                write!(stream, "{:x}\r\n{frame}\r\n", frame.len()).expect("streaming model should write frame chunk");
+                stream.flush().expect("streaming model should flush frame chunk");
+            }
+            stream
+                .write_all(b"0\r\n\r\n")
+                .expect("streaming model should finish chunked response");
+        }
+    });
+    (port, requests, handle)
+}
+
+/// Read one content-length JSON request and return its body.
+fn read_json_request(stream: &mut TcpStream) -> String {
+    let mut raw = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = stream.read(&mut buffer).expect("streaming model should read request");
+        if read == 0 {
+            break;
+        }
+        raw.extend_from_slice(&buffer[..read]);
+        let text = String::from_utf8_lossy(&raw);
+        let Some((headers, body)) = text.split_once("\r\n\r\n") else {
+            continue;
+        };
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        if body.len() >= content_length {
+            return body.get(..content_length).unwrap_or_default().to_owned();
+        }
+    }
+    String::new()
+}
+
+/// Serve Brave-style search results and count how many times the provider is hit.
+fn spawn_counting_search_mock(listener: TcpListener) -> Arc<AtomicUsize> {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&hits);
+    let body = json!({
+        "web": {
+            "results": [{
+                "title": "Praxis Proxy releases",
+                "url": "https://github.com/praxis-proxy/praxis/releases",
+                "description": "Current Praxis Proxy releases."
+            }]
+        }
+    })
+    .to_string();
+    thread::spawn(move || {
+        loop {
+            let Ok((mut stream, _)) = listener.accept() else {
+                break;
+            };
+            let mut buf = [0_u8; 4096];
+            let _read = stream.read(&mut buf).unwrap_or(0);
+            counter.fetch_add(1, Ordering::SeqCst);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _sent = stream.write_all(response.as_bytes());
+        }
+    });
+    hits
 }


### PR DESCRIPTION
## Summary

Inside the iterative router, `responses_to_chat_completions` now always advertises the streaming subrequest capability and picks its transport per request from the effective `stream` bit, so a streaming Responses request translated to Chat Completions dispatches web search exactly once, bridges the results into the resumed inference, and surfaces one coherent Responses SSE lifecycle whose terminal response carries the completed `web_search_call` plus the final assistant message. `file_search_callout` is made streaming-safe (static `Stream` mode with a runtime `StreamBuffer` ratchet) so it can share the IRR inference step with the now always-streaming-capable translator without tripping the per-step build check. The single `web-search-chat-completions.yaml` example serves both finite and streaming requests via `openai_stream_events(logical_stream: true)`, which is a no-op on finite, non-SSE responses.

## Related issue

Closes #986

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis --lib -- responses_to_chat_completions file_search_callout`
- [x] Integration or functional tests — `cargo test -p praxis-tests-integration --test suite examples::web_search_chat_completions` (5 tests) + live vLLM SDK `test_web_search_streams_terminal_round_as_one_logical_response`
- [x] `make lint` (and `make build`)

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None.
