### PR TITLE
perf(responses): remove redundant allocations on the Responses request path

### DIFF
--- a/apis/src/openai/responses/file_resolve/resolve.rs
+++ b/apis/src/openai/responses/file_resolve/resolve.rs
@@ -201,7 +201,7 @@ struct ResolutionRequest<'a> {
     /// Files API client.
     client: &'a FilesApiClient,
     /// Reference source (file ID or file URL).
-    source: ReferenceSource,
+    source: &'a ReferenceSource,
     /// Maximum resolved bytes remaining for this item collection.
     max_resolved_bytes: usize,
     /// Responses content part type.
@@ -264,7 +264,7 @@ impl ResolutionBudget {
         self.register_reference()?;
 
         let resolution = tokio::time::timeout_at(self.deadline, async {
-            match &source {
+            match source {
                 ReferenceSource::FileId(file_id) => {
                     client
                         .resolve_file(file_id, request_headers, max_resolved_bytes, part_type)
@@ -282,7 +282,7 @@ impl ResolutionBudget {
             }
         })
         .await
-        .unwrap_or_else(|_elapsed| overall_timeout_error_for_source(&source));
+        .unwrap_or_else(|_elapsed| overall_timeout_error_for_source(source));
 
         // Retain one owned outcome for repeated references while
         // returning an independently owned value to the JSON part.
@@ -652,7 +652,7 @@ async fn resolve_reference(
         .budget
         .resolve(ResolutionRequest {
             client: resolver.client,
-            source: source.clone(),
+            source,
             max_resolved_bytes: remaining_resolved_bytes,
             part_type,
             request_headers: resolver.request_headers,

--- a/apis/src/openai/responses/mcp_dispatch/mod.rs
+++ b/apis/src/openai/responses/mcp_dispatch/mod.rs
@@ -278,17 +278,13 @@ struct PendingApproval {
 // MCP Tool Call Identification
 // -----------------------------------------------------------------------------
 
-/// Extract MCP tool calls from the `tool_calls` list by checking
+/// Borrow the MCP tool calls from the `tool_calls` list by checking
 /// `mcp_tool_map`.
-fn extract_mcp_tool_calls(
-    tool_calls: &[serde_json::Value],
+fn extract_mcp_tool_calls<'a>(
+    tool_calls: &'a [serde_json::Value],
     tool_map: &HashMap<(String, String), serde_json::Value>,
-) -> Vec<serde_json::Value> {
-    tool_calls
-        .iter()
-        .filter(|tc| is_mcp_tool_call(tc, tool_map))
-        .cloned()
-        .collect()
+) -> Vec<&'a serde_json::Value> {
+    tool_calls.iter().filter(|tc| is_mcp_tool_call(tc, tool_map)).collect()
 }
 
 /// Check whether a tool call is an MCP tool call by matching the
@@ -331,7 +327,7 @@ fn find_by_encoded_name<'a>(
 /// first tool call that requires approval, or `None` if all are
 /// approved.
 fn find_approval_required(
-    mcp_calls: &[serde_json::Value],
+    mcp_calls: &[&serde_json::Value],
     tool_map: &HashMap<(String, String), serde_json::Value>,
 ) -> Option<PendingApproval> {
     mcp_calls.iter().find_map(|tc| check_single_approval(tc, tool_map))
@@ -441,7 +437,7 @@ struct McpCallResult {
 /// Execute MCP tool calls — concurrently when `parallel` is true,
 /// sequentially otherwise.
 async fn execute_mcp_calls(
-    mcp_calls: &[serde_json::Value],
+    mcp_calls: &[&serde_json::Value],
     tool_map: &std::sync::Arc<HashMap<(String, String), serde_json::Value>>,
     parallel: bool,
     timeout: Duration,
@@ -457,7 +453,7 @@ async fn execute_mcp_calls(
 /// Execute MCP tool calls concurrently, emitting error results
 /// for any dropped or panicked tasks.
 async fn execute_parallel(
-    mcp_calls: &[serde_json::Value],
+    mcp_calls: &[&serde_json::Value],
     tool_map: &std::sync::Arc<HashMap<(String, String), serde_json::Value>>,
     timeout: Duration,
     allow_loopback: bool,
@@ -465,7 +461,7 @@ async fn execute_parallel(
     let handles: Vec<_> = mcp_calls
         .iter()
         .map(|tc| {
-            let tc = tc.clone();
+            let tc = (*tc).clone();
             let map = std::sync::Arc::clone(tool_map);
             tokio::spawn(async move { execute_single_call(&tc, &map, timeout, allow_loopback).await })
         })
@@ -493,7 +489,7 @@ async fn execute_parallel(
 /// Execute MCP tool calls sequentially, emitting error results
 /// for any calls that produce no result.
 async fn execute_sequential(
-    mcp_calls: &[serde_json::Value],
+    mcp_calls: &[&serde_json::Value],
     tool_map: &std::sync::Arc<HashMap<(String, String), serde_json::Value>>,
     timeout: Duration,
     allow_loopback: bool,
@@ -553,11 +549,9 @@ fn parse_call_arguments(
     server_label: &str,
     tool_name: &str,
 ) -> Result<(serde_json::Value, String), Box<McpCallResult>> {
-    let raw = tool_call
-        .get("arguments")
-        .cloned()
-        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-    normalize_arguments(&raw).map_err(|e| {
+    let empty = serde_json::Value::Object(serde_json::Map::new());
+    let raw = tool_call.get("arguments").unwrap_or(&empty);
+    normalize_arguments(raw).map_err(|e| {
         warn!(tool_name, error = %e, "malformed JSON in tool call arguments");
         Box::new(build_error_result(
             call_id,

--- a/apis/src/openai/responses/mcp_dispatch/tests.rs
+++ b/apis/src/openai/responses/mcp_dispatch/tests.rs
@@ -26,6 +26,12 @@ use crate::{
     test_utils::{make_filter_context, make_request},
 };
 
+/// Borrow owned test tool calls the way the filter passes them:
+/// the dispatch and approval paths take calls by reference.
+fn call_refs(calls: &[serde_json::Value]) -> Vec<&serde_json::Value> {
+    calls.iter().collect()
+}
+
 // =========================================================================
 // Approval Policy Parsing
 // =========================================================================
@@ -362,7 +368,7 @@ fn find_approval_required_returns_none_when_all_never() {
         json!({"name": "weather__get_weather", "call_id": "call_1"}),
         json!({"name": "docs__search_docs", "call_id": "call_2"}),
     ];
-    assert!(find_approval_required(&calls, &tool_map).is_none());
+    assert!(find_approval_required(&call_refs(&calls), &tool_map).is_none());
 }
 
 #[test]
@@ -372,7 +378,7 @@ fn find_approval_required_returns_first_when_absent() {
         json!({"name": "weather__get_weather", "call_id": "call_1"}),
         json!({"name": "docs__search_docs", "call_id": "call_2"}),
     ];
-    let pending = find_approval_required(&calls, &tool_map).unwrap();
+    let pending = find_approval_required(&call_refs(&calls), &tool_map).unwrap();
     assert_eq!(pending.tool_name, "get_weather");
 }
 
@@ -390,7 +396,7 @@ fn find_approval_required_returns_first_requiring() {
         json!({"name": "weather__get_weather", "call_id": "call_1"}),
         json!({"name": "docs__search_docs", "call_id": "call_2", "arguments": {"query": "rust"}}),
     ];
-    let pending = find_approval_required(&calls, &tool_map).unwrap();
+    let pending = find_approval_required(&call_refs(&calls), &tool_map).unwrap();
     assert_eq!(pending.tool_name, "search_docs");
     assert_eq!(pending.call_id, "call_2");
     assert_eq!(pending.server_label, "docs");
@@ -401,7 +407,7 @@ fn find_approval_required_defaults_to_approval_when_absent() {
     let tool_map = sample_tool_map();
     let calls = vec![json!({"name": "weather__get_weather", "call_id": "call_1"})];
     assert!(
-        find_approval_required(&calls, &tool_map).is_some(),
+        find_approval_required(&call_refs(&calls), &tool_map).is_some(),
         "absent require_approval should default to requiring approval"
     );
 }
@@ -410,7 +416,7 @@ fn find_approval_required_defaults_to_approval_when_absent() {
 fn find_approval_required_ambiguous_tool_requires_approval() {
     let tool_map = lossy_collision_tool_map();
     let calls = vec![json!({"name": "my_server__get", "call_id": "call_1"})];
-    let pending = find_approval_required(&calls, &tool_map);
+    let pending = find_approval_required(&call_refs(&calls), &tool_map);
     assert!(
         pending.is_some(),
         "ambiguous encoded name should require approval even when all servers say never"
@@ -647,9 +653,33 @@ fn parse_call_arguments_malformed_string_returns_error() {
 #[test]
 fn parse_call_arguments_absent_defaults_to_empty_object() {
     let tc = serde_json::json!({"name": "tool"});
-    let (args, _) = parse_call_arguments(&tc, "c1", "srv", "tool").unwrap();
+    let (args, args_str) = parse_call_arguments(&tc, "c1", "srv", "tool").unwrap();
     assert!(args.is_object());
     assert!(args.as_object().unwrap().is_empty());
+    assert_eq!(
+        args_str, "{}",
+        "absent arguments keep the canonical empty-object string"
+    );
+}
+
+#[test]
+fn parse_call_arguments_string_not_double_encoded() {
+    let tc = serde_json::json!({"name": "tool", "arguments": "{\"a\": 1}"});
+    let (_, args_str) = parse_call_arguments(&tc, "c1", "srv", "tool").unwrap();
+    assert_eq!(
+        args_str, "{\"a\": 1}",
+        "string arguments keep their original representation verbatim"
+    );
+}
+
+#[test]
+fn parse_call_arguments_malformed_string_error_keeps_raw_arguments() {
+    let tc = serde_json::json!({"name": "tool", "arguments": "not-json"});
+    let err = parse_call_arguments(&tc, "c1", "srv", "tool").unwrap_err();
+    assert_eq!(
+        err.output_item["arguments"], "not-json",
+        "the malformed raw string must survive into the error body"
+    );
 }
 
 // =========================================================================
@@ -868,7 +898,7 @@ async fn execute_mcp_calls_sequential() {
     let map = std::sync::Arc::new(sample_tool_map());
     let calls = vec![json!({"name": "weather__get_weather", "call_id": "c1", "arguments": {}})];
     let timeout = std::time::Duration::from_millis(200);
-    let results = execute_mcp_calls(&calls, &map, false, timeout, true).await;
+    let results = execute_mcp_calls(&call_refs(&calls), &map, false, timeout, true).await;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].output_item["type"], "mcp_call");
 }
@@ -878,7 +908,7 @@ async fn execute_mcp_calls_parallel() {
     let map = std::sync::Arc::new(sample_tool_map());
     let calls = vec![json!({"name": "weather__get_weather", "call_id": "c1", "arguments": {}})];
     let timeout = std::time::Duration::from_millis(200);
-    let results = execute_mcp_calls(&calls, &map, true, timeout, true).await;
+    let results = execute_mcp_calls(&call_refs(&calls), &map, true, timeout, true).await;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].output_item["type"], "mcp_call");
 }
@@ -888,7 +918,7 @@ async fn execute_mcp_calls_emits_error_for_unknown_tools() {
     let map = std::sync::Arc::new(sample_tool_map());
     let calls = vec![json!({"name": "nonexistent", "call_id": "c1"})];
     let timeout = std::time::Duration::from_millis(100);
-    let results = execute_mcp_calls(&calls, &map, false, timeout, true).await;
+    let results = execute_mcp_calls(&call_refs(&calls), &map, false, timeout, true).await;
     assert_eq!(results.len(), 1);
     assert!(results[0].output_item["error"].as_str().unwrap().contains("no result"));
 }
@@ -898,7 +928,7 @@ async fn execute_mcp_calls_emits_error_for_unknown_tool_without_call_id() {
     let map = std::sync::Arc::new(sample_tool_map());
     let calls = vec![json!({"name": "nonexistent"})];
     let timeout = std::time::Duration::from_millis(100);
-    let results = execute_mcp_calls(&calls, &map, false, timeout, true).await;
+    let results = execute_mcp_calls(&call_refs(&calls), &map, false, timeout, true).await;
     assert_eq!(results.len(), 1, "must emit error even without call_id");
     assert_eq!(results[0].output_item["id"], "unknown");
     assert!(results[0].output_item["error"].as_str().unwrap().contains("no result"));

--- a/apis/src/openai/responses/openai_tool_parse/parser.rs
+++ b/apis/src/openai/responses/openai_tool_parse/parser.rs
@@ -3,9 +3,9 @@
 
 //! Pure request body parser for tool definitions in the Responses API.
 //!
-//! Extracts tool types, function tool metadata, built-in tool
-//! configurations, and `tool_choice` from a JSON request body.
-//! No I/O, no side effects, no mutation of input bytes.
+//! Extracts tool types, built-in tool configurations, and `tool_choice`
+//! from a JSON request body. No I/O, no side effects, no mutation of
+//! input bytes.
 
 // -----------------------------------------------------------------------------
 // ToolType
@@ -33,25 +33,7 @@ pub(crate) enum ToolType {
     /// Tool entry is missing a valid discriminator.
     Unclassified,
     /// Unrecognized tool type (forwarded to inference as-is).
-    Unknown(String),
-}
-
-// -----------------------------------------------------------------------------
-// FunctionTool
-// -----------------------------------------------------------------------------
-
-/// Extracted metadata from a function tool definition.
-///
-/// Only fields the proxy needs for routing and dispatch are extracted.
-/// The full parameter schema is forwarded to inference untouched.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FunctionTool {
-    /// Tool name used for dispatch matching.
-    pub name: String,
-    /// Human-readable description (if present).
-    pub description: Option<String>,
-    /// Whether strict schema validation is requested.
-    pub strict: Option<bool>,
+    Unknown,
 }
 
 // -----------------------------------------------------------------------------
@@ -160,16 +142,10 @@ impl ToolChoice {
 #[derive(Debug)]
 #[expect(clippy::struct_excessive_bools, reason = "presence flags for each hosted tool type")]
 pub(crate) struct ParsedTools {
-    /// Extracted function tool definitions.
-    pub function_tools: Vec<FunctionTool>,
     /// Web search configuration (if a `web_search` entry is present).
     pub web_search: Option<WebSearchConfig>,
     /// File search configuration (if a `file_search` entry is present).
     pub file_search: Option<FileSearchConfig>,
-    /// Number of MCP tool entries found. Full payloads will be
-    /// extracted when the MCP tool listing filter (#43) is added.
-    ///
-    /// Until then, only the count is needed for routing/presence.
     /// Parsed `tool_choice` value.
     pub tool_choice: Option<ToolChoice>,
     /// Number of function tools.
@@ -196,7 +172,6 @@ impl ParsedTools {
     /// Build an empty result with no tools and no `tool_choice`.
     fn empty() -> Self {
         Self {
-            function_tools: Vec::new(),
             web_search: None,
             file_search: None,
             tool_choice: None,
@@ -310,16 +285,14 @@ fn classify_tools_array(tools_array: &[serde_json::Value], tool_choice: Option<T
 
 /// Classify and accumulate a single tool entry.
 ///
-/// Extracts routing-relevant details (names, configs) without
-/// cloning opaque payloads. `tool_dispatch` (#26) will add
-/// owned extraction when it needs full tool entries.
+/// Extracts only the routing-relevant configs that a consumer reads,
+/// without cloning opaque payloads. Filters needing full tool entries
+/// (`openai_mcp_tool_resolve`, `file_search_callout`) parse the body
+/// themselves and read only the promoted presence flags from here.
 fn accumulate_tool(acc: &mut ParsedTools, entry_obj: &serde_json::Map<String, serde_json::Value>) {
     match classify_tool_type(entry_obj) {
         ToolType::Function => {
             acc.function_count += 1;
-            if let Some(ft) = extract_function_tool(entry_obj) {
-                acc.function_tools.push(ft);
-            }
         },
         ToolType::WebSearch if acc.web_search.is_none() => {
             acc.web_search = Some(extract_web_search_config(entry_obj));
@@ -338,7 +311,7 @@ fn accumulate_tool(acc: &mut ParsedTools, entry_obj: &serde_json::Map<String, se
         ToolType::Mcp => {
             acc.mcp_count += 1;
         },
-        ToolType::Unknown(_) => {
+        ToolType::Unknown => {
             acc.unknown_count += 1;
         },
         ToolType::Unclassified | ToolType::WebSearch | ToolType::FileSearch => {},
@@ -383,26 +356,8 @@ fn classify_tool_type(obj: &serde_json::Map<String, serde_json::Value>) -> ToolT
         "image_generation" => ToolType::ImageGeneration,
         "tool_search" => ToolType::ToolSearch,
         "mcp" => ToolType::Mcp,
-        other => ToolType::Unknown(other.to_owned()),
+        _ => ToolType::Unknown,
     }
-}
-
-/// Extract proxy-needed fields from a function tool definition.
-fn extract_function_tool(obj: &serde_json::Map<String, serde_json::Value>) -> Option<FunctionTool> {
-    let name = obj.get("name").and_then(serde_json::Value::as_str)?.to_owned();
-
-    let description = obj
-        .get("description")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_owned);
-
-    let strict = obj.get("strict").and_then(serde_json::Value::as_bool);
-
-    Some(FunctionTool {
-        name,
-        description,
-        strict,
-    })
 }
 
 /// Extract configuration from a `web_search` tool entry.
@@ -514,18 +469,9 @@ mod tests {
         let result = parse_tools(body);
 
         assert_eq!(result.function_count, 2, "should find 2 function tools");
-        assert_eq!(result.function_tools[0].name, "get_weather", "first tool name");
-        assert_eq!(
-            result.function_tools[0].description.as_deref(),
-            Some("Get weather"),
-            "first tool description"
-        );
-        assert_eq!(result.function_tools[0].strict, Some(true), "first tool strict flag");
-        assert_eq!(result.function_tools[1].name, "send_email", "second tool name");
-        assert!(
-            result.function_tools[1].strict.is_none(),
-            "second tool should have no strict flag"
-        );
+        assert_eq!(result.builtin_count, 0, "function tools are not built-ins");
+        assert_eq!(result.mcp_count, 0, "function tools are not MCP tools");
+        assert_eq!(result.unknown_count, 0, "function tools are classified");
         assert!(result.has_tools(), "should have tools");
         assert!(!result.has_web_search(), "should not have web_search");
         assert!(!result.has_file_search(), "should not have file_search");
@@ -538,10 +484,6 @@ mod tests {
 
         assert!(result.has_tools(), "nameless function tool should still set has_tools");
         assert_eq!(result.function_count, 1, "should count the discriminator");
-        assert!(
-            result.function_tools.is_empty(),
-            "metadata not extractable without name"
-        );
     }
 
     #[test]
@@ -904,6 +846,26 @@ mod tests {
     }
 
     #[test]
+    fn distinct_unknown_tool_types_counted_separately() {
+        let body = br#"{
+            "input": "test",
+            "tools": [
+                {"type": "custom_tool"},
+                {"type": "other_tool"},
+                {"type": "custom_tool"}
+            ]
+        }"#;
+        let result = parse_tools(body);
+
+        assert_eq!(
+            result.unknown_count, 3,
+            "every unknown entry counts, including repeats of one type"
+        );
+        assert_eq!(result.function_count, 0, "unknown types are not functions");
+        assert_eq!(result.builtin_count, 0, "unknown types are not built-ins");
+    }
+
+    #[test]
     fn function_tool_missing_name() {
         let body = br#"{"input": "test", "tools": [{"type": "function", "description": "no name"}]}"#;
         let result = parse_tools(body);
@@ -911,10 +873,6 @@ mod tests {
         assert_eq!(
             result.function_count, 1,
             "discriminator should be counted even without name"
-        );
-        assert!(
-            result.function_tools.is_empty(),
-            "metadata not extractable without name"
         );
         assert!(result.has_tools(), "nameless function tool should still set has_tools");
     }


### PR DESCRIPTION
## Summary

Three allocation cleanups in `apis/src/openai/responses/`.

### `file_resolve`: borrow `ReferenceSource` through resolution

`ResolutionRequest` now holds `&'a ReferenceSource` instead of an owned copy, dropping a `source.clone()` per resolved file reference.

- `apis/src/openai/responses/file_resolve/resolve.rs`

### `openai_tool_parse`: drop unread function tool metadata

`ParsedTools::function_tools` was never read outside tests. Downstream filters (`openai_mcp_tool_resolve`, `file_search_callout`) re-parse the body and consume only the promoted presence flags. Removes the `FunctionTool` struct and its per-tool name/description allocations, and makes `ToolType::Unknown` a unit variant so the discriminator string is no longer owned just to be counted. Tool type counts and all promoted metadata are unchanged.

- `apis/src/openai/responses/openai_tool_parse/parser.rs`

### `mcp_dispatch`: avoid tool-call and argument clones

`extract_mcp_tool_calls` returns `Vec<&Value>` rather than cloning matched calls: the dispatch decision, approval checks, and sequential execution are all read-only. `parse_call_arguments` passes arguments to `normalize_arguments` by reference, so object-valued arguments are copied once.

- `apis/src/openai/responses/mcp_dispatch/mod.rs`

**Closes:**

#906 
#908 
#967 

## Validation

- [x] `cargo test -p praxis-ai-apis`
- [x] `make test`
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.
