### PR TITLE
perf(responses-streaming): avoid logical-stream payload copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocation-counter"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb9e990c0a33699f1984d85a6abead615ccc72dd8130bf3e15dcabe2ca149c9"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2848,7 @@ dependencies = [
 name = "praxis-ai-apis"
 version = "0.3.0"
 dependencies = [
+ "allocation-counter",
  "async-trait",
  "axum",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 utoipa = "5.5.0"
 wiremock = "0.6.5"
+allocation-counter = "0.8.1"
 prost = "0.14.4"
 prost-build = "0.14.4"
 prost-types = "0.14.4"

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -47,6 +47,7 @@ url = { workspace = true }
 utoipa = { workspace = true }
 
 [dev-dependencies]
+allocation-counter = { workspace = true }
 axum = { workspace = true }
 rmcp = { workspace = true, features = ["server", "macros", "transport-streamable-http-server"] }
 schemars = { workspace = true }

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -360,7 +360,7 @@ fn parse_and_accumulate(
         record_completion(state, &event, now)?;
         accumulate_event(ctx, state, &event);
         if state.logical_stream {
-            append_logical_event(state, ctx, &event, &mut logical_output);
+            append_logical_event(state, ctx, event, &mut logical_output);
         }
     }
 
@@ -374,13 +374,14 @@ fn parse_and_accumulate(
 fn append_logical_event(
     state: &mut StreamEventsState,
     ctx: &mut HttpFilterContext<'_>,
-    event: &ResponsesEvent,
+    event: ResponsesEvent,
     output: &mut Vec<u8>,
 ) {
     if event.is_terminal() {
+        let event_type = event.event_type().to_owned();
         state.deferred_terminal = Some(DeferredTerminalEvent {
-            event_type: event.event_type().to_owned(),
-            payload: event.payload().clone(),
+            event_type,
+            payload: event.into_payload(),
         });
         return;
     }
@@ -395,9 +396,10 @@ fn append_logical_event(
         return;
     }
 
-    let mut payload = event.payload().clone();
+    let event_type = event.event_type().to_owned();
+    let mut payload = event.into_payload();
     normalize_logical_payload(ctx, &mut payload, state.output_index_offset);
-    encode_sse_event(event.event_type(), &payload, output);
+    encode_sse_event(&event_type, &payload, output);
 }
 
 /// Normalize response identity, sequence numbers, and output indices.
@@ -446,7 +448,11 @@ fn encode_sse_event(event_type: &str, payload: &Value, output: &mut Vec<u8>) {
     output.extend_from_slice(b"event: ");
     output.extend_from_slice(event_type.as_bytes());
     output.extend_from_slice(b"\ndata: ");
-    output.extend_from_slice(payload.to_string().as_bytes());
+    // Serialize into the output buffer so logical-stream emission does not
+    // allocate an intermediate `String` via `Display`.
+    if let Err(error) = serde_json::to_writer(&mut *output, payload) {
+        debug!(%error, "logical-stream payload serialization failed");
+    }
     output.extend_from_slice(b"\n\n");
 }
 

--- a/apis/src/openai/responses/stream_events/mod.rs
+++ b/apis/src/openai/responses/stream_events/mod.rs
@@ -449,11 +449,25 @@ fn encode_sse_event(event_type: &str, payload: &Value, output: &mut Vec<u8>) {
     output.extend_from_slice(event_type.as_bytes());
     output.extend_from_slice(b"\ndata: ");
     // Serialize into the output buffer so logical-stream emission does not
-    // allocate an intermediate `String` via `Display`.
-    if let Err(error) = serde_json::to_writer(&mut *output, payload) {
+    // allocate an intermediate `String` via `Display`. Truncate on failure so
+    // a partial JSON write cannot be followed by the SSE delimiter.
+    if let Err(error) = write_json_or_rollback(output, |out| serde_json::to_writer(out, payload)) {
         debug!(%error, "logical-stream payload serialization failed");
+        return;
     }
     output.extend_from_slice(b"\n\n");
+}
+
+/// Write into `output`, restoring the pre-write length if `write` fails.
+fn write_json_or_rollback<E>(output: &mut Vec<u8>, write: impl FnOnce(&mut Vec<u8>) -> Result<(), E>) -> Result<(), E> {
+    let start = output.len();
+    match write(output) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            output.truncate(start);
+            Err(error)
+        },
+    }
 }
 
 /// Emit the held terminal event only when the current IRR step is terminal.

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -829,6 +829,105 @@ fn encode_sse_event_writes_compact_json_directly_into_output() {
     );
 }
 
+/// Previous logical-stream encoder: compact JSON through an intermediate `String`.
+fn encode_sse_event_with_intermediate_string(event_type: &str, payload: &serde_json::Value, output: &mut Vec<u8>) {
+    output.extend_from_slice(b"event: ");
+    output.extend_from_slice(event_type.as_bytes());
+    output.extend_from_slice(b"\ndata: ");
+    let json = serde_json::to_string(payload).unwrap();
+    output.extend_from_slice(json.as_bytes());
+    output.extend_from_slice(b"\n\n");
+}
+
+fn large_delta_payload() -> serde_json::Value {
+    json!({
+        "type": "response.output_text.delta",
+        "delta": "α".repeat(4096),
+        "sequence_number": 12,
+        "response_id": "resp_logical",
+        "output_index": 3
+    })
+}
+
+fn large_completed_payload() -> serde_json::Value {
+    json!({
+        "type": "response.completed",
+        "sequence_number": 99,
+        "response": {
+            "id": "resp_logical",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "α".repeat(4096)}]
+            }]
+        }
+    })
+}
+
+fn assert_writer_allocates_less_than_string(event_type: &str, payload: &serde_json::Value) {
+    let capacity = serde_json::to_vec(payload).unwrap().len() + 64;
+    let mut via_writer = Vec::with_capacity(capacity);
+    let mut via_string = Vec::with_capacity(capacity);
+    let writer = allocation_counter::measure(|| {
+        super::encode_sse_event(event_type, payload, &mut via_writer);
+    });
+    let string = allocation_counter::measure(|| {
+        encode_sse_event_with_intermediate_string(event_type, payload, &mut via_string);
+    });
+    assert_eq!(
+        via_writer, via_string,
+        "{event_type} SSE bytes must stay equivalent while measuring allocations"
+    );
+    assert!(
+        writer.bytes_total < string.bytes_total,
+        "{event_type} to_writer must allocate fewer bytes than to_string: writer={} string={}",
+        writer.bytes_total,
+        string.bytes_total
+    );
+    assert!(
+        writer.count_total < string.count_total,
+        "{event_type} to_writer must allocate fewer times than to_string: writer={} string={}",
+        writer.count_total,
+        string.count_total
+    );
+}
+
+#[test]
+fn encode_sse_event_allocates_less_than_intermediate_string_for_ordinary_and_deferred_terminal() {
+    assert_writer_allocates_less_than_string("response.output_text.delta", &large_delta_payload());
+    assert_writer_allocates_less_than_string("response.completed", &large_completed_payload());
+}
+
+#[test]
+fn deferred_terminal_stores_moved_payload_without_deep_clone() {
+    let cloned = large_completed_payload();
+    let moved = large_completed_payload();
+    let clone_info = allocation_counter::measure(|| {
+        std::hint::black_box(super::DeferredTerminalEvent {
+            event_type: "response.completed".to_owned(),
+            payload: cloned.clone(),
+        });
+    });
+    let move_info = allocation_counter::measure(|| {
+        std::hint::black_box(super::DeferredTerminalEvent {
+            event_type: "response.completed".to_owned(),
+            payload: moved,
+        });
+    });
+    assert!(
+        clone_info.bytes_total >= 4096,
+        "deferred-terminal clone must copy the completed output text, allocated {}",
+        clone_info.bytes_total
+    );
+    assert!(
+        move_info.bytes_total < clone_info.bytes_total,
+        "deferred-terminal store must move the payload: clone={} move={}",
+        clone_info.bytes_total,
+        move_info.bytes_total
+    );
+}
+
 #[test]
 fn body_passes_through_unchanged() {
     let (filter, mut ctx) = make_armed_context();

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -829,6 +829,35 @@ fn encode_sse_event_writes_compact_json_directly_into_output() {
     );
 }
 
+#[test]
+fn write_json_or_rollback_discards_partial_bytes_on_failure() {
+    let mut output = b"event: response.failed\ndata: ".to_vec();
+    let prefix = output.clone();
+    let result = super::write_json_or_rollback(&mut output, |out| {
+        out.extend_from_slice(br#"{"type":"response.failed""#);
+        Err(std::io::Error::other("injected write failure"))
+    });
+    assert!(
+        result.is_err(),
+        "injected failure must surface so encode_sse_event can skip the SSE delimiter"
+    );
+    let err = result.unwrap_err();
+
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::Other,
+        "rollback must preserve the original write error"
+    );
+    assert_eq!(
+        output, prefix,
+        "a failed payload write must not leave partial JSON in the SSE buffer"
+    );
+    assert!(
+        !output.windows(2).any(|window| window == b"\n\n"),
+        "encode_sse_event must return before appending the SSE delimiter"
+    );
+}
+
 /// Previous logical-stream encoder: compact JSON through an intermediate `String`.
 fn encode_sse_event_with_intermediate_string(event_type: &str, payload: &serde_json::Value, output: &mut Vec<u8>) {
     output.extend_from_slice(b"event: ");

--- a/apis/src/openai/responses/stream_events/tests.rs
+++ b/apis/src/openai/responses/stream_events/tests.rs
@@ -793,6 +793,43 @@ async fn logical_eos_without_terminal_emits_error() {
 }
 
 #[test]
+fn encode_sse_event_writes_compact_json_directly_into_output() {
+    let payload = json!({
+        "type": "response.output_text.delta",
+        "delta": "α".repeat(2048),
+        "sequence_number": 12,
+        "response_id": "resp_logical",
+        "output_index": 3
+    });
+    let json_bytes = serde_json::to_vec(&payload).unwrap();
+    let mut output = Vec::new();
+    super::encode_sse_event("response.output_text.delta", &payload, &mut output);
+
+    let prefix = b"event: response.output_text.delta\ndata: ";
+    let suffix = b"\n\n";
+    assert_eq!(
+        output.len(),
+        prefix.len() + json_bytes.len() + suffix.len(),
+        "logical-stream SSE must be framing plus compact JSON with no intermediate String"
+    );
+    assert_eq!(
+        &output[..prefix.len()],
+        prefix.as_slice(),
+        "SSE event name and data delimiter must be unchanged"
+    );
+    assert_eq!(
+        &output[prefix.len()..prefix.len() + json_bytes.len()],
+        json_bytes.as_slice(),
+        "payload JSON must be written with to_writer compact encoding"
+    );
+    assert_eq!(
+        &output[output.len() - suffix.len()..],
+        suffix.as_slice(),
+        "SSE event delimiter must remain a trailing blank line"
+    );
+}
+
+#[test]
 fn body_passes_through_unchanged() {
     let (filter, mut ctx) = make_armed_context();
     ctx.insert_filter_state(StreamEventsState {

--- a/apis/src/openai/sse/responses/event.rs
+++ b/apis/src/openai/sse/responses/event.rs
@@ -187,6 +187,37 @@ impl ResponsesEvent {
         }
     }
 
+    /// Take ownership of the JSON payload after read-only consumers are done.
+    pub fn into_payload(self) -> Value {
+        match self {
+            Self::ResponseCreated(payload)
+            | Self::ResponseQueued(payload)
+            | Self::ResponseInProgress(payload)
+            | Self::ResponseCompleted(payload)
+            | Self::ResponseIncomplete(payload)
+            | Self::ResponseFailed(payload)
+            | Self::OutputItemAdded(payload)
+            | Self::OutputItemDone(payload)
+            | Self::ContentPartAdded(payload)
+            | Self::ContentPartDone(payload)
+            | Self::OutputTextDelta(payload)
+            | Self::OutputTextDone(payload)
+            | Self::OutputTextAnnotationAdded(payload)
+            | Self::FunctionCallArgumentsDelta(payload)
+            | Self::FunctionCallArgumentsDone(payload)
+            | Self::RefusalDelta(payload)
+            | Self::RefusalDone(payload)
+            | Self::ReasoningDelta(payload)
+            | Self::ReasoningDone(payload)
+            | Self::ReasoningSummaryTextDelta(payload)
+            | Self::ReasoningSummaryTextDone(payload)
+            | Self::ReasoningSummaryPartAdded(payload)
+            | Self::ReasoningSummaryPartDone(payload)
+            | Self::Error(payload)
+            | Self::Unknown { data: payload, .. } => payload,
+        }
+    }
+
     /// Return the event type string.
     pub fn event_type(&self) -> &str {
         match self {
@@ -555,6 +586,18 @@ mod tests {
                 "event_type() should roundtrip for '{event_type}'"
             );
         }
+    }
+
+    #[test]
+    fn into_payload_moves_owned_json() {
+        let data = json!({"id": "resp_1", "delta": "hello"});
+        let event = ResponsesEvent::from_event_type("response.output_text.delta", data.clone());
+        assert_eq!(event.payload(), &data, "payload() should borrow the owned JSON");
+        assert_eq!(
+            event.into_payload(),
+            data,
+            "into_payload() should move the JSON without cloning it first"
+        );
     }
 
     #[test]

--- a/apis/src/openai/sse/responses/event.rs
+++ b/apis/src/openai/sse/responses/event.rs
@@ -590,13 +590,33 @@ mod tests {
 
     #[test]
     fn into_payload_moves_owned_json() {
-        let data = json!({"id": "resp_1", "delta": "hello"});
-        let event = ResponsesEvent::from_event_type("response.output_text.delta", data.clone());
-        assert_eq!(event.payload(), &data, "payload() should borrow the owned JSON");
+        let data = json!({"id": "resp_1", "delta": "x".repeat(4096)});
+        let borrowed = ResponsesEvent::from_event_type("response.output_text.delta", data.clone());
+        assert_eq!(borrowed.payload(), &data, "payload() should borrow the owned JSON");
+
+        let clone_event = ResponsesEvent::from_event_type("response.output_text.delta", data.clone());
+        let move_event = ResponsesEvent::from_event_type("response.output_text.delta", data.clone());
+        let clone_info = allocation_counter::measure(|| {
+            std::hint::black_box(clone_event.payload().clone());
+        });
+        let move_info = allocation_counter::measure(|| {
+            std::hint::black_box(move_event.into_payload());
+        });
+        assert!(
+            clone_info.bytes_total >= 4096,
+            "payload().clone() must deep-copy the delta string, allocated {}",
+            clone_info.bytes_total
+        );
+        assert!(
+            move_info.bytes_total < clone_info.bytes_total,
+            "into_payload() must move the JSON: clone={} bytes, move={} bytes",
+            clone_info.bytes_total,
+            move_info.bytes_total
+        );
         assert_eq!(
-            event.into_payload(),
+            ResponsesEvent::from_event_type("response.output_text.delta", data.clone()).into_payload(),
             data,
-            "into_payload() should move the JSON without cloning it first"
+            "into_payload() should yield the original JSON value"
         );
     }
 


### PR DESCRIPTION
## Summary

Reduce avoidable payload copies on the OpenAI Responses logical-stream path. Ordinary pass-through streaming is unchanged.

- Move the event payload into logical-stream normalization after completion and accumulator consumers finish, instead of deep-cloning the JSON value.
- Move deferred terminal payloads into filter state instead of cloning them.
- Serialize normalized payloads with `serde_json::to_writer` directly into the output `Vec<u8>` instead of allocating an intermediate `String`.

Event names, ordering, JSON payloads, sequence numbers, response IDs, output-index offsets, and SSE delimiters are unchanged. Continuation rounds still suppress repeated lifecycle events and emit the terminal only on the terminal round. No complete response buffering is introduced.

## Related issue

Closes #966

## Validation

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

Covered by existing Responses stream-event and agentic-loop tests, plus `into_payload_moves_owned_json` and `encode_sse_event_writes_compact_json_directly_into_output` (framing + compact JSON written into the output buffer). `make test` passed. `cargo clippy -p praxis-ai-apis --all-targets -- -D warnings` passed.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.