### PR TITLE
ci(vllm): pin transformers to 5.16.1 for OGX file-search indexing

### DIFF
--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -52,6 +52,18 @@ env:
   # identical (uv reuses the same cached environment) and the two jobs can't
   # drift. Bump this line deliberately to pull a newer OGX.
   OGX_SPEC: "ogx[starter]==1.3.1"
+  # Pin transformers alongside OGX. ogx[starter] only constrains
+  # sentence-transformers (>=5.6.0, no upper bound), which in turn allows
+  # transformers >=5.0.0,<6.0.0 with no lower ceiling. transformers 5.17.0
+  # (PyPI 2026-09-09) removed ModuleUtilsMixin.get_extended_attention_mask,
+  # which OGX's inline Nomic embedding model (file-search vector-store indexing)
+  # calls via trust_remote_code, so every run that re-resolved the closure after
+  # 5.17.0 landed failed the two file-search tests with
+  #   'NomicBertModel' object has no attribute 'get_extended_attention_mask'.
+  # 5.16.1 is the last release that still ships the method and satisfies
+  # sentence-transformers 6.0.1's transformers>=5.0.0,<6.0.0 range. Bump this
+  # line deliberately once OGX / the Nomic model support transformers 5.17+.
+  TRANSFORMERS_SPEC: "transformers==5.16.1"
 
 jobs:
   # ----------------------------------------------------------------------------
@@ -143,14 +155,15 @@ jobs:
           # "Wait for OGX readiness" window and loses the race under network
           # variance, so the server never binds port 8321 in time (exit 124).
           echo "Pre-installing OGX ($OGX_SPEC)..."
-          uv run --with "$OGX_SPEC" ogx --help > /dev/null
+          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx --help > /dev/null
           echo "OGX environment ready"
 
       - name: Start OGX
         run: |
-          # Same "$OGX_SPEC" as the pre-install above, so uv reuses the already
-          # materialized environment and the server binds within seconds.
-          uv run --with "$OGX_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          # Same "$OGX_SPEC" + "$TRANSFORMERS_SPEC" as the pre-install above, so
+          # uv reuses the already materialized environment and the server binds
+          # within seconds.
+          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
           echo $! > /tmp/ogx.pid
 
       - name: Build Praxis
@@ -286,14 +299,15 @@ jobs:
           # "Wait for OGX readiness" window and loses the race under network
           # variance, so the server never binds port 8321 in time (exit 124).
           echo "Pre-installing OGX ($OGX_SPEC)..."
-          uv run --with "$OGX_SPEC" ogx --help > /dev/null
+          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx --help > /dev/null
           echo "OGX environment ready"
 
       - name: Start OGX
         run: |
-          # Same "$OGX_SPEC" as the pre-install above, so uv reuses the already
-          # materialized environment and the server binds within seconds.
-          uv run --with "$OGX_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          # Same "$OGX_SPEC" + "$TRANSFORMERS_SPEC" as the pre-install above, so
+          # uv reuses the already materialized environment and the server binds
+          # within seconds.
+          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
           echo $! > /tmp/ogx.pid
 
       - name: Build Praxis


### PR DESCRIPTION
## Problem

The **vLLM Integration** workflow's two file-search tests started erroring
across *all* open PRs on 2026-09-09:

- `TestFileSearchVLLM::test_file_search_with`
- `TestFileSearchChatCompletionsVLLM::test_file_search_translated_to_chat_function_round_trip`

Both fail in the `vector_store` fixture with:

```
RuntimeError: OGX indexing failed: {'code': 'server_error',
  'message': "'NomicBertModel' object has no attribute 'get_extended_attention_mask'"}
```

## Root cause

`transformers==5.17.0` was uploaded to PyPI at **2026-09-09 15:39:53 UTC** and
**removed** `ModuleUtilsMixin.get_extended_attention_mask`:

| version | `def get_extended_attention_mask` |
|---------|-----------------------------------|
| 5.16.1  | present (`modeling_utils.py:972`) |
| 5.17.0  | **removed** (0 occurrences)       |

OGX's inline Nomic embedding model (used for file-search vector-store indexing)
calls `self.get_extended_attention_mask(...)` via `trust_remote_code`, so it
raises `AttributeError` under 5.17.0.

`ogx[starter]==1.3.1` (the latest OGX on PyPI — nothing newer to bump to) only
constrains `sentence-transformers>=5.6.0` with no upper bound; `sentence-transformers`
6.0.1 in turn allows `transformers>=5.0.0,<6.0.0` with **no lower ceiling**. So
every run that re-resolved the dependency closure after 5.17.0 landed pulled it
in and broke. This is environment drift, not a code regression — the last green
`main` run (14:00 UTC, before 5.17.0 existed) resolved to 5.16.1, and `main`
only *looks* green because it has not re-run since.

## Fix

Pin `transformers==5.16.1` (last release that ships the method and satisfies
`sentence-transformers` 6.0.1's range) via a single-sourced `TRANSFORMERS_SPEC`
env var, applied to all four OGX invocations (pre-install + start, in both the
`vllm-responses` and `vllm-responses-postgres` jobs).

The uv `cache-dependency-glob` already keys on this workflow file, so changing
the pin invalidates the cache automatically.

## Verification

- `uv pip compile` (linux x86_64, py3.12) with the pin resolves
  `transformers==5.16.1`, keeps `sentence-transformers==6.0.1`, 247 packages,
  no conflict.
- Confirmed the same failure on an unrelated PR (Azure translation) — this is
  cross-PR, not branch-specific.
- YAML validated; all 4 OGX invocations carry the pin.