### PR TITLE
perf(conversations): move response output items during append-back

### DIFF
--- a/apis/src/openai/conversations/filter.rs
+++ b/apis/src/openai/conversations/filter.rs
@@ -580,7 +580,7 @@ fn extract_append_back_items(ctx: &HttpFilterContext<'_>, body: &Option<Bytes>) 
 /// Parse the response body and combine request input items with
 /// response output items. Returns `None` when both are empty.
 fn merge_input_output_items(ctx: &HttpFilterContext<'_>, bytes: &[u8]) -> Option<Vec<Value>> {
-    let response_json: Value = match serde_json::from_slice(bytes) {
+    let mut response_json: Value = match serde_json::from_slice(bytes) {
         Ok(v) => v,
         Err(e) => {
             warn!(error = %e, "conversation append-back: invalid response JSON");
@@ -588,17 +588,18 @@ fn merge_input_output_items(ctx: &HttpFilterContext<'_>, bytes: &[u8]) -> Option
         },
     };
 
-    let status = response_json.get("status").and_then(Value::as_str).unwrap_or_default();
-    if status != "completed" {
-        trace!(status, "conversation append-back skipped (response not completed)");
-        return None;
+    {
+        let status = response_json.get("status").and_then(Value::as_str).unwrap_or_default();
+        if status != "completed" {
+            trace!(status, "conversation append-back skipped (response not completed)");
+            return None;
+        }
     }
 
-    let output_items = response_json
-        .get("output")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
+    let output_items = match response_json.get_mut("output").map(Value::take) {
+        Some(Value::Array(items)) => items,
+        _ => Vec::new(),
+    };
 
     let input_items = ctx
         .extensions

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -3427,7 +3427,7 @@ async fn on_response_body_appends_completed_response() {
         "content": "hello from append"
     })];
     ctx.extensions.insert(ResponsesState {
-        input: input_items,
+        input: input_items.clone(),
         ..ResponsesState::default()
     });
 
@@ -3446,6 +3446,11 @@ async fn on_response_body_appends_completed_response() {
     let mut body = Some(Bytes::from(serde_json::to_vec(&response_json).unwrap()));
     let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
     assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.extensions.get::<ResponsesState>().map(|state| state.input.as_slice()),
+        Some(input_items.as_slice()),
+        "append-back must clone ResponsesState.input without taking or clearing it"
+    );
 
     let req = make_request(Method::GET, &format!("/v1/conversations/{conv_id}/items?order=asc"));
     let mut ctx = make_filter_context(&req);
@@ -3457,6 +3462,22 @@ async fn on_response_body_appends_completed_response() {
     let resp = rejection_body(&rejection);
     let items = resp["data"].as_array().unwrap();
     assert_eq!(items.len(), 2, "append-back should persist both input and output items");
+    assert_eq!(
+        items[0]["role"], "user",
+        "request input items must be persisted before response output"
+    );
+    assert_eq!(
+        items[0]["content"][0]["text"], "hello from append",
+        "original request input text must be unchanged"
+    );
+    assert_eq!(
+        items[1]["role"], "assistant",
+        "response output items must follow request input"
+    );
+    assert_eq!(
+        items[1]["content"][0]["text"], "hi from model",
+        "moved response output text must be unchanged"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/apis/src/openai/conversations/tests.rs
+++ b/apis/src/openai/conversations/tests.rs
@@ -3447,7 +3447,9 @@ async fn on_response_body_appends_completed_response() {
     let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
     assert!(matches!(action, FilterAction::Continue));
     assert_eq!(
-        ctx.extensions.get::<ResponsesState>().map(|state| state.input.as_slice()),
+        ctx.extensions
+            .get::<ResponsesState>()
+            .map(|state| state.input.as_slice()),
         Some(input_items.as_slice()),
         "append-back must clone ResponsesState.input without taking or clearing it"
     );


### PR DESCRIPTION
## Summary

Move completed response output items out of the locally parsed response during conversation append-back instead of deep-cloning the output array.

After validating `status == completed`, take the `output` array from the mutable local JSON. Keep cloning `ResponsesState.input` from the shared request-context borrow; that field is not taken, cleared, or otherwise mutated.

Input then output order, skip paths (non-completed, malformed, missing/empty output), and conversation persistence / denormalized-message refresh are unchanged.

## Related issue

Closes #969

## Validation

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

Covered by focused conversation append-back tests, including `on_response_body_appends_completed_response` (input/output order and `ResponsesState.input` left intact). `make test` passed. `cargo clippy -p praxis-ai-apis --all-targets -- -D warnings` passed.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.