### PR TITLE
perf(responses-streaming): remove avoidable accumulator clones

### DIFF
--- a/apis/src/openai/responses/stream_events/accumulator.rs
+++ b/apis/src/openai/responses/stream_events/accumulator.rs
@@ -9,6 +9,8 @@
 //! (`output_item.added`, `function_call_arguments.done`) provide
 //! fallback state in case the terminal event is missing.
 
+use std::collections::hash_map::Entry;
+
 use praxis_filter::HttpFilterContext;
 use serde_json::Value;
 use tracing::{debug, warn};
@@ -99,7 +101,6 @@ pub(super) fn accumulate_response_object(
             object.insert("usage".to_owned(), state.usage.clone());
         }
         if let Some(Value::Array(output)) = response.get("output") {
-            state.output_items_mut().clone_from(output);
             replace_completed_tool_calls(state, output);
         }
         state.response_object = response;
@@ -177,18 +178,35 @@ fn handle_function_call_delta(filter_state: &mut StreamEventsState, payload: &Va
         return;
     }
 
-    let buf = filter_state.tool_call_args.entry(key.clone()).or_default();
-    if buf.len().saturating_add(delta.len()) > filter_state.max_tool_call_argument_bytes {
-        warn!(
-            key,
-            limit = filter_state.max_tool_call_argument_bytes,
-            "accumulated tool-call arguments exceed max_tool_call_argument_bytes, dropping"
-        );
-        filter_state.tool_call_args.remove(&key);
-        filter_state.rejected_tool_call_args.insert(key);
-        return;
+    let limit = filter_state.max_tool_call_argument_bytes;
+    match filter_state.tool_call_args.entry(key) {
+        Entry::Occupied(mut occupied) => {
+            if occupied.get().len().saturating_add(delta.len()) > limit {
+                let key = occupied.remove_entry().0;
+                reject_overflowing_tool_call(filter_state, key);
+                return;
+            }
+            occupied.get_mut().push_str(delta);
+        },
+        Entry::Vacant(vacant) => {
+            if delta.len() > limit {
+                let key = vacant.into_key();
+                reject_overflowing_tool_call(filter_state, key);
+                return;
+            }
+            vacant.insert(delta.to_owned());
+        },
     }
-    buf.push_str(delta);
+}
+
+/// Drop an overflowing argument buffer and reject every later event for `key`.
+fn reject_overflowing_tool_call(filter_state: &mut StreamEventsState, key: String) {
+    warn!(
+        key,
+        limit = filter_state.max_tool_call_argument_bytes,
+        "accumulated tool-call arguments exceed max_tool_call_argument_bytes, dropping"
+    );
+    filter_state.rejected_tool_call_args.insert(key);
 }
 
 /// Finalize a function call from the done event's payload and push to `tool_calls`.
@@ -319,7 +337,7 @@ fn upsert_tool_call(tool_calls: &mut Vec<Value>, tool_call: Value) {
         let existing_call_id = existing.get("call_id").and_then(Value::as_str);
         id.is_some_and(|id| existing_id == Some(id)) || call_id.is_some_and(|call_id| existing_call_id == Some(call_id))
     }) {
-        tool_call.clone_into(existing);
+        *existing = tool_call;
         return;
     }
 


### PR DESCRIPTION
## Summary

Remove three avoidable clones from Responses streaming accumulation. Output state, usage, and tool-argument overflow behavior are unchanged.

- Drop the terminal `response.output` clone that `state.response_object = response` immediately overwrote.
- Move function-call keys through the HashMap `Entry` API on accepted delta events.
- Assign the owned tool-call value in `upsert_tool_call` instead of `clone_into`.

## Related issue

Closes #901

## Validation

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

Covered by existing stream accumulator tests: completed output/usage, overflowing tool-call keys stay rejected, oversized done payloads reject before mutation, and output-item replace/append. `cargo test -p praxis-ai-apis -- stream_events` (58 passed) and `cargo clippy -p praxis-ai-apis --all-targets -- -D warnings` passed. Workspace `make test` passed aside from an unrelated xtask fixture timeout that passed on rerun.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.