### PR TITLE
docs(agents): require SDK-client integration tests for openai/anthropic api changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,16 @@ New capabilities require:
 4. Functional integration test for the example config
 5. Generated example and filter documentation kept in sync
 
+When changing anything under `apis/src/openai/`, always add or extend
+integration tests exercised through the OpenAI client where possible, in
+`tests/integration/sdk/openai/test_openai_conversations.py` or
+`tests/integration/sdk/openai/test_openai_responses_vllm.py`.
+
+When changing anything under `apis/src/anthropic/`, always add or extend
+integration tests exercised through the Anthropic client where possible, in
+`tests/integration/sdk/anthropic/` (e.g.
+`tests/integration/sdk/anthropic/test_anthropic_error_formatter.py`).
+
 ## Inference Fixture Maintenance
 
 When an inference transformation behavior changes, update its tests and


### PR DESCRIPTION
## Summary

Adds guidance to `AGENTS.md` requiring provider SDK-client integration tests when touching the OpenAI or Anthropic API code:

- Changes under `apis/src/openai/` must add/extend integration tests exercised through the **OpenAI client**, in `tests/integration/sdk/openai/test_openai_conversations.py` or `tests/integration/sdk/openai/test_openai_responses_vllm.py`.
- Changes under `apis/src/anthropic/` must add/extend integration tests exercised through the **Anthropic client**, in `tests/integration/sdk/anthropic/` (e.g. `tests/integration/sdk/anthropic/test_anthropic_error_formatter.py`).

## Notes

- Docs-only change (`AGENTS.md`, which `.claude/CLAUDE.md` symlinks to). No code, no lint impact.
- The `tests/integration/sdk/anthropic/` directory is introduced by #922 (still open); this guidance is correct going forward once that lands.