### PR TITLE
fix(build): tolerate unresolvable cargo metadata in filter discovery

### DIFF
--- a/server/build.rs
+++ b/server/build.rs
@@ -17,7 +17,7 @@
 #![allow(
     clippy::expect_used,
     clippy::print_stdout,
-    reason = "build script: panics are the only error path; println is cargo directives"
+    reason = "build script: expect covers unrecoverable env errors; println is cargo directives"
 )]
 
 use build_support::ActiveFeatures;
@@ -29,17 +29,44 @@ use cargo_metadata::{CargoOpt, Metadata};
 const MANIFEST_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
 
 fn main() {
-    let metadata = load_metadata();
+    let Some(metadata) = load_metadata() else {
+        // `cargo metadata` could not resolve this package in isolation. That
+        // happens whenever the manifest is read away from its workspace: notably a
+        // vendored build, where `cargo vendor` flattens the tree so the sibling
+        // `path` dependencies are no longer beside it, as in a hermetic container
+        // build.
+        //
+        // Only discovery of *external* filter crates is lost. Praxis AI's own
+        // filters are registered explicitly by `build_full_registry`, so a server
+        // built this way still has its full built-in pipeline. `load_metadata`
+        // has already reported the cause.
+        write_generated_file(&build_support::generate_registration_code(&[]));
+        // Still emit the static directives: without them Cargo falls back to
+        // watching only this package's directory, so fixing the workspace root
+        // afterwards would not re-run discovery and the empty registration would
+        // be silently linked in.
+        emit_static_rerun_directives();
+        return;
+    };
+
     let crates = build_support::discover_external_filter_crate_names(&metadata);
     let code = build_support::generate_registration_code(&crates);
     write_generated_file(&code);
     emit_rerun_directives(&metadata);
 }
 
+/// Report that external filter discovery was skipped, naming the cause.
+fn warn_discovery_skipped(cause: &dyn std::fmt::Display) {
+    println!("cargo::warning=praxis-ai-proxy: external filter discovery skipped: {cause}");
+}
+
 /// Load cargo metadata, narrowed to dependencies available for the current
 /// target when Cargo provides one.
-fn load_metadata() -> Metadata {
-    let active_features = active_features();
+///
+/// Returns `None` when metadata resolution fails, which is not an error: see the
+/// fallback in [`main`]. This mirrors the equivalent build script in Praxis core.
+fn load_metadata() -> Option<Metadata> {
+    let active_features = active_features()?;
     let mut command = cargo_metadata::MetadataCommand::new();
     command.manifest_path(MANIFEST_PATH);
     apply_active_features(&mut command, active_features);
@@ -47,23 +74,43 @@ fn load_metadata() -> Metadata {
         command.other_options(vec!["--filter-platform".to_owned(), target]);
     }
 
-    command.exec().expect("failed to run cargo metadata")
+    match command.exec() {
+        Ok(metadata) => Some(metadata),
+        Err(error) => {
+            warn_discovery_skipped(&error);
+            None
+        },
+    }
 }
 
 /// Resolve active package features from Cargo's build-script environment.
-fn active_features() -> ActiveFeatures {
-    let metadata = cargo_metadata::MetadataCommand::new()
+///
+/// Returns `None` when this package's own manifest cannot be read, for the same
+/// reasons described in [`main`].
+fn active_features() -> Option<ActiveFeatures> {
+    let metadata = match cargo_metadata::MetadataCommand::new()
         .manifest_path(MANIFEST_PATH)
         .no_deps()
         .exec()
-        .expect("failed to read package feature metadata");
-    let package = metadata
-        .packages
-        .iter()
-        .find(|pkg| pkg.name == env!("CARGO_PKG_NAME"))
-        .expect("praxis-ai package not found in metadata");
+    {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            warn_discovery_skipped(&error);
+            return None;
+        },
+    };
+    let Some(package) = metadata.packages.iter().find(|pkg| pkg.name == env!("CARGO_PKG_NAME")) else {
+        warn_discovery_skipped(&concat!(
+            env!("CARGO_PKG_NAME"),
+            " is absent from its own cargo metadata"
+        ));
+        return None;
+    };
 
-    build_support::resolve_active_features(&package.features, std::env::vars())
+    Some(build_support::resolve_active_features(
+        &package.features,
+        std::env::vars(),
+    ))
 }
 
 /// Apply the current build's active feature set to a `cargo metadata` command.
@@ -83,12 +130,20 @@ fn write_generated_file(code: &str) {
     std::fs::write(&dest, code).expect("failed to write external_filters.rs");
 }
 
-/// Tell Cargo when to re-run this build script.
-fn emit_rerun_directives(metadata: &Metadata) {
+/// Tell Cargo to re-run this build script when this crate's own inputs change.
+///
+/// Emitted on every path, including the fallback, because any `rerun-if-changed`
+/// replaces Cargo's default of watching the whole package directory.
+fn emit_static_rerun_directives() {
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=../Cargo.toml");
     println!("cargo:rerun-if-changed=../Cargo.lock");
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+/// Tell Cargo when to re-run this build script.
+fn emit_rerun_directives(metadata: &Metadata) {
+    emit_static_rerun_directives();
 
     for manifest_path in build_support::direct_runtime_dependency_manifest_paths(metadata) {
         println!("cargo:rerun-if-changed={manifest_path}");


### PR DESCRIPTION
## Problem

`server/build.rs` panics when `cargo metadata` cannot resolve `praxis-ai-proxy`'s
manifest on its own:

```
panicked at server/build.rs:50:
failed to run cargo metadata: ... failed to get `praxis-ai-apis` as a
dependency of package `praxis-ai-proxy v0.3.0 (/vendor/praxis-ai-proxy)`
```

This happens whenever the manifest is read away from its workspace. Two real cases:

- `cargo publish` verification.
- A vendored build: `cargo vendor` flattens the tree, so the manifest's
  `path = "../apis"` no longer points anywhere. This blocks hermetic container
  builds, where dependencies are prefetched and the build itself runs with no
  network.

## Fix

Praxis core's equivalent script, `crates/server/build.rs`, already handles this:
`load_metadata` returns `Option<Metadata>` and `main` falls back to an empty
registration. Its doc comment names the same cause — *"Returns `None` when metadata
resolution fails (e.g. during `cargo publish` verification where path dependencies
are not available)."*

This restores that behaviour, which was lost when the discovery logic moved into
`praxis-ai-build-support`. One addition over core: the fallback emits a
`cargo::warning`, so a downstream crate that expected its filters to be discovered
can see why they were not.

## Why this is safe

`build_full_registry` registers Praxis AI's own filters explicitly:

```rust
let mut registry = praxis_filter::FilterRegistry::with_builtins();
praxis_ai_filters::register_ai_filters(&mut registry, Some(subrequest_client));
register_llmd_ext_proc(&mut registry);
register_external_filters(&mut registry);   // generated by build.rs
```

The generated function only ever covers third-party crates carrying
`[package.metadata.praxis-filters]`. A server built in a vendored context keeps its
full built-in pipeline; only third-party discovery is skipped, and it now says so.

## Verification

- Vendored workspace built with `--network none`: before, aborted in this script;
  after, `Finished release profile in 2m 10s` and a working binary.
- `cargo +nightly fmt --check`, `cargo check -p praxis-ai-proxy` (which runs the
  script), `cargo clippy -p praxis-ai-proxy --all-targets -- -D warnings`: clean.
- `cargo test -p praxis-ai-build-support`: 10 passed. The fallback reuses
  `generate_registration_code(&[])`, already covered by
  `generate_registration_code_emits_calls_and_empty_case_suppression`.

No new tests: the change is in the build-script orchestrator, which by the file's own
note cannot carry unit tests; the logic it calls lives in `build_support` and is
unchanged.

## Context

Found while making the experimental gateway image buildable by Konflux for an Open
Data Hub developer preview, where builds are hermetic. Opened as a draft for
maintainer review of the approach.
