### PR TITLE
fix(validate): reject conflicting history selectors

### DIFF
--- a/apis/src/openai/responses/error.rs
+++ b/apis/src/openai/responses/error.rs
@@ -17,11 +17,16 @@ use praxis_filter::Rejection;
 ///
 /// Produces `{"error":{"message":"<msg>","type":"<code>","param":null,"code":"<code>"}}`.
 pub(crate) fn responses_error_body(code: &str, message: &str) -> Bytes {
+    responses_error_body_with_code(code, code, message)
+}
+
+/// Build a non-streaming OpenAI API error JSON body with distinct type and code.
+fn responses_error_body_with_code(error_type: &str, code: &str, message: &str) -> Bytes {
     Bytes::from(
         serde_json::json!({
             "error": {
                 "message": message,
-                "type": code,
+                "type": error_type,
                 "param": null,
                 "code": code,
             },
@@ -77,9 +82,19 @@ fn responses_error_sse_payload_at_sequence(code: &str, message: &str, sequence_n
 /// emitted by the `stream_events` filter, not here. Every rejection therefore
 /// uses `application/json`.
 pub(crate) fn responses_error_rejection(status: u16, code: &str, message: &str) -> Rejection {
+    responses_error_rejection_with_code(status, code, code, message)
+}
+
+/// Build a [`Rejection`] with distinct OpenAI error type and code values.
+pub(crate) fn responses_error_rejection_with_code(
+    status: u16,
+    error_type: &str,
+    code: &str,
+    message: &str,
+) -> Rejection {
     Rejection::status(status)
         .with_header("content-type", "application/json")
-        .with_body(responses_error_body(code, message))
+        .with_body(responses_error_body_with_code(error_type, code, message))
 }
 
 // -----------------------------------------------------------------------------
@@ -113,6 +128,27 @@ mod tests {
         );
         assert_eq!(parsed["error"]["message"], "bad input", "message field should match");
         assert!(parsed["error"]["param"].is_null(), "param should be null");
+    }
+
+    #[test]
+    fn rejection_supports_distinct_error_type_and_code() {
+        let rejection = responses_error_rejection_with_code(
+            400,
+            "invalid_request_error",
+            "mutually_exclusive_parameters",
+            "bad input",
+        );
+        let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+
+        assert_eq!(
+            body["error"]["type"], "invalid_request_error",
+            "error type should match"
+        );
+        assert_eq!(
+            body["error"]["code"], "mutually_exclusive_parameters",
+            "error code should match"
+        );
+        assert!(body["error"]["param"].is_null(), "param should be null");
     }
 
     #[test]

--- a/apis/src/openai/responses/mod.rs
+++ b/apis/src/openai/responses/mod.rs
@@ -19,8 +19,9 @@
 //! request body.
 //!
 //! The `openai_responses_validate` filter runs after the classifier
-//! to validate JSON syntax and extract additional fields without
-//! rejecting provider-owned parameter combinations.
+//! to validate JSON syntax, reject conflicting history selectors, and
+//! extract additional fields without rejecting provider-owned parameter
+//! combinations.
 
 pub(crate) mod agentic_loop;
 mod body_limits;

--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -120,8 +120,8 @@ impl RehydrateFilter {
     /// `conversation`), and populate [`ResponsesState`] with the full
     /// conversation history.
     ///
-    /// `previous_response_id` takes precedence when both fields are
-    /// present.
+    /// The upstream `openai_responses_validate` filter rejects requests that
+    /// supply both selectors; the resolution order here is a silent fallback.
     async fn rehydrate(
         &self,
         ctx: &mut HttpFilterContext<'_>,

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -1513,58 +1513,6 @@ async fn rehydrates_from_conversation_object_form() {
 }
 
 #[tokio::test]
-async fn previous_response_id_takes_precedence_over_conversation() {
-    let response_messages = json!([
-        {"role": "user", "content": "from response"},
-        {"role": "assistant", "content": "response reply"}
-    ]);
-    let mut store = MockStore::with_completed_response("resp_win", json!("from response"), response_messages);
-    store.conversations.insert(
-        "conv_lose".to_owned(),
-        ConversationRecord {
-            conversation_id: "conv_lose".to_owned(),
-            tenant_id: "default".to_owned(),
-            created_at: 1000,
-            metadata: json!({}),
-            messages: json!([
-                {"role": "user", "content": "from conversation"},
-                {"role": "assistant", "content": "conversation reply"}
-            ]),
-        },
-    );
-    let registry = setup_registry(store);
-
-    let filter = default_filter();
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(
-        r#"{"model":"gpt-4.1","input":"next","previous_response_id":"resp_win","conversation":"conv_lose"}"#,
-    ));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    assert!(
-        matches!(action, FilterAction::Release),
-        "should release after rehydration"
-    );
-
-    let state = ctx
-        .extensions
-        .get::<ResponsesState>()
-        .expect("ResponsesState should be populated");
-    assert_eq!(
-        state.messages[0]["content"], "from response",
-        "previous_response_id should take precedence over conversation"
-    );
-    assert_eq!(
-        ctx.get_metadata("responses.previous_response_id"),
-        Some("resp_win"),
-        "previous_response_id metadata should be set"
-    );
-}
-
-#[tokio::test]
 async fn rejects_when_conversation_not_found() {
     let store = MockStore::empty();
     let registry = setup_registry(store);

--- a/apis/src/openai/responses/validate/mod.rs
+++ b/apis/src/openai/responses/validate/mod.rs
@@ -10,9 +10,9 @@
 //! `openai_responses_format.*` metadata.
 //!
 //! This filter validates that the body is JSON, then does targeted field
-//! extraction for `conversation.id`. It does **not** deserialize the full
-//! body into a typed struct or validate provider-owned parameter
-//! combinations.
+//! extraction for `conversation.id` and mutually exclusive history
+//! selectors. It does **not** deserialize the full body into a typed
+//! struct or validate provider-owned parameter combinations.
 //!
 //! # YAML
 //!
@@ -29,7 +29,11 @@ use praxis_filter::{
 };
 use tracing::{debug, trace};
 
-use super::{error::responses_error_rejection, extract_conversation_id, state::ResponsesState};
+use super::{
+    error::{responses_error_rejection, responses_error_rejection_with_code},
+    extract_conversation_id,
+    state::ResponsesState,
+};
 
 // -----------------------------------------------------------------------------
 // OpenaiResponsesValidateFilter
@@ -104,11 +108,7 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
         }
 
         if is_bodyless_responses_request(&ctx.request.method, ctx.request.uri.path()) {
-            trace!(
-                method = %ctx.request.method,
-                path = ctx.request.uri.path(),
-                "skipping validation for bodyless endpoint"
-            );
+            trace!(method = %ctx.request.method, path = ctx.request.uri.path(), "skipping validation for bodyless endpoint");
             return Ok(FilterAction::Release);
         }
 
@@ -116,6 +116,9 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
             Ok(v) => v,
             Err(action) => return Ok(action),
         };
+        if let Some(action) = reject_conflicting_history_selectors(&parsed) {
+            return Ok(action);
+        }
 
         let response_id = format!("resp_{}", ctx.id_generator.generate(ctx.time_source));
         let conversation_id = resolve_conversation_id(ctx, &parsed);
@@ -158,6 +161,20 @@ fn parse_request_body(body: &Option<Bytes>) -> Result<serde_json::Value, FilterA
             Err(reject_invalid(&format!("invalid request body: {e}")))
         },
     }
+}
+
+/// Reject requests that select both supported sources of conversation history.
+fn reject_conflicting_history_selectors(body: &serde_json::Value) -> Option<FilterAction> {
+    let conflicts = body.get("previous_response_id").is_some_and(|value| !value.is_null())
+        && body.get("conversation").is_some_and(|value| !value.is_null());
+    conflicts.then(|| {
+        FilterAction::Reject(responses_error_rejection_with_code(
+            400,
+            "invalid_request_error",
+            "mutually_exclusive_parameters",
+            "Mutually exclusive parameters. Ensure you are only providing one of: 'previous_response_id' or 'conversation'.",
+        ))
+    })
 }
 
 /// Check whether a Responses endpoint has no JSON request body to validate.
@@ -376,6 +393,46 @@ mod tests {
             Some("conv_existing_123"),
             "bare-string conversation ID should be extracted from request body"
         );
+    }
+
+    #[tokio::test]
+    async fn rejects_conflicting_history_selectors() {
+        let action = run_filter_raw(
+            r#"{"input":"next","previous_response_id":"resp_win","conversation":"conv_lose"}"#,
+            &[],
+        )
+        .await;
+        let FilterAction::Reject(rejection) = action else {
+            panic!("expected rejection");
+        };
+        assert_eq!(rejection.status, 400);
+        let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], "mutually_exclusive_parameters");
+        assert_eq!(
+            body["error"]["message"],
+            "Mutually exclusive parameters. Ensure you are only providing one of: 'previous_response_id' or 'conversation'."
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_selector_conflict_uses_json_validation_error() {
+        let action = run_filter_raw(
+            r#"{"input":"next","previous_response_id":"resp_win","conversation":"conv_lose","stream":true}"#,
+            &[("openai_responses_format.stream", "true")],
+        )
+        .await;
+        let FilterAction::Reject(rejection) = action else {
+            panic!("expected rejection");
+        };
+        assert_eq!(rejection.status, 400);
+        assert_eq!(
+            rejection.headers.iter().find(|(name, _)| name == "content-type"),
+            Some(&("content-type".to_owned(), "application/json".to_owned()))
+        );
+        let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], "mutually_exclusive_parameters");
     }
 
     #[tokio::test]

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -1355,6 +1355,29 @@ class TestOpenAIResponsesVLLM:
             f"previous_response_id; got: {lifecycle_previous_ids}"
         )
 
+    @pytest.mark.parametrize("stream", [False, True], ids=["buffered", "streaming"])
+    def test_conflicting_history_selectors_error_shape(self, openai_client, stream):
+        with pytest.raises(BadRequestError) as exc_info:
+            openai_client.responses.create(
+                model=VLLM_MODEL,
+                input="next",
+                previous_response_id="resp_previous",
+                conversation="conv_existing",
+                stream=stream,
+            )
+
+        error = exc_info.value
+        assert error.status_code == 400
+        assert error.body == {
+            "code": "mutually_exclusive_parameters",
+            "message": (
+                "Mutually exclusive parameters. Ensure you are only providing "
+                "one of: 'previous_response_id' or 'conversation'."
+            ),
+            "param": None,
+            "type": "invalid_request_error",
+        }
+
     def test_doc_extract_inline_file_to(self, openai_client):
         """Issue #397: inline file_data is extracted to input_text and
         consumed by vLLM inference.

--- a/tests/integration/tests/suite/conversations_rehydrate.rs
+++ b/tests/integration/tests/suite/conversations_rehydrate.rs
@@ -88,7 +88,7 @@ async fn rehydrates_from_conversation_object_form() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn previous_response_id_takes_precedence_over_conversation() {
+async fn rejects_conflicting_history_selectors() {
     let (proxy, _backend, _db) = start_test_env();
 
     let conv_id = create_conversation(
@@ -109,10 +109,16 @@ async fn previous_response_id_takes_precedence_over_conversation() {
         &json_post("/v1/responses", &serde_json::to_string(&body).unwrap()),
     );
 
-    let status = parse_status(&raw);
-    assert!(
-        status == 400 || status == 404,
-        "should reject with error when previous_response_id is invalid (got {status})"
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "conflicting history selectors should be rejected"
+    );
+    let error: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(error["error"]["type"], "invalid_request_error");
+    assert_eq!(
+        error["error"]["message"],
+        "Mutually exclusive parameters. Ensure you are only providing one of: 'previous_response_id' or 'conversation'."
     );
 }
 


### PR DESCRIPTION
Reject Responses API requests that provide both previous_response_id and conversation instead of silently prioritizing one history source. Return the OpenAI-compatible invalid-request JSON error for both streaming and non-streaming requests.

Fixes: #840