### PR TITLE
feat(token_rate_limit): configurable estimation strategies

### DIFF
--- a/docs/filters/token_rate_limit.md
+++ b/docs/filters/token_rate_limit.md
@@ -9,7 +9,7 @@ Token-denominated rate limiter: reserves an estimated cost at admission, reconci
 
 Experimental: requires the `token-rate-limit-filter` cargo feature, which is off by default and activates the `experimental` marker. This filter delivers the agreed M1/M2/M6 milestone scope, but its parent proposal is not yet `accepted` and open questions remain (HA/clustered-Valkey failure modes, and the relationship to Kuadrant's `TokenRateLimitPolicy` -- see `ai#127`). The configuration surface may change between releases.
 
-Mirrors the `rules:`/`match:` shape from the `00121_token-rate-limiting` proposal in `praxis-proxy/enhancements`, scoped to this milestone's static header-value matchers and per-rule algorithm choice. CEL matchers, soft-limit tiers, weighted per-type accounting, and configurable estimation strategies are still out of scope (see the module doc comment) -- upstream itself defers the first two; the latter two are deferred to a separate follow-up by design, not by upstream mandate.
+Mirrors the `rules:`/`match:` shape from the `00121_token-rate-limiting` proposal in `praxis-proxy/enhancements`, scoped to this milestone's static header-value matchers and per-rule algorithm choice. CEL matchers, soft-limit tiers, and weighted per-type accounting are still out of scope (see the module doc comment) -- upstream itself defers the first two; per-type accounting is deferred to a separate follow-up by design, not by upstream mandate. Configurable estimation strategies (M3) are now supported via the `estimation:` block (see [`EstimationConfig`]).
 
 Assumes request identity has already been resolved upstream (this filter doesn't authenticate callers) -- a catch-all rule (no `match:`) reserves quota for every request that reaches it, including probes and health checks. Scope rules with explicit `match:` conditions, or place an identity/auth filter earlier in the pipeline. Tracked as follow-on integration work in `grid#101`.
 
@@ -26,7 +26,14 @@ Assumes request identity has already been resolved upstream (this filter doesn't
 | `rules[].capacity` | integer | one of | Maximum tokens admitted within `window`. |
 | `rules[].capacity` | integer | one of | Maximum tokens held at once (the bucket's ceiling). |
 | `rules[].refill_rate` | number | one of | Tokens refilled per second, up to `capacity`. |
-| `rules[].reserved_tokens` | integer | yes | Fixed token cost reserved at admission time, before actual usage is known. Placeholder pending M3 (configurable estimation strategies). Real deployments will want this derived from request metadata (e.g. `max_tokens`) rather than a single fixed constant -- that's out of scope for this milestone. |
+| `rules[].reserved_tokens` | integer | no | Fixed token cost reserved at admission time, before actual usage is known. Legacy field, retained for backward compatibility: a bare `reserved_tokens: N` is equivalent to `estimation: { strategy: fixed, fallback_estimate: N }`. Mutually exclusive with [`estimation`](Self::estimation) -- specifying both on the same rule is a config error. |
+| `rules[].estimation` | EstimationConfig | no | Configurable estimation strategy for computing the token cost reserved at admission time. Replaces the legacy `reserved_tokens` field with request-metadata-aware strategies. Mutually exclusive with [`reserved_tokens`](Self::reserved_tokens) -- specifying both on the same rule is a config error. Omitting both is also an error. |
+| `rules[].estimation.strategy` | `fixed` \| `max_tokens` \| `input_plus_max_tokens` \| `model_scaled` | yes | Which strategy to use for this rule's cost estimation. |
+| `rules[].estimation.multiplier` | number | no | Safety-margin multiplier applied to the computed estimate. Defaults to 1.0 (no margin). Must be positive and finite. |
+| `rules[].estimation.fallback_estimate` | integer | no | Token count to use when `max_tokens` is absent from the request. Required for `fixed`; optional for body-dependent strategies (if unset and the strategy can't extract a value, the request is admitted without a reservation). |
+| `rules[].estimation.model_multipliers` | object<string, number> | no | Per-model multiplier map for `model_scaled` strategy. |
+| `rules[].estimation.default_multiplier` | number | no | Default multiplier for models not listed in `model_multipliers`. |
+| `rules[].estimation.bytes_per_token` | number | no | Approximate bytes-per-token ratio for `input_plus_max_tokens`. Defaults to 4.0. |
 | `rules[].reservation_timeout` | string | no | How long an admitted-but-never-reconciled reservation (lost request: timeout, connection reset, upstream crash) is tracked as active before that already-reserved-at-admission charge against its estimate becomes irreversibly locked in (sliding-window: folded into the settled total so it survives the window's normal aging-out; token-bucket: the tokens were already decremented at reserve time regardless, this only bounds how long the reservation is tracked as pending). This does **not** defer when the charge first applies -- it applies immediately at admission, same as any other reservation. Answers the proposal's still-open "lost request handling" question for this milestone. Defaults to [`DEFAULT_RESERVATION_TIMEOUT`] when unset. |
 | `backend` | BackendConfig | no | Where every rule's admission state lives: in-process (default, one budget per gateway instance) or a shared Valkey backend (one budget shared across every gateway instance/replica). One backend for the whole filter, not per rule -- rules already share Valkey key-space isolation via `namespace`/rule-name hashing, so per-rule backend selection bought no isolation benefit, only a separate Valkey connection per rule pointed at the same URL. Revisit if a real deployment ever needs to mix in-process and Valkey rules in one filter instance. |
 | `backend.kind` | `memory` \| `valkey` | no | Which backend implementation to use. |
@@ -49,7 +56,10 @@ rules:
     algorithm: sliding_window        # sliding_window | token_bucket
     window: 1h                       # sliding_window only: window duration
     capacity: 100000                 # max tokens admitted (sliding_window) or held (token_bucket)
-    reserved_tokens: 500             # fixed cost reserved per request at admission
+    estimation:                      # M3: configurable estimation strategy
+      strategy: max_tokens           # fixed | max_tokens | input_plus_max_tokens | model_scaled
+      multiplier: 1.2                # optional safety margin (default: 1.0)
+      fallback_estimate: 500         # used when max_tokens absent from request
   - name: team-beta
     match:
       headers:
@@ -57,5 +67,5 @@ rules:
     algorithm: token_bucket
     capacity: 50000
     refill_rate: 50                  # token_bucket only: tokens refilled per second
-    reserved_tokens: 200
+    reserved_tokens: 200             # legacy: equivalent to estimation: { strategy: fixed, fallback_estimate: 200 }
 ```

--- a/filters/src/token_rate_limit/config.rs
+++ b/filters/src/token_rate_limit/config.rs
@@ -27,11 +27,12 @@ use serde::Deserialize;
 /// Mirrors the `rules:`/`match:` shape from the `00121_token-rate-limiting`
 /// proposal in `praxis-proxy/enhancements`, scoped to this milestone's
 /// static header-value matchers and per-rule algorithm choice. CEL
-/// matchers, soft-limit tiers, weighted per-type accounting, and
-/// configurable estimation strategies are still out of scope (see the
-/// module doc comment) -- upstream itself defers the first two; the
-/// latter two are deferred to a separate follow-up by design, not by
-/// upstream mandate.
+/// matchers, soft-limit tiers, and weighted per-type accounting are
+/// still out of scope (see the module doc comment) -- upstream itself
+/// defers the first two; per-type accounting is deferred to a separate
+/// follow-up by design, not by upstream mandate. Configurable
+/// estimation strategies (M3) are now supported via the `estimation:`
+/// block (see [`EstimationConfig`]).
 ///
 /// Assumes request identity has already been resolved upstream (this
 /// filter doesn't authenticate callers) -- a catch-all rule (no
@@ -104,11 +105,23 @@ pub(super) struct RuleConfig {
     /// Fixed token cost reserved at admission time, before actual usage
     /// is known.
     ///
-    /// Placeholder pending M3 (configurable estimation strategies).
-    /// Real deployments will want this derived from request metadata
-    /// (e.g. `max_tokens`) rather than a single fixed constant -- that's
-    /// out of scope for this milestone.
-    pub reserved_tokens: u64,
+    /// Legacy field, retained for backward compatibility: a bare
+    /// `reserved_tokens: N` is equivalent to
+    /// `estimation: { strategy: fixed, fallback_estimate: N }`.
+    /// Mutually exclusive with [`estimation`](Self::estimation) --
+    /// specifying both on the same rule is a config error.
+    #[serde(default)]
+    pub reserved_tokens: Option<u64>,
+
+    /// Configurable estimation strategy for computing the token cost
+    /// reserved at admission time. Replaces the legacy `reserved_tokens`
+    /// field with request-metadata-aware strategies.
+    ///
+    /// Mutually exclusive with [`reserved_tokens`](Self::reserved_tokens) --
+    /// specifying both on the same rule is a config error. Omitting both
+    /// is also an error.
+    #[serde(default)]
+    pub estimation: Option<EstimationConfig>,
 
     /// How long an admitted-but-never-reconciled reservation (lost
     /// request: timeout, connection reset, upstream crash) is tracked as
@@ -210,6 +223,63 @@ pub(super) enum BackendKind {
     Valkey,
 }
 
+/// Configurable estimation strategy for computing the token cost
+/// reserved at admission time, per rule.
+///
+/// Replaces the fixed `reserved_tokens` field with request-metadata-aware
+/// strategies. The operator picks one strategy per rule; all budgets on
+/// that rule share the same cost model.
+///
+/// Experimental: the `strategy` tag is intentionally extensible —
+/// future variants (e.g. `cel`) can be added without changing
+/// existing configurations.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "strategy", rename_all = "snake_case")]
+pub(super) enum EstimationStrategy {
+    /// Constant per request (equivalent to the legacy `reserved_tokens`).
+    Fixed,
+    /// Extracted from the request body's `max_tokens` field.
+    MaxTokens,
+    /// Content-Length-based input estimate plus `max_tokens`.
+    InputPlusMaxTokens,
+    /// `max_tokens` scaled by a per-model multiplier.
+    ModelScaled,
+}
+
+/// Full estimation configuration block, combining a strategy tag with
+/// shared tuning knobs.
+#[derive(Debug, Deserialize)]
+pub(super) struct EstimationConfig {
+    /// Which strategy to use for this rule's cost estimation.
+    #[serde(flatten)]
+    pub strategy: EstimationStrategy,
+
+    /// Safety-margin multiplier applied to the computed estimate.
+    /// Defaults to 1.0 (no margin). Must be positive and finite.
+    #[serde(default)]
+    pub multiplier: Option<f64>,
+
+    /// Token count to use when `max_tokens` is absent from the request.
+    /// Required for `fixed`; optional for body-dependent strategies
+    /// (if unset and the strategy can't extract a value, the request is
+    /// admitted without a reservation).
+    #[serde(default)]
+    pub fallback_estimate: Option<u64>,
+
+    /// Per-model multiplier map for `model_scaled` strategy.
+    #[serde(default)]
+    pub model_multipliers: Option<BTreeMap<String, f64>>,
+
+    /// Default multiplier for models not listed in `model_multipliers`.
+    #[serde(default)]
+    pub default_multiplier: Option<f64>,
+
+    /// Approximate bytes-per-token ratio for `input_plus_max_tokens`.
+    /// Defaults to 4.0.
+    #[serde(default)]
+    pub bytes_per_token: Option<f64>,
+}
+
 #[cfg(test)]
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(
@@ -242,7 +312,7 @@ mod tests {
             rule.algorithm,
             RuleAlgorithm::SlidingWindow { capacity: 1000, .. }
         ));
-        assert_eq!(rule.reserved_tokens, 50);
+        assert_eq!(rule.reserved_tokens, Some(50));
     }
 
     #[test]

--- a/filters/src/token_rate_limit/mod.rs
+++ b/filters/src/token_rate_limit/mod.rs
@@ -52,8 +52,8 @@
 //!   `ai#123`/`ai#232`); `ai#129`'s single-header-value keying (one budget applied uniformly per key, fallback to
 //!   global) is implemented per rule, and intentionally does not resolve identity to a key itself -- it keys off
 //!   whatever header value an upstream component has already put there.
-//! - **Configurable estimation (M3)**: `reserved_tokens` is a fixed constant per rule, not derived from request
-//!   metadata (e.g. `max_tokens`).
+//! - **Configurable estimation (M3)**: implemented -- per-rule `estimation:` block with pluggable strategies (`fixed`,
+//!   `max_tokens`, `input_plus_max_tokens`, `model_scaled`). See [`config::EstimationConfig`].
 //! - **Token-type-aware accounting (M4)**: reconciles against `token.total` only; per-type (input/output/cached)
 //!   weighting is not modeled yet.
 //! - **Multiple budgets per rule, soft-limit tiers**: the proposal allows several `token_budgets` (e.g. hourly + daily)
@@ -87,7 +87,11 @@ mod config;
 mod ledger;
 mod token_bucket_ledger;
 
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -105,8 +109,8 @@ use self::{
         ValkeyTokenRateLimitBackend,
     },
     config::{
-        BackendConfig, BackendKind, DEFAULT_RESERVATION_TIMEOUT, MatchConfig, RuleAlgorithm, RuleConfig,
-        TokenRateLimitConfig,
+        BackendConfig, BackendKind, DEFAULT_RESERVATION_TIMEOUT, EstimationConfig, EstimationStrategy, MatchConfig,
+        RuleAlgorithm, RuleConfig, TokenRateLimitConfig,
     },
     ledger::{Budget, Ledger, LedgerConfig},
     token_bucket_ledger::{TokenBucketConfig, TokenBucketLedger},
@@ -131,6 +135,11 @@ const META_BUCKET_KEY: &str = "token_rate_limit.bucket_key";
 /// backend/estimate even when other rules exist.
 const META_RULE_INDEX: &str = "token_rate_limit.rule_index";
 
+/// Metadata key stashing this request's computed estimate, so
+/// reconciliation can use the actual per-request estimate (not just
+/// the compiled default) for its settlement math.
+const META_ESTIMATE: &str = "token_rate_limit.estimate";
+
 /// The single budget key every request resolves to in this milestone: all
 /// requests matching a rule share one budget. Kept as a named sentinel
 /// (rather than threading `Option<String>`/`&str` through the backend
@@ -151,6 +160,12 @@ const MAX_KEY_LENGTH: usize = 256;
 
 /// Bound on reservations awaiting reconciliation across all keys, per rule.
 const MAX_ACTIVE_RESERVATIONS: usize = 200_000;
+
+/// Maximum request body bytes buffered for body-dependent estimation
+/// strategies. 2 MiB -- generous enough for the largest realistic
+/// inference request body, small enough not to materially affect
+/// memory pressure.
+const MAX_ESTIMATION_BODY_BYTES: usize = 2_097_152;
 
 /// Rate limit header: configured token budget.
 ///
@@ -295,6 +310,161 @@ fn build_token_bucket_backend(
 }
 
 // -----------------------------------------------------------------------------
+// Estimation
+// -----------------------------------------------------------------------------
+
+/// Minimal serde struct for probing request-body fields needed by
+/// body-dependent estimation strategies, without deserializing the
+/// entire request payload.
+#[derive(serde::Deserialize)]
+struct BodyProbe {
+    /// OpenAI-style `max_tokens` field (preferred over `max_completion_tokens`).
+    max_tokens: Option<u64>,
+    /// OpenAI-style `max_completion_tokens` fallback field.
+    max_completion_tokens: Option<u64>,
+    /// Model identifier, used by `model_scaled` strategy.
+    model: Option<String>,
+}
+
+/// Compiled, ready-to-use estimation strategy for one rule.
+///
+/// Built once at filter construction from the deserialized
+/// [`EstimationConfig`]; all per-request math runs against this
+/// pre-validated form.
+enum CompiledEstimation {
+    /// Constant per request (the legacy `reserved_tokens` path, plus
+    /// the `estimation: { strategy: fixed }` equivalent).
+    Fixed {
+        /// Pre-computed token estimate (already incorporates any multiplier).
+        estimate: u64,
+    },
+
+    /// From request body `max_tokens` (or `max_completion_tokens`).
+    MaxTokens {
+        /// Fallback when body has no `max_tokens`/`max_completion_tokens`.
+        fallback_estimate: Option<u64>,
+        /// Safety-margin multiplier applied to the extracted value.
+        multiplier: f64,
+    },
+
+    /// Content-Length-based input estimate plus `max_tokens` from body.
+    InputPlusMaxTokens {
+        /// Fallback for the output portion when `max_tokens` is absent.
+        fallback_estimate: Option<u64>,
+        /// Safety-margin multiplier applied to the total.
+        multiplier: f64,
+        /// Approximate bytes-per-token ratio for input estimation.
+        bytes_per_token: f64,
+    },
+
+    /// `max_tokens` scaled by a per-model multiplier.
+    ModelScaled {
+        /// Fallback when body has no `max_tokens`/`max_completion_tokens`.
+        fallback_estimate: Option<u64>,
+        /// Per-model multiplier overrides.
+        model_multipliers: BTreeMap<String, f64>,
+        /// Multiplier for models not in `model_multipliers`.
+        default_multiplier: f64,
+    },
+}
+
+impl CompiledEstimation {
+    /// Whether this strategy requires access to the request body.
+    fn needs_body(&self) -> bool {
+        !matches!(self, Self::Fixed { .. })
+    }
+
+    /// Compute the token estimate for a single request.
+    ///
+    /// Returns `None` when the strategy cannot extract the needed
+    /// value (e.g. `max_tokens` absent from the body) and no
+    /// `fallback_estimate` is configured -- the caller should admit
+    /// without a reservation in that case.
+    fn estimate(&self, headers: &http::HeaderMap, body_probe: Option<&BodyProbe>) -> Option<u64> {
+        match self {
+            Self::Fixed { estimate } => Some(*estimate),
+            Self::MaxTokens {
+                fallback_estimate,
+                multiplier,
+            } => {
+                let raw = extract_max_tokens(body_probe, *fallback_estimate)?;
+                Some(apply_multiplier(raw, *multiplier))
+            },
+            Self::InputPlusMaxTokens {
+                fallback_estimate,
+                multiplier,
+                bytes_per_token,
+            } => {
+                let input = content_length_tokens(headers, *bytes_per_token);
+                let output = extract_max_tokens(body_probe, *fallback_estimate)?;
+                Some(apply_multiplier(input.saturating_add(output), *multiplier))
+            },
+            Self::ModelScaled {
+                fallback_estimate,
+                model_multipliers,
+                default_multiplier,
+            } => {
+                let raw = extract_max_tokens(body_probe, *fallback_estimate)?;
+                let model_mult = resolve_model_multiplier(body_probe, headers, model_multipliers, *default_multiplier);
+                Some(apply_multiplier(raw, model_mult))
+            },
+        }
+    }
+}
+
+/// Extract `max_tokens` (preferred) or `max_completion_tokens` from a
+/// body probe, falling back to `fallback` if neither is present.
+fn extract_max_tokens(body_probe: Option<&BodyProbe>, fallback: Option<u64>) -> Option<u64> {
+    body_probe
+        .and_then(|bp| bp.max_tokens.or(bp.max_completion_tokens))
+        .or(fallback)
+}
+
+/// Apply a safety-margin `multiplier` to a raw token count, rounding up.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    reason = "token estimates are bounded by config-validated capacity (u64-safe)"
+)]
+fn apply_multiplier(raw: u64, multiplier: f64) -> u64 {
+    ((raw as f64) * multiplier).ceil() as u64
+}
+
+/// Estimate input tokens from `Content-Length` and `bytes_per_token`.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    reason = "token estimates are bounded by config-validated capacity (u64-safe)"
+)]
+fn content_length_tokens(headers: &http::HeaderMap, bytes_per_token: f64) -> u64 {
+    let content_length = headers
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+    (content_length as f64 / bytes_per_token).ceil() as u64
+}
+
+/// Resolve the model multiplier: body `model` field preferred, then
+/// `x-model` header, then `default_multiplier`.
+fn resolve_model_multiplier(
+    body_probe: Option<&BodyProbe>,
+    headers: &http::HeaderMap,
+    model_multipliers: &BTreeMap<String, f64>,
+    default_multiplier: f64,
+) -> f64 {
+    let model_name = body_probe
+        .and_then(|bp| bp.model.as_deref())
+        .or_else(|| headers.get("x-model").and_then(|v| v.to_str().ok()));
+    model_name
+        .and_then(|name| model_multipliers.get(name))
+        .copied()
+        .unwrap_or(default_multiplier)
+}
+
+// -----------------------------------------------------------------------------
 // CompiledRule
 // -----------------------------------------------------------------------------
 
@@ -313,8 +483,8 @@ struct CompiledRule {
     /// Valkey; sliding-window or token-bucket.
     backend: Arc<dyn TokenRateLimitStateBackend>,
 
-    /// Fixed token cost reserved at admission (M3 placeholder).
-    reserved_tokens: u64,
+    /// Compiled estimation strategy for this rule.
+    estimation: CompiledEstimation,
 }
 
 impl CompiledRule {
@@ -339,19 +509,21 @@ impl CompiledRule {
 /// `capacity`, or `reservation_timeout` isn't a valid duration.
 fn validate_rule_bounds(rule: &RuleConfig, capacity: u64) -> Result<u64, FilterError> {
     validate_capacity_safe_integer_bound(&rule.name, capacity)?;
-    if rule.reserved_tokens == 0 {
-        return Err(format!(
-            "token_rate_limit: rule '{}': reserved_tokens must be greater than 0",
-            rule.name
-        )
-        .into());
-    }
-    if rule.reserved_tokens > capacity {
-        return Err(format!(
-            "token_rate_limit: rule '{}': reserved_tokens must not exceed capacity",
-            rule.name
-        )
-        .into());
+    if let Some(reserved) = rule.reserved_tokens {
+        if reserved == 0 {
+            return Err(format!(
+                "token_rate_limit: rule '{}': reserved_tokens must be greater than 0",
+                rule.name
+            )
+            .into());
+        }
+        if reserved > capacity {
+            return Err(format!(
+                "token_rate_limit: rule '{}': reserved_tokens must not exceed capacity",
+                rule.name
+            )
+            .into());
+        }
     }
     parse_duration_ms(
         rule.reservation_timeout
@@ -438,6 +610,211 @@ fn build_rule_backend(
     }
 }
 
+/// Validate and compile the estimation configuration for one rule,
+/// enforcing mutual exclusion between `reserved_tokens` and `estimation`.
+fn compile_estimation(
+    rule_name: &str,
+    reserved_tokens: Option<u64>,
+    estimation: Option<EstimationConfig>,
+    capacity: u64,
+) -> Result<CompiledEstimation, FilterError> {
+    if reserved_tokens.is_some() && estimation.is_some() {
+        return Err(format!(
+            "token_rate_limit: rule '{rule_name}': cannot specify both reserved_tokens and estimation"
+        )
+        .into());
+    }
+    if let Some(est) = estimation {
+        compile_estimation_config(rule_name, est, capacity)
+    } else if let Some(reserved) = reserved_tokens {
+        Ok(CompiledEstimation::Fixed { estimate: reserved })
+    } else {
+        Err(format!("token_rate_limit: rule '{rule_name}': must have either reserved_tokens or estimation").into())
+    }
+}
+
+/// Compile a deserialized [`EstimationConfig`] into a [`CompiledEstimation`],
+/// validating all strategy-specific invariants.
+fn compile_estimation_config(
+    rule_name: &str,
+    est: EstimationConfig,
+    capacity: u64,
+) -> Result<CompiledEstimation, FilterError> {
+    let multiplier = est.multiplier.unwrap_or(1.0);
+    validate_positive_finite(rule_name, "estimation.multiplier", multiplier)?;
+    match est.strategy {
+        EstimationStrategy::Fixed => compile_fixed_estimation(rule_name, &est, multiplier, capacity),
+        EstimationStrategy::MaxTokens => compile_max_tokens_estimation(rule_name, &est, multiplier, capacity),
+        EstimationStrategy::InputPlusMaxTokens => compile_input_plus_estimation(rule_name, &est, multiplier, capacity),
+        EstimationStrategy::ModelScaled => compile_model_scaled_estimation(rule_name, est, multiplier, capacity),
+    }
+}
+
+/// Compile a `fixed` estimation strategy.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    reason = "token estimates are bounded by config-validated capacity (u64-safe)"
+)]
+fn compile_fixed_estimation(
+    rule_name: &str,
+    est: &EstimationConfig,
+    multiplier: f64,
+    capacity: u64,
+) -> Result<CompiledEstimation, FilterError> {
+    reject_unused_estimation_fields(
+        rule_name,
+        "fixed",
+        &[
+            ("model_multipliers", est.model_multipliers.is_some()),
+            ("default_multiplier", est.default_multiplier.is_some()),
+            ("bytes_per_token", est.bytes_per_token.is_some()),
+        ],
+    )?;
+    let estimate = est.fallback_estimate.ok_or_else(|| {
+        FilterError::from(format!(
+            "token_rate_limit: rule '{rule_name}': fixed strategy requires fallback_estimate"
+        ))
+    })?;
+    let effective = ((estimate as f64) * multiplier).ceil() as u64;
+    if effective == 0 {
+        return Err(
+            format!("token_rate_limit: rule '{rule_name}': effective fixed estimate must be greater than 0").into(),
+        );
+    }
+    if effective > capacity {
+        return Err(
+            format!("token_rate_limit: rule '{rule_name}': effective fixed estimate must not exceed capacity").into(),
+        );
+    }
+    Ok(CompiledEstimation::Fixed { estimate: effective })
+}
+
+/// Compile a `max_tokens` estimation strategy.
+fn compile_max_tokens_estimation(
+    rule_name: &str,
+    est: &EstimationConfig,
+    multiplier: f64,
+    capacity: u64,
+) -> Result<CompiledEstimation, FilterError> {
+    reject_unused_estimation_fields(
+        rule_name,
+        "max_tokens",
+        &[
+            ("model_multipliers", est.model_multipliers.is_some()),
+            ("default_multiplier", est.default_multiplier.is_some()),
+            ("bytes_per_token", est.bytes_per_token.is_some()),
+        ],
+    )?;
+    validate_fallback_within_capacity(rule_name, est.fallback_estimate, capacity)?;
+    Ok(CompiledEstimation::MaxTokens {
+        fallback_estimate: est.fallback_estimate,
+        multiplier,
+    })
+}
+
+/// Compile an `input_plus_max_tokens` estimation strategy.
+fn compile_input_plus_estimation(
+    rule_name: &str,
+    est: &EstimationConfig,
+    multiplier: f64,
+    capacity: u64,
+) -> Result<CompiledEstimation, FilterError> {
+    reject_unused_estimation_fields(
+        rule_name,
+        "input_plus_max_tokens",
+        &[
+            ("model_multipliers", est.model_multipliers.is_some()),
+            ("default_multiplier", est.default_multiplier.is_some()),
+        ],
+    )?;
+    let bytes_per_token = est.bytes_per_token.unwrap_or(4.0);
+    validate_positive_finite(rule_name, "estimation.bytes_per_token", bytes_per_token)?;
+    validate_fallback_within_capacity(rule_name, est.fallback_estimate, capacity)?;
+    Ok(CompiledEstimation::InputPlusMaxTokens {
+        fallback_estimate: est.fallback_estimate,
+        multiplier,
+        bytes_per_token,
+    })
+}
+
+/// Compile a `model_scaled` estimation strategy.
+fn compile_model_scaled_estimation(
+    rule_name: &str,
+    est: EstimationConfig,
+    multiplier: f64,
+    capacity: u64,
+) -> Result<CompiledEstimation, FilterError> {
+    reject_unused_estimation_fields(
+        rule_name,
+        "model_scaled",
+        &[("bytes_per_token", est.bytes_per_token.is_some())],
+    )?;
+    let default_multiplier = est.default_multiplier.unwrap_or(1.0) * multiplier;
+    validate_positive_finite(rule_name, "estimation.default_multiplier", default_multiplier)?;
+    let model_multipliers: BTreeMap<String, f64> = est
+        .model_multipliers
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(model, mult)| (model, mult * multiplier))
+        .collect();
+    for (model, &mult) in &model_multipliers {
+        if !mult.is_finite() || mult <= 0.0 {
+            return Err(format!(
+                "token_rate_limit: rule '{rule_name}': model_multipliers['{model}'] must be finite and positive"
+            )
+            .into());
+        }
+    }
+    validate_fallback_within_capacity(rule_name, est.fallback_estimate, capacity)?;
+    Ok(CompiledEstimation::ModelScaled {
+        fallback_estimate: est.fallback_estimate,
+        model_multipliers,
+        default_multiplier,
+    })
+}
+
+/// Reject strategy-irrelevant `estimation:` fields so a leftover knob from
+/// a previous strategy is a config error instead of a silent no-op.
+fn reject_unused_estimation_fields(
+    rule_name: &str,
+    strategy: &str,
+    unused: &[(&str, bool)],
+) -> Result<(), FilterError> {
+    let names: Vec<&str> = unused
+        .iter()
+        .filter(|(_, present)| *present)
+        .map(|(name, _)| *name)
+        .collect();
+    if names.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "token_rate_limit: rule '{rule_name}': {strategy} strategy does not accept {}",
+        names.join(", ")
+    )
+    .into())
+}
+
+/// Validate that a named f64 parameter is finite and positive.
+fn validate_positive_finite(rule_name: &str, param: &str, value: f64) -> Result<(), FilterError> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(format!("token_rate_limit: rule '{rule_name}': {param} must be finite and positive").into());
+    }
+    Ok(())
+}
+
+/// Validate that a `fallback_estimate`, if set, doesn't exceed `capacity`.
+fn validate_fallback_within_capacity(rule_name: &str, fallback: Option<u64>, capacity: u64) -> Result<(), FilterError> {
+    if let Some(fb) = fallback
+        && fb > capacity
+    {
+        return Err(format!("token_rate_limit: rule '{rule_name}': fallback_estimate must not exceed capacity").into());
+    }
+    Ok(())
+}
+
 /// Compile one YAML `rules:` entry into a [`CompiledRule`], validating
 /// and constructing its backend.
 ///
@@ -450,6 +827,7 @@ fn build_rule_backend(
 fn compile_rule(rule: RuleConfig, backend: &BackendResource) -> Result<CompiledRule, FilterError> {
     let capacity = rule.algorithm.capacity();
     let reservation_timeout_ms = validate_rule_bounds(&rule, capacity)?;
+    let estimation = compile_estimation(&rule.name, rule.reserved_tokens, rule.estimation, capacity)?;
     let backend = build_rule_backend(&rule.algorithm, backend, &rule.name, reservation_timeout_ms)?;
     let matcher = compile_matcher(&rule.name, rule.r#match)?;
 
@@ -457,7 +835,7 @@ fn compile_rule(rule: RuleConfig, backend: &BackendResource) -> Result<CompiledR
         name: rule.name,
         matcher,
         backend,
-        reserved_tokens: rule.reserved_tokens,
+        estimation,
     })
 }
 
@@ -486,7 +864,10 @@ fn compile_rule(rule: RuleConfig, backend: &BackendResource) -> Result<CompiledR
 ///     algorithm: sliding_window        # sliding_window | token_bucket
 ///     window: 1h                       # sliding_window only: window duration
 ///     capacity: 100000                 # max tokens admitted (sliding_window) or held (token_bucket)
-///     reserved_tokens: 500             # fixed cost reserved per request at admission
+///     estimation:                      # M3: configurable estimation strategy
+///       strategy: max_tokens           # fixed | max_tokens | input_plus_max_tokens | model_scaled
+///       multiplier: 1.2                # optional safety margin (default: 1.0)
+///       fallback_estimate: 500         # used when max_tokens absent from request
 ///   - name: team-beta
 ///     match:
 ///       headers:
@@ -494,7 +875,7 @@ fn compile_rule(rule: RuleConfig, backend: &BackendResource) -> Result<CompiledR
 ///     algorithm: token_bucket
 ///     capacity: 50000
 ///     refill_rate: 50                  # token_bucket only: tokens refilled per second
-///     reserved_tokens: 200
+///     reserved_tokens: 200             # legacy: equivalent to estimation: { strategy: fixed, fallback_estimate: 200 }
 /// ```
 ///
 /// Rules are evaluated in order; the first whose `match` is satisfied
@@ -504,6 +885,11 @@ fn compile_rule(rule: RuleConfig, backend: &BackendResource) -> Result<CompiledR
 pub struct TokenRateLimitFilter {
     /// Compiled rules, evaluated in configured order.
     rules: Vec<CompiledRule>,
+
+    /// Whether any rule uses a body-dependent estimation strategy.
+    /// When `true`, `on_request` defers reservation to `on_request_body`
+    /// and the pipeline buffers the request body for inspection.
+    needs_body: bool,
 
     /// Monotonic clock reference; all timestamps are offsets from this.
     epoch: Instant,
@@ -536,8 +922,11 @@ impl TokenRateLimitFilter {
             .map(|rule| compile_rule(rule, &backend))
             .collect::<Result<Vec<_>, _>>()?;
 
+        let needs_body = rules.iter().any(|r| r.estimation.needs_body());
+
         Ok(Box::new(Self {
             rules,
+            needs_body,
             epoch: Instant::now(),
         }))
     }
@@ -608,7 +997,7 @@ impl TokenRateLimitFilter {
         ctx: &mut HttpFilterContext<'_>,
         rule_index: usize,
         rule: &CompiledRule,
-        key: String,
+        pending: PendingReservation,
         outcome: Result<BackendReserve, BackendError>,
     ) -> FilterAction {
         match outcome {
@@ -617,17 +1006,18 @@ impl TokenRateLimitFilter {
                 estimate,
             }) => {
                 let admitted = AdmittedReservation {
-                    key,
+                    key: pending.key,
                     reservation_id,
                     estimate,
                 };
                 Self::record_admission(ctx, rule_index, rule, admitted);
+                ctx.set_metadata(META_ESTIMATE, pending.request_estimate.to_string());
                 FilterAction::Continue
             },
             Ok(BackendReserve::Denied { retry_after_ms }) => {
                 tracing::info!(
-                    estimate = rule.reserved_tokens,
-                    key,
+                    estimate = pending.request_estimate,
+                    key = pending.key,
                     rule = rule.name,
                     "token_rate_limit: rejecting request (429)"
                 );
@@ -658,11 +1048,15 @@ impl TokenRateLimitFilter {
         if actual.is_none() {
             tracing::trace!("token_rate_limit: no token.total metadata at end of stream, charging at estimate");
         }
+        let Some(estimate) = ctx.get_metadata(META_ESTIMATE).and_then(|v| v.parse::<u64>().ok()) else {
+            tracing::warn!("token_rate_limit: META_ESTIMATE missing at reconciliation, skipping");
+            return None;
+        };
         let request = ReconcileRequest {
             key,
             reservation_id,
             actual,
-            estimate: rule.reserved_tokens,
+            estimate,
             now_ms: self.now_ms(),
         };
         Some((request, rule))
@@ -700,6 +1094,16 @@ impl TokenRateLimitFilter {
     }
 }
 
+/// Bundle for the budget key and computed estimate awaiting a backend
+/// `reserve()` call, keeping [`TokenRateLimitFilter::handle_reserve_outcome`]
+/// within clippy's argument-count budget.
+struct PendingReservation {
+    /// The budget key this reservation will use.
+    key: String,
+    /// The computed token estimate for this request.
+    request_estimate: u64,
+}
+
 /// The bucket key, reservation ID, and estimate an admitted
 /// [`BackendReserve::Admitted`] carries, bundled so
 /// [`TokenRateLimitFilter::record_admission`] stays within clippy's
@@ -710,7 +1114,7 @@ struct AdmittedReservation {
     key: String,
     /// The backend-issued reservation ID, stashed for later reconciliation.
     reservation_id: u64,
-    /// Tokens reserved at admission (the rule's `reserved_tokens`, echoed
+    /// Tokens reserved at admission (the rule's computed estimate, echoed
     /// back by the backend).
     estimate: u64,
 }
@@ -757,6 +1161,24 @@ impl HttpFilter for TokenRateLimitFilter {
         "token_rate_limit"
     }
 
+    fn request_body_access(&self) -> BodyAccess {
+        if self.needs_body {
+            BodyAccess::ReadOnly
+        } else {
+            BodyAccess::None
+        }
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        if self.needs_body {
+            BodyMode::StreamBuffer {
+                max_bytes: Some(MAX_ESTIMATION_BODY_BYTES),
+            }
+        } else {
+            BodyMode::Stream
+        }
+    }
+
     fn response_body_access(&self) -> BodyAccess {
         BodyAccess::ReadOnly
     }
@@ -766,24 +1188,72 @@ impl HttpFilter for TokenRateLimitFilter {
     }
 
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if self.needs_body {
+            return Ok(FilterAction::Continue);
+        }
         let now_ms = self.now_ms();
         let Some((rule_index, rule)) = self.matching_rule(&ctx.request.headers) else {
-            // No configured rule applies to this request -- not rate
-            // limited by this filter instance. Operators wanting a
-            // catch-all budget add a trailing rule with no `match`.
             return Ok(FilterAction::Continue);
         };
         Self::cleanup_and_record_state(rule, now_ms);
+        let estimate = rule.estimation.estimate(&ctx.request.headers, None);
+        let Some(estimate) = estimate else {
+            return Ok(FilterAction::Continue);
+        };
         let key = FALLBACK_KEY.to_owned();
         let outcome = rule
             .backend
             .reserve(ReserveRequest {
                 key: key.clone(),
-                estimate: rule.reserved_tokens,
+                estimate,
                 now_ms,
             })
             .await;
-        Ok(Self::handle_reserve_outcome(ctx, rule_index, rule, key, outcome))
+        let pending = PendingReservation {
+            key,
+            request_estimate: estimate,
+        };
+        Ok(Self::handle_reserve_outcome(ctx, rule_index, rule, pending, outcome))
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream || !self.needs_body {
+            return Ok(FilterAction::Continue);
+        }
+        let now_ms = self.now_ms();
+        let Some((rule_index, rule)) = self.matching_rule(&ctx.request.headers) else {
+            return Ok(FilterAction::Continue);
+        };
+        Self::cleanup_and_record_state(rule, now_ms);
+
+        let body_probe = body
+            .as_ref()
+            .and_then(|raw| serde_json::from_slice::<BodyProbe>(raw).ok());
+        let estimate = rule.estimation.estimate(&ctx.request.headers, body_probe.as_ref());
+
+        let Some(estimate) = estimate else {
+            return Ok(FilterAction::Continue);
+        };
+
+        let key = FALLBACK_KEY.to_owned();
+        let outcome = rule
+            .backend
+            .reserve(ReserveRequest {
+                key: key.clone(),
+                estimate,
+                now_ms,
+            })
+            .await;
+        let pending = PendingReservation {
+            key,
+            request_estimate: estimate,
+        };
+        Ok(Self::handle_reserve_outcome(ctx, rule_index, rule, pending, outcome))
     }
 
     fn on_response_body(
@@ -797,6 +1267,7 @@ impl HttpFilter for TokenRateLimitFilter {
             ctx.filter_metadata.remove(META_RESERVATION_ID);
             ctx.filter_metadata.remove(META_BUCKET_KEY);
             ctx.filter_metadata.remove(META_RULE_INDEX);
+            ctx.filter_metadata.remove(META_ESTIMATE);
         }
         Ok(FilterAction::Continue)
     }
@@ -884,7 +1355,7 @@ mod backend_injection_tests {
     use praxis_filter::HttpFilter as _;
 
     use super::{
-        CompiledRule, TokenRateLimitFilter,
+        CompiledEstimation, CompiledRule, TokenRateLimitFilter,
         backend::{
             BackendError, BackendReserve, BackendSettlement, ReconcileRequest, ReserveRequest,
             TokenRateLimitStateBackend,
@@ -937,8 +1408,9 @@ mod backend_injection_tests {
                 name: "default".to_owned(),
                 matcher: None,
                 backend: std::sync::Arc::new(EnqueueAlwaysFailsBackend),
-                reserved_tokens: 1,
+                estimation: CompiledEstimation::Fixed { estimate: 1 },
             }],
+            needs_body: false,
             epoch: std::time::Instant::now(),
         };
 

--- a/filters/src/token_rate_limit/tests.rs
+++ b/filters/src/token_rate_limit/tests.rs
@@ -560,6 +560,38 @@ async fn reconcile_is_a_noop_without_prior_admission_metadata() {
     ));
 }
 
+/// Missing `META_ESTIMATE` must skip settlement rather than treat the
+/// estimate as 0 (which would debit `actual - 0` on top of the original
+/// reservation and over-charge the window).
+#[tokio::test]
+async fn missing_meta_estimate_skips_reconciliation_instead_of_settling_at_zero() {
+    let yaml = single_rule_yaml("algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nreserved_tokens: 500");
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    assert!(matches!(
+        filter.on_request(&mut ctx).await.unwrap(),
+        FilterAction::Continue
+    ));
+    ctx.filter_metadata.remove(super::META_ESTIMATE);
+    ctx.set_metadata(META_TOKEN_TOTAL, "200");
+    let mut body = None;
+    assert!(matches!(
+        filter.on_response_body(&mut ctx, &mut body, true).unwrap(),
+        FilterAction::Continue
+    ));
+
+    // Reservation of 500 still stands (no bogus +200 overage). A second
+    // 500-token admit fits remaining capacity; it would not if settlement
+    // had charged 700.
+    let mut second = crate::test_utils::make_filter_context(&req);
+    assert!(
+        matches!(filter.on_request(&mut second).await.unwrap(), FilterAction::Continue),
+        "skipping reconcile must leave the original 500-token reservation, not 700"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Lost-request handling (the proposal's still-open question, answered here
 // via reservation_timeout)
@@ -649,8 +681,10 @@ fn debug_format_lists_configured_rule_names() {
         .map(|rule| super::compile_rule(rule, &backend))
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
+    let needs_body = rules.iter().any(|r| r.estimation.needs_body());
     let filter = TokenRateLimitFilter {
         rules,
+        needs_body,
         epoch: std::time::Instant::now(),
     };
     let debug = format!("{filter:?}");
@@ -898,6 +932,63 @@ async fn token_bucket_rule_admits_within_capacity_and_denies_over_it() {
         filter.on_request(&mut ctx).await.unwrap(),
         FilterAction::Reject(_)
     ));
+}
+
+#[tokio::test]
+async fn input_plus_max_tokens_strategy_computes_from_body_and_content_length() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 10000\nestimation:\n  strategy: \
+         input_plus_max_tokens\n  fallback_estimate: 100\n  bytes_per_token: 4.0",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let body_bytes = br#"{"max_tokens": 200, "messages": [{"role": "user", "content": "hello"}]}"#;
+    req.headers.insert(
+        http::header::CONTENT_LENGTH,
+        http::HeaderValue::from_str(&body_bytes.len().to_string()).unwrap(),
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "needs_body=true, on_request should defer to on_request_body"
+    );
+
+    let mut body = Some(bytes::Bytes::from(&body_bytes[..]));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "estimate = ceil(body_len/4) + 200 should be within capacity"
+    );
+    assert!(
+        ctx.get_metadata("token_rate_limit.reservation_id").is_some(),
+        "reservation should have been created"
+    );
+}
+
+#[tokio::test]
+async fn malformed_json_body_uses_fallback_estimate() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  \
+         fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from("not valid json at all"));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "malformed JSON should fall back to fallback_estimate=100 and admit"
+    );
+    assert!(
+        ctx.get_metadata("token_rate_limit.reservation_id").is_some(),
+        "fallback estimate should create a reservation"
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -1153,5 +1244,670 @@ async fn valkey_token_bucket_worker_reconciles_usage_off_the_response_path() {
     assert!(
         settled,
         "worker-based reconciliation should eventually credit into the shared bucket"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Estimation strategies (M3)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn from_config_parses_fixed_estimation_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: fixed\n  fallback_estimate: 500",
+    );
+    assert!(TokenRateLimitFilter::from_config(&yaml).is_ok());
+}
+
+#[test]
+fn from_config_parses_max_tokens_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    assert!(TokenRateLimitFilter::from_config(&yaml).is_ok());
+}
+
+#[test]
+fn from_config_parses_input_plus_max_tokens_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: input_plus_max_tokens\n  fallback_estimate: 100\n  bytes_per_token: 3.5",
+    );
+    assert!(TokenRateLimitFilter::from_config(&yaml).is_ok());
+}
+
+#[test]
+fn from_config_parses_model_scaled_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: model_scaled\n  fallback_estimate: 100\n  default_multiplier: 1.5\n  model_multipliers:\n    gpt-4: 2.0\n    gpt-3.5-turbo: 0.5",
+    );
+    assert!(TokenRateLimitFilter::from_config(&yaml).is_ok());
+}
+
+#[test]
+fn from_config_rejects_both_reserved_tokens_and_estimation() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nreserved_tokens: 50\nestimation:\n  strategy: fixed\n  fallback_estimate: 500",
+    );
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("cannot specify both"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_neither_reserved_tokens_nor_estimation() {
+    let yaml = single_rule_yaml("algorithm: sliding_window\nwindow: 1h\ncapacity: 1000");
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("must have either"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_fixed_strategy_without_fallback_estimate() {
+    let yaml =
+        single_rule_yaml("algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: fixed");
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("fallback_estimate"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_strategy_irrelevant_estimation_fields() {
+    let cases: &[(&str, &str)] = &[
+        (
+            "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: fixed\n  fallback_estimate: 100\n  model_multipliers:\n    gpt-4: 2.0",
+            "fixed",
+        ),
+        (
+            "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100\n  bytes_per_token: 3.5",
+            "max_tokens",
+        ),
+        (
+            "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: input_plus_max_tokens\n  fallback_estimate: 100\n  default_multiplier: 1.5",
+            "input_plus_max_tokens",
+        ),
+        (
+            "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: model_scaled\n  fallback_estimate: 100\n  bytes_per_token: 3.5",
+            "model_scaled",
+        ),
+    ];
+    for (body, strategy) in cases {
+        let err = TokenRateLimitFilter::from_config(&single_rule_yaml(body))
+            .err()
+            .unwrap_or_else(|| panic!("{strategy} must reject irrelevant fields"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not accept"),
+            "{strategy}: expected unused-field error, got: {msg}"
+        );
+    }
+}
+
+#[test]
+fn from_config_rejects_fixed_estimate_exceeding_capacity() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 100\nestimation:\n  strategy: fixed\n  fallback_estimate: 200",
+    );
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("must not exceed capacity"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_non_finite_estimation_multiplier() {
+    for literal in [".nan", ".inf"] {
+        let yaml = single_rule_yaml(&format!(
+            "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  multiplier: {literal}\n  fallback_estimate: 100"
+        ));
+        let err = TokenRateLimitFilter::from_config(&yaml)
+            .err()
+            .unwrap_or_else(|| panic!("multiplier: {literal} must be rejected"));
+        assert!(
+            err.to_string().contains("multiplier"),
+            "got: {err} for multiplier: {literal}"
+        );
+    }
+}
+
+#[test]
+fn from_config_rejects_non_finite_bytes_per_token() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: input_plus_max_tokens\n  bytes_per_token: .nan\n  fallback_estimate: 100",
+    );
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("bytes_per_token"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_non_finite_model_multiplier_entry() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: model_scaled\n  default_multiplier: 1.0\n  fallback_estimate: 100\n  model_multipliers:\n    gpt-4: .inf",
+    );
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("model_multipliers"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_non_finite_default_multiplier() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: model_scaled\n  default_multiplier: .nan\n  fallback_estimate: 100",
+    );
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(err.to_string().contains("default_multiplier"), "got: {err}");
+}
+
+#[test]
+fn from_config_rejects_fallback_estimate_exceeding_capacity() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 100\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 200",
+    );
+    let err = TokenRateLimitFilter::from_config(&yaml).err().expect("should error");
+    assert!(
+        err.to_string().contains("fallback_estimate must not exceed capacity"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn fixed_estimation_strategy_reserves_like_legacy_reserved_tokens() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: fixed\n  fallback_estimate: 200",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "fixed estimation should admit within budget"
+    );
+    assert!(ctx.get_metadata("token_rate_limit.reservation_id").is_some());
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_defers_to_on_request_body() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "on_request should pass through when needs_body=true"
+    );
+    assert!(
+        ctx.get_metadata("token_rate_limit.reservation_id").is_none(),
+        "no reservation should be made in on_request when needs_body=true"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_extracts_from_body_and_reserves() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 500, "messages": []}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should admit with max_tokens=500 within capacity=1000"
+    );
+    assert!(
+        ctx.get_metadata("token_rate_limit.reservation_id").is_some(),
+        "reservation should be made in on_request_body"
+    );
+
+    let estimate_meta = ctx.get_metadata("token_rate_limit.estimate").unwrap();
+    assert_eq!(
+        estimate_meta, "500",
+        "estimate metadata should reflect extracted max_tokens"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_prefers_max_tokens_over_max_completion_tokens() {
+    let yaml =
+        single_rule_yaml("algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens");
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(
+        r#"{"max_tokens": 300, "max_completion_tokens": 500, "messages": []}"#,
+    ));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "300",
+        "max_tokens should take priority over max_completion_tokens"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_falls_back_to_max_completion_tokens() {
+    let yaml =
+        single_rule_yaml("algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens");
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_completion_tokens": 250, "messages": []}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "250",
+        "should fall back to max_completion_tokens when max_tokens is absent"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_uses_fallback_when_body_has_no_tokens_field() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 42",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"messages": []}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "42",
+        "should fall back to fallback_estimate when body has no max_tokens"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_admits_without_reservation_when_no_fallback_and_no_body_field() {
+    let yaml =
+        single_rule_yaml("algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens");
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"messages": []}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should admit without reservation when strategy can't extract a value and no fallback"
+    );
+    assert!(
+        ctx.get_metadata("token_rate_limit.reservation_id").is_none(),
+        "no reservation should be made when estimate is unavailable"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_applies_multiplier() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 10000\nestimation:\n  strategy: max_tokens\n  multiplier: 1.5",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 100}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "150",
+        "100 * 1.5 = 150"
+    );
+}
+
+#[tokio::test]
+async fn max_tokens_strategy_denies_when_body_estimate_exceeds_budget() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 100\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 50",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut first_ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut first_ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 60}"#));
+    let action = filter.on_request_body(&mut first_ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut second_ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut second_ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 60}"#));
+    let action = filter.on_request_body(&mut second_ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "second 60-token request should be denied (only 40 of 100 remaining)"
+    );
+}
+
+#[tokio::test]
+async fn on_request_body_is_noop_before_end_of_stream() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 500}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, false).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue without reservation before end_of_stream"
+    );
+    assert!(
+        ctx.get_metadata("token_rate_limit.reservation_id").is_none(),
+        "no reservation before end_of_stream"
+    );
+}
+
+#[tokio::test]
+async fn model_scaled_strategy_applies_per_model_multiplier() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 10000\nestimation:\n  strategy: model_scaled\n  default_multiplier: 1.0\n  model_multipliers:\n    gpt-4: 2.0\n    gpt-3.5-turbo: 0.5",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 100, "model": "gpt-4"}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "200",
+        "100 * 2.0 (gpt-4 multiplier) = 200"
+    );
+}
+
+#[tokio::test]
+async fn model_scaled_strategy_uses_default_multiplier_for_unknown_model() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 10000\nestimation:\n  strategy: model_scaled\n  default_multiplier: 1.5\n  model_multipliers:\n    gpt-4: 2.0",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 100, "model": "claude-3"}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "150",
+        "100 * 1.5 (default multiplier for unknown model) = 150"
+    );
+}
+
+#[tokio::test]
+async fn model_scaled_strategy_reads_model_from_x_model_header_fallback() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 10000\nestimation:\n  strategy: model_scaled\n  default_multiplier: 1.0\n  model_multipliers:\n    gpt-4: 3.0",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    req.headers.insert(
+        http::header::HeaderName::from_static("x-model"),
+        http::HeaderValue::from_static("gpt-4"),
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 100}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "300",
+        "100 * 3.0 (gpt-4 via x-model header) = 300"
+    );
+}
+
+#[tokio::test]
+async fn body_dependent_reconciliation_uses_meta_estimate() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 500}"#));
+    drop(filter.on_request_body(&mut ctx, &mut body, true).await.unwrap());
+
+    ctx.set_metadata(META_TOKEN_TOTAL, "200");
+
+    let mut resp_body = None;
+    drop(filter.on_response_body(&mut ctx, &mut resp_body, true).unwrap());
+
+    // Reserved 500 via body, actual 200 -> refund 300 -> 800 remaining.
+    // A second 500-token request body should be admitted (800 >= 500).
+    let mut second_ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut second_ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 500}"#));
+    let action = filter.on_request_body(&mut second_ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "800 remaining should admit a 500-token request"
+    );
+}
+
+#[test]
+fn from_config_estimation_with_token_bucket_algorithm() {
+    let yaml = single_rule_yaml(
+        "algorithm: token_bucket\ncapacity: 1000\nrefill_rate: 10\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    assert!(
+        TokenRateLimitFilter::from_config(&yaml).is_ok(),
+        "estimation strategies must work with both algorithms"
+    );
+}
+
+#[test]
+fn from_config_fixed_strategy_applies_multiplier_to_estimate() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: fixed\n  fallback_estimate: 100\n  multiplier: 1.5",
+    );
+    assert!(TokenRateLimitFilter::from_config(&yaml).is_ok());
+}
+
+#[test]
+fn request_body_access_is_none_for_fixed_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: fixed\n  fallback_estimate: 500",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.request_body_access(), praxis_filter::BodyAccess::None);
+}
+
+#[test]
+fn request_body_access_is_read_only_for_body_dependent_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.request_body_access(), praxis_filter::BodyAccess::ReadOnly);
+}
+
+#[test]
+fn request_body_mode_is_stream_buffer_for_body_dependent_strategy() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  fallback_estimate: 100",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    assert!(
+        matches!(
+            filter.request_body_mode(),
+            praxis_filter::BodyMode::StreamBuffer {
+                max_bytes: Some(2_097_152)
+            }
+        ),
+        "body-dependent strategies should buffer up to 2 MiB"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Edge cases: empty body, mixed strategies, missing Content-Length,
+// model_scaled outer multiplier composition
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_body_uses_fallback_estimate() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: max_tokens\n  \
+         fallback_estimate: 75",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body: Option<bytes::Bytes> = None;
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "empty body should fall back to fallback_estimate=75 and admit"
+    );
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "75",
+        "estimate should be the fallback when body is absent"
+    );
+}
+
+#[tokio::test]
+async fn mixed_rules_fixed_strategy_ignores_body_when_filter_buffers() {
+    let filter = TokenRateLimitFilter::from_config(&mixed_fixed_and_body_dependent_yaml()).unwrap();
+
+    let fixed_req = make_request_with_header("x-app-id", "fixed-app");
+    let mut ctx = crate::test_utils::make_filter_context(&fixed_req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 9999}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "200",
+        "fixed-strategy rule must use its constant (200), not the body's max_tokens"
+    );
+}
+
+#[tokio::test]
+async fn mixed_rules_body_dependent_strategy_extracts_from_body() {
+    let filter = TokenRateLimitFilter::from_config(&mixed_fixed_and_body_dependent_yaml()).unwrap();
+
+    let body_req = make_request_with_header("x-app-id", "body-app");
+    let mut ctx = crate::test_utils::make_filter_context(&body_req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 300}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "300",
+        "body-dependent rule must use extracted max_tokens (300)"
+    );
+}
+
+fn mixed_fixed_and_body_dependent_yaml() -> serde_yaml::Value {
+    serde_yaml::from_str(
+        "rules:\n\
+         \x20 - name: fixed-rule\n\
+         \x20   match:\n\
+         \x20     headers:\n\
+         \x20       x-app-id: fixed-app\n\
+         \x20   algorithm: sliding_window\n\
+         \x20   window: 1h\n\
+         \x20   capacity: 1000\n\
+         \x20   reserved_tokens: 200\n\
+         \x20 - name: body-rule\n\
+         \x20   match:\n\
+         \x20     headers:\n\
+         \x20       x-app-id: body-app\n\
+         \x20   algorithm: sliding_window\n\
+         \x20   window: 1h\n\
+         \x20   capacity: 1000\n\
+         \x20   estimation:\n\
+         \x20     strategy: max_tokens\n\
+         \x20     fallback_estimate: 100\n",
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn input_plus_max_tokens_defaults_to_zero_input_when_content_length_absent() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 1000\nestimation:\n  strategy: \
+         input_plus_max_tokens\n  fallback_estimate: 100\n  bytes_per_token: 4.0",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    // No Content-Length header set.
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 400}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    // input = ceil(0 / 4.0) = 0, output = 400, total = 400
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "400",
+        "missing Content-Length should default input to 0, estimate = 0 + max_tokens"
+    );
+}
+
+#[tokio::test]
+async fn model_scaled_outer_multiplier_composes_with_per_model_multiplier() {
+    let yaml = single_rule_yaml(
+        "algorithm: sliding_window\nwindow: 1h\ncapacity: 10000\nestimation:\n  strategy: model_scaled\n  \
+         multiplier: 1.5\n  model_multipliers:\n    gpt-4: 2.0\n  default_multiplier: 1.0",
+    );
+    let filter = TokenRateLimitFilter::from_config(&yaml).unwrap();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    // gpt-4: effective multiplier = 2.0 * 1.5 = 3.0, max_tokens=100 → estimate=300
+    let mut body = Some(bytes::Bytes::from(r#"{"max_tokens": 100, "model": "gpt-4"}"#));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+    assert_eq!(
+        ctx.get_metadata("token_rate_limit.estimate").unwrap(),
+        "300",
+        "gpt-4 with outer multiplier 1.5 × model multiplier 2.0 = 3.0 × 100 = 300"
     );
 }


### PR DESCRIPTION
## Summary

Replace the fixed `reserved_tokens` field with pluggable per-rule estimation
strategies. Each rule selects a strategy that computes the estimated token
cost from request metadata before forwarding.

Built-in strategies:

| Strategy | Basis | Use case |
|---|---|---|
| `fixed` | constant per request | Uniform cost (current behavior, backward-compatible) |
| `max_tokens` | `max_tokens` request field | Simple output upper bound |
| `input_plus_max_tokens` | Content-Length + `max_tokens` | Conservative full-cost estimate |
| `model_scaled` | `max_tokens` × model multiplier | Model-aware budgets |

Config shape:
```yaml
rules:
  - name: team-alpha
    algorithm: sliding_window
    window: 1h
    capacity: 100000
    estimation:
      strategy: max_tokens
      multiplier: 1.2
      fallback_estimate: 500
```

Body-dependent strategies conditionally enable request body buffering
(`ReadOnly` + `StreamBuffer`), deferring reservation from `on_request` to
`on_request_body`. Fixed-only configs preserve the existing `on_request` flow
with zero overhead change.

`reserved_tokens` remains supported as shorthand for the fixed strategy
with full backward compatibility — all 118 pre-existing tests pass unchanged.

## Related issue

Closes #882

## Validation

- [x] Unit tests: 157 pass (118 existing + 39 new)
- [x] Config parsing: all 4 strategies, mutual exclusion, parameter validation
- [x] Body-dependent flow: `on_request` deferral, body extraction, fallback chains
- [x] Edge cases: empty body, malformed JSON, missing Content-Length, mixed rules
- [x] model_scaled: per-model multipliers, default fallback, x-model header, outer multiplier composition
- [x] Reconciliation: META_ESTIMATE stashing, overestimate/underestimate settlement
- [x] Backward compat: `reserved_tokens: N` compiles to `Fixed { estimate: N }`
- [x] `make lint` equivalent: clippy (all features) + fmt clean
- [x] Full workspace build clean

## Checklist

- [x] Conventional commit with DCO sign-off
- [x] No new dependencies
- [x] Behind existing `token-rate-limit-filter` feature gate (experimental)
- [x] Doc comments updated (deferred list corrected, YAML example added)
- [x] No backend changes (`backend.rs`, `ledger.rs`, `token_bucket_ledger.rs` untouched)