### PR TITLE
perf(anthropic-translation): consume owned request fields and tool schemas

### DIFF
--- a/apis/src/anthropic/messages_to_chat_completions/mod.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/mod.rs
@@ -153,8 +153,10 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
             _ => return Ok(FilterAction::Continue),
         };
 
-        extract_request_metadata(ctx, bytes);
-        Ok(transform_request_body(body))
+        let value = serde_json::from_slice::<serde_json::Value>(bytes);
+
+        extract_request_metadata(ctx, &value);
+        Ok(transform_request_body(body, value))
     }
 
     fn on_response_body(
@@ -200,9 +202,9 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
 // Request Body Helpers
 // -----------------------------------------------------------------------------
 
-/// Extract streaming and model metadata from the request body.
-fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, bytes: &[u8]) {
-    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+/// Extract streaming and model metadata from the parsed request body.
+fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, value: &Result<serde_json::Value, serde_json::Error>) {
+    let Ok(value) = value else {
         ctx.set_metadata("anthropic_messages_to_chat_completions.streaming", "false");
         return;
     };
@@ -225,12 +227,15 @@ fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, bytes: &[u8]) {
 }
 
 /// Transform the request body and return the appropriate filter action.
-fn transform_request_body(body: &mut Option<Bytes>) -> FilterAction {
+fn transform_request_body(
+    body: &mut Option<Bytes>,
+    value: Result<serde_json::Value, serde_json::Error>,
+) -> FilterAction {
     let Some(bytes) = body.as_ref() else {
         return FilterAction::Continue;
     };
 
-    match request::transform_request(bytes) {
+    match request::transform_request(value) {
         Ok(transformed) => {
             debug!(
                 original_len = bytes.len(),
@@ -536,9 +541,9 @@ mod tests {
     fn extract_request_metadata_streaming_true_with_model() {
         let request = make_request(Method::POST, "/v1/messages");
         let mut ctx = make_filter_context(&request);
-        let bytes = br#"{"stream":true,"model":"claude-opus-4-8"}"#;
+        let value = serde_json::from_slice(br#"{"stream":true,"model":"claude-opus-4-8"}"#);
 
-        extract_request_metadata(&mut ctx, bytes);
+        extract_request_metadata(&mut ctx, &value);
 
         assert_eq!(
             ctx.filter_metadata
@@ -558,9 +563,9 @@ mod tests {
     fn extract_request_metadata_streaming_false() {
         let request = make_request(Method::POST, "/v1/messages");
         let mut ctx = make_filter_context(&request);
-        let bytes = br#"{"stream":false,"model":"gpt-4"}"#;
+        let value = serde_json::from_slice(br#"{"stream":false,"model":"gpt-4"}"#);
 
-        extract_request_metadata(&mut ctx, bytes);
+        extract_request_metadata(&mut ctx, &value);
 
         assert_eq!(
             ctx.filter_metadata
@@ -581,7 +586,7 @@ mod tests {
         let request = make_request(Method::POST, "/v1/messages");
         let mut ctx = make_filter_context(&request);
 
-        extract_request_metadata(&mut ctx, b"not json");
+        extract_request_metadata(&mut ctx, &serde_json::from_slice::<serde_json::Value>(b"not json"));
 
         assert_eq!(
             ctx.filter_metadata
@@ -602,7 +607,7 @@ mod tests {
     #[test]
     fn transform_request_body_none_continues() {
         let mut body: Option<Bytes> = None;
-        let action = transform_request_body(&mut body);
+        let action = transform_request_body(&mut body, serde_json::from_slice(br#"{"model":"claude-opus-4-8"}"#));
 
         assert!(matches!(action, FilterAction::Continue));
         assert!(body.is_none());
@@ -625,10 +630,9 @@ mod tests {
 
     #[test]
     fn transform_request_body_valid_transforms() {
-        let mut body = Some(Bytes::from(
-            br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#.to_vec(),
-        ));
-        let action = transform_request_body(&mut body);
+        let raw = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
+        let mut body = Some(Bytes::from(raw.to_vec()));
+        let action = transform_request_body(&mut body, serde_json::from_slice(raw));
 
         assert!(matches!(action, FilterAction::Continue));
         assert!(body.is_some());
@@ -643,7 +647,7 @@ mod tests {
     #[test]
     fn transform_request_body_invalid_rejects() {
         let mut body = Some(Bytes::from_static(b"not json"));
-        let action = transform_request_body(&mut body);
+        let action = transform_request_body(&mut body, serde_json::from_slice(b"not json"));
 
         let FilterAction::Reject(rejection) = action else {
             panic!("invalid body should produce a rejection");

--- a/apis/src/anthropic/messages_to_chat_completions/mod.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/mod.rs
@@ -157,7 +157,7 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
         let transformed = match serde_json::from_slice::<serde_json::Value>(bytes) {
             Ok(value) => {
                 extract_request_metadata(ctx, Some(&value));
-                request::transform_request(value)
+                request::transform_request(value, bytes.len())
             },
             Err(error) => {
                 extract_request_metadata(ctx, None);
@@ -554,7 +554,7 @@ mod tests {
     fn translate(body: &[u8]) -> Result<Vec<u8>, String> {
         let value: serde_json::Value =
             serde_json::from_slice(body).map_err(|error| format!("invalid JSON: {error}"))?;
-        request::transform_request(value)
+        request::transform_request(value, body.len())
     }
 
     #[test]

--- a/apis/src/anthropic/messages_to_chat_completions/mod.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/mod.rs
@@ -156,7 +156,7 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
         let transformed = match serde_json::from_slice::<serde_json::Value>(bytes) {
             Ok(value) => {
                 extract_request_metadata(ctx, Some(&value));
-                request::transform_request(value, bytes.len())
+                request::transform_request(value)
             },
             Err(error) => {
                 extract_request_metadata(ctx, None);
@@ -551,7 +551,7 @@ mod tests {
     fn translate(body: &[u8]) -> Result<Vec<u8>, String> {
         let value: serde_json::Value =
             serde_json::from_slice(body).map_err(|error| format!("invalid JSON: {error}"))?;
-        request::transform_request(value, body.len())
+        request::transform_request(value)
     }
 
     #[test]

--- a/apis/src/anthropic/messages_to_chat_completions/mod.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/mod.rs
@@ -153,7 +153,6 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
             _ => return Ok(FilterAction::Continue),
         };
 
-        // Parse once: the metadata pass borrows the value, then translation consumes it.
         let transformed = match serde_json::from_slice::<serde_json::Value>(bytes) {
             Ok(value) => {
                 extract_request_metadata(ctx, Some(&value));
@@ -212,8 +211,6 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
 // -----------------------------------------------------------------------------
 
 /// Extract streaming and model metadata from the parsed request body.
-///
-/// `None` means the body did not parse, which is reported as non-streaming.
 fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, value: Option<&serde_json::Value>) {
     let Some(value) = value else {
         ctx.set_metadata("anthropic_messages_to_chat_completions.streaming", "false");

--- a/apis/src/anthropic/messages_to_chat_completions/mod.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/mod.rs
@@ -153,10 +153,19 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
             _ => return Ok(FilterAction::Continue),
         };
 
-        let value = serde_json::from_slice::<serde_json::Value>(bytes);
+        // Parse once: the metadata pass borrows the value, then translation consumes it.
+        let transformed = match serde_json::from_slice::<serde_json::Value>(bytes) {
+            Ok(value) => {
+                extract_request_metadata(ctx, Some(&value));
+                request::transform_request(value)
+            },
+            Err(error) => {
+                extract_request_metadata(ctx, None);
+                Err(format!("invalid JSON: {error}"))
+            },
+        };
 
-        extract_request_metadata(ctx, &value);
-        Ok(transform_request_body(body, value))
+        Ok(transform_request_body(body, transformed))
     }
 
     fn on_response_body(
@@ -203,8 +212,10 @@ impl HttpFilter for AnthropicMessagesToChatCompletionsFilter {
 // -----------------------------------------------------------------------------
 
 /// Extract streaming and model metadata from the parsed request body.
-fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, value: &Result<serde_json::Value, serde_json::Error>) {
-    let Ok(value) = value else {
+///
+/// `None` means the body did not parse, which is reported as non-streaming.
+fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, value: Option<&serde_json::Value>) {
+    let Some(value) = value else {
         ctx.set_metadata("anthropic_messages_to_chat_completions.streaming", "false");
         return;
     };
@@ -226,16 +237,13 @@ fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, value: &Result<serd
     ctx.set_metadata("anthropic_messages_to_chat_completions.model", model);
 }
 
-/// Transform the request body and return the appropriate filter action.
-fn transform_request_body(
-    body: &mut Option<Bytes>,
-    value: Result<serde_json::Value, serde_json::Error>,
-) -> FilterAction {
+/// Install a translated request body, or reject when translation failed.
+fn transform_request_body(body: &mut Option<Bytes>, transformed: Result<Vec<u8>, String>) -> FilterAction {
     let Some(bytes) = body.as_ref() else {
         return FilterAction::Continue;
     };
 
-    match request::transform_request(value) {
+    match transformed {
         Ok(transformed) => {
             debug!(
                 original_len = bytes.len(),
@@ -537,13 +545,25 @@ mod tests {
 
     // --- extract_request_metadata ---
 
+    /// Parse a raw body the way `on_request_body` does, for the metadata pass.
+    fn parse(body: &[u8]) -> Option<serde_json::Value> {
+        serde_json::from_slice(body).ok()
+    }
+
+    /// Translate a raw body the way `on_request_body` does, parse errors included.
+    fn translate(body: &[u8]) -> Result<Vec<u8>, String> {
+        let value: serde_json::Value =
+            serde_json::from_slice(body).map_err(|error| format!("invalid JSON: {error}"))?;
+        request::transform_request(value)
+    }
+
     #[test]
     fn extract_request_metadata_streaming_true_with_model() {
         let request = make_request(Method::POST, "/v1/messages");
         let mut ctx = make_filter_context(&request);
-        let value = serde_json::from_slice(br#"{"stream":true,"model":"claude-opus-4-8"}"#);
+        let value = parse(br#"{"stream":true,"model":"claude-opus-4-8"}"#);
 
-        extract_request_metadata(&mut ctx, &value);
+        extract_request_metadata(&mut ctx, value.as_ref());
 
         assert_eq!(
             ctx.filter_metadata
@@ -563,9 +583,9 @@ mod tests {
     fn extract_request_metadata_streaming_false() {
         let request = make_request(Method::POST, "/v1/messages");
         let mut ctx = make_filter_context(&request);
-        let value = serde_json::from_slice(br#"{"stream":false,"model":"gpt-4"}"#);
+        let value = parse(br#"{"stream":false,"model":"gpt-4"}"#);
 
-        extract_request_metadata(&mut ctx, &value);
+        extract_request_metadata(&mut ctx, value.as_ref());
 
         assert_eq!(
             ctx.filter_metadata
@@ -586,7 +606,7 @@ mod tests {
         let request = make_request(Method::POST, "/v1/messages");
         let mut ctx = make_filter_context(&request);
 
-        extract_request_metadata(&mut ctx, &serde_json::from_slice::<serde_json::Value>(b"not json"));
+        extract_request_metadata(&mut ctx, parse(b"not json").as_ref());
 
         assert_eq!(
             ctx.filter_metadata
@@ -607,7 +627,7 @@ mod tests {
     #[test]
     fn transform_request_body_none_continues() {
         let mut body: Option<Bytes> = None;
-        let action = transform_request_body(&mut body, serde_json::from_slice(br#"{"model":"claude-opus-4-8"}"#));
+        let action = transform_request_body(&mut body, translate(br#"{"model":"claude-opus-4-8"}"#));
 
         assert!(matches!(action, FilterAction::Continue));
         assert!(body.is_none());
@@ -632,7 +652,7 @@ mod tests {
     fn transform_request_body_valid_transforms() {
         let raw = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
         let mut body = Some(Bytes::from(raw.to_vec()));
-        let action = transform_request_body(&mut body, serde_json::from_slice(raw));
+        let action = transform_request_body(&mut body, translate(raw));
 
         assert!(matches!(action, FilterAction::Continue));
         assert!(body.is_some());
@@ -647,7 +667,7 @@ mod tests {
     #[test]
     fn transform_request_body_invalid_rejects() {
         let mut body = Some(Bytes::from_static(b"not json"));
-        let action = transform_request_body(&mut body, serde_json::from_slice(b"not json"));
+        let action = transform_request_body(&mut body, translate(b"not json"));
 
         let FilterAction::Reject(rejection) = action else {
             panic!("invalid body should produce a rejection");

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -431,24 +431,29 @@ fn flatten_search_result(mut block: Map<String, Value>) -> Option<String> {
         return None;
     }
 
-    let mut lines = Vec::new();
+    let mut flattened = String::new();
 
     if let Some(title) = title {
-        lines.push(format!("Search result: {}", quote_label_value(&title)));
+        flattened.push_str("Search result: ");
+        flattened.push_str(&quote_label_value(&title));
     } else {
-        lines.push("Search result".to_owned());
+        flattened.push_str("Search result");
     }
 
     if let Some(source) = source {
-        lines.push(format!("Source: {}", quote_label_value(&source)));
+        flattened.push_str("\nSource: ");
+        flattened.push_str(&quote_label_value(&source));
     }
 
     if !content.is_empty() {
-        lines.push("Content:".to_owned());
+        flattened.push_str("\nContent:");
+        for text in content {
+            flattened.push('\n');
+            flattened.push_str(&text);
+        }
     }
 
-    lines.extend(content);
-    non_empty_lines(&lines)
+    Some(flattened)
 }
 
 /// Flatten an Anthropic `document` block to plain text.
@@ -461,23 +466,26 @@ fn flatten_document(mut block: Map<String, Value>) -> Option<String> {
         return None;
     }
 
-    let mut lines = Vec::new();
+    let mut flattened = String::new();
 
     if let Some(title) = title {
-        lines.push(format!("Document: {}", quote_label_value(&title)));
+        flattened.push_str("Document: ");
+        flattened.push_str(&quote_label_value(&title));
     } else {
-        lines.push("Document".to_owned());
+        flattened.push_str("Document");
     }
 
     if let Some(context) = context {
-        lines.push(format!("Context: {}", quote_label_value(&context)));
+        flattened.push_str("\nContext: ");
+        flattened.push_str(&quote_label_value(&context));
     }
 
     if let Some(source_text) = source_text {
-        lines.push(source_text);
+        flattened.push('\n');
+        flattened.push_str(&source_text);
     }
 
-    non_empty_lines(&lines)
+    Some(flattened)
 }
 
 /// Flatten a `document.source` value to extractable text or a stable reference.

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -13,7 +13,7 @@ use tracing::warn;
 /// Transform a parsed Anthropic Messages request body into Chat
 /// Completions-compatible format.
 /// Returns the transformed JSON bytes, or an error message.
-pub(crate) fn transform_request(value: Value, original_len: usize) -> Result<Vec<u8>, String> {
+pub(crate) fn transform_request(value: Value) -> Result<Vec<u8>, String> {
     let Value::Object(mut body) = value else {
         return Err("request body is not a JSON object".to_owned());
     };
@@ -45,7 +45,7 @@ pub(crate) fn transform_request(value: Value, original_len: usize) -> Result<Vec
     convert_parallel_tool_calls(&mut chat, tool_choice.as_ref());
     convert_tool_choice(&mut chat, tool_choice, had_tools);
 
-    serialize_chat(chat, original_len)
+    serde_json::to_vec(&Value::Object(chat)).map_err(|e| format!("serialization failed: {e}"))
 }
 
 // -----------------------------------------------------------------------------
@@ -71,18 +71,6 @@ fn insert_if_some(target: &mut Map<String, Value>, key: &str, value: Option<Valu
     if let Some(value) = value {
         target.insert(key.to_owned(), value);
     }
-}
-
-// -----------------------------------------------------------------------------
-// Serialization
-// -----------------------------------------------------------------------------
-
-/// Serialize the translated body into a buffer pre-sized from the Anthropic
-/// body it was translated from.
-fn serialize_chat(chat: Map<String, Value>, original_len: usize) -> Result<Vec<u8>, String> {
-    let mut buffer = Vec::with_capacity(original_len);
-    serde_json::to_writer(&mut buffer, &Value::Object(chat)).map_err(|e| format!("serialization failed: {e}"))?;
-    Ok(buffer)
 }
 
 /// Build the Chat Completions `messages` array from the Anthropic `system` and
@@ -791,7 +779,7 @@ mod tests {
     /// parse-once call path including its parse-error message.
     fn transform_bytes(body: &[u8]) -> Result<Vec<u8>, String> {
         let value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
-        transform_request(value, body.len())
+        transform_request(value)
     }
 
     #[test]

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -48,8 +48,6 @@ pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
     convert_stream(&mut chat, stream, stream_options);
     map_parameters(&mut chat, stop_sequences, temperature, top_p, top_k);
     convert_tools(&mut chat, tools);
-    // Borrows `tool_choice`; the conversion below consumes it. Reordering the
-    // two is a borrow-check error rather than a silent behavior change.
     convert_parallel_tool_calls(&mut chat, tool_choice.as_ref());
     convert_tool_choice(&mut chat, tool_choice, had_tools);
 
@@ -66,13 +64,7 @@ fn build_messages(system: Option<Value>, messages: Option<Value>) -> Value {
 }
 
 /// Build a Chat Completions message carrying plain string content.
-fn text_message(role: &str, content: String) -> Value {
-    owned_text_message(role.to_owned(), content)
-}
-
-/// [`text_message`] for callers that already own the role, so it moves through
-/// instead of being copied out of a string that dies immediately after.
-fn owned_text_message(role: String, content: String) -> Value {
+fn text_message(role: String, content: String) -> Value {
     let mut message = Map::new();
     message.insert("role".to_owned(), Value::String(role));
     message.insert("content".to_owned(), Value::String(content));
@@ -80,9 +72,6 @@ fn owned_text_message(role: String, content: String) -> Value {
 }
 
 /// Build a Chat Completions `text` content part, moving `text` into it.
-///
-/// Built by hand rather than with `json!`, which would deep-clone the string
-/// back through the serializer.
 fn text_content_part(text: String) -> Value {
     let mut part = Map::new();
     part.insert("type".to_owned(), Value::String("text".to_owned()));
@@ -91,9 +80,6 @@ fn text_content_part(text: String) -> Value {
 }
 
 /// Build a Chat Completions `image_url` content part, moving `url` into it.
-///
-/// `url` carries the whole base64 payload for inline images, so it must not be
-/// re-serialized through `json!`.
 fn image_content_part(url: String) -> Value {
     let mut image_url = Map::new();
     image_url.insert("url".to_owned(), Value::String(url));
@@ -127,7 +113,7 @@ fn hoist_system(messages: &mut Vec<Value>, system: Option<Value>) {
     };
 
     if !content.is_empty() {
-        messages.push(text_message("system", content));
+        messages.push(text_message("system".to_owned(), content));
     }
 }
 
@@ -151,34 +137,28 @@ fn convert_messages(messages: &mut Vec<Value>, source: Option<Value>) {
 
         match msg.remove("content") {
             Some(Value::String(text)) => {
-                messages.push(owned_text_message(role, text));
+                messages.push(text_message(role, text));
             },
             Some(Value::Array(blocks)) => {
                 convert_content_blocks(messages, &role, blocks);
             },
             _ => {
-                messages.push(owned_text_message(role, String::new()));
+                messages.push(text_message(role, String::new()));
             },
         }
     }
 }
 
 /// Convert typed content blocks to Chat Completions-compatible format.
-///
-/// Consumes the blocks: in an agentic request they carry the bulk of the body
-/// (inline images, tool results, accumulated turn history), so every leaf below
-/// moves its payload into the translated message instead of copying it.
+/// Consumes the blocks to move their payloads into the translated message.
 fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: Vec<Value>) {
     let mut acc = BlockAccumulator::default();
 
     for block in blocks {
-        let Value::Object(mut block) = block else {
-            // A non-object block exposes no `type`, exactly as reading through
-            // `Value::get` saw it.
-            warn!(block_type = "", "dropping unknown Anthropic content block type");
-            continue;
+        let mut block = match block {
+            Value::Object(block) => block,
+            _ => Map::new(),
         };
-        // No branch below reads `type` again, so it is taken out with the rest.
         let block_type = take_string(&mut block, "type").unwrap_or_default();
         convert_single_block(block, &block_type, messages, role, &mut acc);
     }
@@ -189,8 +169,7 @@ fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: Vec<Val
 /// Chat Completions output accumulated across one message's content blocks.
 #[derive(Default)]
 struct BlockAccumulator {
-    /// Content parts in wire order. A lone text part later collapses to string
-    /// content, so the text is not tracked separately.
+    /// Content parts in wire order.
     content_parts: Vec<Value>,
     /// Tool calls hoisted out of `tool_use` blocks.
     tool_calls: Vec<Value>,
@@ -254,9 +233,6 @@ fn convert_document_block(block: Map<String, Value>, content_parts: &mut Vec<Val
 }
 
 /// Take the string out of a `text` content part, leaving other parts untouched.
-///
-/// The part is about to be dropped by both callers, so the payload moves out
-/// instead of being copied.
 fn take_text_part(part: &mut Value) -> Option<String> {
     let part = part.as_object_mut()?;
     if part.get("type").and_then(Value::as_str) != Some("text") {
@@ -266,10 +242,6 @@ fn take_text_part(part: &mut Value) -> Option<String> {
 }
 
 /// Concatenate the text of every text content part, moving each string out.
-///
-/// `None` means no text part was present, which is distinct from text parts
-/// that are all empty: the caller emits no `content` for the former and an
-/// empty string for the latter.
 fn take_joined_text(content_parts: &mut [Value]) -> Option<String> {
     let mut joined: Option<String> = None;
     for part in content_parts {
@@ -277,8 +249,6 @@ fn take_joined_text(content_parts: &mut [Value]) -> Option<String> {
             continue;
         };
         match &mut joined {
-            // The first text moves in whole, so the common single-text case
-            // never copies its payload.
             None => joined = Some(text),
             Some(acc) => acc.push_str(&text),
         }
@@ -291,11 +261,9 @@ fn convert_tool_use_block(mut block: Map<String, Value>, tool_calls: &mut Vec<Va
     let id = take_string(&mut block, "id").unwrap_or_default();
     let name = take_string(&mut block, "name").unwrap_or_default();
 
-    // An absent `input` serializes as the empty object the old placeholder
-    // produced; an explicit `null` still serializes as `null`.
     let args = match block.remove("input") {
         Some(input) => serde_json::to_string(&input).unwrap_or_default(),
-        None => "{}".to_owned(),
+        None => serde_json::to_string(&Value::Object(Map::new())).unwrap_or_default(),
     };
 
     let mut function = Map::new();
@@ -312,8 +280,6 @@ fn convert_tool_use_block(mut block: Map<String, Value>, tool_calls: &mut Vec<Va
 /// Convert a `tool_result` content block to a Chat Completions tool message.
 fn convert_tool_result_block(mut block: Map<String, Value>, messages: &mut Vec<Value>) {
     let tool_call_id = take_string(&mut block, "tool_use_id").unwrap_or_default();
-    // Read before `content` is taken: `is_error` decides how the text below is
-    // marked, and both live in the same map.
     let is_error = block.get("is_error").and_then(Value::as_bool) == Some(true);
 
     let (mut result_content, image_content) = split_tool_result_content(block.remove("content"));
@@ -341,8 +307,6 @@ fn finalize_content_blocks(messages: &mut Vec<Value>, role: &str, mut acc: Block
     if role == "assistant" && !acc.tool_calls.is_empty() {
         let mut msg = Map::new();
         msg.insert("role".to_owned(), Value::String("assistant".to_owned()));
-        // This branch carries string content only, so any image part collected
-        // alongside the text is dropped here.
         if let Some(text) = take_joined_text(&mut acc.content_parts) {
             msg.insert("content".to_owned(), Value::String(text));
         }
@@ -359,18 +323,14 @@ fn flush_content_parts(messages: &mut Vec<Value>, content_parts: &mut Vec<Value>
         return;
     }
 
-    // A lone text part collapses to string content; anything else stays an
-    // array. Resolved before the `else` branch so the borrow ends here.
     let lone_text = match content_parts.as_mut_slice() {
         [part] => take_text_part(part),
         _ => None,
     };
 
     if let Some(text) = lone_text {
-        messages.push(text_message(role, text));
+        messages.push(text_message(role.to_owned(), text));
     } else {
-        // `json!` would deep-clone every content part — including full inline
-        // image payloads — straight back out of the taken vector.
         let mut msg = Map::new();
         msg.insert("role".to_owned(), Value::String(role.to_owned()));
         msg.insert("content".to_owned(), Value::Array(std::mem::take(content_parts)));
@@ -384,10 +344,8 @@ fn flush_content_parts(messages: &mut Vec<Value>, content_parts: &mut Vec<Value>
 // Image Source Conversion
 // -----------------------------------------------------------------------------
 
-/// Convert Anthropic image source to an `image_url` URL string.
-///
-/// Consumes the source so a `url` source moves its string through untouched and
-/// a `base64` source is copied exactly once, into the data URL.
+/// Convert Anthropic image source to an `image_url` URL string consuming the
+/// source.
 fn convert_image_source(source: Value) -> Option<String> {
     let Value::Object(mut source) = source else {
         return None;
@@ -411,10 +369,6 @@ fn convert_image_source(source: Value) -> Option<String> {
 
 /// Split a `tool_result` block's `content` into its flattened text and the
 /// image parts promoted to a follow-up user message.
-///
-/// One pass over the owned content: a string result moves out whole, and each
-/// part is consumed by the branch that claims it, so nothing is traversed — or
-/// copied — twice.
 fn split_tool_result_content(content: Option<Value>) -> (String, Vec<Value>) {
     match content {
         Some(Value::String(text)) => (text, Vec::new()),
@@ -612,7 +566,7 @@ fn convert_stream(chat: &mut Map<String, Value>, stream: Option<Value>, stream_o
     chat.insert("stream_options".to_owned(), Value::Object(opts));
 }
 
-/// Map Anthropic sampling parameters to Chat Completions-compatible equivalents.
+/// Map Anthropic parameters to Chat Completions-compatible equivalents.
 ///
 /// `top_k` has no standard Chat Completions equivalent but is preserved
 /// as an extra body parameter for backends that support it
@@ -697,12 +651,10 @@ fn convert_tool_definition(tool: Value) -> Option<Value> {
         return None;
     }
 
-    // A non-object tool entry carries no fields, so it translates to an empty
-    // function exactly as reading through `Value::get` did.
-    let mut tool = if let Value::Object(fields) = tool {
-        fields
-    } else {
-        Map::new()
+    // A non-object tool entry carries no fields, so it translates to an empty function.
+    let mut tool = match tool {
+        Value::Object(fields) => fields,
+        _ => Map::new(),
     };
 
     let name = take_string(&mut tool, "name").unwrap_or_default();
@@ -731,9 +683,6 @@ fn convert_tool_definition(tool: Value) -> Option<Value> {
 // -----------------------------------------------------------------------------
 
 /// Convert Anthropic `disable_parallel_tool_use` to Chat Completions format.
-///
-/// Reads `tool_choice` without consuming it; [`convert_tool_choice`] takes
-/// ownership afterwards.
 fn convert_parallel_tool_calls(chat: &mut Map<String, Value>, tool_choice: Option<&Value>) {
     let Some(Value::Object(tool_choice)) = tool_choice else {
         return;
@@ -749,10 +698,6 @@ fn convert_parallel_tool_calls(chat: &mut Map<String, Value>, tool_choice: Optio
 }
 
 /// Convert Anthropic `tool_choice` to Chat Completions format.
-///
-/// `had_tools` records whether the request carried a `tools` field at all. A
-/// choice is dropped when every tool was filtered out, so a request whose tools
-/// were all typed server tools cannot force a tool call the backend never saw.
 fn convert_tool_choice(chat: &mut Map<String, Value>, tool_choice: Option<Value>, had_tools: bool) {
     let Some(tool_choice) = tool_choice else {
         return;
@@ -782,8 +727,6 @@ fn tool_choice_keyword(anthropic: &str) -> &'static str {
 
 /// Convert an object-form `tool_choice`, moving a named tool's name through.
 fn object_tool_choice(mut tool_choice: Map<String, Value>) -> Value {
-    // Settled before the named-tool branch so the type lookup does not hold a
-    // borrow while `name` is taken out.
     let names_a_tool = tool_choice.get("type").and_then(Value::as_str) == Some("tool");
 
     if names_a_tool && let Some(name) = take_string(&mut tool_choice, "name") {

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -15,7 +15,7 @@ use crate::json_body::{insert_if_some, take_string};
 /// Transform a parsed Anthropic Messages request body into Chat
 /// Completions-compatible format.
 /// Returns the transformed JSON bytes, or an error message.
-pub(crate) fn transform_request(value: Value) -> Result<Vec<u8>, String> {
+pub(crate) fn transform_request(value: Value, original_len: usize) -> Result<Vec<u8>, String> {
     let Value::Object(mut body) = value else {
         return Err("request body is not a JSON object".to_owned());
     };
@@ -35,8 +35,6 @@ pub(crate) fn transform_request(value: Value) -> Result<Vec<u8>, String> {
     let tools = body.remove("tools");
     let tool_choice = body.remove("tool_choice");
     let had_tools = tools.is_some();
-    // Fields with no Chat Completions mapping are not forwarded. Dropping the
-    // parsed body here makes any later read of it a compile error.
     drop(body);
 
     let mut chat = Map::new();
@@ -49,7 +47,15 @@ pub(crate) fn transform_request(value: Value) -> Result<Vec<u8>, String> {
     convert_parallel_tool_calls(&mut chat, tool_choice.as_ref());
     convert_tool_choice(&mut chat, tool_choice, had_tools);
 
-    serde_json::to_vec(&Value::Object(chat)).map_err(|e| format!("serialization failed: {e}"))
+    serialize_chat(chat, original_len)
+}
+
+/// Serialize the translated body into a buffer pre-sized from the Anthropic
+/// body it was translated from.
+fn serialize_chat(chat: Map<String, Value>, original_len: usize) -> Result<Vec<u8>, String> {
+    let mut buffer = Vec::with_capacity(original_len);
+    serde_json::to_writer(&mut buffer, &Value::Object(chat)).map_err(|e| format!("serialization failed: {e}"))?;
+    Ok(buffer)
 }
 
 /// Build the Chat Completions `messages` array from the Anthropic `system` and
@@ -765,7 +771,29 @@ mod tests {
     /// parse-once call path including its parse-error message.
     fn transform_bytes(body: &[u8]) -> Result<Vec<u8>, String> {
         let value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
-        transform_request(value)
+        transform_request(value, body.len())
+    }
+
+    #[test]
+    fn output_buffer_is_sized_from_the_original_body() {
+        // Server tools are dropped, so the translation is far smaller than the
+        // body it came from and cannot have grown the buffer on its own.
+        let body = format!(
+            r#"{{"model":"claude-opus-4-8","messages":[],"tools":[{{"type":"web_search_20250305","name":"{}"}}]}}"#,
+            "s".repeat(4096)
+        );
+        let result = transform_bytes(body.as_bytes()).unwrap();
+
+        assert!(
+            result.len() < body.len(),
+            "translation should be smaller than the original body"
+        );
+        assert!(
+            result.capacity() >= body.len(),
+            "output buffer should be pre-sized from the original body, got {} for a {}-byte body",
+            result.capacity(),
+            body.len()
+        );
     }
 
     #[test]

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -57,7 +57,7 @@ pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
 }
 
 /// Build the Chat Completions `messages` array from the Anthropic `system` and
-/// `messages` fields, which are the only two inputs to it.
+/// `messages` fields.
 fn build_messages(system: Option<Value>, messages: Option<Value>) -> Value {
     let mut converted = Vec::new();
     hoist_system(&mut converted, system);
@@ -67,10 +67,41 @@ fn build_messages(system: Option<Value>, messages: Option<Value>) -> Value {
 
 /// Build a Chat Completions message carrying plain string content.
 fn text_message(role: &str, content: String) -> Value {
+    owned_text_message(role.to_owned(), content)
+}
+
+/// [`text_message`] for callers that already own the role, so it moves through
+/// instead of being copied out of a string that dies immediately after.
+fn owned_text_message(role: String, content: String) -> Value {
     let mut message = Map::new();
-    message.insert("role".to_owned(), Value::String(role.to_owned()));
+    message.insert("role".to_owned(), Value::String(role));
     message.insert("content".to_owned(), Value::String(content));
     Value::Object(message)
+}
+
+/// Build a Chat Completions `text` content part, moving `text` into it.
+///
+/// Built by hand rather than with `json!`, which would deep-clone the string
+/// back through the serializer.
+fn text_content_part(text: String) -> Value {
+    let mut part = Map::new();
+    part.insert("type".to_owned(), Value::String("text".to_owned()));
+    part.insert("text".to_owned(), Value::String(text));
+    Value::Object(part)
+}
+
+/// Build a Chat Completions `image_url` content part, moving `url` into it.
+///
+/// `url` carries the whole base64 payload for inline images, so it must not be
+/// re-serialized through `json!`.
+fn image_content_part(url: String) -> Value {
+    let mut image_url = Map::new();
+    image_url.insert("url".to_owned(), Value::String(url));
+
+    let mut part = Map::new();
+    part.insert("type".to_owned(), Value::String("image_url".to_owned()));
+    part.insert("image_url".to_owned(), Value::Object(image_url));
+    Value::Object(part)
 }
 
 // -----------------------------------------------------------------------------
@@ -120,62 +151,67 @@ fn convert_messages(messages: &mut Vec<Value>, source: Option<Value>) {
 
         match msg.remove("content") {
             Some(Value::String(text)) => {
-                messages.push(text_message(&role, text));
+                messages.push(owned_text_message(role, text));
             },
             Some(Value::Array(blocks)) => {
-                convert_content_blocks(messages, &role, &blocks);
+                convert_content_blocks(messages, &role, blocks);
             },
             _ => {
-                messages.push(text_message(&role, String::new()));
+                messages.push(owned_text_message(role, String::new()));
             },
         }
     }
 }
 
 /// Convert typed content blocks to Chat Completions-compatible format.
-fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: &[Value]) {
-    let mut text_parts = Vec::new();
-    let mut content_parts: Vec<Value> = Vec::new();
-    let mut tool_calls: Vec<Value> = Vec::new();
+///
+/// Consumes the blocks: in an agentic request they carry the bulk of the body
+/// (inline images, tool results, accumulated turn history), so every leaf below
+/// moves its payload into the translated message instead of copying it.
+fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: Vec<Value>) {
+    let mut acc = BlockAccumulator::default();
 
     for block in blocks {
-        let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
-        convert_single_block(
-            block,
-            block_type,
-            messages,
-            role,
-            &mut text_parts,
-            &mut content_parts,
-            &mut tool_calls,
-        );
+        let Value::Object(mut block) = block else {
+            // A non-object block exposes no `type`, exactly as reading through
+            // `Value::get` saw it.
+            warn!(block_type = "", "dropping unknown Anthropic content block type");
+            continue;
+        };
+        // No branch below reads `type` again, so it is taken out with the rest.
+        let block_type = take_string(&mut block, "type").unwrap_or_default();
+        convert_single_block(block, &block_type, messages, role, &mut acc);
     }
 
-    finalize_content_blocks(messages, role, &mut text_parts, &mut content_parts, tool_calls);
+    finalize_content_blocks(messages, role, acc);
+}
+
+/// Chat Completions output accumulated across one message's content blocks.
+#[derive(Default)]
+struct BlockAccumulator {
+    /// Content parts in wire order. A lone text part later collapses to string
+    /// content, so the text is not tracked separately.
+    content_parts: Vec<Value>,
+    /// Tool calls hoisted out of `tool_use` blocks.
+    tool_calls: Vec<Value>,
 }
 
 /// Process a single content block within a message.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "accumulator pattern requires passing all state"
-)]
 fn convert_single_block(
-    block: &Value,
+    block: Map<String, Value>,
     block_type: &str,
     messages: &mut Vec<Value>,
     role: &str,
-    text_parts: &mut Vec<String>,
-    content_parts: &mut Vec<Value>,
-    tool_calls: &mut Vec<Value>,
+    acc: &mut BlockAccumulator,
 ) {
     match block_type {
-        "text" => convert_text_block(block, text_parts, content_parts),
-        "image" => convert_image_block(block, content_parts),
-        "search_result" => convert_search_result_block(block, text_parts, content_parts),
-        "document" => convert_document_block(block, text_parts, content_parts),
-        "tool_use" => convert_tool_use_block(block, tool_calls),
+        "text" => convert_text_block(block, &mut acc.content_parts),
+        "image" => convert_image_block(block, &mut acc.content_parts),
+        "search_result" => convert_search_result_block(block, &mut acc.content_parts),
+        "document" => convert_document_block(block, &mut acc.content_parts),
+        "tool_use" => convert_tool_use_block(block, &mut acc.tool_calls),
         "tool_result" => {
-            flush_text_parts(messages, text_parts, content_parts, role);
+            flush_content_parts(messages, &mut acc.content_parts, role);
             convert_tool_result_block(block, messages);
         },
         "thinking" | "redacted_thinking" => {
@@ -188,127 +224,159 @@ fn convert_single_block(
 }
 
 /// Convert a text content block.
-fn convert_text_block(block: &Value, text_parts: &mut Vec<String>, content_parts: &mut Vec<Value>) {
-    if let Some(text) = block.get("text").and_then(Value::as_str) {
-        append_text_content(text, text_parts, content_parts);
+fn convert_text_block(mut block: Map<String, Value>, content_parts: &mut Vec<Value>) {
+    if let Some(text) = take_string(&mut block, "text") {
+        content_parts.push(text_content_part(text));
     }
 }
 
 /// Convert an image content block.
-fn convert_image_block(block: &Value, content_parts: &mut Vec<Value>) {
-    if let Some(source) = block.get("source")
+fn convert_image_block(mut block: Map<String, Value>, content_parts: &mut Vec<Value>) {
+    if let Some(source) = block.remove("source")
         && let Some(url_val) = convert_image_source(source)
     {
-        content_parts.push(json!({"type": "image_url", "image_url": {"url": url_val}}));
+        content_parts.push(image_content_part(url_val));
     }
 }
 
 /// Convert a `search_result` block to backend-visible text context.
-fn convert_search_result_block(block: &Value, text_parts: &mut Vec<String>, content_parts: &mut Vec<Value>) {
+fn convert_search_result_block(block: Map<String, Value>, content_parts: &mut Vec<Value>) {
     if let Some(text) = flatten_search_result(block) {
-        append_text_content(&text, text_parts, content_parts);
+        content_parts.push(text_content_part(text));
     }
 }
 
 /// Convert a `document` block to backend-visible text context.
-fn convert_document_block(block: &Value, text_parts: &mut Vec<String>, content_parts: &mut Vec<Value>) {
+fn convert_document_block(block: Map<String, Value>, content_parts: &mut Vec<Value>) {
     if let Some(text) = flatten_document(block) {
-        append_text_content(&text, text_parts, content_parts);
+        content_parts.push(text_content_part(text));
     }
 }
 
-/// Append one Chat Completions text content part and its string equivalent.
-fn append_text_content(text: &str, text_parts: &mut Vec<String>, content_parts: &mut Vec<Value>) {
-    text_parts.push(text.to_owned());
-    content_parts.push(json!({"type": "text", "text": text}));
+/// Take the string out of a `text` content part, leaving other parts untouched.
+///
+/// The part is about to be dropped by both callers, so the payload moves out
+/// instead of being copied.
+fn take_text_part(part: &mut Value) -> Option<String> {
+    let part = part.as_object_mut()?;
+    if part.get("type").and_then(Value::as_str) != Some("text") {
+        return None;
+    }
+    take_string(part, "text")
+}
+
+/// Concatenate the text of every text content part, moving each string out.
+///
+/// `None` means no text part was present, which is distinct from text parts
+/// that are all empty: the caller emits no `content` for the former and an
+/// empty string for the latter.
+fn take_joined_text(content_parts: &mut [Value]) -> Option<String> {
+    let mut joined: Option<String> = None;
+    for part in content_parts {
+        let Some(text) = take_text_part(part) else {
+            continue;
+        };
+        match &mut joined {
+            // The first text moves in whole, so the common single-text case
+            // never copies its payload.
+            None => joined = Some(text),
+            Some(acc) => acc.push_str(&text),
+        }
+    }
+    joined
 }
 
 /// Convert a `tool_use` content block to a Chat Completions tool call.
-fn convert_tool_use_block(block: &Value, tool_calls: &mut Vec<Value>) {
-    let id = block.get("id").and_then(Value::as_str).unwrap_or("");
-    let name = block.get("name").and_then(Value::as_str).unwrap_or("");
+fn convert_tool_use_block(mut block: Map<String, Value>, tool_calls: &mut Vec<Value>) {
+    let id = take_string(&mut block, "id").unwrap_or_default();
+    let name = take_string(&mut block, "name").unwrap_or_default();
 
-    let empty = Value::Object(Map::new());
-    let input = block.get("input").unwrap_or(&empty);
-    let args = serde_json::to_string(input).unwrap_or_default();
+    // An absent `input` serializes as the empty object the old placeholder
+    // produced; an explicit `null` still serializes as `null`.
+    let args = match block.remove("input") {
+        Some(input) => serde_json::to_string(&input).unwrap_or_default(),
+        None => "{}".to_owned(),
+    };
 
-    tool_calls.push(json!({
-        "id": id,
-        "type": "function",
-        "function": {"name": name, "arguments": args}
-    }));
+    let mut function = Map::new();
+    function.insert("name".to_owned(), Value::String(name));
+    function.insert("arguments".to_owned(), Value::String(args));
+
+    let mut tool_call = Map::new();
+    tool_call.insert("id".to_owned(), Value::String(id));
+    tool_call.insert("type".to_owned(), Value::String("function".to_owned()));
+    tool_call.insert("function".to_owned(), Value::Object(function));
+    tool_calls.push(Value::Object(tool_call));
 }
 
 /// Convert a `tool_result` content block to a Chat Completions tool message.
-fn convert_tool_result_block(block: &Value, messages: &mut Vec<Value>) {
-    let tool_call_id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
-    let mut result_content = extract_tool_result_content(block);
-    let image_content = extract_tool_result_image_content(block);
+fn convert_tool_result_block(mut block: Map<String, Value>, messages: &mut Vec<Value>) {
+    let tool_call_id = take_string(&mut block, "tool_use_id").unwrap_or_default();
+    // Read before `content` is taken: `is_error` decides how the text below is
+    // marked, and both live in the same map.
+    let is_error = block.get("is_error").and_then(Value::as_bool) == Some(true);
 
-    if block.get("is_error").and_then(Value::as_bool) == Some(true) {
+    let (mut result_content, image_content) = split_tool_result_content(block.remove("content"));
+
+    if is_error {
         result_content = mark_tool_result_error(result_content);
     }
 
-    messages.push(json!({
-        "role": "tool",
-        "tool_call_id": tool_call_id,
-        "content": result_content
-    }));
+    let mut tool_message = Map::new();
+    tool_message.insert("role".to_owned(), Value::String("tool".to_owned()));
+    tool_message.insert("tool_call_id".to_owned(), Value::String(tool_call_id));
+    tool_message.insert("content".to_owned(), Value::String(result_content));
+    messages.push(Value::Object(tool_message));
 
     if !image_content.is_empty() {
-        messages.push(json!({
-            "role": "user",
-            "content": image_content
-        }));
+        let mut image_message = Map::new();
+        image_message.insert("role".to_owned(), Value::String("user".to_owned()));
+        image_message.insert("content".to_owned(), Value::Array(image_content));
+        messages.push(Value::Object(image_message));
     }
 }
 
 /// Emit the final message for accumulated content and tool calls.
-fn finalize_content_blocks(
-    messages: &mut Vec<Value>,
-    role: &str,
-    text_parts: &mut Vec<String>,
-    content_parts: &mut Vec<Value>,
-    tool_calls: Vec<Value>,
-) {
-    if role == "assistant" && !tool_calls.is_empty() {
-        let mut msg = json!({"role": "assistant"});
-        if let Some(obj) = msg.as_object_mut() {
-            if !text_parts.is_empty() {
-                obj.insert("content".to_owned(), Value::String(text_parts.join("")));
-            }
-            obj.insert("tool_calls".to_owned(), Value::Array(tool_calls));
+fn finalize_content_blocks(messages: &mut Vec<Value>, role: &str, mut acc: BlockAccumulator) {
+    if role == "assistant" && !acc.tool_calls.is_empty() {
+        let mut msg = Map::new();
+        msg.insert("role".to_owned(), Value::String("assistant".to_owned()));
+        // This branch carries string content only, so any image part collected
+        // alongside the text is dropped here.
+        if let Some(text) = take_joined_text(&mut acc.content_parts) {
+            msg.insert("content".to_owned(), Value::String(text));
         }
-        messages.push(msg);
+        msg.insert("tool_calls".to_owned(), Value::Array(acc.tool_calls));
+        messages.push(Value::Object(msg));
     } else {
-        flush_text_parts(messages, text_parts, content_parts, role);
+        flush_content_parts(messages, &mut acc.content_parts, role);
     }
 }
 
-/// Flush accumulated text/content parts as a message.
-fn flush_text_parts(
-    messages: &mut Vec<Value>,
-    text_parts: &mut Vec<String>,
-    content_parts: &mut Vec<Value>,
-    role: &str,
-) {
-    if content_parts.is_empty() && text_parts.is_empty() {
+/// Flush accumulated content parts as a message.
+fn flush_content_parts(messages: &mut Vec<Value>, content_parts: &mut Vec<Value>, role: &str) {
+    if content_parts.is_empty() {
         return;
     }
 
-    if content_parts.len() == 1
-        && content_parts
-            .first()
-            .and_then(|p| p.get("type"))
-            .and_then(Value::as_str)
-            == Some("text")
-    {
-        messages.push(text_message(role, text_parts.join("")));
-    } else if !content_parts.is_empty() {
-        messages.push(json!({"role": role, "content": std::mem::take(content_parts)}));
+    // A lone text part collapses to string content; anything else stays an
+    // array. Resolved before the `else` branch so the borrow ends here.
+    let lone_text = match content_parts.as_mut_slice() {
+        [part] => take_text_part(part),
+        _ => None,
+    };
+
+    if let Some(text) = lone_text {
+        messages.push(text_message(role, text));
+    } else {
+        // `json!` would deep-clone every content part — including full inline
+        // image payloads — straight back out of the taken vector.
+        let mut msg = Map::new();
+        msg.insert("role".to_owned(), Value::String(role.to_owned()));
+        msg.insert("content".to_owned(), Value::Array(std::mem::take(content_parts)));
+        messages.push(Value::Object(msg));
     }
 
-    text_parts.clear();
     content_parts.clear();
 }
 
@@ -317,16 +385,22 @@ fn flush_text_parts(
 // -----------------------------------------------------------------------------
 
 /// Convert Anthropic image source to an `image_url` URL string.
-fn convert_image_source(source: &Value) -> Option<String> {
-    let source_type = source.get("type").and_then(Value::as_str)?;
+///
+/// Consumes the source so a `url` source moves its string through untouched and
+/// a `base64` source is copied exactly once, into the data URL.
+fn convert_image_source(source: Value) -> Option<String> {
+    let Value::Object(mut source) = source else {
+        return None;
+    };
+    let source_type = take_string(&mut source, "type")?;
 
-    match source_type {
+    match source_type.as_str() {
         "base64" => {
-            let media_type = source.get("media_type").and_then(Value::as_str)?;
-            let data = source.get("data").and_then(Value::as_str)?;
+            let media_type = take_string(&mut source, "media_type")?;
+            let data = take_string(&mut source, "data")?;
             Some(format!("data:{media_type};base64,{data}"))
         },
-        "url" => source.get("url").and_then(Value::as_str).map(str::to_owned),
+        "url" => take_string(&mut source, "url"),
         _ => None,
     }
 }
@@ -335,36 +409,52 @@ fn convert_image_source(source: &Value) -> Option<String> {
 // Tool Result Content Extraction
 // -----------------------------------------------------------------------------
 
-/// Extract text content from a `tool_result` block.
-fn extract_tool_result_content(block: &Value) -> String {
-    match block.get("content") {
-        Some(Value::String(s)) => s.clone(),
-        Some(Value::Array(parts)) => {
-            let mut text_parts = Vec::new();
-            for part in parts {
-                match part.get("type").and_then(Value::as_str) {
-                    Some("text") => {
-                        if let Some(text) = part.get("text").and_then(Value::as_str) {
-                            text_parts.push(text.to_owned());
-                        }
-                    },
-                    Some("search_result") => {
-                        if let Some(text) = flatten_search_result(part) {
-                            text_parts.push(text);
-                        }
-                    },
-                    Some("document") => {
-                        if let Some(text) = flatten_document(part) {
-                            text_parts.push(text);
-                        }
-                    },
-                    _ => {},
-                }
-            }
-            text_parts.join("\n")
-        },
-        _ => String::new(),
+/// Split a `tool_result` block's `content` into its flattened text and the
+/// image parts promoted to a follow-up user message.
+///
+/// One pass over the owned content: a string result moves out whole, and each
+/// part is consumed by the branch that claims it, so nothing is traversed — or
+/// copied — twice.
+fn split_tool_result_content(content: Option<Value>) -> (String, Vec<Value>) {
+    match content {
+        Some(Value::String(text)) => (text, Vec::new()),
+        Some(Value::Array(parts)) => split_tool_result_parts(parts),
+        _ => (String::new(), Vec::new()),
     }
+}
+
+/// Split the parts of an array-form `tool_result.content`.
+fn split_tool_result_parts(parts: Vec<Value>) -> (String, Vec<Value>) {
+    let mut text_parts = Vec::new();
+    let mut image_parts = Vec::new();
+
+    for part in parts {
+        let Value::Object(mut part) = part else {
+            continue;
+        };
+        // No branch below reads `type` again, so it is taken out with the rest.
+        match take_string(&mut part, "type").as_deref() {
+            Some("text") => {
+                if let Some(text) = take_string(&mut part, "text") {
+                    text_parts.push(text);
+                }
+            },
+            Some("search_result") => {
+                if let Some(text) = flatten_search_result(part) {
+                    text_parts.push(text);
+                }
+            },
+            Some("document") => {
+                if let Some(text) = flatten_document(part) {
+                    text_parts.push(text);
+                }
+            },
+            Some("image") => convert_image_block(part, &mut image_parts),
+            _ => {},
+        }
+    }
+
+    (text_parts.join("\n"), image_parts)
 }
 
 /// Preserve Anthropic's `tool_result.is_error` semantic in text-only tool messages.
@@ -377,32 +467,11 @@ fn mark_tool_result_error(mut content: String) -> String {
     }
 }
 
-/// Extract image content from a `tool_result` block.
-fn extract_tool_result_image_content(block: &Value) -> Vec<Value> {
-    let Some(Value::Array(parts)) = block.get("content") else {
-        return Vec::new();
-    };
-
-    let mut image_parts = Vec::new();
-    for part in parts {
-        if part.get("type").and_then(Value::as_str) == Some("image") {
-            convert_image_block(part, &mut image_parts);
-        }
-    }
-    image_parts
-}
-
 /// Flatten an Anthropic `search_result` block to plain text.
-fn flatten_search_result(block: &Value) -> Option<String> {
-    let title = block
-        .get("title")
-        .and_then(Value::as_str)
-        .filter(|title| !title.is_empty());
-    let source = block
-        .get("source")
-        .and_then(Value::as_str)
-        .filter(|source| !source.is_empty());
-    let content = extract_text_blocks(block.get("content"));
+fn flatten_search_result(mut block: Map<String, Value>) -> Option<String> {
+    let title = take_string(&mut block, "title").filter(|title| !title.is_empty());
+    let source = take_string(&mut block, "source").filter(|source| !source.is_empty());
+    let content = extract_text_blocks(block.remove("content"));
 
     if title.is_none() && source.is_none() && content.is_empty() {
         return None;
@@ -411,13 +480,13 @@ fn flatten_search_result(block: &Value) -> Option<String> {
     let mut lines = Vec::new();
 
     if let Some(title) = title {
-        lines.push(format!("Search result: {}", quote_label_value(title)));
+        lines.push(format!("Search result: {}", quote_label_value(&title)));
     } else {
         lines.push("Search result".to_owned());
     }
 
     if let Some(source) = source {
-        lines.push(format!("Source: {}", quote_label_value(source)));
+        lines.push(format!("Source: {}", quote_label_value(&source)));
     }
 
     if !content.is_empty() {
@@ -429,16 +498,10 @@ fn flatten_search_result(block: &Value) -> Option<String> {
 }
 
 /// Flatten an Anthropic `document` block to plain text.
-fn flatten_document(block: &Value) -> Option<String> {
-    let title = block
-        .get("title")
-        .and_then(Value::as_str)
-        .filter(|title| !title.is_empty());
-    let context = block
-        .get("context")
-        .and_then(Value::as_str)
-        .filter(|context| !context.is_empty());
-    let source_text = flatten_document_source(block.get("source"));
+fn flatten_document(mut block: Map<String, Value>) -> Option<String> {
+    let title = take_string(&mut block, "title").filter(|title| !title.is_empty());
+    let context = take_string(&mut block, "context").filter(|context| !context.is_empty());
+    let source_text = flatten_document_source(block.remove("source"));
 
     if title.is_none() && context.is_none() && source_text.is_none() {
         return None;
@@ -447,13 +510,13 @@ fn flatten_document(block: &Value) -> Option<String> {
     let mut lines = Vec::new();
 
     if let Some(title) = title {
-        lines.push(format!("Document: {}", quote_label_value(title)));
+        lines.push(format!("Document: {}", quote_label_value(&title)));
     } else {
         lines.push("Document".to_owned());
     }
 
     if let Some(context) = context {
-        lines.push(format!("Context: {}", quote_label_value(context)));
+        lines.push(format!("Context: {}", quote_label_value(&context)));
     }
 
     if let Some(source_text) = source_text {
@@ -464,33 +527,27 @@ fn flatten_document(block: &Value) -> Option<String> {
 }
 
 /// Flatten a `document.source` value to extractable text or a stable reference.
-fn flatten_document_source(source: Option<&Value>) -> Option<String> {
-    let source = source?;
-    let source_type = source.get("type").and_then(Value::as_str)?;
+fn flatten_document_source(source: Option<Value>) -> Option<String> {
+    let Value::Object(mut source) = source? else {
+        return None;
+    };
+    let source_type = take_string(&mut source, "type")?;
 
-    match source_type {
-        "text" => source
-            .get("data")
-            .and_then(Value::as_str)
+    match source_type.as_str() {
+        "text" => take_string(&mut source, "data")
             .filter(|data| !data.is_empty())
             .map(|data| format!("Content:\n{data}")),
         "content" => {
-            let lines = extract_text_blocks(source.get("content"));
+            let lines = extract_text_blocks(source.remove("content"));
             non_empty_lines(&lines).map(|content| format!("Content:\n{content}"))
         },
-        "url" => source
-            .get("url")
-            .and_then(Value::as_str)
+        "url" => take_string(&mut source, "url")
             .filter(|url| !url.is_empty())
-            .map(|url| format!("Source: {}", quote_label_value(url))),
-        "file" => source
-            .get("file_id")
-            .and_then(Value::as_str)
+            .map(|url| format!("Source: {}", quote_label_value(&url))),
+        "file" => take_string(&mut source, "file_id")
             .filter(|file_id| !file_id.is_empty())
             .map(|file_id| format!("Source: {}", quote_label_value(&format!("file:{file_id}")))),
-        "base64" => source
-            .get("media_type")
-            .and_then(Value::as_str)
+        "base64" => take_string(&mut source, "media_type")
             .filter(|media_type| !media_type.is_empty())
             .map(|media_type| format!("Source: {}", quote_label_value(&format!("base64:{media_type}")))),
         _ => None,
@@ -502,19 +559,27 @@ fn quote_label_value(value: &str) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| format!("{value:?}"))
 }
 
-/// Extract text from an array of Anthropic text blocks.
-fn extract_text_blocks(value: Option<&Value>) -> Vec<String> {
+/// Extract text from an array of Anthropic text blocks, moving each string out.
+fn extract_text_blocks(value: Option<Value>) -> Vec<String> {
     let Some(Value::Array(blocks)) = value else {
         return Vec::new();
     };
 
-    blocks
-        .iter()
-        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
-        .filter_map(|block| block.get("text").and_then(Value::as_str))
-        .filter(|text| !text.is_empty())
-        .map(str::to_owned)
-        .collect()
+    let mut texts = Vec::new();
+    for block in blocks {
+        let Value::Object(mut block) = block else {
+            continue;
+        };
+        if block.get("type").and_then(Value::as_str) != Some("text") {
+            continue;
+        }
+        if let Some(text) = take_string(&mut block, "text")
+            && !text.is_empty()
+        {
+            texts.push(text);
+        }
+    }
+    texts
 }
 
 /// Join lines if at least one line contains content.
@@ -1410,6 +1475,82 @@ mod tests {
     }
 
     #[test]
+    fn two_text_blocks_stay_two_content_parts() {
+        // String content is emitted only for a *single* text part. Two text
+        // blocks keep their part boundaries rather than being joined.
+        let body = br#"{"model":"m","messages":[{"role":"user","content":[{"type":"text","text":"one"},{"type":"text","text":"two"}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let content = parsed["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2, "two text blocks stay two parts");
+        assert_eq!(content[0]["text"], "one");
+        assert_eq!(content[1]["text"], "two");
+    }
+
+    #[test]
+    fn assistant_tool_calls_join_all_text_blocks() {
+        // The assistant+tool_calls branch joins every text part into one string,
+        // a different rule from the single-part case above.
+        let body = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"text","text":"one"},{"type":"text","text":"two"},{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let msg = &parsed["messages"][0];
+        assert_eq!(msg["content"], "onetwo", "assistant text parts are joined");
+        assert_eq!(msg["tool_calls"][0]["id"], "c1");
+    }
+
+    #[test]
+    fn assistant_tool_calls_distinguish_empty_text_from_no_text() {
+        // An empty text block still emits `content: ""`; no text block at all
+        // emits no `content` key.
+        let empty = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"text","text":""},{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
+        let parsed: Value = serde_json::from_slice(&transform_request(empty).unwrap()).unwrap();
+        assert_eq!(
+            parsed["messages"][0]["content"], "",
+            "an empty text block still emits content"
+        );
+
+        let none = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
+        let parsed: Value = serde_json::from_slice(&transform_request(none).unwrap()).unwrap();
+        assert!(
+            parsed["messages"][0].get("content").is_none(),
+            "no text block emits no content key"
+        );
+    }
+
+    #[test]
+    fn assistant_tool_calls_drop_image_parts() {
+        // The joined-string branch cannot carry an image part, so it is dropped
+        // while the surrounding text is still joined.
+        let body = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"text","text":"one"},{"type":"image","source":{"type":"url","url":"https://example.com/i.png"}},{"type":"text","text":"two"},{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
+        let parsed: Value = serde_json::from_slice(&transform_request(body).unwrap()).unwrap();
+
+        assert_eq!(
+            parsed["messages"][0]["content"], "onetwo",
+            "text joins across the dropped image"
+        );
+    }
+
+    #[test]
+    fn tool_use_without_input_serializes_an_empty_object() {
+        let body = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"c1","name":"f"},{"type":"tool_use","id":"c2","name":"g","input":null}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let calls = parsed["messages"][0]["tool_calls"].as_array().unwrap();
+        assert_eq!(
+            calls[0]["function"]["arguments"], "{}",
+            "absent input becomes an empty object"
+        );
+        assert_eq!(
+            calls[1]["function"]["arguments"], "null",
+            "an explicit null input is preserved as null"
+        );
+    }
+
+    #[test]
     fn only_tool_result_blocks_produce_tool_messages() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"result1"},{"type":"tool_result","tool_use_id":"call_2","content":"result2"}]}]}"#;
         let result = transform_request(body).unwrap();
@@ -1427,16 +1568,33 @@ mod tests {
 
     #[test]
     fn extract_tool_result_content_null() {
-        let block = json!({"type": "tool_result", "tool_use_id": "call_1", "content": null});
-        let result = extract_tool_result_content(&block);
-        assert!(result.is_empty(), "null content should return empty string");
+        let (text, images) = split_tool_result_content(Some(Value::Null));
+        assert!(text.is_empty(), "null content should return empty string");
+        assert!(images.is_empty(), "null content carries no images");
     }
 
     #[test]
     fn extract_tool_result_content_missing() {
-        let block = json!({"type": "tool_result", "tool_use_id": "call_1"});
-        let result = extract_tool_result_content(&block);
-        assert!(result.is_empty(), "missing content should return empty string");
+        let (text, images) = split_tool_result_content(None);
+        assert!(text.is_empty(), "missing content should return empty string");
+        assert!(images.is_empty(), "missing content carries no images");
+    }
+
+    #[test]
+    fn tool_result_content_split_keeps_text_and_images_in_one_pass() {
+        let content = json!([
+            {"type": "text", "text": "before"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+            {"type": "text", "text": "after"},
+            {"type": "thinking", "thinking": "ignored"},
+            "not an object"
+        ]);
+
+        let (text, images) = split_tool_result_content(Some(content));
+
+        assert_eq!(text, "before\nafter", "text parts join in order, skipping non-text");
+        assert_eq!(images.len(), 1, "one image part promoted");
+        assert_eq!(images[0]["image_url"]["url"], "data:image/png;base64,AAAA");
     }
 
     #[test]

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -6,44 +6,71 @@
 use serde_json::{Map, Value, json};
 use tracing::warn;
 
+use crate::json_body::{insert_if_some, take_string};
+
 // -----------------------------------------------------------------------------
 // Request Transformation
 // -----------------------------------------------------------------------------
 
 /// Transform an Anthropic Messages request body into Chat
 /// Completions-compatible format.
-///
 /// Returns the transformed JSON bytes, or an error message.
 pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
     let value: Value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
 
-    let Some(obj) = value.as_object() else {
+    let Value::Object(mut body) = value else {
         return Err("request body is not a JSON object".to_owned());
     };
 
+    // Take every mapped field up front, in one place. Each becomes an owned
+    // local that is moved into the helper emitting it.
+    let model = body.remove("model");
+    let max_tokens = body.remove("max_tokens");
+    let system = body.remove("system");
+    let messages = body.remove("messages");
+    let stream = body.remove("stream");
+    let stream_options = body.remove("stream_options");
+    let stop_sequences = body.remove("stop_sequences");
+    let temperature = body.remove("temperature");
+    let top_p = body.remove("top_p");
+    let top_k = body.remove("top_k");
+    let tools = body.remove("tools");
+    let tool_choice = body.remove("tool_choice");
+    let had_tools = tools.is_some();
+    // Fields with no Chat Completions mapping are not forwarded. Dropping the
+    // parsed body here makes any later read of it a compile error.
+    drop(body);
+
     let mut chat = Map::new();
-
-    if let Some(model) = obj.get("model") {
-        chat.insert("model".to_owned(), model.clone());
-    }
-
-    let mut messages = Vec::new();
-    hoist_system(&mut messages, obj);
-    convert_messages(&mut messages, obj);
-    chat.insert("messages".to_owned(), Value::Array(messages));
-
-    if let Some(max_tokens) = obj.get("max_tokens") {
-        chat.insert("max_completion_tokens".to_owned(), max_tokens.clone());
-    }
-
-    convert_stream(&mut chat, obj);
-
-    map_parameters(&mut chat, obj);
-    convert_tools(&mut chat, obj);
-    convert_parallel_tool_calls(&mut chat, obj);
-    convert_tool_choice(&mut chat, obj);
+    insert_if_some(&mut chat, "model", model);
+    chat.insert("messages".to_owned(), build_messages(system, messages));
+    insert_if_some(&mut chat, "max_completion_tokens", max_tokens);
+    convert_stream(&mut chat, stream, stream_options);
+    map_parameters(&mut chat, stop_sequences, temperature, top_p, top_k);
+    convert_tools(&mut chat, tools);
+    // Borrows `tool_choice`; the conversion below consumes it. Reordering the
+    // two is a borrow-check error rather than a silent behavior change.
+    convert_parallel_tool_calls(&mut chat, tool_choice.as_ref());
+    convert_tool_choice(&mut chat, tool_choice, had_tools);
 
     serde_json::to_vec(&Value::Object(chat)).map_err(|e| format!("serialization failed: {e}"))
+}
+
+/// Build the Chat Completions `messages` array from the Anthropic `system` and
+/// `messages` fields, which are the only two inputs to it.
+fn build_messages(system: Option<Value>, messages: Option<Value>) -> Value {
+    let mut converted = Vec::new();
+    hoist_system(&mut converted, system);
+    convert_messages(&mut converted, messages);
+    Value::Array(converted)
+}
+
+/// Build a Chat Completions message carrying plain string content.
+fn text_message(role: &str, content: String) -> Value {
+    let mut message = Map::new();
+    message.insert("role".to_owned(), Value::String(role.to_owned()));
+    message.insert("content".to_owned(), Value::String(content));
+    Value::Object(message)
 }
 
 // -----------------------------------------------------------------------------
@@ -51,18 +78,16 @@ pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
 // -----------------------------------------------------------------------------
 
 /// Hoist Anthropic top-level `system` to a Chat Completions system message.
-fn hoist_system(messages: &mut Vec<Value>, obj: &Map<String, Value>) {
-    let Some(system) = obj.get("system") else {
-        return;
-    };
-
+fn hoist_system(messages: &mut Vec<Value>, system: Option<Value>) {
     let content = match system {
-        Value::String(s) => s.clone(),
-        Value::Array(blocks) => {
+        Some(Value::String(text)) => text,
+        Some(Value::Array(blocks)) => {
             let mut parts = Vec::new();
             for block in blocks {
-                if let Some(text) = block.get("text").and_then(Value::as_str) {
-                    parts.push(text.to_owned());
+                if let Value::Object(mut block) = block
+                    && let Some(text) = take_string(&mut block, "text")
+                {
+                    parts.push(text);
                 }
             }
             parts.join("\n")
@@ -71,7 +96,7 @@ fn hoist_system(messages: &mut Vec<Value>, obj: &Map<String, Value>) {
     };
 
     if !content.is_empty() {
-        messages.push(json!({"role": "system", "content": content}));
+        messages.push(text_message("system", content));
     }
 }
 
@@ -80,25 +105,28 @@ fn hoist_system(messages: &mut Vec<Value>, obj: &Map<String, Value>) {
 // -----------------------------------------------------------------------------
 
 /// Convert Anthropic messages array to Chat Completions messages.
-fn convert_messages(messages: &mut Vec<Value>, obj: &Map<String, Value>) {
-    let Some(Value::Array(anthropic_messages)) = obj.get("messages") else {
+fn convert_messages(messages: &mut Vec<Value>, source: Option<Value>) {
+    let Some(Value::Array(anthropic_messages)) = source else {
         return;
     };
 
     for msg in anthropic_messages {
-        let Some(role) = msg.get("role").and_then(Value::as_str) else {
+        let Value::Object(mut msg) = msg else {
+            continue;
+        };
+        let Some(role) = take_string(&mut msg, "role") else {
             continue;
         };
 
-        match msg.get("content") {
+        match msg.remove("content") {
             Some(Value::String(text)) => {
-                messages.push(json!({"role": role, "content": text}));
+                messages.push(text_message(&role, text));
             },
             Some(Value::Array(blocks)) => {
-                convert_content_blocks(messages, role, blocks);
+                convert_content_blocks(messages, &role, &blocks);
             },
             _ => {
-                messages.push(json!({"role": role, "content": ""}));
+                messages.push(text_message(&role, String::new()));
             },
         }
     }
@@ -275,7 +303,7 @@ fn flush_text_parts(
             .and_then(Value::as_str)
             == Some("text")
     {
-        messages.push(json!({"role": role, "content": text_parts.join("")}));
+        messages.push(text_message(role, text_parts.join("")));
     } else if !content_parts.is_empty() {
         messages.push(json!({"role": role, "content": std::mem::take(content_parts)}));
     }
@@ -498,45 +526,43 @@ fn non_empty_lines(lines: &[String]) -> Option<String> {
 // Parameter Mapping
 // -----------------------------------------------------------------------------
 
-/// Copy `stream` and request streaming usage when enabled.
-fn convert_stream(chat: &mut Map<String, Value>, obj: &Map<String, Value>) {
-    let Some(stream) = obj.get("stream") else {
+/// Move `stream` through and request streaming usage when enabled.
+fn convert_stream(chat: &mut Map<String, Value>, stream: Option<Value>, stream_options: Option<Value>) {
+    let Some(stream) = stream else {
         return;
     };
-    chat.insert("stream".to_owned(), stream.clone());
 
-    if stream.as_bool() == Some(true) {
-        let mut opts = obj
-            .get("stream_options")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        opts.insert("include_usage".to_owned(), Value::Bool(true));
-        chat.insert("stream_options".to_owned(), Value::Object(opts));
+    let streaming = stream.as_bool() == Some(true);
+    chat.insert("stream".to_owned(), stream);
+
+    if !streaming {
+        return;
     }
+
+    let mut opts = match stream_options {
+        Some(Value::Object(opts)) => opts,
+        _ => Map::new(),
+    };
+    opts.insert("include_usage".to_owned(), Value::Bool(true));
+    chat.insert("stream_options".to_owned(), Value::Object(opts));
 }
 
-/// Map Anthropic parameters to Chat Completions-compatible equivalents.
+/// Map Anthropic sampling parameters to Chat Completions-compatible equivalents.
 ///
 /// `top_k` has no standard Chat Completions equivalent but is preserved
 /// as an extra body parameter for backends that support it
 /// (e.g. vLLM).
-fn map_parameters(chat: &mut Map<String, Value>, obj: &Map<String, Value>) {
-    if let Some(stop) = obj.get("stop_sequences") {
-        chat.insert("stop".to_owned(), stop.clone());
-    }
-
-    if let Some(temp) = obj.get("temperature") {
-        chat.insert("temperature".to_owned(), temp.clone());
-    }
-
-    if let Some(top_p) = obj.get("top_p") {
-        chat.insert("top_p".to_owned(), top_p.clone());
-    }
-
-    if let Some(top_k) = obj.get("top_k") {
-        chat.insert("top_k".to_owned(), top_k.clone());
-    }
+fn map_parameters(
+    chat: &mut Map<String, Value>,
+    stop_sequences: Option<Value>,
+    temperature: Option<Value>,
+    top_p: Option<Value>,
+    top_k: Option<Value>,
+) {
+    insert_if_some(chat, "stop", stop_sequences);
+    insert_if_some(chat, "temperature", temperature);
+    insert_if_some(chat, "top_p", top_p);
+    insert_if_some(chat, "top_k", top_k);
 }
 
 // -----------------------------------------------------------------------------
@@ -544,8 +570,8 @@ fn map_parameters(chat: &mut Map<String, Value>, obj: &Map<String, Value>) {
 // -----------------------------------------------------------------------------
 
 /// Convert Anthropic tool definitions to Chat Completions function tools.
-fn convert_tools(chat: &mut Map<String, Value>, obj: &Map<String, Value>) {
-    let Some(Value::Array(tools)) = obj.get("tools") else {
+fn convert_tools(chat: &mut Map<String, Value>, tools: Option<Value>) {
+    let Some(Value::Array(tools)) = tools else {
         return;
     };
 
@@ -598,30 +624,41 @@ fn is_translatable_client_tool(tool: &Value) -> bool {
 }
 
 /// Convert one Anthropic client tool definition to a Chat Completions tool.
-fn convert_tool_definition(tool: &Value) -> Option<Value> {
-    if !is_translatable_client_tool(tool) {
+///
+/// Consumes the definition so `input_schema` — the largest value in a typical
+/// agentic request — moves into the generated function parameters.
+fn convert_tool_definition(tool: Value) -> Option<Value> {
+    if !is_translatable_client_tool(&tool) {
         return None;
     }
 
-    let name = tool.get("name").and_then(Value::as_str).unwrap_or("");
-    let description = tool.get("description").and_then(Value::as_str).unwrap_or("");
-    let parameters = tool
-        .get("input_schema")
-        .cloned()
-        .unwrap_or_else(|| json!({"type": "object"}));
+    // A non-object tool entry carries no fields, so it translates to an empty
+    // function exactly as reading through `Value::get` did.
+    let mut tool = if let Value::Object(fields) = tool {
+        fields
+    } else {
+        Map::new()
+    };
+
+    let name = take_string(&mut tool, "name").unwrap_or_default();
+    let description = take_string(&mut tool, "description").unwrap_or_default();
+    let parameters = tool.remove("input_schema").unwrap_or_else(|| json!({"type": "object"}));
+    let strict = tool.get("strict").and_then(Value::as_bool);
 
     let mut function = Map::new();
-    function.insert("name".to_owned(), Value::String(name.to_owned()));
-    function.insert("description".to_owned(), Value::String(description.to_owned()));
+    function.insert("name".to_owned(), Value::String(name));
+    function.insert("description".to_owned(), Value::String(description));
     function.insert("parameters".to_owned(), parameters);
-    if let Some(strict) = tool.get("strict").and_then(Value::as_bool) {
+    if let Some(strict) = strict {
         function.insert("strict".to_owned(), Value::Bool(strict));
     }
 
-    Some(json!({
-        "type": "function",
-        "function": function
-    }))
+    // Built by hand rather than with `json!`, which would deep-clone the
+    // function map back through the serializer.
+    let mut chat_tool = Map::new();
+    chat_tool.insert("type".to_owned(), Value::String("function".to_owned()));
+    chat_tool.insert("function".to_owned(), Value::Object(function));
+    Some(Value::Object(chat_tool))
 }
 
 // -----------------------------------------------------------------------------
@@ -629,8 +666,11 @@ fn convert_tool_definition(tool: &Value) -> Option<Value> {
 // -----------------------------------------------------------------------------
 
 /// Convert Anthropic `disable_parallel_tool_use` to Chat Completions format.
-fn convert_parallel_tool_calls(chat: &mut Map<String, Value>, obj: &Map<String, Value>) {
-    let Some(Value::Object(tool_choice)) = obj.get("tool_choice") else {
+///
+/// Reads `tool_choice` without consuming it; [`convert_tool_choice`] takes
+/// ownership afterwards.
+fn convert_parallel_tool_calls(chat: &mut Map<String, Value>, tool_choice: Option<&Value>) {
+    let Some(Value::Object(tool_choice)) = tool_choice else {
         return;
     };
 
@@ -644,37 +684,56 @@ fn convert_parallel_tool_calls(chat: &mut Map<String, Value>, obj: &Map<String, 
 }
 
 /// Convert Anthropic `tool_choice` to Chat Completions format.
-fn convert_tool_choice(chat: &mut Map<String, Value>, obj: &Map<String, Value>) {
-    let Some(tool_choice) = obj.get("tool_choice") else {
+///
+/// `had_tools` records whether the request carried a `tools` field at all. A
+/// choice is dropped when every tool was filtered out, so a request whose tools
+/// were all typed server tools cannot force a tool call the backend never saw.
+fn convert_tool_choice(chat: &mut Map<String, Value>, tool_choice: Option<Value>, had_tools: bool) {
+    let Some(tool_choice) = tool_choice else {
         return;
     };
 
-    if obj.contains_key("tools") && !chat.contains_key("tools") {
+    if had_tools && !chat.contains_key("tools") {
         return;
     }
 
     let chat_choice = match tool_choice {
-        Value::String(s) => match s.as_str() {
-            "any" => Value::String("required".to_owned()),
-            "none" => Value::String("none".to_owned()),
-            _ => Value::String("auto".to_owned()),
-        },
-        Value::Object(tc) => match tc.get("type").and_then(Value::as_str) {
-            Some("any") => Value::String("required".to_owned()),
-            Some("none") => Value::String("none".to_owned()),
-            Some("tool") => {
-                if let Some(name) = tc.get("name").and_then(Value::as_str) {
-                    json!({"type": "function", "function": {"name": name}})
-                } else {
-                    Value::String("auto".to_owned())
-                }
-            },
-            _ => Value::String("auto".to_owned()),
-        },
+        Value::String(keyword) => Value::String(tool_choice_keyword(&keyword).to_owned()),
+        Value::Object(tool_choice) => object_tool_choice(tool_choice),
         _ => return,
     };
 
     chat.insert("tool_choice".to_owned(), chat_choice);
+}
+
+/// Map an Anthropic `tool_choice` type to its Chat Completions keyword.
+fn tool_choice_keyword(anthropic: &str) -> &'static str {
+    match anthropic {
+        "any" => "required",
+        "none" => "none",
+        _ => "auto",
+    }
+}
+
+/// Convert an object-form `tool_choice`, moving a named tool's name through.
+fn object_tool_choice(mut tool_choice: Map<String, Value>) -> Value {
+    // Settled before the named-tool branch so the type lookup does not hold a
+    // borrow while `name` is taken out.
+    let names_a_tool = tool_choice.get("type").and_then(Value::as_str) == Some("tool");
+
+    if names_a_tool && let Some(name) = take_string(&mut tool_choice, "name") {
+        let mut function = Map::new();
+        function.insert("name".to_owned(), Value::String(name));
+
+        let mut choice = Map::new();
+        choice.insert("type".to_owned(), Value::String("function".to_owned()));
+        choice.insert("function".to_owned(), Value::Object(function));
+        return Value::Object(choice);
+    }
+
+    // A `tool` choice without a usable name degrades to `auto`.
+    let kind = tool_choice.get("type").and_then(Value::as_str).unwrap_or_default();
+    Value::String(tool_choice_keyword(kind).to_owned())
 }
 
 // -----------------------------------------------------------------------------
@@ -703,6 +762,109 @@ mod tests {
         );
         assert_eq!(parsed["messages"][0]["role"], "user", "user message role");
         assert_eq!(parsed["messages"][0]["content"], "Hello", "user message content");
+    }
+
+    #[test]
+    fn mapped_fields_keep_a_stable_serialized_key_order() {
+        // `serde_json` runs with `preserve_order`, so the order fields are
+        // emitted in `transform_request` is the order sent upstream. Pin it so
+        // reordering the emission sequence cannot silently reshape the wire body.
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"stream":true,"stop_sequences":["x"],"temperature":0.5,"top_p":0.9,"top_k":40,"tools":[{"name":"t","input_schema":{"type":"object"}}],"tool_choice":{"type":"any","disable_parallel_tool_use":true},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let keys: Vec<&str> = parsed.as_object().unwrap().keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "model",
+                "messages",
+                "max_completion_tokens",
+                "stream",
+                "stream_options",
+                "stop",
+                "temperature",
+                "top_p",
+                "top_k",
+                "tools",
+                "parallel_tool_calls",
+                "tool_choice",
+            ],
+            "translated request key order must stay stable"
+        );
+    }
+
+    #[test]
+    fn untranslated_top_level_fields_are_dropped() {
+        let body = br#"{"model":"m","metadata":{"user_id":"u"},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert!(
+            parsed.get("metadata").is_none(),
+            "fields with no Chat Completions mapping are not forwarded"
+        );
+    }
+
+    #[test]
+    fn tool_input_schema_is_preserved_verbatim() {
+        let body = br#"{"model":"m","tools":[{"name":"t","description":"d","input_schema":{"type":"object","properties":{"a":{"type":"array","items":{"type":"string"}},"b":{"enum":[1,2,3]}},"required":["a"],"additionalProperties":false}}],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["tools"][0]["function"]["parameters"],
+            json!({
+                "type": "object",
+                "properties": {"a": {"type": "array", "items": {"type": "string"}}, "b": {"enum": [1, 2, 3]}},
+                "required": ["a"],
+                "additionalProperties": false
+            }),
+            "moving the schema must not alter its contents"
+        );
+    }
+
+    #[test]
+    fn tool_definition_with_non_string_name_falls_back_to_empty() {
+        let body = br#"{"model":"m","tools":[{"name":42,"description":true,"input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["tools"][0]["function"]["name"], "",
+            "non-string name yields empty"
+        );
+        assert_eq!(
+            parsed["tools"][0]["function"]["description"], "",
+            "non-string description yields empty"
+        );
+    }
+
+    #[test]
+    fn stream_options_dropped_when_streaming_disabled() {
+        let body = br#"{"model":"m","stream":false,"stream_options":{"include_usage":false},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["stream"], false);
+        assert!(
+            parsed.get("stream_options").is_none(),
+            "stream_options is meaningless without streaming"
+        );
+    }
+
+    #[test]
+    fn caller_stream_options_are_preserved_alongside_include_usage() {
+        let body =
+            br#"{"model":"m","stream":true,"stream_options":{"custom":1},"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["stream_options"]["custom"], 1,
+            "caller options are moved through"
+        );
+        assert_eq!(parsed["stream_options"]["include_usage"], true);
     }
 
     #[test]

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -6,8 +6,6 @@
 use serde_json::{Map, Value, json};
 use tracing::warn;
 
-use crate::json_body::{insert_if_some, take_string};
-
 // -----------------------------------------------------------------------------
 // Request Transformation
 // -----------------------------------------------------------------------------
@@ -49,6 +47,35 @@ pub(crate) fn transform_request(value: Value, original_len: usize) -> Result<Vec
 
     serialize_chat(chat, original_len)
 }
+
+// -----------------------------------------------------------------------------
+// Field Consumption
+// -----------------------------------------------------------------------------
+
+/// Remove `key` from `map` and return the owned `String` when the value was a JSON string.
+///
+/// The entry is removed either way: a non-string value is dropped and `None` returned, matching the
+/// `get(..).and_then(Value::as_str)` behavior, without re-allocating the string.
+fn take_string(map: &mut Map<String, Value>, key: &str) -> Option<String> {
+    match map.remove(key) {
+        Some(Value::String(text)) => Some(text),
+        _ => None,
+    }
+}
+
+/// Move `value` into `target` under `key`, doing nothing when the field is absent.
+///
+/// Pairs with [`Map::remove`] so a mapped field travels from the parsed body into the translated body
+/// without an intermediate copy.
+fn insert_if_some(target: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        target.insert(key.to_owned(), value);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Serialization
+// -----------------------------------------------------------------------------
 
 /// Serialize the translated body into a buffer pre-sized from the Anthropic
 /// body it was translated from.
@@ -392,7 +419,6 @@ fn split_tool_result_parts(parts: Vec<Value>) -> (String, Vec<Value>) {
         let Value::Object(mut part) = part else {
             continue;
         };
-        // No branch below reads `type` again, so it is taken out with the rest.
         match take_string(&mut part, "type").as_deref() {
             Some("text") => {
                 if let Some(text) = take_string(&mut part, "text") {
@@ -657,15 +683,12 @@ fn is_translatable_client_tool(tool: &Value) -> bool {
 }
 
 /// Convert one Anthropic client tool definition to a Chat Completions tool.
-///
-/// Consumes the definition so `input_schema` — the largest value in a typical
-/// agentic request — moves into the generated function parameters.
+/// Consumes the definition so `input_schema` moves into the generated function parameters.
 fn convert_tool_definition(tool: Value) -> Option<Value> {
     if !is_translatable_client_tool(&tool) {
         return None;
     }
 
-    // A non-object tool entry carries no fields, so it translates to an empty function.
     let mut tool = match tool {
         Value::Object(fields) => fields,
         _ => Map::new(),
@@ -684,8 +707,6 @@ fn convert_tool_definition(tool: Value) -> Option<Value> {
         function.insert("strict".to_owned(), Value::Bool(strict));
     }
 
-    // Built by hand rather than with `json!`, which would deep-clone the
-    // function map back through the serializer.
     let mut chat_tool = Map::new();
     chat_tool.insert("type".to_owned(), Value::String("function".to_owned()));
     chat_tool.insert("function".to_owned(), Value::Object(function));
@@ -753,7 +774,6 @@ fn object_tool_choice(mut tool_choice: Map<String, Value>) -> Value {
         return Value::Object(choice);
     }
 
-    // A `tool` choice without a usable name degrades to `auto`.
     let kind = tool_choice.get("type").and_then(Value::as_str).unwrap_or_default();
     Value::String(tool_choice_keyword(kind).to_owned())
 }
@@ -772,28 +792,6 @@ mod tests {
     fn transform_bytes(body: &[u8]) -> Result<Vec<u8>, String> {
         let value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
         transform_request(value, body.len())
-    }
-
-    #[test]
-    fn output_buffer_is_sized_from_the_original_body() {
-        // Server tools are dropped, so the translation is far smaller than the
-        // body it came from and cannot have grown the buffer on its own.
-        let body = format!(
-            r#"{{"model":"claude-opus-4-8","messages":[],"tools":[{{"type":"web_search_20250305","name":"{}"}}]}}"#,
-            "s".repeat(4096)
-        );
-        let result = transform_bytes(body.as_bytes()).unwrap();
-
-        assert!(
-            result.len() < body.len(),
-            "translation should be smaller than the original body"
-        );
-        assert!(
-            result.capacity() >= body.len(),
-            "output buffer should be pre-sized from the original body, got {} for a {}-byte body",
-            result.capacity(),
-            body.len()
-        );
     }
 
     #[test]
@@ -842,18 +840,6 @@ mod tests {
                 "tool_choice",
             ],
             "translated request key order must stay stable"
-        );
-    }
-
-    #[test]
-    fn untranslated_top_level_fields_are_dropped() {
-        let body = br#"{"model":"m","metadata":{"user_id":"u"},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_bytes(body).unwrap();
-        let parsed: Value = serde_json::from_slice(&result).unwrap();
-
-        assert!(
-            parsed.get("metadata").is_none(),
-            "fields with no Chat Completions mapping are not forwarded"
         );
     }
 

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -3,7 +3,7 @@
 
 //! Anthropic Messages to Chat Completions-compatible request transformation.
 
-use serde_json::{Map, Value, json};
+use serde_json::{Error, Map, Value, json};
 use tracing::warn;
 
 use crate::json_body::{insert_if_some, take_string};
@@ -12,11 +12,11 @@ use crate::json_body::{insert_if_some, take_string};
 // Request Transformation
 // -----------------------------------------------------------------------------
 
-/// Transform an Anthropic Messages request body into Chat
+/// Transform parsed Anthropic Messages request body into Chat
 /// Completions-compatible format.
 /// Returns the transformed JSON bytes, or an error message.
-pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
-    let value: Value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
+pub(crate) fn transform_request(value: Result<Value, Error>) -> Result<Vec<u8>, String> {
+    let value = value.map_err(|e| format!("invalid JSON: {e}"))?;
 
     let Value::Object(mut body) = value else {
         return Err("request body is not a JSON object".to_owned());
@@ -152,7 +152,8 @@ fn convert_messages(messages: &mut Vec<Value>, source: Option<Value>) {
 /// Convert typed content blocks to Chat Completions-compatible format.
 /// Consumes the blocks to move their payloads into the translated message.
 fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: Vec<Value>) {
-    let mut acc = BlockAccumulator::default();
+    let mut content_parts = Vec::new();
+    let mut tool_calls = Vec::new();
 
     for block in blocks {
         let mut block = match block {
@@ -160,37 +161,33 @@ fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: Vec<Val
             _ => Map::new(),
         };
         let block_type = take_string(&mut block, "type").unwrap_or_default();
-        convert_single_block(block, &block_type, messages, role, &mut acc);
+        convert_single_block(block, &block_type, messages, role, &mut content_parts, &mut tool_calls);
     }
 
-    finalize_content_blocks(messages, role, acc);
-}
-
-/// Chat Completions output accumulated across one message's content blocks.
-#[derive(Default)]
-struct BlockAccumulator {
-    /// Content parts in wire order.
-    content_parts: Vec<Value>,
-    /// Tool calls hoisted out of `tool_use` blocks.
-    tool_calls: Vec<Value>,
+    finalize_content_blocks(messages, role, &mut content_parts, tool_calls);
 }
 
 /// Process a single content block within a message.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "accumulator pattern requires passing all state"
+)]
 fn convert_single_block(
     block: Map<String, Value>,
     block_type: &str,
     messages: &mut Vec<Value>,
     role: &str,
-    acc: &mut BlockAccumulator,
+    content_parts: &mut Vec<Value>,
+    tool_calls: &mut Vec<Value>,
 ) {
     match block_type {
-        "text" => convert_text_block(block, &mut acc.content_parts),
-        "image" => convert_image_block(block, &mut acc.content_parts),
-        "search_result" => convert_search_result_block(block, &mut acc.content_parts),
-        "document" => convert_document_block(block, &mut acc.content_parts),
-        "tool_use" => convert_tool_use_block(block, &mut acc.tool_calls),
+        "text" => convert_text_block(block, content_parts),
+        "image" => convert_image_block(block, content_parts),
+        "search_result" => convert_search_result_block(block, content_parts),
+        "document" => convert_document_block(block, content_parts),
+        "tool_use" => convert_tool_use_block(block, tool_calls),
         "tool_result" => {
-            flush_content_parts(messages, &mut acc.content_parts, role);
+            flush_content_parts(messages, content_parts, role);
             convert_tool_result_block(block, messages);
         },
         "thinking" | "redacted_thinking" => {
@@ -303,17 +300,22 @@ fn convert_tool_result_block(mut block: Map<String, Value>, messages: &mut Vec<V
 }
 
 /// Emit the final message for accumulated content and tool calls.
-fn finalize_content_blocks(messages: &mut Vec<Value>, role: &str, mut acc: BlockAccumulator) {
-    if role == "assistant" && !acc.tool_calls.is_empty() {
+fn finalize_content_blocks(
+    messages: &mut Vec<Value>,
+    role: &str,
+    content_parts: &mut Vec<Value>,
+    tool_calls: Vec<Value>,
+) {
+    if role == "assistant" && !tool_calls.is_empty() {
         let mut msg = Map::new();
         msg.insert("role".to_owned(), Value::String("assistant".to_owned()));
-        if let Some(text) = take_joined_text(&mut acc.content_parts) {
+        if let Some(text) = take_joined_text(content_parts) {
             msg.insert("content".to_owned(), Value::String(text));
         }
-        msg.insert("tool_calls".to_owned(), Value::Array(acc.tool_calls));
+        msg.insert("tool_calls".to_owned(), Value::Array(tool_calls));
         messages.push(Value::Object(msg));
     } else {
-        flush_content_parts(messages, &mut acc.content_parts, role);
+        flush_content_parts(messages, content_parts, role);
     }
 }
 
@@ -753,10 +755,16 @@ fn object_tool_choice(mut tool_choice: Map<String, Value>) -> Value {
 mod tests {
     use super::*;
 
+    /// Parse a raw request body and transform it, mirroring the filter's
+    /// parse-once call path.
+    fn transform_bytes(body: &[u8]) -> Result<Vec<u8>, String> {
+        transform_request(serde_json::from_slice(body))
+    }
+
     #[test]
     fn basic_text_request() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["model"], "claude-opus-4-8", "model preserved");
@@ -778,7 +786,7 @@ mod tests {
         // emitted in `transform_request` is the order sent upstream. Pin it so
         // reordering the emission sequence cannot silently reshape the wire body.
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"stream":true,"stop_sequences":["x"],"temperature":0.5,"top_p":0.9,"top_k":40,"tools":[{"name":"t","input_schema":{"type":"object"}}],"tool_choice":{"type":"any","disable_parallel_tool_use":true},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let keys: Vec<&str> = parsed.as_object().unwrap().keys().map(String::as_str).collect();
@@ -805,7 +813,7 @@ mod tests {
     #[test]
     fn untranslated_top_level_fields_are_dropped() {
         let body = br#"{"model":"m","metadata":{"user_id":"u"},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -817,7 +825,7 @@ mod tests {
     #[test]
     fn tool_input_schema_is_preserved_verbatim() {
         let body = br#"{"model":"m","tools":[{"name":"t","description":"d","input_schema":{"type":"object","properties":{"a":{"type":"array","items":{"type":"string"}},"b":{"enum":[1,2,3]}},"required":["a"],"additionalProperties":false}}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -835,7 +843,7 @@ mod tests {
     #[test]
     fn tool_definition_with_non_string_name_falls_back_to_empty() {
         let body = br#"{"model":"m","tools":[{"name":42,"description":true,"input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -851,7 +859,7 @@ mod tests {
     #[test]
     fn stream_options_dropped_when_streaming_disabled() {
         let body = br#"{"model":"m","stream":false,"stream_options":{"include_usage":false},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["stream"], false);
@@ -865,7 +873,7 @@ mod tests {
     fn caller_stream_options_are_preserved_alongside_include_usage() {
         let body =
             br#"{"model":"m","stream":true,"stream_options":{"custom":1},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -878,7 +886,7 @@ mod tests {
     #[test]
     fn system_hoisted() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":"Be helpful.","messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -892,7 +900,7 @@ mod tests {
     #[test]
     fn system_text_blocks_joined() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":[{"type":"text","text":"Part 1"},{"type":"text","text":"Part 2"}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -904,7 +912,7 @@ mod tests {
     #[test]
     fn tool_use_converted() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"NYC"}}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let msg = &parsed["messages"][0];
@@ -922,7 +930,7 @@ mod tests {
     #[test]
     fn tool_result_converted() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"72F sunny"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["messages"][0]["role"], "tool", "tool role");
@@ -933,7 +941,7 @@ mod tests {
     #[test]
     fn tool_result_error_marked_in_tool_message_content() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"cat: missing.txt: No such file or directory","is_error":true}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -946,7 +954,7 @@ mod tests {
     #[test]
     fn tool_result_image_promoted_to_followup_user_message() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"text","text":"chart"},{"type":"image","source":{"type":"url","url":"https://example.com/chart.png"}}]}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["messages"][0]["role"], "tool", "first message is tool result");
@@ -968,7 +976,7 @@ mod tests {
     #[test]
     fn top_level_search_result_preserved_as_text_context() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"search_result","source":"https://docs.example.test/product","title":"Product Guide","content":[{"type":"text","text":"The default timeout is 30 seconds."},{"type":"text","text":"The maximum timeout is 120 seconds."}]},{"type":"text","text":"What is the timeout range?"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
         let content = parsed["messages"][0]["content"].as_array().unwrap();
 
@@ -987,7 +995,7 @@ mod tests {
     #[test]
     fn tool_result_search_result_preserved_in_tool_message_content() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"search_result","source":"kb://timeouts","title":"Timeout KB","content":[{"type":"text","text":"Timeouts default to 30 seconds."}]},{"type":"text","text":"Applies to version 2."}]}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["messages"][0]["role"], "tool");
@@ -1001,7 +1009,7 @@ mod tests {
     #[test]
     fn tool_result_document_preserved_in_tool_message_content() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"text","text":"Before document."},{"type":"document","source":{"type":"content","content":[{"type":"text","text":"Nested document fact."}]},"title":"Nested Doc"},{"type":"text","text":"After document."}]}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1014,7 +1022,7 @@ mod tests {
     #[test]
     fn document_text_source_preserved_as_text_context() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"text","media_type":"text/plain","data":"The grass is green. The sky is blue."},"title":"Color Notes","context":"trusted notes","citations":{"enabled":true}},{"type":"text","text":"What color is the grass?"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
         let content = parsed["messages"][0]["content"].as_array().unwrap();
 
@@ -1029,7 +1037,7 @@ mod tests {
     #[test]
     fn document_file_source_preserved_as_reference_text() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"file","file_id":"file_abc123"},"title":"Uploaded Contract"},{"type":"text","text":"Summarize the uploaded contract."}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
         let content = parsed["messages"][0]["content"].as_array().unwrap();
 
@@ -1042,7 +1050,7 @@ mod tests {
     #[test]
     fn document_source_variants_preserved_or_dropped_intentionally() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"content","content":[{"type":"text","text":"Content block fact."}]},"title":"Content Doc"},{"type":"document","source":{"type":"url","url":"https://docs.example.test/file.pdf"}},{"type":"document","source":{"type":"base64","media_type":"application/pdf"}},{"type":"document","source":{"type":"unknown","data":"ignored"}}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
         let content = parsed["messages"][0]["content"].as_array().unwrap();
 
@@ -1081,7 +1089,7 @@ mod tests {
             }]
         })
         .to_string();
-        let result = transform_request(body.as_bytes()).unwrap();
+        let result = transform_bytes(body.as_bytes()).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1107,7 +1115,7 @@ mod tests {
             }]
         })
         .to_string();
-        let result = transform_request(body.as_bytes()).unwrap();
+        let result = transform_bytes(body.as_bytes()).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1120,7 +1128,7 @@ mod tests {
     #[test]
     fn empty_search_result_and_document_blocks_dropped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"search_result","content":[]},{"type":"document","source":{"type":"content","content":[]}},{"type":"document","source":{"type":"text","data":""}},{"type":"document","source":{"type":"url","url":""}},{"type":"document","source":{"type":"file","file_id":""}},{"type":"document","source":{"type":"base64","media_type":""}}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -1133,7 +1141,7 @@ mod tests {
     fn stop_sequences_mapped() {
         let body =
             br#"{"model":"claude-opus-4-8","max_tokens":1024,"stop_sequences":["END"],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["stop"][0], "END", "stop_sequences mapped to stop");
@@ -1142,7 +1150,7 @@ mod tests {
     #[test]
     fn tool_choice_any_mapped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":"any","messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["tool_choice"], "required", "any maps to required");
@@ -1151,7 +1159,7 @@ mod tests {
     #[test]
     fn tool_choice_object_any_mapped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"any"},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["tool_choice"], "required", "object-form any maps to required");
@@ -1160,7 +1168,7 @@ mod tests {
     #[test]
     fn tool_choice_dropped_when_all_tools_filtered() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"type":"web_search_20250305","name":"web_search"}],"tool_choice":"any","messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(parsed.get("tools").is_none(), "server-side tools should be filtered");
@@ -1173,7 +1181,7 @@ mod tests {
     #[test]
     fn disable_parallel_tool_use_mapped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"auto","disable_parallel_tool_use":true},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1185,7 +1193,7 @@ mod tests {
     #[test]
     fn tool_definitions_converted() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}}}}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["tools"][0]["type"], "function", "tool type should be function");
@@ -1195,7 +1203,7 @@ mod tests {
     #[test]
     fn tool_definition_strict_mapped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}}},"strict":true},{"name":"get_time","description":"Get time","input_schema":{"type":"object"},"strict":false},{"name":"get_news","description":"Get news","input_schema":{"type":"object"},"strict":"yes"}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1215,7 +1223,7 @@ mod tests {
     #[test]
     fn image_base64_converted() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"abc123"}},{"type":"text","text":"What is this?"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let content = &parsed["messages"][0]["content"];
@@ -1231,7 +1239,7 @@ mod tests {
     fn top_k_preserved_as_extra_param() {
         let body =
             br#"{"model":"claude-opus-4-8","max_tokens":1024,"top_k":40,"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["top_k"], 40, "top_k should be preserved as extra body parameter");
@@ -1240,7 +1248,7 @@ mod tests {
     #[test]
     fn transform_request_non_json_body() {
         let body = b"not json at all";
-        let result = transform_request(body);
+        let result = transform_bytes(body);
         assert!(result.is_err(), "non-JSON body should return Err");
         assert!(
             result.unwrap_err().contains("invalid JSON"),
@@ -1251,7 +1259,7 @@ mod tests {
     #[test]
     fn transform_request_json_array_body() {
         let body = b"[1,2,3]";
-        let result = transform_request(body);
+        let result = transform_bytes(body);
         assert!(result.is_err(), "JSON array body should return Err");
         assert!(
             result.unwrap_err().contains("not a JSON object"),
@@ -1263,7 +1271,7 @@ mod tests {
     fn hoist_system_non_string_non_array_skipped() {
         let body =
             br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":42,"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1277,7 +1285,7 @@ mod tests {
     #[test]
     fn hoist_system_array_empty_text_skipped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":[{"type":"text","text":""}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1291,7 +1299,7 @@ mod tests {
     #[test]
     fn convert_messages_missing_role_skipped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -1303,7 +1311,7 @@ mod tests {
     #[test]
     fn convert_messages_content_not_string_or_array() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":42}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["messages"][0]["role"], "user");
@@ -1316,7 +1324,7 @@ mod tests {
     #[test]
     fn thinking_block_dropped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think..."}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -1328,7 +1336,7 @@ mod tests {
     #[test]
     fn unknown_block_type_dropped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"custom_xyz","data":"something"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -1340,7 +1348,7 @@ mod tests {
     #[test]
     fn tool_choice_string_none() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":"none","messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["tool_choice"], "none", "string none maps to none");
@@ -1349,7 +1357,7 @@ mod tests {
     #[test]
     fn tool_choice_string_unknown_maps_to_auto() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":"foo","messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["tool_choice"], "auto", "unknown string tool_choice maps to auto");
@@ -1358,7 +1366,7 @@ mod tests {
     #[test]
     fn tool_choice_object_none() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"f","description":"d","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"none"},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["tool_choice"], "none", "object-form none maps to none");
@@ -1367,7 +1375,7 @@ mod tests {
     #[test]
     fn tool_choice_object_tool_with_name() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"fn","description":"d","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"tool","name":"fn"},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1383,7 +1391,7 @@ mod tests {
     #[test]
     fn tool_choice_object_tool_without_name_maps_to_auto() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"f","description":"d","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"tool"},"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(
@@ -1395,7 +1403,7 @@ mod tests {
     #[test]
     fn tool_choice_non_string_non_object_skipped() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":true,"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -1407,7 +1415,7 @@ mod tests {
     #[test]
     fn multipart_image_and_text_produces_array_content() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"text","text":"Describe this"},{"type":"image","source":{"type":"url","url":"https://example.com/img.png"}}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let content = &parsed["messages"][0]["content"];
@@ -1422,7 +1430,7 @@ mod tests {
         // String content is emitted only for a *single* text part. Two text
         // blocks keep their part boundaries rather than being joined.
         let body = br#"{"model":"m","messages":[{"role":"user","content":[{"type":"text","text":"one"},{"type":"text","text":"two"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let content = parsed["messages"][0]["content"].as_array().unwrap();
@@ -1436,7 +1444,7 @@ mod tests {
         // The assistant+tool_calls branch joins every text part into one string,
         // a different rule from the single-part case above.
         let body = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"text","text":"one"},{"type":"text","text":"two"},{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let msg = &parsed["messages"][0];
@@ -1449,14 +1457,14 @@ mod tests {
         // An empty text block still emits `content: ""`; no text block at all
         // emits no `content` key.
         let empty = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"text","text":""},{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
-        let parsed: Value = serde_json::from_slice(&transform_request(empty).unwrap()).unwrap();
+        let parsed: Value = serde_json::from_slice(&transform_bytes(empty).unwrap()).unwrap();
         assert_eq!(
             parsed["messages"][0]["content"], "",
             "an empty text block still emits content"
         );
 
         let none = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
-        let parsed: Value = serde_json::from_slice(&transform_request(none).unwrap()).unwrap();
+        let parsed: Value = serde_json::from_slice(&transform_bytes(none).unwrap()).unwrap();
         assert!(
             parsed["messages"][0].get("content").is_none(),
             "no text block emits no content key"
@@ -1468,7 +1476,7 @@ mod tests {
         // The joined-string branch cannot carry an image part, so it is dropped
         // while the surrounding text is still joined.
         let body = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"text","text":"one"},{"type":"image","source":{"type":"url","url":"https://example.com/i.png"}},{"type":"text","text":"two"},{"type":"tool_use","id":"c1","name":"f","input":{}}]}]}"#;
-        let parsed: Value = serde_json::from_slice(&transform_request(body).unwrap()).unwrap();
+        let parsed: Value = serde_json::from_slice(&transform_bytes(body).unwrap()).unwrap();
 
         assert_eq!(
             parsed["messages"][0]["content"], "onetwo",
@@ -1479,7 +1487,7 @@ mod tests {
     #[test]
     fn tool_use_without_input_serializes_an_empty_object() {
         let body = br#"{"model":"m","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"c1","name":"f"},{"type":"tool_use","id":"c2","name":"g","input":null}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let calls = parsed["messages"][0]["tool_calls"].as_array().unwrap();
@@ -1496,7 +1504,7 @@ mod tests {
     #[test]
     fn only_tool_result_blocks_produce_tool_messages() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"result1"},{"type":"tool_result","tool_use_id":"call_2","content":"result2"}]}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let messages = parsed["messages"].as_array().unwrap();
@@ -1543,7 +1551,7 @@ mod tests {
     #[test]
     fn only_client_tools_converted() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"type":"bash_20241022","name":"bash"},{"type":"text_editor_20241022","name":"text_editor"},{"type":"code_execution_20250522","name":"code_execution"},{"type":"computer_20250124","name":"computer","display_width_px":1024,"display_height_px":768},{"type":"future_server_tool_20270101","name":"future_server_tool"},{"type":42,"name":"invalid_type","input_schema":{"type":"object"}},{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{}}},{"type":"custom","name":"get_time","description":"Get time","input_schema":{"type":"object","properties":{}}}],"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         let tools = parsed["tools"].as_array().unwrap();
@@ -1555,7 +1563,7 @@ mod tests {
     #[test]
     fn streaming_request_includes_usage_option() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["stream"], true, "stream should be true");
@@ -1568,7 +1576,7 @@ mod tests {
     #[test]
     fn non_streaming_request_omits_stream_options() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert!(
@@ -1580,7 +1588,7 @@ mod tests {
     #[test]
     fn stream_false_omits_stream_options() {
         let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"stream":false,"messages":[{"role":"user","content":"Hi"}]}"#;
-        let result = transform_request(body).unwrap();
+        let result = transform_bytes(body).unwrap();
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["stream"], false, "stream should be false");

--- a/apis/src/anthropic/messages_to_chat_completions/request.rs
+++ b/apis/src/anthropic/messages_to_chat_completions/request.rs
@@ -3,7 +3,7 @@
 
 //! Anthropic Messages to Chat Completions-compatible request transformation.
 
-use serde_json::{Error, Map, Value, json};
+use serde_json::{Map, Value, json};
 use tracing::warn;
 
 use crate::json_body::{insert_if_some, take_string};
@@ -12,12 +12,10 @@ use crate::json_body::{insert_if_some, take_string};
 // Request Transformation
 // -----------------------------------------------------------------------------
 
-/// Transform parsed Anthropic Messages request body into Chat
+/// Transform a parsed Anthropic Messages request body into Chat
 /// Completions-compatible format.
 /// Returns the transformed JSON bytes, or an error message.
-pub(crate) fn transform_request(value: Result<Value, Error>) -> Result<Vec<u8>, String> {
-    let value = value.map_err(|e| format!("invalid JSON: {e}"))?;
-
+pub(crate) fn transform_request(value: Value) -> Result<Vec<u8>, String> {
     let Value::Object(mut body) = value else {
         return Err("request body is not a JSON object".to_owned());
     };
@@ -756,9 +754,10 @@ mod tests {
     use super::*;
 
     /// Parse a raw request body and transform it, mirroring the filter's
-    /// parse-once call path.
+    /// parse-once call path including its parse-error message.
     fn transform_bytes(body: &[u8]) -> Result<Vec<u8>, String> {
-        transform_request(serde_json::from_slice(body))
+        let value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
+        transform_request(value)
     }
 
     #[test]

--- a/apis/src/json_body.rs
+++ b/apis/src/json_body.rs
@@ -22,12 +22,16 @@
 //!
 //! Request-side only: core repairs upstream `Content-Length` framing for mutated request bodies via
 //! `mutated_request_body_len`, so filters must not set `Content-Length` themselves.
+//!
+//! [`take_string`] and [`insert_if_some`] cover the other half of the problem: a filter that translates a
+//! body it is about to discard should *move* each field into the request it builds instead of cloning it out
+//! of a parsed value that dies moments later.
 
 use std::io::{self, Write};
 
 use bytes::Bytes;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use tracing::debug;
 
 /// Serialize `value` for a later body replacement.
@@ -205,6 +209,34 @@ impl BodyMutation {
         let new = i64::try_from(self.new_len).unwrap_or(i64::MAX);
         let old = i64::try_from(self.original_len).unwrap_or(i64::MAX);
         new - old
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Field Consumption
+// -----------------------------------------------------------------------------
+
+/// Remove `key` from `map` and return the owned `String` when the value was a JSON string.
+///
+/// The entry is removed either way: a non-string value is dropped and `None` returned, matching the
+/// `get(..).and_then(Value::as_str)` reads this replaces, without re-allocating the string.
+///
+/// If `serde_json` is built with `preserve_order`, [`Map::remove`] is a *swap* remove: the last entry
+/// takes the vacated slot. Take only from a map you are consuming.
+pub fn take_string(map: &mut Map<String, Value>, key: &str) -> Option<String> {
+    match map.remove(key) {
+        Some(Value::String(text)) => Some(text),
+        _ => None,
+    }
+}
+
+/// Move `value` into `target` under `key`, doing nothing when the field is absent.
+///
+/// Pairs with [`Map::remove`] so a mapped field travels from the parsed body into the translated body
+/// without an intermediate copy.
+pub fn insert_if_some(target: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        target.insert(key.to_owned(), value);
     }
 }
 
@@ -390,6 +422,70 @@ mod tests {
         let value = json!({"a": 1});
         let serialized = serialize_json_body(&value).unwrap();
         assert_eq!(serialized.as_bytes(), &Bytes::from(serde_json::to_vec(&value).unwrap()));
+    }
+
+    // --- Field consumption ---
+
+    #[test]
+    fn take_string_returns_only_json_strings_and_still_removes_the_field() {
+        let Value::Object(mut tool) = json!({"name": "get_weather", "strict": true}) else {
+            unreachable!("object literal");
+        };
+
+        assert_eq!(take_string(&mut tool, "name"), Some("get_weather".to_owned()));
+        assert_eq!(
+            take_string(&mut tool, "strict"),
+            None,
+            "a non-string value yields None rather than a coerced string"
+        );
+        assert!(tool.is_empty(), "both fields are removed regardless of type");
+    }
+
+    #[test]
+    fn take_string_of_an_absent_key_is_none() {
+        let mut map = Map::new();
+
+        assert_eq!(take_string(&mut map, "name"), None);
+    }
+
+    #[test]
+    fn take_string_moves_rather_than_copies_the_string() {
+        let text = "x".repeat(4096);
+        let mut map = Map::new();
+        map.insert("description".to_owned(), Value::String(text.clone()));
+
+        let taken = take_string(&mut map, "description").expect("string value");
+
+        assert_eq!(taken, text, "the value should come out intact");
+        assert!(map.is_empty(), "a taken field should no longer be in the object");
+    }
+
+    #[test]
+    fn insert_if_some_skips_absent_fields_and_preserves_insertion_order() {
+        let mut target = Map::new();
+        insert_if_some(&mut target, "model", Some(json!("m")));
+        insert_if_some(&mut target, "stream", None);
+        insert_if_some(&mut target, "temperature", Some(json!(0.5)));
+
+        assert_eq!(
+            serde_json::to_string(&Value::Object(target)).unwrap(),
+            r#"{"model":"m","temperature":0.5}"#,
+            "absent fields are skipped and insertion order is the serialized order"
+        );
+    }
+
+    #[test]
+    fn insert_if_some_overwrites_an_existing_key_in_place() {
+        let mut target = Map::new();
+        target.insert("model".to_owned(), json!("old"));
+        target.insert("stream".to_owned(), json!(true));
+        insert_if_some(&mut target, "model", Some(json!("new")));
+
+        assert_eq!(
+            serde_json::to_string(&Value::Object(target)).unwrap(),
+            r#"{"model":"new","stream":true}"#,
+            "an overwrite must not move the key to the end"
+        );
     }
 
     #[test]

--- a/apis/src/json_body.rs
+++ b/apis/src/json_body.rs
@@ -220,9 +220,6 @@ impl BodyMutation {
 ///
 /// The entry is removed either way: a non-string value is dropped and `None` returned, matching the
 /// `get(..).and_then(Value::as_str)` reads this replaces, without re-allocating the string.
-///
-/// If `serde_json` is built with `preserve_order`, [`Map::remove`] is a *swap* remove: the last entry
-/// takes the vacated slot. Take only from a map you are consuming.
 pub fn take_string(map: &mut Map<String, Value>, key: &str) -> Option<String> {
     match map.remove(key) {
         Some(Value::String(text)) => Some(text),

--- a/apis/src/json_body.rs
+++ b/apis/src/json_body.rs
@@ -22,16 +22,12 @@
 //!
 //! Request-side only: core repairs upstream `Content-Length` framing for mutated request bodies via
 //! `mutated_request_body_len`, so filters must not set `Content-Length` themselves.
-//!
-//! [`take_string`] and [`insert_if_some`] cover the other half of the problem: a filter that translates a
-//! body it is about to discard should *move* each field into the request it builds instead of cloning it out
-//! of a parsed value that dies moments later.
 
 use std::io::{self, Write};
 
 use bytes::Bytes;
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 use tracing::debug;
 
 /// Serialize `value` for a later body replacement.
@@ -209,31 +205,6 @@ impl BodyMutation {
         let new = i64::try_from(self.new_len).unwrap_or(i64::MAX);
         let old = i64::try_from(self.original_len).unwrap_or(i64::MAX);
         new - old
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Field Consumption
-// -----------------------------------------------------------------------------
-
-/// Remove `key` from `map` and return the owned `String` when the value was a JSON string.
-///
-/// The entry is removed either way: a non-string value is dropped and `None` returned, matching the
-/// `get(..).and_then(Value::as_str)` behavior, without re-allocating the string.
-pub fn take_string(map: &mut Map<String, Value>, key: &str) -> Option<String> {
-    match map.remove(key) {
-        Some(Value::String(text)) => Some(text),
-        _ => None,
-    }
-}
-
-/// Move `value` into `target` under `key`, doing nothing when the field is absent.
-///
-/// Pairs with [`Map::remove`] so a mapped field travels from the parsed body into the translated body
-/// without an intermediate copy.
-pub fn insert_if_some(target: &mut Map<String, Value>, key: &str, value: Option<Value>) {
-    if let Some(value) = value {
-        target.insert(key.to_owned(), value);
     }
 }
 
@@ -419,70 +390,6 @@ mod tests {
         let value = json!({"a": 1});
         let serialized = serialize_json_body(&value).unwrap();
         assert_eq!(serialized.as_bytes(), &Bytes::from(serde_json::to_vec(&value).unwrap()));
-    }
-
-    // --- Field consumption ---
-
-    #[test]
-    fn take_string_returns_only_json_strings_and_still_removes_the_field() {
-        let Value::Object(mut tool) = json!({"name": "get_weather", "strict": true}) else {
-            unreachable!("object literal");
-        };
-
-        assert_eq!(take_string(&mut tool, "name"), Some("get_weather".to_owned()));
-        assert_eq!(
-            take_string(&mut tool, "strict"),
-            None,
-            "a non-string value yields None rather than a coerced string"
-        );
-        assert!(tool.is_empty(), "both fields are removed regardless of type");
-    }
-
-    #[test]
-    fn take_string_of_an_absent_key_is_none() {
-        let mut map = Map::new();
-
-        assert_eq!(take_string(&mut map, "name"), None);
-    }
-
-    #[test]
-    fn take_string_moves_rather_than_copies_the_string() {
-        let text = "x".repeat(4096);
-        let mut map = Map::new();
-        map.insert("description".to_owned(), Value::String(text.clone()));
-
-        let taken = take_string(&mut map, "description").expect("string value");
-
-        assert_eq!(taken, text, "the value should come out intact");
-        assert!(map.is_empty(), "a taken field should no longer be in the object");
-    }
-
-    #[test]
-    fn insert_if_some_skips_absent_fields_and_preserves_insertion_order() {
-        let mut target = Map::new();
-        insert_if_some(&mut target, "model", Some(json!("m")));
-        insert_if_some(&mut target, "stream", None);
-        insert_if_some(&mut target, "temperature", Some(json!(0.5)));
-
-        assert_eq!(
-            serde_json::to_string(&Value::Object(target)).unwrap(),
-            r#"{"model":"m","temperature":0.5}"#,
-            "absent fields are skipped and insertion order is the serialized order"
-        );
-    }
-
-    #[test]
-    fn insert_if_some_overwrites_an_existing_key_in_place() {
-        let mut target = Map::new();
-        target.insert("model".to_owned(), json!("old"));
-        target.insert("stream".to_owned(), json!(true));
-        insert_if_some(&mut target, "model", Some(json!("new")));
-
-        assert_eq!(
-            serde_json::to_string(&Value::Object(target)).unwrap(),
-            r#"{"model":"new","stream":true}"#,
-            "an overwrite must not move the key to the end"
-        );
     }
 
     #[test]

--- a/apis/src/json_body.rs
+++ b/apis/src/json_body.rs
@@ -219,7 +219,7 @@ impl BodyMutation {
 /// Remove `key` from `map` and return the owned `String` when the value was a JSON string.
 ///
 /// The entry is removed either way: a non-string value is dropped and `None` returned, matching the
-/// `get(..).and_then(Value::as_str)` reads this replaces, without re-allocating the string.
+/// `get(..).and_then(Value::as_str)` behavior, without re-allocating the string.
 pub fn take_string(map: &mut Map<String, Value>, key: &str) -> Option<String> {
     match map.remove(key) {
         Some(Value::String(text)) => Some(text),


### PR DESCRIPTION
## Summary

### Why the diff is shaped this way

`AnthropicMessagesToChatCompletionsFilter` contained many redundant deep clones at multiple nesting levels across the request JSON body. Replacing those clones with moves means each field can only be read once, so `transform_request` now deconstructs the parsed body into owned locals up front instead of threading a `&mut Map` through every helper. Threading it and `remove`ing incrementally could lead to silent errors: a later read returns `None` on already moved field. Each field is now a let moved exactly once, so a double-consume is a compile error.

Output is byte-identical, the change is ownership only.

### Addressed redundant allocations

1. **Double request body parse** (`51c48e7b`) — parsed once. Metadata borrows, translation consumes.
2. **Top-level mapped fields** (`cdce7809`) — `model`, `max_tokens`, `system`, `messages`, `stream`, `stream_options`, `stop_sequences`, `temperature`, `top_p`, `top_k`, `tools`, `tool_choice` moved instead of cloned. Remainder dropped.
4. **Tool `input_schema`** (`cdce7809`) — previously deep-cloned into `function.parameters`. The tool object is hand-built rather than via `json!`, which would re-serialize the function map.
5. **Message content payloads** (`99bbcf58`) — text, base64 image data, and `tool_use.input` consumed out of their blocks rather than copied via `as_str().to_owned()`.
7. **`search_result` / `document` flattening** (`796b0d2f`) — appended into a single `String` instead of `Vec<String>` + `join`, which copied every payload twice.
8. **Output buffer growth** (`149e5564`) — pre-sized from the original body length instead of growing from empty. `original_len` is a bounded estimate.

### Known remaining, deferred

Listed so the boundary is explicit:

- `split_tool_result_parts` and `hoist_system` — the same `Vec<String>` + `join` pattern fixed in `796b0d2f`.
- `flatten_document_source — `document `source.content` text copied three times (`Vec` → join → `format!`) (non-trivial to address, `format!` is needed for Anthropic → OpenAI translation).
- `request.rs:526` — `quote_label_value` allocates a temporary per label; `file:`/`base64:` sources allocate twice (minor - short string labels).

Closes #968 

## Validation

- [x] `cargo test -p praxis-ai-apis`
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

No breaking change.
