### PR TITLE
feat: praxis playground catalog generation

### DIFF
--- a/.github/workflows/config-catalog.yaml
+++ b/.github/workflows/config-catalog.yaml
@@ -1,0 +1,58 @@
+name: AI Config Catalog
+
+on:
+  pull_request:
+    paths:
+      - "xtask/**"
+      - "filters/**"
+      - "apis/**"
+      - "docs/catalog/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/config-catalog.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "xtask/**"
+      - "filters/**"
+      - "apis/**"
+      - "docs/catalog/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/config-catalog.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    name: catalog (${{ matrix.feature || 'default' }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - ""
+          - catalog-http-callout
+          - catalog-azure-ad
+          - catalog-gcp-adc
+          - catalog-token-rate-limit
+          - catalog-all
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@7e1e8d97c2dc820d24b31f9a65b119c4d0e5342c # v0.1.0
+      - name: Test catalog profile
+        run: >-
+          cargo test -p xtask
+          ${{ matrix.feature != '' && format('--features {0}', matrix.feature) || '' }}
+          config_catalog::tests::
+      - name: Generate or lint catalog profile
+        run: |
+          if [ "${{ matrix.feature }}" = "" ]; then
+            cargo xtask lint-config-catalog
+          else
+            cargo run -p xtask --features "${{ matrix.feature }}" -- generate-config-catalog
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,8 +113,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Generate release notes
+      - name: Setup Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@7e1e8d97c2dc820d24b31f9a65b119c4d0e5342c # v0.1.0
+
+      - name: Generate and verify AI catalog release artifact
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          PRAXIS_SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          cargo xtask generate-config-catalog
+          cargo xtask lint-config-catalog
+          cargo test -p xtask config_catalog::tests::
+          cp docs/catalog/config-catalog.json "praxis-ai-config-catalog-${VERSION}.json"
+
+      - name: Create GitHub release with catalog artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" --generate-notes
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: gh release create "$TAG" --generate-notes "praxis-ai-config-catalog-${VERSION}.json"

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ coverage.json
 
 # Docs are markdown only
 docs/**/
+!docs/catalog/
+!docs/catalog/config-catalog.json
 !docs/
 !docs/architecture/
 !docs/conformance/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -121,7 +110,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -132,7 +121,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -164,46 +153,18 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
 ]
 
 [[package]]
@@ -529,11 +490,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -656,7 +617,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -996,19 +957,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1047,25 +995,11 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1080,17 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,7 +1021,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1184,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1307,7 +1229,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1542,7 +1464,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1554,15 +1476,6 @@ name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1937,16 +1850,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2025,7 +1928,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.20",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -2074,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2089,7 +1992,7 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7070bf0681439ff992bb94947cb3a361f57c880561c1e9e90ddb5941c7ec2d04"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
@@ -2126,7 +2029,7 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4309c6b52390b1ebdd2053e513e9f23d4bb18d0c3c2df8142eded3eb188a85bf"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bytecount",
  "fraction",
  "getrandom 0.3.4",
@@ -2385,11 +2288,11 @@ checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
  "evmap",
- "indexmap 2.14.0",
+ "indexmap",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -2401,7 +2304,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "metrics",
  "ordered-float",
  "quanta",
@@ -2541,7 +2444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2640,20 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2777,7 +2671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2788,7 +2682,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2868,7 +2762,7 @@ dependencies = [
  "axum",
  "base64 0.23.1",
  "bytes",
- "dashmap 6.2.1",
+ "dashmap",
  "futures",
  "http 1.5.0",
  "jsonschema",
@@ -2886,7 +2780,7 @@ dependencies = [
  "sqlx",
  "sse-stream",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror",
  "tiktoken-rs",
  "tokio",
  "tokio-util",
@@ -2915,7 +2809,7 @@ dependencies = [
  "base64 0.23.1",
  "bytes",
  "chrono",
- "dashmap 6.2.1",
+ "dashmap",
  "http 1.5.0",
  "metrics",
  "metrics-util",
@@ -2933,7 +2827,7 @@ dependencies = [
  "serde_json_path",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2961,7 +2855,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sync_wrapper",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -3022,6 +2916,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "praxis-proxy-config-catalog"
+version = "0.5.4"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "praxis-proxy-core"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,7 +2932,7 @@ checksum = "40057cbaa0e3d0e91e77173560532408117b95570a405fd12f445431f5be8cdc"
 dependencies = [
  "bytes",
  "chrono",
- "dashmap 6.2.1",
+ "dashmap",
  "http 1.5.0",
  "metrics",
  "percent-encoding",
@@ -3039,7 +2942,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "serde",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -3056,7 +2959,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
- "dashmap 6.2.1",
+ "dashmap",
  "http 1.5.0",
  "metrics",
  "percent-encoding",
@@ -3069,7 +2972,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "yaml_serde",
@@ -3113,7 +3016,7 @@ dependencies = [
  "notify",
  "rustls",
  "serde",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "zeroize",
@@ -3149,7 +3052,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -3362,7 +3265,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -3374,7 +3277,7 @@ dependencies = [
  "logos 0.15.1",
  "miette",
  "prost-types",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -3426,7 +3329,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3449,7 +3352,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.20",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3466,16 +3369,16 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-cache"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a820a1a3e59644b38bc03606b638b41f1c5a474215efcec37f94b15871a7e1c"
+checksum = "2170cdcd123450231d0828912839eef227bb1d0055f005cccbc8c4879c505fda"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "blake2",
  "bstr",
@@ -3484,7 +3387,7 @@ dependencies = [
  "http 1.5.0",
  "httparse",
  "httpdate",
- "indexmap 1.9.3",
+ "indexmap",
  "log",
  "lru",
  "once_cell",
@@ -3495,7 +3398,7 @@ dependencies = [
  "quixotic-plecostomus-http",
  "quixotic-plecostomus-lru",
  "quixotic-plecostomus-timeout",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "rmp",
  "rmp-serde",
@@ -3506,11 +3409,11 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-core"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d6d9e04414ba6819c51ec210eddf17865c505431a492c86c6356338c2b4f60"
+checksum = "10afcc507d2cb09b581d71f2ed501bbd9f68117d3e5dcdb280bb486049f019e1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "brotli",
  "bstr",
@@ -3519,7 +3422,6 @@ dependencies = [
  "clap",
  "daemonix",
  "daggy",
- "derivative",
  "flate2",
  "flurry",
  "futures",
@@ -3541,10 +3443,9 @@ dependencies = [
  "quixotic-plecostomus-runtime",
  "quixotic-plecostomus-rustls",
  "quixotic-plecostomus-timeout",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "serde",
- "serde_yaml",
  "sfv",
  "socket2",
  "strum 0.26.3",
@@ -3554,21 +3455,22 @@ dependencies = [
  "tokio-test",
  "unicase",
  "windows-sys 0.59.0",
- "x509-parser 0.16.0",
+ "x509-parser",
+ "yaml_serde",
  "zstd",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-error"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af30024450d6dc4785ccadf33e7cfd91f837bc6a226f133f9e77b397b4206c5"
+checksum = "babdfdca7e2daabbef281e3d0a6b9eac958afcdb28c4c4c4a882384690c7d3cc"
 
 [[package]]
 name = "quixotic-plecostomus-header-serde"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fe7db0e7899a6b2d2cf06e71adacfad4c1bcfe3b5f238494dd3b3eafb2c1b1"
+checksum = "c18c8ab3e8b558bfd8fb7c9953869fedc07b5a0acf4a9fc547f4dbfb21bcd286"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -3582,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-http"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f337131150ff271246df2584da8bdb0280b8424646d2c76e3926faa70409dc9"
+checksum = "3f9a488e14da09575fa4b108cc8ee31385692c5f73700ec88ddd0438dc2cf092"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -3593,24 +3495,24 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-lru"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec55d3bcbd56e52b3424bc62739a237d43c14df8ed04aaf294ae187b60da348a"
+checksum = "ace25e7acff2509609f603331204eaf416a62d92233785e7a0ad58d91a328dba"
 dependencies = [
  "arrayvec",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-pool"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6383d2998b2298a0f34bb8a7330f5fea4bb0fb55671db2dc788b5f703c2009f"
+checksum = "0c3a8ab05fe009d7ef2cc7236dee12904bd60efa2a5a2cb5a8b0955b08f3baa4"
 dependencies = [
  "crossbeam-queue",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "log",
  "lru",
@@ -3621,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-proxy"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953dcda74a2c196497ddc7892e571cdaa0bdb8acc8f7afb6d7b97339b28c658"
+checksum = "4e9987508338ed682178a703bfc9ce6c050112fae1eb6687d2b3f38544f77d35"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3637,20 +3539,20 @@ dependencies = [
  "quixotic-plecostomus-core",
  "quixotic-plecostomus-error",
  "quixotic-plecostomus-http",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "tokio",
 ]
 
 [[package]]
 name = "quixotic-plecostomus-runtime"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51621ff504cfde18409889d6d5b8773e0b0de0e4defa610006a36c27adc06a10"
+checksum = "8b2906b043f5511fff32636a80ff45624a68675f3cc42ffd5b5b7acb691ca29a"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.7",
+ "rand 0.10.2",
  "serde",
  "thread_local",
  "tokio",
@@ -3658,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-rustls"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ba2674ecab001d9ebdc6dc9944326857c07f9c65e7c0779f25db17f96ee84"
+checksum = "a2359930255ece5446d6f62246f4781870d8f2230df3e5abfb764f1fd69490ec"
 dependencies = [
  "log",
  "no_debug",
@@ -3675,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "quixotic-plecostomus-timeout"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f76d183bcbdae3c0f4b0547e0fb7afdc658853a5e7421bbae1b59e48c25e667"
+checksum = "7ef2ccca7162912fc19e1e1aa4902793c084995bc0bc0acd3fed1e89d17dd0ad"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3709,22 +3611,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3741,31 +3632,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3829,15 +3701,15 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.18.1",
+ "x509-parser",
  "yasna",
 ]
 
 [[package]]
 name = "redis"
-version = "1.7.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acbc41a996f7652b2ddd9dfd98cc4ff602cfd742ae35382f07f608405ab50ed"
+checksum = "e37a4ca5c6ca42aa3e6df2fd32b987a65d32a4c2159a6f3fe0fd1df306a2658f"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -3891,7 +3763,7 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0304d4734d208eaf24528093715e2cb5260c977b1be1eb81cd487f601e3ff35d"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.17.1",
@@ -4000,7 +3872,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rand 0.10.2",
@@ -4010,7 +3882,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4095,7 +3967,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4176,7 +4048,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4380,7 +4252,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4412,7 +4284,7 @@ dependencies = [
  "serde_json",
  "serde_json_path_core",
  "serde_json_path_macros",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -4424,7 +4296,7 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -4450,16 +4322,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_spanned"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "serde_core",
 ]
 
 [[package]]
@@ -4469,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa1f336066b758b7c9df34ed049c0e693a426afe2b27ff7d5b14f410ab1a132"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap",
  "rust_decimal",
 ]
 
@@ -4581,7 +4449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4624,7 +4492,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "percent-encoding",
@@ -4633,7 +4501,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4708,7 +4576,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.20",
+ "thiserror",
  "tracing",
  "whoami",
 ]
@@ -4732,7 +4600,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror 2.0.20",
+ "thiserror",
  "tracing",
  "url",
 ]
@@ -4836,17 +4704,6 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -4894,19 +4751,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4915,18 +4763,7 @@ version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.20",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5134,6 +4971,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tonic"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,7 +5085,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5270,7 +5146,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -5357,7 +5233,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -5442,12 +5318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5483,7 +5353,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -5713,7 +5583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5947,6 +5817,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5983,36 +5865,19 @@ checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs 0.6.2",
- "data-encoding",
- "der-parser 9.0.0",
- "lazy_static",
- "nom",
- "oid-registry 0.7.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
+ "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
 ]
 
@@ -6022,8 +5887,11 @@ version = "0.3.0"
 dependencies = [
  "clap",
  "praxis-ai-apis",
+ "praxis-ai-filters",
  "praxis-ai-proxy",
+ "praxis-proxy-config-catalog",
  "praxis-proxy-core",
+ "praxis-proxy-filter",
  "praxis-test-utils",
  "quote",
  "reqwest",
@@ -6033,6 +5901,7 @@ dependencies = [
  "syn 3.0.5",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "yaml_serde",
@@ -6050,7 +5919,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "libyaml-rs",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,12 @@ tonic = "0.14.6"
 tonic-prost = "0.14.6"
 tonic-prost-build = { version = "0.14.6", features = ["transport"] }
 tokio-stream = "0.1.19"
+toml = "0.9.8"
 zeroize = "1.9.0"
 
 # Praxis core dependencies
 praxis-core = { version = "0.5.4", package = "praxis-proxy-core" }
+praxis-config-catalog = { version = "0.5.4", package = "praxis-proxy-config-catalog" }
 praxis-filter = { version = "0.5.4", package = "praxis-proxy-filter" }
 praxis-protocol = { version = "0.5.4", package = "praxis-proxy-protocol" }
 praxis-tls = { version = "0.5.4", package = "praxis-proxy-tls" }

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ endif
 	test-token-rate-limit-valkey-unit test-token-rate-limit-valkey-integration \
 	openai-conformance check-openai-conformance-reference test-openai-conformance \
 	test-responses-conformance \
+	test-config-catalog test-config-catalog-local \
 	lint fmt doc audit coverage-check \
+	generate-config-catalog lint-config-catalog \
 	require-container-engine \
 	container container-run \
 	setup-hooks help \
@@ -128,6 +130,26 @@ test-environment:
 # Quality
 # -------------------------------------------------------------------
 
+generate-config-catalog:
+	cargo xtask generate-config-catalog
+
+lint-config-catalog:
+	cargo xtask lint-config-catalog
+
+test-config-catalog:
+	cargo test -p xtask config_catalog::tests::
+	cargo test -p xtask --all-features config_catalog::tests::
+
+# Run catalog tests against a local Core catalog crate without patching the
+# runtime Core crates. This remains usable while the local Core checkout has
+# unrelated API changes that AI does not need for source/catalog extraction.
+test-config-catalog-local:
+	@if [ ! -d "../praxis/crates/config-catalog" ]; then \
+		echo "ERROR: ../praxis/crates/config-catalog not found"; \
+		exit 1; \
+	fi
+	cargo test --config 'patch.crates-io."praxis-proxy-config-catalog".path="../praxis/crates/config-catalog"' -p xtask config_catalog::tests::
+
 lint:
 	cargo clippy --workspace --all-targets -- -D warnings
 	cargo clippy --workspace --all-targets \
@@ -138,6 +160,8 @@ lint:
 	cargo xtask lint-deps
 	cargo xtask lint-separators
 	cargo xtask lint-filter-docs
+	cargo xtask lint-config-catalog
+	$(MAKE) test-config-catalog
 	cargo xtask lint-example-tests
 	cargo xtask lint-markdown-links
 	cargo xtask sync-example-readme
@@ -182,12 +206,14 @@ patch-praxis:
 		echo "Already patched — run 'make unpatch-praxis' first"; \
 		exit 1; \
 	fi
-	@printf '\n[patch.crates-io]\n\
-	praxis-proxy-core = { path = "../praxis/core" }\n\
-	praxis-proxy-filter = { path = "../praxis/filter" }\n\
-	praxis-proxy-protocol = { path = "../praxis/protocol" }\n\
-	praxis-proxy-tls = { path = "../praxis/tls" }\n\
-	praxis-proxy = { path = "../praxis/server" }\n' >> Cargo.toml
+	@printf '%s\n' \
+		'[patch.crates-io]' \
+		'praxis-proxy-core = { path = "../praxis/crates/core" }' \
+		'praxis-proxy-config-catalog = { path = "../praxis/crates/config-catalog" }' \
+		'praxis-proxy-filter = { path = "../praxis/crates/filter" }' \
+		'praxis-proxy-protocol = { path = "../praxis/crates/protocol" }' \
+		'praxis-proxy-tls = { path = "../praxis/crates/tls" }' \
+		'praxis-proxy = { path = "../praxis/crates/server" }' >> Cargo.toml
 	@echo "Patched Cargo.toml to use ../praxis path dependencies"
 
 unpatch-praxis:

--- a/docs/catalog/config-catalog.json
+++ b/docs/catalog/config-catalog.json
@@ -1,0 +1,7738 @@
+{
+  "format_version": {
+    "major": 1,
+    "minor": 0
+  },
+  "producer": {
+    "component": "ai",
+    "package": "praxis-ai",
+    "version": "0.3.0"
+  },
+  "compatibility": {
+    "requires_format_major": 1,
+    "requires_core": "^0.5.4"
+  },
+  "feature_profile": {
+    "available": [
+      "apis",
+      "azure-ad-filter",
+      "experimental",
+      "gcp-adc-filter",
+      "http-callout-filter",
+      "opentelemetry",
+      "praxis-main",
+      "token-rate-limit-filter"
+    ],
+    "default_enabled": [
+      "apis"
+    ]
+  },
+  "schemas": {
+    "ai.filter.http.agentic.a2a": {
+      "id": "ai.filter.http.agentic.a2a",
+      "title": "a2a",
+      "description": "Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method, family, task ID, streaming detection, and version to request headers, filter results, and durable metadata for routing.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.A2aHeaders"
+                },
+                "description": "Header names for A2A metadata promotion.\n\nMust not be hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` names. Dedicated `x-praxis-a2a-*`\ndefaults remain allowed.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body size in bytes for `StreamBuffer`.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "method_aliases",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Method aliases for compatibility (slash-delimited → `PascalCase`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_invalid",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject",
+                    "error"
+                  ]
+                },
+                "description": "Invalid input handling behavior.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "task_routing",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.TaskRoutingConfig"
+                },
+                "description": "Task-ownership routing configuration.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.agentic.mcp": {
+      "id": "ai.filter.http.agentic.mcp",
+      "title": "mcp",
+      "description": "Extracts MCP protocol metadata from JSON-RPC request bodies and promotes method, tool/resource/prompt name, JSON-RPC kind, protocol version, and session presence to request headers/filter results; stores session ID in durable metadata.",
+      "node": {
+        "kind": {
+          "kind": "one_of",
+          "variants": [
+            {
+              "kind": {
+                "kind": "object",
+                "fields": [
+                  {
+                    "serialized_name": "header_validation",
+                    "schema": {
+                      "kind": {
+                        "kind": "reference",
+                        "schema_id": "ai.type.HeaderValidation"
+                      },
+                      "description": "Header validation settings.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "headers",
+                    "schema": {
+                      "kind": {
+                        "kind": "reference",
+                        "schema_id": "ai.type.McpHeaders"
+                      },
+                      "description": "Header names for MCP metadata promotion.\n\nMust not be hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` names. Dedicated `x-praxis-mcp-*`\ndefaults remain allowed.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "max_body_bytes",
+                    "schema": {
+                      "kind": {
+                        "kind": "integer"
+                      },
+                      "description": "Maximum body size in bytes for `StreamBuffer`.",
+                      "default": 1,
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "on_invalid",
+                    "schema": {
+                      "kind": {
+                        "kind": "enum",
+                        "values": [
+                          "continue",
+                          "reject",
+                          "error"
+                        ]
+                      },
+                      "description": "Invalid input handling behavior.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  }
+                ],
+                "additional_properties": false
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "object",
+                "fields": [
+                  {
+                    "serialized_name": "cache_scope",
+                    "schema": {
+                      "kind": {
+                        "kind": "enum",
+                        "values": [
+                          "public",
+                          "private"
+                        ]
+                      },
+                      "description": "Cache scope for stateless responses. Requires `protocol_profile: stateless`.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "cache_ttl_ms",
+                    "schema": {
+                      "kind": {
+                        "kind": "integer"
+                      },
+                      "description": "Cache TTL in milliseconds for stateless responses. Requires `protocol_profile: stateless`.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "default_version",
+                    "schema": {
+                      "kind": {
+                        "kind": "string"
+                      },
+                      "description": "Fallback MCP protocol version. When omitted, derived from the profile.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "invalid_tool_policy",
+                    "schema": {
+                      "kind": {
+                        "kind": "enum",
+                        "values": [
+                          "reject_server",
+                          "filter_out"
+                        ]
+                      },
+                      "description": "Behavior when a tool has an invalid schema.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "max_body_bytes",
+                    "schema": {
+                      "kind": {
+                        "kind": "integer"
+                      },
+                      "description": "Maximum body size in bytes.",
+                      "default": 1,
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "path",
+                    "schema": {
+                      "kind": {
+                        "kind": "string"
+                      },
+                      "description": "Public MCP path handled by Praxis.",
+                      "default": "/mcp",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "protocol_profile",
+                    "schema": {
+                      "kind": {
+                        "kind": "enum",
+                        "values": [
+                          "current",
+                          "stateless"
+                        ]
+                      },
+                      "description": "Protocol profile governing session semantics and header\nrequirements for this broker instance.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "servers",
+                    "schema": {
+                      "kind": {
+                        "kind": "array",
+                        "items": {
+                          "kind": {
+                            "kind": "reference",
+                            "schema_id": "ai.type.McpServerConfig"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        "min_items": null,
+                        "max_items": null
+                      },
+                      "description": "Backend server definitions.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  },
+                  {
+                    "serialized_name": "supported_versions",
+                    "schema": {
+                      "kind": {
+                        "kind": "array",
+                        "items": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        "min_items": null,
+                        "max_items": null
+                      },
+                      "description": "Protocol versions accepted during negotiation.\nWhen omitted, derived from the profile.",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    "required": false,
+                    "flattened": false
+                  }
+                ],
+                "additional_properties": false
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            }
+          ],
+          "discriminator": null
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.anthropic.anthropic_messages_format": {
+      "id": "ai.filter.http.anthropic.anthropic_messages_format",
+      "title": "anthropic_messages_format",
+      "description": "Classifies Anthropic Messages API requests and promotes routing facts to headers, metadata, and filter results.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "on_invalid",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject",
+                    "error"
+                  ]
+                },
+                "description": "Behavior when the body cannot be classified.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body size in bytes for `StreamBuffer` mode.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.AnthropicMessagesFormatHeaders"
+                },
+                "description": "Header names for promoted classification facts.\n\nMust not be hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` names. Dedicated defaults remain allowed.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.anthropic.anthropic_messages_protocol": {
+      "id": "ai.filter.http.anthropic.anthropic_messages_protocol",
+      "title": "anthropic_messages_protocol",
+      "description": "Normalizes Anthropic Messages protocol headers for native backends.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "default_version",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Default `anthropic-version` header value when absent.",
+                "default": "x-praxis-a2a-version",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.anthropic.anthropic_messages_to_chat_completions": {
+      "id": "ai.filter.http.anthropic.anthropic_messages_to_chat_completions",
+      "title": "anthropic_messages_to_chat_completions",
+      "description": "Transforms Anthropic Messages API requests to Chat Completions-compatible request bodies and transforms compatible responses back. The name refers to the Chat Completions wire shape, not the OpenAI Responses API; any Chat Completions-compatible backend is a valid target, not only OpenAI.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body size in bytes for `StreamBuffer` mode.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.anthropic.anthropic_messages_to_chat_completions_stream": {
+      "id": "ai.filter.http.anthropic.anthropic_messages_to_chat_completions_stream",
+      "title": "anthropic_messages_to_chat_completions_stream",
+      "description": "Transforms streaming SSE responses between the Chat Completions and Anthropic Messages formats, processing each chunk as it arrives.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_partial_event_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum incomplete SSE event bytes retained between chunks.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_tool_blocks",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of distinct streaming tool-call content blocks\nretained per response. Each tool-call index an upstream streams\npins per-block state for the response's lifetime, so an upstream\nthat emits unbounded unique indices would grow memory without\nlimit. Exceeding this cap fails the stream closed. Default:\n10,000.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.anthropic.anthropic_validate": {
+      "id": "ai.filter.http.anthropic.anthropic_validate",
+      "title": "anthropic_validate",
+      "description": "Validates Anthropic Messages request bodies for proxy-owned JSON envelope requirements.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body size in bytes for `StreamBuffer` mode.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.anthropic.anthropic_web_search": {
+      "id": "ai.filter.http.anthropic.anthropic_web_search",
+      "title": "anthropic_web_search",
+      "description": "Executes server-owned `WebSearch` tool calls in an Anthropic Messages loop.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "provider",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "brave",
+                    "tavily",
+                    "you"
+                  ]
+                },
+                "description": "Search backend provider.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "api_key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "API key for the search provider (supports `${ENV_VAR}`).\nWrapped in [`SecretString`] to prevent accidental logging.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "default_context_size",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Default search context size when the client omits it.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Callout timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum request body bytes to buffer.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "base_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Override the provider's default API base URL.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_base_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow a `base_url` that targets local-sensitive addresses.\n\nDNS names are resolved once per request and every result is checked\nimmediately before the transport connects. By default, any private,\nloopback, link-local, or otherwise non-public result rejects the\ncallout. Enable this only for a trusted private provider endpoint.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "terminal_streaming",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Select Praxis streaming transport for effective `stream: true`\nMessages requests. When enabled, the terminal inference response is\nstreamed incrementally as one coherent client-visible SSE lifecycle\nwhile intermediate tool/search transitions stay internal. This knob is\nanthropic-only; `openai_web_search` does not accept it.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.aws.aws_sigv4_sign": {
+      "id": "ai.filter.http.aws.aws_sigv4_sign",
+      "title": "aws_sigv4_sign",
+      "description": "Signs outbound requests to AWS services using `SigV4`.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.azure.azure_ad": {
+      "id": "ai.filter.http.azure.azure_ad",
+      "title": "azure_ad",
+      "description": "Injects an Azure AD (Entra ID) bearer token into outbound requests.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.azure.openai_chat_completions_to_azureai_chat_completions": {
+      "id": "ai.filter.http.azure.openai_chat_completions_to_azureai_chat_completions",
+      "title": "openai_chat_completions_to_azureai_chat_completions",
+      "description": "Transforms requests targeting Azure OpenAI deployments into standard Chat Completions-compatible form and normalizes responses back.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "api_version",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Azure API version query parameter injected on every upstream request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body size in bytes for `StreamBuffer` mode.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.callout.http_callout": {
+      "id": "ai.filter.http.callout.http_callout",
+      "title": "http_callout",
+      "description": "Calls an external HTTP service during request processing and feeds its response into branch-chain evaluation.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "target",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.TargetConfig"
+                },
+                "description": "Callout target configuration.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "request",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.RequestConfig"
+                },
+                "description": "Request phase and body forwarding options.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.ResponseConfig"
+                },
+                "description": "Response extraction and header injection.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_failure",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "closed",
+                    "open"
+                  ]
+                },
+                "description": "Behavior when the callout itself fails (DNS, connect, timeout,\nI/O): `open` continues the request, `closed` rejects it.\n\nNote: this is distinct from the pipeline entry's own\n`failure_mode` key, which governs how the pipeline reacts when a\nfilter returns an error. Core strips `failure_mode` as a\nstructural key before this config is parsed, so it cannot be\nused as an alias here.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status_on_error",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "HTTP error status code (`400..=599`) to return when rejecting on error.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "circuit_breaker",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.CircuitBreakerConfig"
+                },
+                "description": "Circuit breaker configuration.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_depth",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum callout depth for loop prevention.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.gcp.gcp_adc": {
+      "id": "ai.filter.http.gcp.gcp_adc",
+      "title": "gcp_adc",
+      "description": "Injects a GCP `OAuth2` access token into outbound requests.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "source",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "adc",
+                    "metadata",
+                    "key_file"
+                  ]
+                },
+                "description": "Credential source. Defaults to `adc`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "scope",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`OAuth2` scope requested with the access token.",
+                "default": "https://www.googleapis.com/auth/cloud-platform",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "service_account",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Metadata service account email, or `default` (the default). Only\nused with the `metadata` and `adc` sources; rejected for\n`key_file`. Interpolated into the metadata path, so it must be\n`default` or a service-account email (letters, digits, `@`, `.`,\n`-`, `_`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "credentials_file",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to a service-account key JSON file. Required when `source` is\n`key_file`; rejected for the other sources (`adc` reads\n`GOOGLE_APPLICATION_CREDENTIALS` instead).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "metadata_host",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "GCE/GKE metadata server host. Defaults to the real metadata\nserver; the only other accepted value is a `127.0.0.1` loopback\naddress, to point tests at a local mock. The metadata endpoint is\nonly safe to reach over plain HTTP because it never leaves the\nVM/host, so nothing else is accepted (not even `localhost`, which\nis a resolvable hostname rather than a fixed address).",
+                "default": "metadata.google.internal",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.guardrails.ai_guardrails": {
+      "id": "ai.filter.http.guardrails.ai_guardrails",
+      "title": "ai_guardrails",
+      "description": "Calls an external AI guardrail provider to evaluate request and response bodies. The provider determines whether content should be passed, blocked, or redacted.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "provider",
+              "schema": {
+                "kind": {
+                  "kind": "object",
+                  "fields": [
+                    {
+                      "serialized_name": "type",
+                      "schema": {
+                        "kind": {
+                          "kind": "literal",
+                          "value": "nemo"
+                        },
+                        "description": "",
+                        "examples": [],
+                        "rules": [],
+                        "sensitive": false
+                      },
+                      "required": true,
+                      "flattened": false
+                    },
+                    {
+                      "serialized_name": "endpoint",
+                      "schema": {
+                        "kind": {
+                          "kind": "string"
+                        },
+                        "description": "`NeMo` endpoint URL.",
+                        "examples": [],
+                        "rules": [],
+                        "sensitive": false
+                      },
+                      "required": true,
+                      "flattened": false
+                    },
+                    {
+                      "serialized_name": "allow_private_endpoint",
+                      "schema": {
+                        "kind": {
+                          "kind": "boolean"
+                        },
+                        "description": "Allow the endpoint to resolve to non-public addresses.",
+                        "examples": [],
+                        "rules": [],
+                        "sensitive": false
+                      },
+                      "required": false,
+                      "flattened": false
+                    },
+                    {
+                      "serialized_name": "model",
+                      "schema": {
+                        "kind": {
+                          "kind": "string"
+                        },
+                        "description": "Model name sent in each request. Defaults to `\"\"` when omitted.",
+                        "examples": [],
+                        "rules": [],
+                        "sensitive": false
+                      },
+                      "required": false,
+                      "flattened": false
+                    },
+                    {
+                      "serialized_name": "timeout_ms",
+                      "schema": {
+                        "kind": {
+                          "kind": "integer"
+                        },
+                        "description": "Per-request timeout in milliseconds.",
+                        "default": 64,
+                        "examples": [],
+                        "rules": [],
+                        "sensitive": false
+                      },
+                      "required": false,
+                      "flattened": false
+                    }
+                  ],
+                  "additional_properties": false
+                },
+                "description": "External provider configuration (required).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "phase",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.PhaseConfig"
+                },
+                "description": "Which phases to evaluate.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.inference.model_to_header": {
+      "id": "ai.filter.http.inference.model_to_header",
+      "title": "model_to_header",
+      "description": "Promotes the JSON `\"model\"` field from the request body to a request header.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the promoted model value.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\ninternal `x-praxis-*` header. Defaults to `X-Model`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.metering.external_metering": {
+      "id": "ai.filter.http.metering.external_metering",
+      "title": "external_metering",
+      "description": "Integrates with an external metering service for pre-request balance checks and post-response token usage reporting.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "metering_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Base URL of the external metering service (required).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_endpoint",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow the metering endpoint to resolve to non-public addresses\n(loopback, private, link-local). Defaults to `false`, so callouts\nare rejected before connecting unless the operator opts in.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_seconds",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "HTTP timeout in seconds for all metering calls.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "feature_key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Entitlement feature key used in balance check URL path.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "source",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`CloudEvents` `source` field value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "fail_open",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "When `true` (default), requests proceed if the metering service\nis unavailable. When `false`, requests are rejected with 503.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "identity_header_prefix",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Prefix for tenant identity headers to capture and strip.\nExpected headers: `{prefix}username`, `{prefix}group`,\n`{prefix}subscription`, `{prefix}model`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "identity_metadata_namespace",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Metadata namespace the `identity_header_guard` filter writes captured\nidentity headers under. Must match that filter's\n`metadata_namespace` setting when both run in one pipeline.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "default_username",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Fallback username when no identity header is present.\nIf set, requests without `{prefix}username` are still metered\nunder this name. If unset, metering is skipped entirely.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "default_model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Fallback model name when no identity model header is present.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_agentic_loop": {
+      "id": "ai.filter.http.openai.openai_agentic_loop",
+      "title": "openai_agentic_loop",
+      "description": "Agentic loop controller for the Responses API pipeline.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_infer_iters",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of inference loop iterations (Praxis-only,\nnot part of the OpenAI API spec). When the iteration counter\nreaches this limit, the loop returns a 508 Loop Detected error.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_conversations": {
+      "id": "ai.filter.http.openai.openai_conversations",
+      "title": "openai_conversations",
+      "description": "Handles all `/v1/conversations` endpoints locally.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "backend",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "sqlite",
+                    "postgres"
+                  ]
+                },
+                "description": "Storage backend to use.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "database_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Database connection URL. Wrapped in [`SecretString`] to\nprevent accidental logging of credentials.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "conversations_table",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Table name for conversation records.",
+                "default": "openai_conversations",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "items_table",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Table name for conversation item records.",
+                "default": "openai_conversation_items",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "ssl_mode",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "disable",
+                    "prefer",
+                    "require",
+                    "verify-ca",
+                    "verify-full"
+                  ]
+                },
+                "description": "TLS mode for `PostgreSQL` connections.\n\nOnly valid when `backend` is `postgres`. Overrides any\n`sslmode` parameter in the connection URL.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "ssl_root_cert",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to a PEM-encoded root CA certificate for `PostgreSQL`\nTLS verification.\n\nOnly valid when `backend` is `postgres` and the effective\nSSL mode is `verify-ca` or `verify-full`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_database_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow `PostgreSQL` URLs that target local-sensitive addresses.\n\nBy default, DNS names, localhost, loopback, private,\nlink-local, cloud metadata, unspecified, and Unix socket\ntargets are rejected. This opt-in is intended for local\ndevelopment and tests.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "pool",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.PoolConfig"
+                },
+                "description": "Connection pool tuning options.\n\nWhen omitted, sqlx defaults apply (`max_connections = 10`,\n`idle_timeout = 600s`, `acquire_timeout = 30s`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_doc_extract": {
+      "id": "ai.filter.http.openai.openai_doc_extract",
+      "title": "openai_doc_extract",
+      "description": "Converts `input_file` content parts to `input_text` for backends that do not support `input_file` natively (e.g. vLLM, llm-d).",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_pre_security_callout",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Acknowledge that `StreamBuffer` body processing runs before\nheader-phase security filters.  Must be `true`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_rewritten_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum size in bytes of the request body this filter *produces*\nafter converting `input_file` parts to `input_text` (default 64\nMiB).\n\nRaw request body size is governed by the pipeline's `body_limits`,\nnot this field.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_content_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum decoded content bytes per file (default 10 MiB).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_file_references",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum `input_file` parts processed per request (default 32).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_total_text_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum total extracted text bytes across all files in one\nrequest (default 64 MiB).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_unsupported",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject"
+                  ]
+                },
+                "description": "Behavior when a file's MIME type is not text-safe.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_file_resolve": {
+      "id": "ai.filter.http.openai.openai_file_resolve",
+      "title": "openai_file_resolve",
+      "description": "Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via `ApiClient` and inlining the base64-encoded content in the provider-native field.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_private_files_api_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow `files_api_url` to resolve to private, loopback, link-local,\nor otherwise non-public addresses. Default `false` permits DNS\nnames only when every connect-time result is public. Set to `true`\nonly when the Files API is a trusted private service.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_pre_security_callout",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow Files API callouts from the `StreamBuffer` pre-read\nphase, before header-phase security filters execute.\n\nThis must be explicitly enabled only when an outer trust\nboundary authenticates and authorizes requests before they\nreach this listener. Forwarded headers are the original\ndownstream values, not mutations from request filters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "files_api_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Base URL of the Files API endpoint.\n\nExample: `http://files-api:8321`",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "forward_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to forward from the original request to the\nFiles API for authentication and tenant isolation. No\ndownstream headers are forwarded by default.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_rewritten_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum size in bytes of the request body this filter *produces*\nafter inlining resolved `file_id` / `file_url` content (default 64\nMiB).\n\nRaw request body size is governed by the pipeline's `body_limits`,\nnot this field. The resolved body can grow larger than the raw\ninput because references are replaced with inline content.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_resolved_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum total size in bytes of inline file content this filter\nadds to one request (default 64 MiB).\n\nCharged against the *encoded* inline form — base64 `file_data`\nand `data:` URL `image_url` values — not the raw bytes fetched\nfrom the Files API or remote URL, and shared as a single budget\nacross every reference resolved in the request rather than\napplied per file. A file whose raw content would fit can still be\nrejected once base64 expansion is counted, and several\nindividually small files can exhaust the budget together.\n\nBounds inline expansion independently of the total rewritten body\nsize (`max_rewritten_body_bytes`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_file_references",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of distinct content-part / `file_id` pairs to\nresolve in one request, including rehydrated history.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_missing",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject"
+                  ]
+                },
+                "description": "Behavior when a `file_id` reference cannot be fetched. Does not\napply to `file_url`: a failed `file_url` fetch is always\nrejected, regardless of this setting.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "HTTP timeout in milliseconds for Files API callout requests.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "file_url",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "resolve",
+                    "passthrough"
+                  ]
+                },
+                "description": "Mode for `file_url` content parts in `input_file`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allowed_file_url_origins",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Exact origins allowed to resolve to private addresses.\nCloud metadata, unspecified, and multicast remain blocked.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_file_search_callout": {
+      "id": "ai.filter.http.openai.openai_file_search_callout",
+      "title": "openai_file_search_callout",
+      "description": "Executes pending file search calls against a vector store API compatible backend.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_private_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow URLs that target local-sensitive addresses.\n\nDNS names are allowed by default when every connect-time result is\npublic. Enable this only for a trusted private vector-store service.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_failure",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "closed",
+                    "open"
+                  ]
+                },
+                "description": "Behaviour when a vector-store callout fails.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "forward_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to forward from the original request to the\nvector store API for authentication and tenant isolation.\nNo downstream headers are forwarded by default.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_response_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum response body size in bytes per callout.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_total_response_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum cumulative successful response bytes per filter execution.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_state_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum combined iterative-router and file-search continuation\nbytes. The filter's value may differ from the enclosing\n`iterative_request_router`; the smaller limit wins at runtime.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Whole-call timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "vector_store_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Base URL for the vector store API.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_mcp_dispatch": {
+      "id": "ai.filter.http.openai.openai_mcp_dispatch",
+      "title": "openai_mcp_dispatch",
+      "description": "Executes MCP tool calls against upstream MCP servers within the Responses API agentic loop.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_loopback",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow connections to loopback addresses (default: false).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-call timeout in milliseconds for `tools/call` calls.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_calls_per_round",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Hard cap on MCP calls processed from one model response (1..=1024; default: 32).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_parallel_calls",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum concurrent MCP calls when `parallel_tool_calls` is enabled (1..=64; default: 8).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_result_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum retained bytes for one MCP result (minimum: 1 `KiB`; default: 1 `MiB`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_total_result_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum retained bytes across one MCP result batch (default: 8 MiB).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_mcp_tool_resolve": {
+      "id": "ai.filter.http.openai.openai_mcp_tool_resolve",
+      "title": "openai_mcp_tool_resolve",
+      "description": "Resolves MCP tool entries from the Responses API `tools` array into concrete tool definitions by calling `tools/list` on each upstream MCP server.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_rewritten_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum size in bytes of the request body this filter *produces*\nafter expanding `mcp` tool entries into `function` entries.\n\nRaw request body size is governed by the pipeline's `body_limits`,\nnot this field. This bounds only the post-expansion body, which can\ngrow larger than the raw input.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-server timeout in milliseconds for `tools/list` calls.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_servers",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of distinct MCP servers per request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_tools",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of tools returned by a single MCP server.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_loopback",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow connections to loopback addresses (`127.0.0.0/8`,\n`::1`, `localhost`). Disabled by default for SSRF\nprotection; enable for development environments where MCP\nservers run locally.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "connectors",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.ConnectorConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Named connectors mapping connector IDs to server URLs.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_response_store": {
+      "id": "ai.filter.http.openai.openai_response_store",
+      "title": "openai_response_store",
+      "description": "Persists Responses API responses to the configured response store backend.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "backend",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "sqlite",
+                    "postgres"
+                  ]
+                },
+                "description": "Storage backend to use.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "database_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Database connection URL. Wrapped in [`SecretString`] to\nprevent accidental logging of credentials.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "responses_table",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Table name for response records.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "conversations_table",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Table name for conversation message records.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "ssl_mode",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "disable",
+                    "prefer",
+                    "require",
+                    "verify-ca",
+                    "verify-full"
+                  ]
+                },
+                "description": "TLS mode for `PostgreSQL` connections.\n\nOnly valid when `backend` is `postgres`. Overrides any\n`sslmode` parameter in the connection URL.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "ssl_root_cert",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to a PEM-encoded root CA certificate for `PostgreSQL`\nTLS verification.\n\nOnly valid when `backend` is `postgres` and the effective\nSSL mode is `verify-ca` or `verify-full`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_database_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow `PostgreSQL` URLs that target local-sensitive addresses.\n\nBy default, DNS names, localhost, loopback, private,\nlink-local, cloud metadata, unspecified, and Unix socket\ntargets are rejected. This opt-in is intended for local\ndevelopment and tests.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "pool",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.PoolConfig"
+                },
+                "description": "Connection pool tuning options.\n\nWhen omitted, sqlx defaults apply (`max_connections = 10`,\n`idle_timeout = 600s`, `acquire_timeout = 30s`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_responses_compact": {
+      "id": "ai.filter.http.openai.openai_responses_compact",
+      "title": "openai_responses_compact",
+      "description": "Summarizes conversation history when the token count exceeds a configured threshold.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_pre_security_callout",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow summarization callouts from the `StreamBuffer` pre-read\nphase, before header-phase security filters execute.\n\nThis must be explicitly enabled only when an outer trust\nboundary authenticates and authorizes requests before they\nreach this listener.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "inference_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "URL of the inference backend for summarization calls.\nE.g., `\"http://localhost:11434/v1/chat/completions\"`",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_inference_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow the inference target to resolve to non-public addresses.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "default_model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Default model for summarization when not overridden\nin the request's `context_management`.",
+                "default": "x-praxis-ai-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tiktoken_encoding",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Tiktoken encoding name for local token estimation of the\nconversation text.",
+                "default": "cl100k_base",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Callout timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_failure",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "closed",
+                    "open"
+                  ]
+                },
+                "description": "Failure mode for the inference callout.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status_on_error",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "HTTP error status code (`400..=599`) to return when rejecting on error.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_responses_format": {
+      "id": "ai.filter.http.openai.openai_responses_format",
+      "title": "openai_responses_format",
+      "description": "Classifies AI API request bodies and promotes routing facts to headers, metadata, and filter results without mutating the body.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "on_invalid",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject",
+                    "error"
+                  ]
+                },
+                "description": "Behavior when the body cannot be classified.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.ResponsesFormatHeaders"
+                },
+                "description": "Header names for promoted classification facts.\n\nMust not be hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` names. Dedicated defaults remain allowed.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_responses_model_rewrite": {
+      "id": "ai.filter.http.openai.openai_responses_model_rewrite",
+      "title": "openai_responses_model_rewrite",
+      "description": "Rewrites the `model` field in Responses API request bodies.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "default_model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Model name to inject when the request body has no `model`\nfield or when the field is `null`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.ModelRewriteHeaders"
+                },
+                "description": "Header names for promoted model values.\n\n`effective_model` and `original_model` must use distinct names.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "model_aliases",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Map from client-facing model names or single-wildcard patterns\nto backend model names. Quote wildcard keys in YAML. Exact aliases win\nbefore wildcard aliases; wildcard aliases are matched by literal specificity.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_invalid",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject",
+                    "error"
+                  ]
+                },
+                "description": "Behavior when the body is not valid JSON.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_responses_proxy": {
+      "id": "ai.filter.http.openai.openai_responses_proxy",
+      "title": "openai_responses_proxy",
+      "description": "Rebuilds the request body from `ResponsesState` when present.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_rewritten_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum size in bytes of the request body this filter *produces*\nwhen it rebuilds the outbound body from `ResponsesState`.\n\nRaw request body size is governed by the pipeline's `body_limits`,\nnot this field. This bounds only the rebuilt body, which can grow\nlarger than the raw input when conversation history is rehydrated.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_responses_rehydrate": {
+      "id": "ai.filter.http.openai.openai_responses_rehydrate",
+      "title": "openai_responses_rehydrate",
+      "description": "Validates `previous_response_id` by fetching the stored response, confirming its status is `\"completed\"`, and populating `ResponsesState` with the full conversation history (stored turns + current input).",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_history_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum serialized byte size of stored conversation history. Default: 2,097,152 (2 MiB).",
+                "default": 2,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_history_items",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Optional cap on the number of stored history items.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_responses_validate": {
+      "id": "ai.filter.http.openai.openai_responses_validate",
+      "title": "openai_responses_validate",
+      "description": "Validates and enriches Responses API requests.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_stream_events": {
+      "id": "ai.filter.http.openai.openai_stream_events",
+      "title": "openai_stream_events",
+      "description": "Accumulates state from native Responses API SSE event streams.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "logical_stream",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Treat successive IRR inference streams as one logical Responses\nstream. Per-iteration lifecycle events are normalized and only the\nfinal terminal event is exposed downstream.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_buffer_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum bytes buffered for incomplete SSE lines/data across\nchunk boundaries. Default: 10 MiB.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_events",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of SSE events before the parser errors.\nDefault: 100,000.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum seconds from first chunk to stream completion.\nDefault: 300 (5 minutes).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_tool_call_argument_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum bytes accepted per function-call argument string from\n`function_call_arguments.delta` or `function_call_arguments.done` events.\nDefault: 1 MiB.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_tool_parse": {
+      "id": "ai.filter.http.openai.openai_tool_parse",
+      "title": "openai_tool_parse",
+      "description": "Parses tool definitions and `tool_choice` from Responses API request bodies and promotes routing facts to metadata and filter results without mutating the body.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.openai_web_search": {
+      "id": "ai.filter.http.openai.openai_web_search",
+      "title": "openai_web_search",
+      "description": "Web search filter for model-driven `web_search_call` dispatch.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "provider",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "brave",
+                    "tavily",
+                    "you"
+                  ]
+                },
+                "description": "Search backend provider.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "api_key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "API key for the search provider (supports `${ENV_VAR}`).\nWrapped in [`SecretString`] to prevent accidental logging.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "default_context_size",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Default search context size when the client omits it.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Callout timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_calls_per_round",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Hard cap on web-search calls processed from one model response (1..=1024; default: 32).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "base_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Override the provider's default API base URL.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_base_url",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow a `base_url` that targets local-sensitive addresses.\n\nDNS names are resolved once per request and every result is checked\nimmediately before the transport connects. By default, any private,\nloopback, link-local, or otherwise non-public result rejects the\ncallout. Enable this only for a trusted private provider endpoint.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.openai.responses_to_chat_completions": {
+      "id": "ai.filter.http.openai.responses_to_chat_completions",
+      "title": "responses_to_chat_completions",
+      "description": "Translates canonical Responses create requests for a Chat Completions backend.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.prompt_enrich.prompt_enrich": {
+      "id": "ai.filter.http.prompt_enrich.prompt_enrich",
+      "title": "prompt_enrich",
+      "description": "Injects statically configured messages into the `messages` array of OpenAI-compatible chat completion request bodies.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum request body size to buffer before parsing.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_invalid",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue",
+                    "reject"
+                  ]
+                },
+                "description": "Behavior when the body is not valid JSON or lacks a\n`messages` array.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "prepend",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.MessageConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Messages to prepend at the beginning of the `messages` array.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "append",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.MessageConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Messages to append at the end of the `messages` array.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.routing.credential_inject": {
+      "id": "ai.filter.http.routing.credential_inject",
+      "title": "credential_inject",
+      "description": "Replaces caller credentials with the upstream credential selected by `intelligent_route` or `provider_route`.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "credentials",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.CredentialEntryConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Credential entries, keyed by secretRef (name/namespace/key).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.routing.intelligent_route": {
+      "id": "ai.filter.http.routing.intelligent_route",
+      "title": "intelligent_route",
+      "description": "Selects an upstream cluster from a site/capability descriptor by matching either an inference model name or MCP tool name.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "candidates",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.CandidateConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Static list of route candidates (mutually exclusive with `overlay_file`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "local_site",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the local site (required in static mode, provided by overlay\nin overlay mode).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "model_header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name that carries the model name (default: `X-Model`).",
+                "default": "x-praxis-ai-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "provider_hop_clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Clusters that terminate the authenticated provider-hop protocol.\n\nA selected candidate emits the fixed routing context only when\nits cluster is present in this allowlist. Each named cluster must use an\nmTLS-authenticated Praxis provider gateway. Direct API/backend clusters\nremain absent.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "expected_overlay_scope",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.ExpectedOverlayScope"
+                },
+                "description": "Expected scope of the overlay envelope.\n\nWhen set, each specified field is validated against the\nenvelope scope on load and every reload. Rejected on mismatch.\nOnly relevant in overlay mode with envelope-format files.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "overlay_file",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to a routing overlay JSON file (`routing-overlay.json` envelope or\nlegacy `routing-config.json`).\n\nWhen set, candidates and `local_site` are read from the overlay\ninstead of the YAML config.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "reload",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.ReloadConfig"
+                },
+                "description": "Hot reload configuration for overlay mode.\n\nOnly valid when `overlay_file` is set.  Providing a `reload:`\nblock with static `candidates` is rejected — static candidates\nare immutable for the lifetime of the filter.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "session_affinity",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.SessionAffinityConfig"
+                },
+                "description": "Session affinity configuration (disabled by default).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.routing.provider_route": {
+      "id": "ai.filter.http.routing.provider_route",
+      "title": "provider_route",
+      "description": "Exact provider-local mapping from an authenticated intelligent routing selection to a private backend cluster.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "provider_id",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Provider-owned identifier used for observability and demo attribution.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "model_header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header populated by an inference parser with the requested model.",
+                "default": "x-praxis-ai-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "routes",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.ProviderRouteConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Exact provider-local candidate mappings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "emit_demo_attribution",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Add provider gateway and selected-backend response attribution headers.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.time_to_first_token.time_to_first_token": {
+      "id": "ai.filter.http.time_to_first_token.time_to_first_token",
+      "title": "time_to_first_token",
+      "description": "Measures time-to-first-token for streaming AI responses.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.token_rate_limit.token_rate_limit": {
+      "id": "ai.filter.http.token_rate_limit.token_rate_limit",
+      "title": "token_rate_limit",
+      "description": "Token-denominated rate limiter: reserves an estimated cost at admission, reconciles against actual usage after the response completes. Evaluates an ordered list of rules, each with its own optional match condition, algorithm choice, and budget.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "rules",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.RuleConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Evaluated in order; the first rule whose `match` is satisfied (or\nwhich has no `match` at all) applies to a given request. A\nrequest satisfying no rule's `match` is not rate limited by this\nfilter instance -- add a trailing rule with no `match` to enforce\na catch-all budget instead.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "backend",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.BackendConfig"
+                },
+                "description": "Where every rule's admission state lives: in-process (default,\none budget per gateway instance) or a shared Valkey backend (one\nbudget shared across every gateway instance/replica). One\nbackend for the whole filter, not per rule -- rules already\nshare Valkey key-space isolation via `namespace`/rule-name\nhashing, so per-rule backend selection bought no isolation\nbenefit, only a separate Valkey connection per rule pointed at\nthe same URL. Revisit if a real deployment ever needs to mix\nin-process and Valkey rules in one filter instance.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.token_usage.token_count": {
+      "id": "ai.filter.http.token_usage.token_count",
+      "title": "token_count",
+      "description": "Extracts token usage from AI inference responses and writes unified counts to [`filter_metadata`].",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "provider",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "openai",
+                    "anthropic",
+                    "google",
+                    "bedrock",
+                    "bedrock_invoke_model",
+                    "azure"
+                  ]
+                },
+                "description": "AI provider whose response format to parse.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum bytes to buffer for a non-streaming JSON response before\ngiving up on locating its usage field. Must be greater than 0 and\nat most 64 MiB.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_scratch_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum scratch bytes (buffered line + in-progress event data) for\nthe SSE scanner before an event is discarded as oversized. Must be\ngreater than 0 and at most 64 MiB.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.filter.http.token_usage.token_usage_headers": {
+      "id": "ai.filter.http.token_usage.token_usage_headers",
+      "title": "token_usage_headers",
+      "description": "Injects `Praxis-Token-Input`, `Praxis-Token-Output`, and `Praxis-Token-Total` headers into downstream responses when token usage data is present in [`filter_metadata`]. Also injects `Praxis-Token-Status` when usage capture failed (e.g. overflow), so an unavailable count is never silently indistinguishable from a genuine zero.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.A2aHeaders": {
+      "id": "ai.type.A2aHeaders",
+      "title": "A2aHeaders",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "context_id",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the extracted context ID (e.g. `x-praxis-a2a-context-id`).",
+                "default": "x-praxis-a2a-context-id",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "family",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the A2A family (e.g. `x-praxis-a2a-family`).",
+                "default": "x-praxis-a2a-family",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "kind",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the JSON-RPC kind (e.g. `x-praxis-a2a-kind`).",
+                "default": "x-praxis-a2a-kind",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "method",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the canonical A2A method (e.g. `x-praxis-a2a-method`).",
+                "default": "x-praxis-a2a-method",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "streaming",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for streaming detection (e.g. `x-praxis-a2a-streaming`).",
+                "default": "x-praxis-a2a-streaming",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "task_id",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the extracted task ID (e.g. `x-praxis-a2a-task-id`).",
+                "default": "x-praxis-a2a-task-id",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "version",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for A2A version (e.g. `x-praxis-a2a-version`).",
+                "default": "x-praxis-a2a-version",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.AnthropicMessagesFormatHeaders": {
+      "id": "ai.type.AnthropicMessagesFormatHeaders",
+      "title": "AnthropicMessagesFormatHeaders",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "format",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the detected format.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-format` remains allowed.",
+                "default": "x-praxis-ai-format",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the extracted model value.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-model` remains allowed. Must not overwrite other\nclassification facts such as `x-praxis-ai-format`.",
+                "default": "x-praxis-ai-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "stream",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the extracted stream flag.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-stream` remains allowed.",
+                "default": "x-praxis-ai-stream",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.BackendConfig": {
+      "id": "ai.type.BackendConfig",
+      "title": "BackendConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "kind",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "memory",
+                    "valkey"
+                  ]
+                },
+                "description": "Which backend implementation to use.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Backend connection URL. Supports one `${ENV_VAR}` reference, so\ncredentials/hostnames don't need to be committed to config.\nRequired when `kind: valkey`, ignored otherwise.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "namespace",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Key namespace prefix, so multiple filter rules or deployments can\nshare one Valkey instance without colliding. Ignored for\n`kind: memory`. Defaults to `\"praxis:token_rate_limit\"` when unset.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.CandidateConfig": {
+      "id": "ai.type.CandidateConfig",
+      "title": "CandidateConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "cluster",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Cluster name to select when this candidate is chosen.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "credential",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.CandidateCredential"
+                },
+                "description": "Optional final-hop credential reference.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "fresh",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether this candidate is fresh (default: `true`).",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "kind",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "inference_model",
+                    "mcp_tool"
+                  ]
+                },
+                "description": "Capability kind.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Capability name (model name, tool name, or agent name).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "site",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Site that owns this capability.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.CandidateCredential": {
+      "id": "ai.type.CandidateCredential",
+      "title": "CandidateCredential",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "strategy",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Injection strategy.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "secretRef",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.CredentialRef"
+                },
+                "description": "Secret locator, never secret bytes.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.CircuitBreakerConfig": {
+      "id": "ai.type.CircuitBreakerConfig",
+      "title": "CircuitBreakerConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "failure_threshold",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Consecutive failures to trip the breaker.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "recovery_timeout",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Recovery window (e.g. `\"30s\"`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ConnectorConfig": {
+      "id": "ai.type.ConnectorConfig",
+      "title": "ConnectorConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "id",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Connector identifier referenced in requests.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "server_url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "MCP server URL for this connector.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.CredentialEntryConfig": {
+      "id": "ai.type.CredentialEntryConfig",
+      "title": "CredentialEntryConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Kubernetes Secret name — must match `intelligent_route.credential.name`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "namespace",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Kubernetes Secret namespace — must match `intelligent_route.credential.namespace`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Key within `Secret.data` — must match `intelligent_route.credential.key`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "strategy",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Credential strategy.  Currently only `\"bearer_token\"` is supported.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "value",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Inline token value.  Mutually exclusive with `env_var` and `file`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "env_var",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Environment variable holding the token.  Mutually exclusive with `value` and `file`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "file",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to a file containing the token, read once at filter construction.\n\nThe file contents are trimmed of leading/trailing whitespace before use.\nThe file must exist, be readable, and be non-empty; construction fails\notherwise.  Use this source when the token is mounted from a Kubernetes\nSecret volume so that token bytes never appear in Praxis `ConfigMap`s.\n\nMutually exclusive with `value` and `env_var`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.CredentialRef": {
+      "id": "ai.type.CredentialRef",
+      "title": "CredentialRef",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Secret data key.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Secret name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "namespace",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Secret namespace.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ExpectedOverlayScope": {
+      "id": "ai.type.ExpectedOverlayScope",
+      "title": "ExpectedOverlayScope",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "network",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Expected network name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "gateway",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Expected gateway name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "namespace",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Expected namespace.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "local_site",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Expected local site.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ExtractionConfig": {
+      "id": "ai.type.ExtractionConfig",
+      "title": "ExtractionConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "json_path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`JSONPath` expression to evaluate against the response body.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "result_key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Key to write the result under in [`FilterResultSet`].\n\n[`FilterResultSet`]: praxis_filter::FilterResultSet",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.HeaderEntry": {
+      "id": "ai.type.HeaderEntry",
+      "title": "HeaderEntry",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "value",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header value. Supports `${VAR}` env-var expansion.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.HeaderValidation": {
+      "id": "ai.type.HeaderValidation",
+      "title": "HeaderValidation",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "mismatch",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "reject",
+                    "ignore"
+                  ]
+                },
+                "description": "Behavior when header value conflicts with body-derived value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "missing",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "ignore",
+                    "synthesize",
+                    "reject"
+                  ]
+                },
+                "description": "Behavior when expected MCP headers are absent.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.MatchConfig": {
+      "id": "ai.type.MatchConfig",
+      "title": "MatchConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Every header must be present on the request with this exact\nvalue for the rule to match (`ANDed` across all entries).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.McpHeaders": {
+      "id": "ai.type.McpHeaders",
+      "title": "McpHeaders",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "kind",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the JSON-RPC kind (e.g. `x-praxis-mcp-kind`).",
+                "default": "x-praxis-a2a-kind",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "method",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the MCP method (e.g. `x-praxis-mcp-method`).",
+                "default": "x-praxis-a2a-method",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the tool/resource/prompt name (e.g. `x-praxis-mcp-name`).",
+                "default": "x-praxis-mcp-name",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "protocol_version",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the MCP protocol version (e.g. `x-praxis-mcp-protocol-version`).",
+                "default": "x-praxis-mcp-protocol-version",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "session_present",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for MCP session presence (e.g. `x-praxis-mcp-session-present`).",
+                "default": "x-praxis-mcp-session-present",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.McpServerConfig": {
+      "id": "ai.type.McpServerConfig",
+      "title": "McpServerConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Unique server name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "cluster",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Backend cluster name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Backend MCP path.",
+                "default": "/mcp",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tool_prefix",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Tool prefix for this server.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tools",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.ToolConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Statically defined tools.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.MessageConfig": {
+      "id": "ai.type.MessageConfig",
+      "title": "MessageConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "role",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "system",
+                    "user"
+                  ]
+                },
+                "description": "Role for the injected message.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "content",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Text content of the injected message.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ModelRewriteHeaders": {
+      "id": "ai.type.ModelRewriteHeaders",
+      "title": "ModelRewriteHeaders",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "effective_model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the effective (post-rewrite) model value.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-effective-model` remains allowed. Must differ from\n`original_model`.",
+                "default": "x-praxis-ai-effective-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "original_model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the original (pre-rewrite) model value.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-original-model` remains allowed. Must differ from\n`effective_model`.",
+                "default": "x-praxis-ai-original-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.PhaseConfig": {
+      "id": "ai.type.PhaseConfig",
+      "title": "PhaseConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "request",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Evaluate client requests before forwarding to the upstream.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Evaluate upstream responses before forwarding to the client.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.PoolConfig": {
+      "id": "ai.type.PoolConfig",
+      "title": "PoolConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_connections",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of connections in the pool.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "min_connections",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Minimum number of idle connections to maintain.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "idle_timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum time (in seconds) a connection can sit idle before\nbeing closed. Set to `0` to disable idle timeout.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "acquire_timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum time (in seconds) to wait when acquiring a connection\nfrom the pool.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ProviderRouteConfig": {
+      "id": "ai.type.ProviderRouteConfig",
+      "title": "ProviderRouteConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "candidate_id",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Stable candidate ID selected by the edge `intelligent_route`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "cluster",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Provider-local backend cluster.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "credential",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.CandidateCredential"
+                },
+                "description": "Optional provider-local credential reference for the final API hop.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Exact model accepted for this candidate.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "paths",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Exact inference paths accepted for this candidate.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ReloadConfig": {
+      "id": "ai.type.ReloadConfig",
+      "title": "ReloadConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "enabled",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether file watching is enabled (default: `true`).",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "debounce_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Debounce window in milliseconds (default: 500).",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.RequestConfig": {
+      "id": "ai.type.RequestConfig",
+      "title": "RequestConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "phase",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "request_headers",
+                    "request_body"
+                  ]
+                },
+                "description": "Phase at which the callout executes.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body bytes to buffer. Caps both the forwarded request\nbody and the accepted callout response body.",
+                "default": 1,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ResponseConfig": {
+      "id": "ai.type.ResponseConfig",
+      "title": "ResponseConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "extract",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.ExtractionConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "`JSONPath` extractions to write into [`FilterResultSet`].\n\n[`FilterResultSet`]: praxis_filter::FilterResultSet",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "inject_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Callout response headers to inject into the upstream request\non success.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ResponsesFormatHeaders": {
+      "id": "ai.type.ResponsesFormatHeaders",
+      "title": "ResponsesFormatHeaders",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "format",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the detected format (e.g. `openai_responses`, `openai_chat_completions`).\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-format` remains allowed.",
+                "default": "x-praxis-ai-format",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "model",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the extracted model value.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-model` remains allowed. Must not overwrite other\nclassification facts such as `x-praxis-ai-format`.",
+                "default": "x-praxis-ai-model",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "stream",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the extracted stream flag.\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-ai-stream` remains allowed.",
+                "default": "x-praxis-ai-stream",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "mode",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for the computed mode (`stateless` or `stateful`).\n\nMust not be a hop-by-hop, framing, Host, credential, API-key, or\nother internal `x-praxis-*` header. Dedicated default\n`x-praxis-responses-mode` remains allowed.",
+                "default": "x-praxis-responses-mode",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.RuleConfig": {
+      "id": "ai.type.RuleConfig",
+      "title": "RuleConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Human-readable rule identifier, folded into Valkey key\nnamespacing so distinct rules sharing one backend never collide.\n\nRenaming a live `valkey`-backed rule is therefore not a\nno-op for operators: it changes the Valkey key hash, so the old\nname's tracked budget is orphaned (left to expire on its own TTL)\nand the new name starts with a fresh budget. There's no\nmigration/rename path today -- routine config hygiene (e.g.\nrenaming `\"gold\"` to `\"gold-tier\"`) silently resets that rule's\nstate.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "match",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.MatchConfig"
+                },
+                "description": "Static header-value match condition. Every listed header must be\npresent on the request with an exact value match (`ANDed`) for\nthis rule to apply. Omit entirely for a catch-all rule.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "algorithm",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "object",
+                        "fields": [
+                          {
+                            "serialized_name": "algorithm",
+                            "schema": {
+                              "kind": {
+                                "kind": "literal",
+                                "value": "sliding_window"
+                              },
+                              "description": "",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "window",
+                            "schema": {
+                              "kind": {
+                                "kind": "string"
+                              },
+                              "description": "Sliding window duration (e.g. `\"1h\"`, `\"60s\"`).",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "capacity",
+                            "schema": {
+                              "kind": {
+                                "kind": "integer"
+                              },
+                              "description": "Maximum tokens admitted within `window`.",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          }
+                        ],
+                        "additional_properties": false
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "object",
+                        "fields": [
+                          {
+                            "serialized_name": "algorithm",
+                            "schema": {
+                              "kind": {
+                                "kind": "literal",
+                                "value": "token_bucket"
+                              },
+                              "description": "",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "capacity",
+                            "schema": {
+                              "kind": {
+                                "kind": "integer"
+                              },
+                              "description": "Maximum tokens held at once (the bucket's ceiling).",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "refill_rate",
+                            "schema": {
+                              "kind": {
+                                "kind": "number"
+                              },
+                              "description": "Tokens refilled per second, up to `capacity`.",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          }
+                        ],
+                        "additional_properties": false
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": "algorithm"
+                },
+                "description": "Which admission algorithm this rule enforces, and that\nalgorithm's own parameters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": true
+            },
+            {
+              "serialized_name": "reserved_tokens",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Fixed token cost reserved at admission time, before actual usage\nis known.\n\nPlaceholder pending M3 (configurable estimation strategies).\nReal deployments will want this derived from request metadata\n(e.g. `max_tokens`) rather than a single fixed constant -- that's\nout of scope for this milestone.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "reservation_timeout",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "How long an admitted-but-never-reconciled reservation (lost\nrequest: timeout, connection reset, upstream crash) is tracked as\nactive before that already-reserved-at-admission charge against\nits estimate becomes irreversibly locked in (sliding-window:\nfolded into the settled total so it survives the window's normal\naging-out; token-bucket: the tokens were already decremented at\nreserve time regardless, this only bounds how long the\nreservation is tracked as pending). This does **not** defer when\nthe charge first applies -- it applies immediately at admission,\nsame as any other reservation.\n\nAnswers the proposal's still-open \"lost request handling\"\nquestion for this milestone. Defaults to [`DEFAULT_RESERVATION_TIMEOUT`]\nwhen unset.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.SessionAffinityConfig": {
+      "id": "ai.type.SessionAffinityConfig",
+      "title": "SessionAffinityConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "cookie",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of a cookie to extract the session key from.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "enabled",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether session affinity is enabled (default: `false`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name to extract the session key from.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "ttl_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Binding TTL in seconds (default: 3600, max: 86400).",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.TargetConfig": {
+      "id": "ai.type.TargetConfig",
+      "title": "TargetConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "url",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Absolute HTTP(S) URL to call.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_addresses",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow the target to resolve to a private, loopback, or\nlink-local address.\n\nDefaults to `false`. Set to `true` explicitly when a trusted\nloopback/sidecar or private service is the intended destination.\nWhen disabled, the callout is rejected at request time if any\nresolved peer address is private/loopback/link-local — including a\nhostname that resolves to such an address (e.g. cloud metadata at\n`169.254.169.254`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Request timeout (e.g. `\"2s\"`, `\"500ms\"`).",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "ai.type.HeaderEntry"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Static headers to send with every callout.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "forward_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to copy from the downstream request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "body",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Reshape the downstream request body for the callout.\n\nEach key becomes a field in the callout JSON body; each\nvalue is a `JSONPath` expression evaluated against the\ndownstream body. When set, only the listed fields are\nsent — the downstream body goes to upstream untouched.\n\nWhen absent, the downstream body is forwarded verbatim.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.TaskRoutingConfig": {
+      "id": "ai.type.TaskRoutingConfig",
+      "title": "TaskRoutingConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "enabled",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether task routing is enabled.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_response_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum response body bytes to buffer for task route capture.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_lookup_miss",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "continue"
+                  ]
+                },
+                "description": "Behavior when a task route lookup misses.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "route_cluster_header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Internal header name injected on task or context route hit.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "store",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    "local"
+                  ]
+                },
+                "description": "Storage backend for task routes.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "terminal_ttl_seconds",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "TTL in seconds for terminal task routes (0 = remove immediately).\nMust be at most 2,592,000 (30 days).",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "ttl_seconds",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "TTL in seconds for non-terminal task routes. Must be greater\nthan 0 and at most 2,592,000 (30 days).",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.ToolConfig": {
+      "id": "ai.type.ToolConfig",
+      "title": "ToolConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Tool name on the backend.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "description",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Optional description.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "inputSchema",
+              "aliases": [
+                "input_schema",
+                "schema"
+              ],
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.json_value"
+                },
+                "description": "Optional input schema. `schema` is accepted as a local shorthand.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "annotations",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "ai.type.json_value"
+                },
+                "description": "Optional tool annotations.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    "ai.type.json_value": {
+      "id": "ai.type.json_value",
+      "title": "JSON value",
+      "description": "Any JSON value accepted by the MCP tool schema fields.",
+      "node": {
+        "kind": {
+          "kind": "one_of",
+          "variants": [
+            {
+              "kind": {
+                "kind": "null"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "boolean"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "number"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "string"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "array",
+                "items": {
+                  "kind": {
+                    "kind": "reference",
+                    "schema_id": "ai.type.json_value"
+                  },
+                  "description": "",
+                  "examples": [],
+                  "rules": [],
+                  "sensitive": false
+                },
+                "min_items": null,
+                "max_items": null
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "map",
+                "values": {
+                  "kind": {
+                    "kind": "reference",
+                    "schema_id": "ai.type.json_value"
+                  },
+                  "description": "",
+                  "examples": [],
+                  "rules": [],
+                  "sensitive": false
+                }
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            }
+          ],
+          "discriminator": null
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    }
+  },
+  "roots": [],
+  "filters": [
+    {
+      "name": "a2a",
+      "protocol": "http",
+      "category": "agentic",
+      "description": "Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method, family, task ID, streaming detection, and version to request headers, filter results, and durable metadata for routing.",
+      "config_schema": "ai.filter.http.agentic.a2a",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: a2a"
+        },
+        {
+          "yaml": "filter: a2a\nmax_body_bytes: 65536\non_invalid: reject\nmethod_aliases:\n  message/send: SendMessage\n  message/stream: SendStreamingMessage\n  tasks/get: GetTask\n  tasks/cancel: CancelTask\nheaders:\n  method: x-praxis-a2a-method\n  family: x-praxis-a2a-family\n  context_id: x-praxis-a2a-context-id\n  task_id: x-praxis-a2a-task-id\n  kind: x-praxis-a2a-kind\n  streaming: x-praxis-a2a-streaming\n  version: x-praxis-a2a-version\ntask_routing:\n  enabled: true\n  store: local\n  route_cluster_header: x-praxis-a2a-route-cluster\n  ttl_seconds: 3600\n  terminal_ttl_seconds: 300\n  max_response_body_bytes: 65536"
+        }
+      ],
+      "source": {
+        "path": "filters/src/agentic/a2a/mod.rs",
+        "line": 140
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "mcp",
+      "protocol": "http",
+      "category": "agentic",
+      "description": "Extracts MCP protocol metadata from JSON-RPC request bodies and promotes method, tool/resource/prompt name, JSON-RPC kind, protocol version, and session presence to request headers/filter results; stores session ID in durable metadata.",
+      "config_schema": "ai.filter.http.agentic.mcp",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: mcp"
+        },
+        {
+          "yaml": "filter: mcp\nmax_body_bytes: 65536\non_invalid: reject\nheader_validation:\n  mismatch: reject\n  missing: ignore\nheaders:\n  method: x-praxis-mcp-method\n  name: x-praxis-mcp-name\n  kind: x-praxis-mcp-kind\n  protocol_version: x-praxis-mcp-protocol-version\n  session_present: x-praxis-mcp-session-present"
+        },
+        {
+          "yaml": "filter: mcp\npath: /mcp\nmax_body_bytes: 65536\nservers:\n  - name: weather\n    cluster: weather-mcp\n    path: /mcp\n    tool_prefix: weather_\n    tools:\n      - name: get_weather\n        description: Get current weather\n  - name: calendar\n    cluster: calendar-mcp\n    path: /mcp\n    tool_prefix: cal_\n    tools:\n      - name: create_event\n        description: Create a calendar event"
+        }
+      ],
+      "source": {
+        "path": "filters/src/agentic/mcp/mod.rs",
+        "line": 122
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "anthropic_messages_format",
+      "protocol": "http",
+      "category": "anthropic",
+      "description": "Classifies Anthropic Messages API requests and promotes routing facts to headers, metadata, and filter results.",
+      "config_schema": "ai.filter.http.anthropic.anthropic_messages_format",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: anthropic_messages_format"
+        },
+        {
+          "yaml": "filter: anthropic_messages_format\non_invalid: continue\nmax_body_bytes: 1048576\nheaders:\n  format: x-praxis-ai-format\n  model: x-praxis-ai-model\n  stream: x-praxis-ai-stream"
+        }
+      ],
+      "source": {
+        "path": "apis/src/anthropic/messages_format/mod.rs",
+        "line": 97
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "anthropic_messages_protocol",
+      "protocol": "http",
+      "category": "anthropic",
+      "description": "Normalizes Anthropic Messages protocol headers for native backends.",
+      "config_schema": "ai.filter.http.anthropic.anthropic_messages_protocol",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: anthropic_messages_protocol"
+        },
+        {
+          "yaml": "filter: anthropic_messages_protocol\ndefault_version: \"2023-06-01\""
+        }
+      ],
+      "source": {
+        "path": "apis/src/anthropic/protocol/mod.rs",
+        "line": 76
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "anthropic_messages_to_chat_completions",
+      "protocol": "http",
+      "category": "anthropic",
+      "description": "Transforms Anthropic Messages API requests to Chat Completions-compatible request bodies and transforms compatible responses back. The name refers to the Chat Completions wire shape, not the OpenAI Responses API; any Chat Completions-compatible backend is a valid target, not only OpenAI.",
+      "config_schema": "ai.filter.http.anthropic.anthropic_messages_to_chat_completions",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: anthropic_messages_to_chat_completions"
+        },
+        {
+          "yaml": "filter: anthropic_messages_to_chat_completions\nmax_body_bytes: 1048576"
+        }
+      ],
+      "source": {
+        "path": "apis/src/anthropic/messages_to_chat_completions/mod.rs",
+        "line": 82
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "anthropic_messages_to_chat_completions_stream",
+      "protocol": "http",
+      "category": "anthropic",
+      "description": "Transforms streaming SSE responses between the Chat Completions and Anthropic Messages formats, processing each chunk as it arrives.",
+      "config_schema": "ai.filter.http.anthropic.anthropic_messages_to_chat_completions_stream",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: anthropic_messages_to_chat_completions_stream"
+        },
+        {
+          "yaml": "filter: anthropic_messages_to_chat_completions_stream\nmax_partial_event_bytes: 10485760\nmax_tool_blocks: 10000"
+        }
+      ],
+      "source": {
+        "path": "apis/src/anthropic/messages_to_chat_completions_stream/mod.rs",
+        "line": 155
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "anthropic_validate",
+      "protocol": "http",
+      "category": "anthropic",
+      "description": "Validates Anthropic Messages request bodies for proxy-owned JSON envelope requirements.",
+      "config_schema": "ai.filter.http.anthropic.anthropic_validate",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: anthropic_validate"
+        }
+      ],
+      "source": {
+        "path": "apis/src/anthropic/validate/mod.rs",
+        "line": 63
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "anthropic_web_search",
+      "protocol": "http",
+      "category": "anthropic",
+      "description": "Executes server-owned `WebSearch` tool calls in an Anthropic Messages loop.",
+      "config_schema": "ai.filter.http.anthropic.anthropic_web_search",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: anthropic_web_search\nprovider: you\napi_key: ${WEB_SEARCH_API_KEY}"
+        },
+        {
+          "yaml": "filter: anthropic_web_search\nprovider: you\napi_key: ${WEB_SEARCH_API_KEY}\ndefault_context_size: medium\ntimeout_ms: 10000\nmax_body_bytes: 67108864"
+        },
+        {
+          "yaml": "# cargo run -p praxis-test-utils --example anthropic_messages_web_search_mock\n# WEB_SEARCH_API_KEY=\"$WEB_SEARCH_API_KEY\" cargo run -p praxis-ai-proxy -- \\\n#   -c examples/configs/anthropic/full-flow-agentic.yaml\n# curl http://127.0.0.1:8080/v1/messages \\\n#   -H 'content-type: application/json' \\\n#   -d '{\"model\":\"openai/gpt-oss-20b\",\"max_tokens\":1024,\"stream\":false,\"messages\":[{\"role\":\"user\",\"content\":\"Use web search to look up potato, then summarize in one sentence.\"}],\"tools\":[{\"name\":\"WebSearch\",\"description\":\"Search the web\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]}}]}'"
+        }
+      ],
+      "source": {
+        "path": "apis/src/anthropic/web_search/mod.rs",
+        "line": 418
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "aws_sigv4_sign",
+      "protocol": "http",
+      "category": "aws",
+      "description": "Signs outbound requests to AWS services using `SigV4`.",
+      "config_schema": "ai.filter.http.aws.aws_sigv4_sign",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: aws_sigv4_sign\nregion: us-east-1\nservice: bedrock\nhost: bedrock-runtime.us-east-1.amazonaws.com\naccess_key_env_var: AWS_ACCESS_KEY_ID\nsecret_key_env_var: AWS_SECRET_ACCESS_KEY\nsession_token_env_var: AWS_SESSION_TOKEN   # optional\nmax_body_bytes: 1048576                    # optional, default 1 MiB"
+        }
+      ],
+      "source": {
+        "path": "filters/src/aws/sigv4.rs",
+        "line": 288
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "azure_ad",
+      "protocol": "http",
+      "category": "azure",
+      "description": "Injects an Azure AD (Entra ID) bearer token into outbound requests.",
+      "config_schema": "ai.filter.http.azure.azure_ad",
+      "required_features": [
+        "azure-ad-filter"
+      ],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: azure_ad\ntenant_id: 00000000-0000-0000-0000-000000000000\nclient_id: 11111111-1111-1111-1111-111111111111\nscope: https://cognitiveservices.azure.com/.default\nclient_secret_env_var: AZURE_CLIENT_SECRET\nauthority_host: login.microsoftonline.com   # optional, for sovereign clouds\nallow_private_authority: false               # opt in only for a trusted private authority"
+        }
+      ],
+      "source": {
+        "path": "filters/src/azure/azure_ad.rs",
+        "line": 253
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_chat_completions_to_azureai_chat_completions",
+      "protocol": "http",
+      "category": "azure",
+      "description": "Transforms requests targeting Azure OpenAI deployments into standard Chat Completions-compatible form and normalizes responses back.",
+      "config_schema": "ai.filter.http.azure.openai_chat_completions_to_azureai_chat_completions",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_chat_completions_to_azureai_chat_completions"
+        },
+        {
+          "yaml": "filter: openai_chat_completions_to_azureai_chat_completions\napi_version: \"2024-10-21\"\nmax_body_bytes: 1048576"
+        }
+      ],
+      "source": {
+        "path": "apis/src/azure/to_openai/mod.rs",
+        "line": 90
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "http_callout",
+      "protocol": "http",
+      "category": "callout",
+      "description": "Calls an external HTTP service during request processing and feeds its response into branch-chain evaluation.",
+      "config_schema": "ai.filter.http.callout.http_callout",
+      "required_features": [
+        "http-callout-filter"
+      ],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [],
+      "source": {
+        "path": "filters/src/callout/mod.rs",
+        "line": 482
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "gcp_adc",
+      "protocol": "http",
+      "category": "gcp",
+      "description": "Injects a GCP `OAuth2` access token into outbound requests.",
+      "config_schema": "ai.filter.http.gcp.gcp_adc",
+      "required_features": [
+        "gcp-adc-filter"
+      ],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: gcp_adc\nsource: adc\nscope: https://www.googleapis.com/auth/cloud-platform"
+        }
+      ],
+      "source": {
+        "path": "filters/src/gcp/filter.rs",
+        "line": 141
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "ai_guardrails",
+      "protocol": "http",
+      "category": "guardrails",
+      "description": "Calls an external AI guardrail provider to evaluate request and response bodies. The provider determines whether content should be passed, blocked, or redacted.",
+      "config_schema": "ai.filter.http.guardrails.ai_guardrails",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: ai_guardrails\nprovider:\n  type: nemo\n  endpoint: \"http://nemo:8000/v1/guardrail/checks\"\n  allow_private_endpoint: true\n  timeout_ms: 5000\nphase:\n  request: true\n  response: true"
+        }
+      ],
+      "source": {
+        "path": "filters/src/guardrails/filter.rs",
+        "line": 121
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "model_to_header",
+      "protocol": "http",
+      "category": "inference",
+      "description": "Promotes the JSON `\"model\"` field from the request body to a request header.",
+      "config_schema": "ai.filter.http.inference.model_to_header",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: model_to_header\nheader: X-Model   # optional, defaults to X-Model"
+        }
+      ],
+      "source": {
+        "path": "filters/src/inference/model_to_header.rs",
+        "line": 116
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "external_metering",
+      "protocol": "http",
+      "category": "metering",
+      "description": "Integrates with an external metering service for pre-request balance checks and post-response token usage reporting.",
+      "config_schema": "ai.filter.http.metering.external_metering",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: external_metering\nmetering_url: \"http://metering-service:8080\"\ntimeout_seconds: 5\nfeature_key: \"inference-tokens\"\nsource: \"ai-gateway\"\nfail_open: true\nidentity_header_prefix: \"x-tenant-\"\nidentity_metadata_namespace: \"identity\"\ndefault_username: \"anonymous\"\ndefault_model: \"unknown\""
+        }
+      ],
+      "source": {
+        "path": "filters/src/metering/mod.rs",
+        "line": 338
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_agentic_loop",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Agentic loop controller for the Responses API pipeline.",
+      "config_schema": "ai.filter.http.openai.openai_agentic_loop",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_agentic_loop"
+        },
+        {
+          "yaml": "filter: openai_agentic_loop\nmax_infer_iters: 10"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/agentic_loop/mod.rs",
+        "line": 203
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_conversations",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Handles all `/v1/conversations` endpoints locally.",
+      "config_schema": "ai.filter.http.openai.openai_conversations",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_conversations\nbackend: sqlite\ndatabase_url: sqlite://conversations.db?mode=rwc\nconversations_table: conversations\nitems_table: conversation_items"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/conversations/filter.rs",
+        "line": 386
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_doc_extract",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Converts `input_file` content parts to `input_text` for backends that do not support `input_file` natively (e.g. vLLM, llm-d).",
+      "config_schema": "ai.filter.http.openai.openai_doc_extract",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_doc_extract\nallow_pre_security_callout: true"
+        },
+        {
+          "yaml": "filter: openai_doc_extract\nallow_pre_security_callout: true\non_unsupported: continue\nmax_rewritten_body_bytes: 67108864\nmax_content_bytes: 10485760\nmax_file_references: 32\nmax_total_text_bytes: 67108864"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/doc_extract/mod.rs",
+        "line": 112
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_file_resolve",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Resolves `file_id` and `file_url` references in Responses API input by fetching content from a Files API or remote URL via `ApiClient` and inlining the base64-encoded content in the provider-native field.",
+      "config_schema": "ai.filter.http.openai.openai_file_resolve",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_file_resolve\nfiles_api_url: \"http://files-api:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true"
+        },
+        {
+          "yaml": "filter: openai_file_resolve\nfiles_api_url: \"http://files-api:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true\nforward_headers:\n  - authorization\n  - x-tenant-id\non_missing: continue\ntimeout_ms: 30000\nmax_rewritten_body_bytes: 67108864\nmax_resolved_bytes: 67108864\nmax_file_references: 32"
+        },
+        {
+          "yaml": "filter: openai_file_resolve\nfiles_api_url: \"http://ogx:8321\"\nallow_private_files_api_url: true\nallow_pre_security_callout: true\nfile_url: resolve\nallowed_file_url_origins:\n  - \"https://files.internal:8443\""
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/file_resolve/mod.rs",
+        "line": 257
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_file_search_callout",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Executes pending file search calls against a vector store API compatible backend.",
+      "config_schema": "ai.filter.http.openai.openai_file_search_callout",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [],
+      "source": {
+        "path": "apis/src/openai/responses/file_search_callout/mod.rs",
+        "line": 438
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_mcp_dispatch",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Executes MCP tool calls against upstream MCP servers within the Responses API agentic loop.",
+      "config_schema": "ai.filter.http.openai.openai_mcp_dispatch",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_mcp_dispatch"
+        },
+        {
+          "yaml": "filter: openai_mcp_dispatch\ntimeout_ms: 30000\nmax_calls_per_round: 32\nmax_parallel_calls: 8\nmax_result_bytes: 1048576\nmax_total_result_bytes: 8388608"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/mcp_dispatch/mod.rs",
+        "line": 367
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_mcp_tool_resolve",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Resolves MCP tool entries from the Responses API `tools` array into concrete tool definitions by calling `tools/list` on each upstream MCP server.",
+      "config_schema": "ai.filter.http.openai.openai_mcp_tool_resolve",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": true
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_mcp_tool_resolve"
+        },
+        {
+          "yaml": "filter: openai_mcp_tool_resolve\ntimeout_ms: 5000\nmax_rewritten_body_bytes: 67108864\nmax_tools: 128"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/openai_mcp_tool_resolve/mod.rs",
+        "line": 269
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_response_store",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Persists Responses API responses to the configured response store backend.",
+      "config_schema": "ai.filter.http.openai.openai_response_store",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_response_store\nbackend: sqlite\ndatabase_url: sqlite://responses.db?mode=rwc\nresponses_table: openai_responses\nconversations_table: openai_conversation_messages"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/store/filter.rs",
+        "line": 678
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_responses_compact",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Summarizes conversation history when the token count exceeds a configured threshold.",
+      "config_schema": "ai.filter.http.openai.openai_responses_compact",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_responses_compact\nallow_pre_security_callout: true\ninference_url: \"http://localhost:11434/v1/chat/completions\"\nallow_private_inference_url: true\ndefault_model: llama3.2:1b"
+        },
+        {
+          "yaml": "filter: openai_responses_compact\nallow_pre_security_callout: true\ninference_url: \"http://localhost:11434/v1/chat/completions\"\nallow_private_inference_url: true\ndefault_model: gpt-4o-mini\ntiktoken_encoding: cl100k_base\ntimeout_ms: 30000\non_failure: closed\nstatus_on_error: 502"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/compact/mod.rs",
+        "line": 241
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_responses_format",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Classifies AI API request bodies and promotes routing facts to headers, metadata, and filter results without mutating the body.",
+      "config_schema": "ai.filter.http.openai.openai_responses_format",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_responses_format"
+        },
+        {
+          "yaml": "filter: openai_responses_format\non_invalid: continue\nheaders:\n  format: x-praxis-ai-format\n  model: x-praxis-ai-model\n  stream: x-praxis-ai-stream\n  mode: x-praxis-responses-mode"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/mod.rs",
+        "line": 229
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_responses_model_rewrite",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Rewrites the `model` field in Responses API request bodies.",
+      "config_schema": "ai.filter.http.openai.openai_responses_model_rewrite",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_responses_model_rewrite\ndefault_model: \"llama-3.3-70b\"\nmodel_aliases:\n  \"codex-mini-latest\": \"llama-3.3-70b\"\n  \"gpt-4.1-*\": \"qwen-2.5-72b\"\n  \"gpt-4.1-mini\": \"qwen-2.5-72b\""
+        },
+        {
+          "yaml": "filter: openai_responses_model_rewrite\ndefault_model: \"llama-3.3-70b\"\nmodel_aliases:\n  \"codex-mini-latest\": \"llama-3.3-70b\"\n  \"gpt-4.1-*\": \"qwen-2.5-72b\"\non_invalid: continue\nheaders:\n  effective_model: x-praxis-ai-effective-model\n  original_model: x-praxis-ai-original-model"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/model_rewrite/mod.rs",
+        "line": 149
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_responses_proxy",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Rebuilds the request body from `ResponsesState` when present.",
+      "config_schema": "ai.filter.http.openai.openai_responses_proxy",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_responses_proxy"
+        },
+        {
+          "yaml": "filter: openai_responses_proxy\nmax_rewritten_body_bytes: 67108864"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/openai_responses_proxy/mod.rs",
+        "line": 148
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_responses_rehydrate",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Validates `previous_response_id` by fetching the stored response, confirming its status is `\"completed\"`, and populating `ResponsesState` with the full conversation history (stored turns + current input).",
+      "config_schema": "ai.filter.http.openai.openai_responses_rehydrate",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_responses_rehydrate"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/rehydrate/mod.rs",
+        "line": 220
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_responses_validate",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Validates and enriches Responses API requests.",
+      "config_schema": "ai.filter.http.openai.openai_responses_validate",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_responses_validate"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/validate/mod.rs",
+        "line": 72
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_stream_events",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Accumulates state from native Responses API SSE event streams.",
+      "config_schema": "ai.filter.http.openai.openai_stream_events",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_stream_events\n# All fields optional:\n# logical_stream: false\n# max_buffer_bytes: 10485760\n# max_events: 100000\n# timeout_secs: 300\n# max_tool_call_argument_bytes: 1048576"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/stream_events/mod.rs",
+        "line": 193
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_tool_parse",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Parses tool definitions and `tool_choice` from Responses API request bodies and promotes routing facts to metadata and filter results without mutating the body.",
+      "config_schema": "ai.filter.http.openai.openai_tool_parse",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_tool_parse"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/openai_tool_parse/mod.rs",
+        "line": 84
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "openai_web_search",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Web search filter for model-driven `web_search_call` dispatch.",
+      "config_schema": "ai.filter.http.openai.openai_web_search",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: openai_web_search\nprovider: brave\napi_key: ${WEB_SEARCH_API_KEY}"
+        },
+        {
+          "yaml": "filter: openai_web_search\nprovider: brave\napi_key: ${WEB_SEARCH_API_KEY}\ndefault_context_size: medium\ntimeout_ms: 10000\nmax_calls_per_round: 32"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/web_search/mod.rs",
+        "line": 294
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "responses_to_chat_completions",
+      "protocol": "http",
+      "category": "openai",
+      "description": "Translates canonical Responses create requests for a Chat Completions backend.",
+      "config_schema": "ai.filter.http.openai.responses_to_chat_completions",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: responses_to_chat_completions"
+        },
+        {
+          "yaml": "filter: responses_to_chat_completions\nmax_rewritten_body_bytes: 67108864"
+        }
+      ],
+      "source": {
+        "path": "apis/src/openai/responses/responses_to_chat_completions/mod.rs",
+        "line": 329
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "prompt_enrich",
+      "protocol": "http",
+      "category": "prompt_enrich",
+      "description": "Injects statically configured messages into the `messages` array of OpenAI-compatible chat completion request bodies.",
+      "config_schema": "ai.filter.http.prompt_enrich.prompt_enrich",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: prompt_enrich\nmax_body_bytes: 10485760\non_invalid: continue\nprepend:\n  - role: system\n    content: \"You are a helpful assistant.\"\nappend:\n  - role: user\n    content: \"Remember to cite your sources.\""
+        }
+      ],
+      "source": {
+        "path": "filters/src/prompt_enrich/mod.rs",
+        "line": 129
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "credential_inject",
+      "protocol": "http",
+      "category": "routing",
+      "description": "Replaces caller credentials with the upstream credential selected by `intelligent_route` or `provider_route`.",
+      "config_schema": "ai.filter.http.routing.credential_inject",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: credential_inject\ncredentials:\n  - name: my-api-secret        # matches intelligent_route.credential.name\n    namespace: grid-system      # matches intelligent_route.credential.namespace\n    key: token                  # matches intelligent_route.credential.key\n    strategy: bearer_token      # optional, defaults to bearer_token\n    file: /run/secrets/grid-credentials/my-api-secret/token\n  - name: other-secret\n    namespace: default\n    key: api-key\n    strategy: bearer_token\n    env_var: OTHER_API_TOKEN    # token from environment variable"
+        }
+      ],
+      "source": {
+        "path": "filters/src/routing/credential_inject.rs",
+        "line": 244
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "intelligent_route",
+      "protocol": "http",
+      "category": "routing",
+      "description": "Selects an upstream cluster from a site/capability descriptor by matching either an inference model name or MCP tool name.",
+      "config_schema": "ai.filter.http.routing.intelligent_route",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [],
+      "source": {
+        "path": "filters/src/routing/intelligent_route.rs",
+        "line": 625
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "provider_route",
+      "protocol": "http",
+      "category": "routing",
+      "description": "Exact provider-local mapping from an authenticated intelligent routing selection to a private backend cluster.",
+      "config_schema": "ai.filter.http.routing.provider_route",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [],
+      "source": {
+        "path": "filters/src/routing/provider_route.rs",
+        "line": 202
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "time_to_first_token",
+      "protocol": "http",
+      "category": "time_to_first_token",
+      "description": "Measures time-to-first-token for streaming AI responses.",
+      "config_schema": "ai.filter.http.time_to_first_token.time_to_first_token",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: time_to_first_token"
+        }
+      ],
+      "source": {
+        "path": "filters/src/time_to_first_token/mod.rs",
+        "line": 80
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "token_rate_limit",
+      "protocol": "http",
+      "category": "token_rate_limit",
+      "description": "Token-denominated rate limiter: reserves an estimated cost at admission, reconciles against actual usage after the response completes. Evaluates an ordered list of rules, each with its own optional match condition, algorithm choice, and budget.",
+      "config_schema": "ai.filter.http.token_rate_limit.token_rate_limit",
+      "required_features": [
+        "token-rate-limit-filter"
+      ],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: token_rate_limit\nbackend:                           # optional: defaults to in-process state, shared by every rule\n  kind: valkey                      # memory (default) | valkey\n  url: \"${TOKEN_RATE_LIMIT_VALKEY_URL}\"\n  namespace: praxis:token_rate_limit\nrules:\n  - name: team-alpha                 # human-readable, unique per filter instance\n    match:                           # optional: omit for a catch-all rule\n      headers:\n        x-app-id: alpha\n    algorithm: sliding_window        # sliding_window | token_bucket\n    window: 1h                       # sliding_window only: window duration\n    capacity: 100000                 # max tokens admitted (sliding_window) or held (token_bucket)\n    reserved_tokens: 500             # fixed cost reserved per request at admission\n  - name: team-beta\n    match:\n      headers:\n        x-app-id: beta\n    algorithm: token_bucket\n    capacity: 50000\n    refill_rate: 50                  # token_bucket only: tokens refilled per second\n    reserved_tokens: 200"
+        }
+      ],
+      "source": {
+        "path": "filters/src/token_rate_limit/mod.rs",
+        "line": 755
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "token_count",
+      "protocol": "http",
+      "category": "token_usage",
+      "description": "Extracts token usage from AI inference responses and writes unified counts to [`filter_metadata`].",
+      "config_schema": "ai.filter.http.token_usage.token_count",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: token_count\nprovider: openai   # openai | anthropic | google | bedrock | bedrock_invoke_model | azure\nmax_body_bytes: 1048576    # optional, JSON capture limit\nmax_scratch_bytes: 65536   # optional, SSE per-event capture limit"
+        }
+      ],
+      "source": {
+        "path": "filters/src/token_usage/count.rs",
+        "line": 257
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "name": "token_usage_headers",
+      "protocol": "http",
+      "category": "token_usage",
+      "description": "Injects `Praxis-Token-Input`, `Praxis-Token-Output`, and `Praxis-Token-Total` headers into downstream responses when token usage data is present in [`filter_metadata`]. Also injects `Praxis-Token-Status` when usage capture failed (e.g. overflow), so an unavailable count is never silently indistinguishable from a genuine zero.",
+      "config_schema": "ai.filter.http.token_usage.token_usage_headers",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: token_usage_headers"
+        }
+      ],
+      "source": {
+        "path": "filters/src/token_usage/headers.rs",
+        "line": 80
+      },
+      "producer": {
+        "component": "ai",
+        "package": "praxis-ai",
+        "version": "0.3.0"
+      }
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "a2a.on_invalid",
+      "message": "default function `OnInvalidBehavior::default_reject` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "a2a.max_response_body_bytes",
+      "message": "default function `default_max_response_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "a2a.route_cluster_header",
+      "message": "default function `default_route_cluster_header` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "anthropic_messages_format.on_invalid",
+      "message": "default function `OnInvalidBehavior::default_continue` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "anthropic_messages_to_chat_completions_stream.max_partial_event_bytes",
+      "message": "default function `default_max_partial_event_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "anthropic_messages_to_chat_completions_stream.max_tool_blocks",
+      "message": "default function `default_max_tool_blocks` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "credential_inject.strategy",
+      "message": "default function `default_strategy` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "external_metering.feature_key",
+      "message": "default function `default_feature_key` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "external_metering.source",
+      "message": "default function `default_source` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "external_metering.identity_header_prefix",
+      "message": "default function `default_identity_header_prefix` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "external_metering.identity_metadata_namespace",
+      "message": "default function `default_identity_metadata_namespace` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "mcp.on_invalid",
+      "message": "default function `OnInvalidBehavior::default_reject` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "model_to_header.header",
+      "message": "default function `default_header` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_chat_completions_to_azureai_chat_completions.api_version",
+      "message": "default function `default_api_version` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_doc_extract.max_rewritten_body_bytes",
+      "message": "default function `default_max_rewritten_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_doc_extract.max_content_bytes",
+      "message": "default function `default_max_content_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_doc_extract.max_file_references",
+      "message": "default function `default_max_file_references` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_doc_extract.max_total_text_bytes",
+      "message": "default function `default_max_total_text_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_file_resolve.max_rewritten_body_bytes",
+      "message": "default function `default_max_rewritten_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_file_resolve.max_resolved_bytes",
+      "message": "default function `default_max_resolved_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_file_resolve.max_file_references",
+      "message": "default function `default_max_file_references` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_dispatch.max_calls_per_round",
+      "message": "default function `default_max_calls_per_round` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_dispatch.max_parallel_calls",
+      "message": "default function `default_max_parallel_calls` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_dispatch.max_result_bytes",
+      "message": "default function `default_max_result_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_dispatch.max_total_result_bytes",
+      "message": "default function `default_max_total_result_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_tool_resolve.max_rewritten_body_bytes",
+      "message": "default function `default_max_rewritten_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_tool_resolve.max_servers",
+      "message": "default function `default_max_servers` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_mcp_tool_resolve.max_tools",
+      "message": "default function `default_max_tools` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_responses_format.on_invalid",
+      "message": "default function `OnInvalidBehavior::default_continue` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_responses_proxy.max_rewritten_body_bytes",
+      "message": "default function `default_max_rewritten_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "openai_web_search.max_calls_per_round",
+      "message": "default function `default_max_calls_per_round` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "token_count.max_scratch_bytes",
+      "message": "default function `default_max_scratch_bytes` could not be evaluated safely"
+    }
+  ]
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,6 +10,19 @@ repository.workspace = true
 readme = "../README.md"
 publish = false
 
+[features]
+default = []
+catalog-http-callout = ["praxis-ai-filters/http-callout-filter"]
+catalog-azure-ad = ["praxis-ai-filters/azure-ad-filter"]
+catalog-gcp-adc = ["praxis-ai-filters/gcp-adc-filter"]
+catalog-token-rate-limit = ["praxis-ai-filters/token-rate-limit-filter"]
+catalog-all = [
+    "catalog-http-callout",
+    "catalog-azure-ad",
+    "catalog-gcp-adc",
+    "catalog-token-rate-limit",
+]
+
 [lints]
 workspace = true
 
@@ -19,7 +32,10 @@ quote = { workspace = true }
 syn = { workspace = true }
 praxis-ai = { path = "../server", package = "praxis-ai-proxy" }
 praxis-ai-apis = { workspace = true }
+praxis-ai-filters = { workspace = true }
 praxis-core = { workspace = true }
+praxis-filter = { workspace = true }
+praxis-config-catalog = { workspace = true, features = ["generator"] }
 praxis-test-utils = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
@@ -27,6 +43,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
+toml = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/xtask/src/config_catalog.rs
+++ b/xtask/src/config_catalog.rs
@@ -1,0 +1,990 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Generate and lint the machine-readable Praxis AI catalog fragment.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use praxis_config_catalog::SchemaId;
+
+use super::filter_docs::*;
+
+/// Generator-owned unions for factories that intentionally dispatch between
+/// multiple serde shapes under one registered filter name. MCP's public
+/// `mcp` factory selects broker mode when `servers` is present; this is a
+/// source-level dispatch, not two registry entries. The emitted schema is a
+/// typed `one_of`, preserving both configuration contracts without changing
+/// runtime registration.
+const MCP_FACTORY_UNIONS: &[(&str, &str, &str)] = &[("mcp", "McpConfig", "McpBrokerConfig")];
+
+/// Arguments for catalog generation.
+#[derive(Parser)]
+pub(crate) struct GenerateArgs {}
+
+/// Arguments for catalog linting.
+#[derive(Parser)]
+pub(crate) struct LintArgs {}
+
+pub(crate) fn generate(_args: GenerateArgs) {
+    let root = workspace_root();
+    let path = root.join("docs/catalog/config-catalog.json");
+    let bytes = render_catalog_impl(&root);
+    fs::create_dir_all(path.parent().expect("catalog parent")).expect("create catalog directory");
+    fs::write(&path, bytes).unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+    println!("wrote {}", path.display());
+}
+
+pub(crate) fn lint(_args: LintArgs) {
+    let root = workspace_root();
+    let path = root.join("docs/catalog/config-catalog.json");
+    let expected = render_catalog_impl(&root);
+    match fs::read(&path) {
+        Ok(actual) if actual == expected => println!("configuration catalog is up to date"),
+        _ => {
+            eprintln!("configuration catalog is stale or missing: {}", path.display());
+            std::process::exit(1);
+        },
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask has workspace parent")
+        .to_path_buf()
+}
+
+// -----------------------------------------------------------------------------
+// Machine-readable catalog
+// -----------------------------------------------------------------------------
+
+/// Render the AI-owned catalog fragment from the same parsed source metadata
+/// used by the filter documentation generator. Keeping this seam here makes
+/// the human and machine-readable descriptions fail together when a config
+/// shape changes.
+pub(crate) fn render_catalog_impl(root: &Path) -> Vec<u8> {
+    use praxis_config_catalog::{
+        CatalogCompatibility, CatalogFormatVersion, CatalogFragment, ConfigExample, ConfigSchema, FilterDescriptor,
+        ProducerComponent, ProducerInfo, Protocol, SchemaNode, VersionRequirement,
+    };
+
+    let shared = parse_shared_config_items(root);
+    validate_factory_variants(root, MCP_FACTORY_UNIONS).unwrap_or_else(|error| panic!("{error}"));
+    let entries = discover_all_filters(root, &shared);
+    let registry = praxis_ai_filters::build_ai_registry();
+    validate_yaml_examples(&entries).unwrap_or_else(|error| panic!("{error}"));
+    let mut feature_profile = ai_feature_profile(root).expect("valid filters Cargo.toml");
+    feature_profile.available.extend(
+        ["apis", "experimental", "opentelemetry", "praxis-main"]
+            .into_iter()
+            .map(str::to_owned),
+    );
+    for entry in &entries {
+        feature_profile
+            .available
+            .extend(required_features_for(root, &entry.filter));
+    }
+    feature_profile.default_enabled.insert("apis".to_owned());
+    validate_registry_parity(root, &entries, &registry, &active_catalog_features());
+    let mut fragment = CatalogFragment {
+        format_version: CatalogFormatVersion { major: 1, minor: 0 },
+        producer: ProducerInfo {
+            component: ProducerComponent::Ai,
+            package: "praxis-ai".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            source_revision: std::env::var("PRAXIS_SOURCE_REVISION")
+                .ok()
+                .filter(|revision| !revision.trim().is_empty()),
+        },
+        compatibility: CatalogCompatibility {
+            requires_format_major: 1,
+            requires_core: Some(VersionRequirement::from("^0.5.4")),
+        },
+        feature_profile,
+        schemas: BTreeMap::new(),
+        roots: Vec::new(),
+        filters: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+
+    for entry in entries {
+        let schema_id = SchemaId::from(format!("ai.filter.http.{}.{}", entry.category, entry.filter.name));
+        let node = if entry.filter.name == "mcp" && entry.filter.variants.len() > 1 {
+            let mut variants = Vec::new();
+            for variant in &entry.filter.variants {
+                let fields = CatalogSchemaBuilder::new(
+                    &mut fragment.schemas,
+                    &mut fragment.diagnostics,
+                    &variant.source_items,
+                    root,
+                    &entry.filter.name,
+                    Some(&variant.config_type_name),
+                    entry.filter.name == "mcp",
+                )
+                .fields(&variant.raw_fields)
+                .unwrap_or_else(|error| panic!("cannot represent AI filter {}: {error}", entry.filter.name));
+                variants.push(SchemaNode::object(fields));
+            }
+            SchemaNode::one_of(variants)
+        } else {
+            let fields = CatalogSchemaBuilder::new(
+                &mut fragment.schemas,
+                &mut fragment.diagnostics,
+                &entry.filter.source_items,
+                root,
+                &entry.filter.name,
+                entry.filter.config_type_name.as_deref(),
+                false,
+            )
+            .fields(&entry.filter.raw_fields)
+            .unwrap_or_else(|error| panic!("cannot represent AI filter {}: {error}", entry.filter.name));
+            SchemaNode::object(fields)
+        };
+        fragment.schemas.insert(
+            schema_id.clone(),
+            ConfigSchema {
+                id: schema_id.clone(),
+                title: entry.filter.name.clone(),
+                description: entry.filter.description.clone(),
+                shared: false,
+                node: SchemaNode {
+                    kind: node.kind,
+                    title: None,
+                    description: String::new(),
+                    default: None,
+                    examples: Vec::new(),
+                    rules: Vec::new(),
+                    sensitive: false,
+                },
+                producer: Some(fragment.producer.clone()),
+            },
+        );
+        let name = entry.filter.name.clone();
+        let required_features = required_features_for(root, &entry.filter);
+        let capabilities = filter_capabilities(&entry.filter, registry.is_security_filter(&name));
+        let source = source_location(root, &entry.filter);
+        fragment.filters.push(FilterDescriptor {
+            name: name.clone(),
+            protocol: Protocol::Http,
+            category: entry.category,
+            description: entry.filter.description,
+            config_schema: schema_id,
+            required_features,
+            capabilities,
+            examples: entry
+                .filter
+                .yaml_examples
+                .into_iter()
+                .map(|yaml| ConfigExample { yaml })
+                .collect(),
+            source,
+            producer: Some(fragment.producer.clone()),
+        });
+    }
+    praxis_config_catalog::generator::render(fragment)
+        .unwrap_or_else(|error| panic!("invalid generated AI catalog: {error}"))
+}
+
+/// A recursive converter from serde-facing Rust types to catalog schemas.
+struct CatalogSchemaBuilder<'a> {
+    schemas: &'a mut BTreeMap<SchemaId, praxis_config_catalog::ConfigSchema>,
+    diagnostics: &'a mut Vec<praxis_config_catalog::CatalogDiagnostic>,
+    source: &'a ModuleItems,
+    root: &'a Path,
+    owner: String,
+    config_type_name: Option<String>,
+    allow_json_value: bool,
+    visiting: HashSet<String>,
+}
+
+impl<'a> CatalogSchemaBuilder<'a> {
+    fn new(
+        schemas: &'a mut BTreeMap<SchemaId, praxis_config_catalog::ConfigSchema>,
+        diagnostics: &'a mut Vec<praxis_config_catalog::CatalogDiagnostic>,
+        source: &'a ModuleItems,
+        root: &'a Path,
+        owner: &str,
+        config_type_name: Option<&str>,
+        allow_json_value: bool,
+    ) -> Self {
+        Self {
+            schemas,
+            diagnostics,
+            source,
+            root,
+            owner: owner.to_owned(),
+            config_type_name: config_type_name.map(str::to_owned),
+            allow_json_value,
+            visiting: HashSet::new(),
+        }
+    }
+
+    fn fields(&mut self, fields: &[RawField]) -> Result<Vec<praxis_config_catalog::ObjectField>, String> {
+        if let Some(config) = self
+            .config_type_name
+            .as_deref()
+            .and_then(|name| self.source.configs.iter().find(|config| config.name == name))
+            && let Some(try_from) = config.try_from.as_deref()
+        {
+            return Err(format!(
+                "catalog_error=unsupported_try_from target={} type={try_from}",
+                self.owner
+            ));
+        }
+        fields
+            .iter()
+            .map(|field| {
+                Ok(praxis_config_catalog::ObjectField {
+                    serialized_name: field.name.clone(),
+                    aliases: field.aliases.clone(),
+                    schema: self.field_node(field)?,
+                    required: matches!(field.requirement_hint, RequirementHint::Normal)
+                        && !field.has_default
+                        && !is_option_type(&field.ty),
+                    flattened: field.flatten,
+                })
+            })
+            .collect()
+    }
+
+    fn field_node(&mut self, field: &RawField) -> Result<praxis_config_catalog::SchemaNode, String> {
+        let mut node = if let Some(kind) = custom_deserializer_kind(field)? {
+            praxis_config_catalog::SchemaNode::simple(kind)
+        } else {
+            self.type_node(&field.ty)?
+        };
+        node.description = field.doc.clone();
+        let ty = &field.ty;
+        node.sensitive = quote::quote!(#ty).to_string().to_ascii_lowercase().contains("secret");
+        if let Some(default_path) = field.default_path.as_deref() {
+            match evaluate_default(self.root, default_path) {
+                Some(value) => node.default = Some(value),
+                None => self.diagnostics.push(praxis_config_catalog::CatalogDiagnostic {
+                    severity: praxis_config_catalog::DiagnosticSeverity::Warning,
+                    code: "unevaluable_default".to_owned(),
+                    target: format!("{}.{}", self.owner, field.name),
+                    message: format!("default function `{default_path}` could not be evaluated safely"),
+                }),
+            }
+        }
+        Ok(node)
+    }
+
+    fn type_node(&mut self, ty: &syn::Type) -> Result<praxis_config_catalog::SchemaNode, String> {
+        use praxis_config_catalog::{SchemaKind, SchemaNode};
+        match ty {
+            syn::Type::Reference(reference) => self.type_node(&reference.elem),
+            syn::Type::Array(array) => Ok(SchemaNode::array(self.type_node(&array.elem)?)),
+            syn::Type::Slice(slice) => Ok(SchemaNode::array(self.type_node(&slice.elem)?)),
+            syn::Type::Tuple(tuple) if tuple.elems.is_empty() => Ok(SchemaNode::simple(SchemaKind::Null)),
+            syn::Type::Tuple(_) => Err(format!("unsupported tuple type `{}`", quote::quote!(#ty))),
+            syn::Type::Path(path) => self.path_node(path),
+            _ => Err(format!("unsupported Rust type `{}`", quote::quote!(#ty))),
+        }
+    }
+
+    fn path_node(&mut self, path: &syn::TypePath) -> Result<praxis_config_catalog::SchemaNode, String> {
+        use praxis_config_catalog::{SchemaKind, SchemaNode};
+        let segment = path.path.segments.last().ok_or_else(|| "empty type path".to_owned())?;
+        let name = segment.ident.to_string();
+        let args = type_args(&segment.arguments);
+        match name.as_str() {
+            "Option" | "Box" | "Arc" | "Rc" | "Cow" | "Zeroizing" => args
+                .last()
+                .ok_or_else(|| format!("missing inner type for `{name}`"))
+                .and_then(|ty| self.type_node(ty)),
+            "Vec" | "VecDeque" | "SmallVec" => args
+                .last()
+                .ok_or_else(|| format!("missing item type for `{name}`"))
+                .and_then(|ty| self.type_node(ty))
+                .map(SchemaNode::array),
+            "BTreeMap" | "HashMap" | "IndexMap" => {
+                let key = args.first().ok_or_else(|| format!("missing map key for `{name}`"))?;
+                let key_name = quote::quote!(#key).to_string();
+                if key_name != "String" && key_name != "str" {
+                    return Err(format!("non-string map key `{key_name}`"));
+                }
+                args.get(1)
+                    .ok_or_else(|| format!("missing map value for `{name}`"))
+                    .and_then(|ty| self.type_node(ty))
+                    .map(SchemaNode::map)
+            },
+            "bool" => Ok(SchemaNode::simple(SchemaKind::Boolean)),
+            "f32" | "f64" => Ok(SchemaNode::simple(SchemaKind::Number)),
+            "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+                Ok(SchemaNode::simple(SchemaKind::Integer))
+            },
+            "String" | "PathBuf" | "Url" | "Uri" | "HeaderName" | "HeaderValue" | "IpAddr" | "Ipv4Addr"
+            | "Ipv6Addr" | "SocketAddr" | "SocketAddrV4" | "SocketAddrV6" | "Duration" | "Regex" | "SecretString" => {
+                Ok(SchemaNode::simple(SchemaKind::String))
+            },
+            // This Core enum is re-exported through `praxis_filter` and its
+            // source module is not part of the filter-local AST scope.
+            "OnInvalidBehavior" => Ok(SchemaNode::enum_strings(vec![
+                "continue".to_owned(),
+                "reject".to_owned(),
+                "error".to_owned(),
+            ])),
+            "Value" if self.allow_json_value => {
+                self.ensure_json_value_schema();
+                Ok(SchemaNode::reference("ai.type.json_value".to_owned()))
+            },
+            "Value" | "Condition" | "ResponseCondition" => Err(format!(
+                "opaque serde value `{name}` has no portable catalog representation"
+            )),
+            _ if self.source.structs.contains_key(&name) => self.struct_node(&name),
+            _ if self.source.enums.contains_key(&name) => self.enum_node(&name),
+            _ => Err(format!("unresolved configuration type `{name}`")),
+        }
+    }
+
+    fn ensure_json_value_schema(&mut self) {
+        use praxis_config_catalog::{SchemaKind, SchemaNode};
+        let id = SchemaId::from("ai.type.json_value");
+        if self.schemas.contains_key(&id) {
+            return;
+        }
+        let reference = || SchemaNode::reference(id.0.clone());
+        let node = SchemaNode::one_of(vec![
+            SchemaNode::simple(SchemaKind::Null),
+            SchemaNode::simple(SchemaKind::Boolean),
+            SchemaNode::simple(SchemaKind::Number),
+            SchemaNode::simple(SchemaKind::String),
+            SchemaNode::array(reference()),
+            SchemaNode::map(reference()),
+        ]);
+        self.schemas.insert(
+            id.clone(),
+            praxis_config_catalog::ConfigSchema {
+                id,
+                title: "JSON value".to_owned(),
+                description: "Any JSON value accepted by the MCP tool schema fields.".to_owned(),
+                shared: false,
+                node,
+                producer: None,
+            },
+        );
+    }
+
+    fn struct_node(&mut self, name: &str) -> Result<praxis_config_catalog::SchemaNode, String> {
+        if let Some(config) = self.source.structs.get(name)
+            && let Some(try_from) = config.try_from.as_deref()
+        {
+            return Err(format!(
+                "catalog_error=unsupported_try_from target={name} type={try_from}"
+            ));
+        }
+        if name == "ProviderConfig" && self.source.structs.contains_key("NemoConfig") {
+            let mut fields = self
+                .source
+                .structs
+                .get("NemoConfig")
+                .ok_or_else(|| "missing NemoConfig".to_owned())?
+                .fields
+                .clone();
+            fields.insert(
+                0,
+                RawField {
+                    name: "type".to_owned(),
+                    aliases: Vec::new(),
+                    ty: syn::parse_str("String").expect("literal type parses"),
+                    doc: "Provider discriminator.".to_owned(),
+                    has_default: false,
+                    default_path: None,
+                    deserialize_with: None,
+                    flatten: false,
+                    requirement_hint: RequirementHint::Normal,
+                },
+            );
+            let mut node = praxis_config_catalog::SchemaNode::object(self.fields(&fields)?);
+            if let praxis_config_catalog::SchemaKind::Object { fields, .. } = &mut node.kind
+                && let Some(discriminator) = fields.first_mut()
+            {
+                discriminator.schema =
+                    praxis_config_catalog::SchemaNode::literal(serde_json::Value::String("nemo".to_owned()));
+            }
+            return Ok(node);
+        }
+        let id = SchemaId::from(format!("ai.type.{name}"));
+        if self.visiting.contains(name) {
+            return Ok(praxis_config_catalog::SchemaNode::reference(id.0.clone()));
+        }
+        if !self.schemas.contains_key(&id) {
+            let fields = self
+                .source
+                .structs
+                .get(name)
+                .ok_or_else(|| format!("missing struct `{name}`"))?
+                .fields
+                .clone();
+            self.visiting.insert(name.to_owned());
+            let object = praxis_config_catalog::SchemaNode::object(self.fields(&fields)?);
+            self.visiting.remove(name);
+            self.schemas.insert(
+                id.clone(),
+                praxis_config_catalog::ConfigSchema {
+                    id: id.clone(),
+                    title: name.to_owned(),
+                    description: String::new(),
+                    shared: false,
+                    node: object,
+                    producer: None,
+                },
+            );
+        }
+        Ok(praxis_config_catalog::SchemaNode::reference(id.0.clone()))
+    }
+
+    fn enum_node(&mut self, name: &str) -> Result<praxis_config_catalog::SchemaNode, String> {
+        let info = self
+            .source
+            .enums
+            .get(name)
+            .ok_or_else(|| format!("missing enum `{name}`"))?;
+        if !info.untagged
+            && info.tag.is_none()
+            && info
+                .variant_shapes
+                .iter()
+                .all(|shape| matches!(shape, EnumVariantShape::Unit))
+        {
+            return Ok(praxis_config_catalog::SchemaNode::enum_strings(info.variants.clone()));
+        }
+        let variants = info
+            .variant_shapes
+            .iter()
+            .zip(info.variants.iter())
+            .enumerate()
+            .map(|(index, (shape, label))| match shape {
+                EnumVariantShape::Unit if info.tag.is_none() => Ok(praxis_config_catalog::SchemaNode::literal(
+                    serde_json::Value::String(label.clone()),
+                )),
+                EnumVariantShape::Unit => self.tagged_variant_node(info, index, label, Vec::new()),
+                EnumVariantShape::Unnamed(ty) if info.content.is_some() => {
+                    let field = praxis_config_catalog::ObjectField {
+                        serialized_name: info.content.clone().unwrap_or_default(),
+                        aliases: Vec::new(),
+                        schema: self.type_node(ty)?,
+                        required: true,
+                        flattened: false,
+                    };
+                    self.tagged_variant_node(info, index, label, vec![field])
+                },
+                EnumVariantShape::Unnamed(ty) => self.type_node(ty),
+                EnumVariantShape::Named => {
+                    let fields = info.variant_fields.get(index).cloned().unwrap_or_default();
+                    let fields = self.fields(&fields)?;
+                    self.tagged_variant_node(info, index, label, fields)
+                },
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(praxis_config_catalog::SchemaNode {
+            kind: praxis_config_catalog::SchemaKind::OneOf {
+                variants,
+                discriminator: info.tag.clone(),
+            },
+            title: None,
+            description: String::new(),
+            default: None,
+            examples: Vec::new(),
+            rules: Vec::new(),
+            sensitive: false,
+        })
+    }
+
+    fn tagged_variant_node(
+        &mut self,
+        info: &EnumInfo,
+        _index: usize,
+        label: &str,
+        mut fields: Vec<praxis_config_catalog::ObjectField>,
+    ) -> Result<praxis_config_catalog::SchemaNode, String> {
+        let Some(tag) = info.tag.as_ref() else {
+            return Ok(praxis_config_catalog::SchemaNode::literal(serde_json::Value::String(
+                label.to_owned(),
+            )));
+        };
+        fields.insert(
+            0,
+            praxis_config_catalog::ObjectField {
+                serialized_name: tag.clone(),
+                aliases: Vec::new(),
+                schema: praxis_config_catalog::SchemaNode::literal(serde_json::Value::String(label.to_owned())),
+                required: true,
+                flattened: false,
+            },
+        );
+        let mut node = praxis_config_catalog::SchemaNode::object(fields);
+        if info.content.is_some() {
+            node.description = "Adjacent serde-tagged variant.".to_owned();
+        }
+        Ok(node)
+    }
+}
+
+/// Convert the small set of AI custom deserializers whose wire shape is known.
+/// Unknown custom deserializers fail generation rather than being represented
+/// by the Rust field type, which may not describe the YAML contract.
+fn custom_deserializer_kind(field: &RawField) -> Result<Option<praxis_config_catalog::SchemaKind>, String> {
+    let Some(path) = field.deserialize_with.as_deref() else {
+        return Ok(None);
+    };
+    let name = path.rsplit("::").next().unwrap_or(path);
+    match name {
+        // Duration is parsed from a human-readable string at the YAML boundary.
+        "deserialize_duration" => Ok(Some(praxis_config_catalog::SchemaKind::String)),
+        // These preserve the underlying serde shape already represented by the
+        // field type; the custom function only broadens accepted input forms.
+        "nullable_vec" | "deserialize_metadata_object" => Ok(None),
+        _ => Err(format!(
+            "catalog_error=unsupported_deserializer field={} deserializer={path}",
+            field.name
+        )),
+    }
+}
+
+/// Parse examples during generation so malformed documentation cannot enter
+/// the machine-readable catalog as if it were usable configuration.
+fn validate_yaml_examples(entries: &[FilterEntry]) -> Result<(), String> {
+    for entry in entries {
+        for (index, example) in entry.filter.yaml_examples.iter().enumerate() {
+            serde_yaml::from_str::<serde_yaml::Value>(example).map_err(|error| {
+                format!(
+                    "catalog_error=invalid_example filter={} index={} error={error}",
+                    entry.filter.name, index
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Safely evaluate only literal defaults. Runtime-dependent defaults produce a
+/// warning diagnostic and remain without a literal value.
+fn evaluate_default(root: &Path, function: &str) -> Option<serde_json::Value> {
+    for directory in [root.join("apis/src"), root.join("filters/src")] {
+        for path in collect_rs_files(&directory) {
+            let Ok(source) = fs::read_to_string(path) else { continue };
+            let marker = format!("fn {function}");
+            let Some(start) = source.find(&marker) else { continue };
+            let tail = &source[start..];
+            let body = &tail[..tail.find('}').unwrap_or(tail.len())];
+            if body.contains("true") {
+                return Some(serde_json::Value::Bool(true));
+            }
+            if body.contains("false") {
+                return Some(serde_json::Value::Bool(false));
+            }
+            if let Some(value) = body.split('"').nth(1) {
+                return Some(serde_json::Value::String(value.to_owned()));
+            }
+            if let Some(number) = body
+                .split(|character: char| !character.is_ascii_digit() && character != '-')
+                .find(|value| !value.is_empty() && *value != "-")
+                && let Ok(value) = number.parse::<i64>()
+            {
+                return Some(serde_json::Value::from(value));
+            }
+        }
+    }
+    None
+}
+
+fn ai_feature_profile(root: &Path) -> Result<praxis_config_catalog::FeatureProfile, String> {
+    let path = root.join("filters/Cargo.toml");
+    let Ok(source) = fs::read_to_string(&path) else {
+        return Err(format!("missing {}", path.display()));
+    };
+    feature_profile_from_manifest(&source)
+}
+
+fn feature_profile_from_manifest(source: &str) -> Result<praxis_config_catalog::FeatureProfile, String> {
+    let mut profile = praxis_config_catalog::FeatureProfile::default();
+    let Ok(document) = toml::from_str::<toml::Table>(source) else {
+        return Err("invalid TOML feature manifest".to_owned());
+    };
+    let Some(features) = document.get("features").and_then(toml::Value::as_table) else {
+        return Err("missing [features] table".to_owned());
+    };
+    if let Some(values) = features.get("default").and_then(toml::Value::as_array) {
+        profile
+            .default_enabled
+            .extend(values.iter().filter_map(toml::Value::as_str).map(str::to_owned));
+    }
+    for (name, _value) in features {
+        if name != "default" {
+            profile.available.insert(name.clone());
+        }
+    }
+    Ok(profile)
+}
+
+fn required_features_for(root: &Path, filter: &FilterInfo) -> BTreeSet<String> {
+    let registrations = fs::read_to_string(root.join("filters/src/register.rs")).unwrap_or_default();
+    required_features_for_source(&registrations, &filter.name)
+}
+
+fn required_features_for_source(registrations: &str, filter_name: &str) -> BTreeSet<String> {
+    let mut features = BTreeSet::new();
+    let registration_lines: Vec<&str> = registrations.lines().collect();
+    let mut function_feature = None;
+    let mut depth = 0usize;
+    for line in registration_lines {
+        let trimmed = line.trim();
+        if let Some(feature) = trimmed
+            .strip_prefix("#[cfg(feature = \"")
+            .and_then(|line| line.strip_suffix("\")]"))
+        {
+            function_feature = Some(feature.to_owned());
+        }
+        if trimmed.starts_with("fn ") {
+            depth = 0;
+        }
+        if trimmed.contains(&format!("\"{filter_name}\""))
+            && let Some(feature) = &function_feature
+        {
+            features.insert(feature.clone());
+        }
+        depth = depth.saturating_add(line.matches('{').count());
+        depth = depth.saturating_sub(line.matches('}').count());
+        if function_feature.is_some() && (trimmed == ")" || trimmed == ");") {
+            function_feature = None;
+        }
+        if depth == 0 && trimmed.contains('}') {
+            function_feature = None;
+        }
+    }
+    features
+}
+
+fn source_location(root: &Path, filter: &FilterInfo) -> Option<praxis_config_catalog::SourceLocation> {
+    let path = filter.source_path.as_ref()?;
+    let source = fs::read_to_string(path).ok()?;
+    let line = source.lines().position(|line| line.contains("HttpFilter for"));
+    Some(praxis_config_catalog::SourceLocation {
+        path: relative_path(root, path).to_string_lossy().replace('\\', "/"),
+        line: line.map(|line| line as u32 + 1),
+    })
+}
+
+fn filter_capabilities(filter: &FilterInfo, is_security: bool) -> praxis_config_catalog::FilterCapabilities {
+    let source = filter
+        .source_path
+        .as_ref()
+        .and_then(|path| fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    capabilities_from_source(&source, is_security)
+}
+
+fn capabilities_from_source(source: &str, is_security: bool) -> praxis_config_catalog::FilterCapabilities {
+    praxis_config_catalog::FilterCapabilities {
+        security_class: if is_security {
+            praxis_config_catalog::SecurityClass::Security
+        } else {
+            praxis_config_catalog::SecurityClass::Standard
+        },
+        request_headers: source.contains("fn on_request("),
+        request_body: source.contains("fn on_request_body("),
+        response_headers: source.contains("fn on_response("),
+        response_body: source.contains("fn on_response_body("),
+        terminal: source.contains("TerminalResponse") || source.contains("StreamingTerminalResponse"),
+    }
+}
+
+fn active_catalog_features() -> BTreeSet<String> {
+    let feature_names = [
+        "apis",
+        #[cfg(feature = "catalog-http-callout")]
+        "http-callout-filter",
+        #[cfg(feature = "catalog-azure-ad")]
+        "azure-ad-filter",
+        #[cfg(feature = "catalog-gcp-adc")]
+        "gcp-adc-filter",
+        #[cfg(feature = "catalog-token-rate-limit")]
+        "token-rate-limit-filter",
+    ];
+    feature_names.into_iter().map(str::to_owned).collect()
+}
+
+fn validate_registry_parity(
+    root: &Path,
+    entries: &[FilterEntry],
+    registry: &praxis_filter::FilterRegistry,
+    active_features: &BTreeSet<String>,
+) {
+    let discovered: BTreeSet<String> = entries
+        .iter()
+        .filter(|entry| required_features_for(root, &entry.filter).is_subset(active_features))
+        .map(|entry| entry.filter.name.clone())
+        .collect();
+    let core: BTreeSet<String> = praxis_filter::FilterRegistry::with_builtins()
+        .available_filters()
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    let registered: BTreeSet<String> = registry
+        .available_filters()
+        .into_iter()
+        .filter(|name| !core.contains(*name))
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(
+        registered, discovered,
+        "default AI registry and catalog discovery differ"
+    );
+    for entry in entries {
+        for feature in required_features_for(root, &entry.filter) {
+            assert!(
+                active_features.contains(&feature)
+                    || ai_feature_profile(root).is_ok_and(|profile| profile.available.contains(&feature)),
+                "unknown required feature {feature}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use praxis_config_catalog::{
+        CatalogCompatibility, CatalogFormatVersion, CatalogFragment, ProducerComponent, ProducerInfo, SchemaId,
+    };
+
+    use super::*;
+
+    #[test]
+    fn capabilities_follow_http_filter_callbacks() {
+        let capabilities = capabilities_from_source(
+            "impl HttpFilter for Example { fn on_request(&self) {} fn on_response_body(&self) {} FilterAction::TerminalResponse }",
+            false,
+        );
+        assert!(capabilities.request_headers);
+        assert!(capabilities.response_body);
+        assert!(!capabilities.request_body);
+        assert!(!capabilities.response_headers);
+        assert!(capabilities.terminal);
+    }
+
+    #[test]
+    fn custom_deserializers_are_explicitly_allowlisted() {
+        let field = RawField {
+            name: "timeout".to_owned(),
+            aliases: Vec::new(),
+            ty: syn::parse_str("Duration").unwrap(),
+            doc: String::new(),
+            has_default: false,
+            default_path: None,
+            deserialize_with: Some("deserialize_duration".to_owned()),
+            flatten: false,
+            requirement_hint: RequirementHint::Normal,
+        };
+        assert!(matches!(
+            custom_deserializer_kind(&field),
+            Ok(Some(praxis_config_catalog::SchemaKind::String))
+        ));
+        let mut unsupported = field;
+        unsupported.deserialize_with = Some("custom::unknown".to_owned());
+        let error = custom_deserializer_kind(&unsupported).err().unwrap_or_default();
+        assert!(error.contains("catalog_error=unsupported_deserializer"));
+    }
+
+    #[test]
+    fn literal_defaults_are_evaluated_without_running_code() {
+        let root = workspace_root();
+        assert_eq!(
+            evaluate_default(&root, "default_true"),
+            Some(serde_json::Value::Bool(true))
+        );
+        assert_eq!(evaluate_default(&root, "does_not_exist"), None);
+    }
+
+    fn fragment(component: ProducerComponent, package: &str, version: &str) -> CatalogFragment {
+        CatalogFragment {
+            format_version: CatalogFormatVersion { major: 1, minor: 0 },
+            producer: ProducerInfo {
+                component,
+                package: package.to_owned(),
+                version: version.to_owned(),
+                source_revision: None,
+            },
+            compatibility: CatalogCompatibility {
+                requires_format_major: 1,
+                requires_core: None,
+            },
+            feature_profile: Default::default(),
+            schemas: BTreeMap::new(),
+            roots: Vec::new(),
+            filters: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn registration_features_associate_with_adjacent_functions() {
+        let source = r#"
+            #[cfg(feature = "gated-a")]
+            fn register_a() { register!("a"); }
+            fn register_b() { register!("b"); }
+            #[cfg(feature = "gated-c")]
+            fn register_c() { register!("c"); }
+        "#;
+        assert_eq!(
+            required_features_for_source(source, "a"),
+            ["gated-a".to_owned()].into_iter().collect()
+        );
+        assert!(required_features_for_source(source, "b").is_empty());
+        assert_eq!(
+            required_features_for_source(source, "c"),
+            ["gated-c".to_owned()].into_iter().collect()
+        );
+    }
+
+    #[test]
+    fn non_string_map_keys_fail_closed() {
+        let ty: syn::Type = syn::parse_str("BTreeMap<u32, String>").unwrap();
+        let mut schemas = BTreeMap::new();
+        let mut diagnostics = Vec::new();
+        let source = ModuleItems::new();
+        let mut builder = CatalogSchemaBuilder::new(
+            &mut schemas,
+            &mut diagnostics,
+            &source,
+            Path::new("."),
+            "test",
+            None,
+            false,
+        );
+        assert!(builder.type_node(&ty).is_err());
+    }
+
+    #[test]
+    fn generated_ai_artifact_has_nemo_schema_and_provenance() {
+        let root = workspace_root();
+        let tracked = fs::read(root.join("docs/catalog/config-catalog.json")).expect("tracked catalog");
+        let rendered = render_catalog_impl(&root);
+        if active_catalog_features().len() == 1 {
+            assert_eq!(tracked, rendered, "tracked catalog must equal deterministic render");
+        }
+        let fragment: CatalogFragment = serde_json::from_slice(&rendered).expect("catalog JSON");
+        fragment.validate().expect("catalog validates");
+        let schema = fragment
+            .schemas
+            .get(&SchemaId::from("ai.filter.http.guardrails.ai_guardrails"))
+            .expect("guardrails schema");
+        let praxis_config_catalog::SchemaKind::Object { fields, .. } = &schema.node.kind else {
+            panic!("guardrails object")
+        };
+        let names: BTreeSet<_> = fields.iter().map(|field| field.serialized_name.as_str()).collect();
+        assert_eq!(names, ["provider", "phase"].into_iter().collect());
+        let provider = &fields
+            .iter()
+            .find(|field| field.serialized_name == "provider")
+            .unwrap()
+            .schema;
+        let praxis_config_catalog::SchemaKind::Object { fields, .. } = &provider.kind else {
+            panic!("provider object")
+        };
+        let provider_names: BTreeSet<_> = fields.iter().map(|field| field.serialized_name.as_str()).collect();
+        assert_eq!(
+            provider_names,
+            ["type", "endpoint", "allow_private_endpoint", "model", "timeout_ms"]
+                .into_iter()
+                .collect()
+        );
+        let discriminator = &fields
+            .iter()
+            .find(|field| field.serialized_name == "type")
+            .unwrap()
+            .schema
+            .kind;
+        assert!(matches!(discriminator, praxis_config_catalog::SchemaKind::Literal { value } if value == "nemo"));
+        assert!(fragment.filters.iter().all(|filter| filter.producer.is_some()));
+        assert!(fragment.schemas.values().all(|schema| schema.producer.is_some()));
+        assert!(
+            fragment
+                .filters
+                .iter()
+                .all(|filter| filter.source.as_ref().is_some_and(|source| source.line.is_some()))
+        );
+    }
+
+    #[test]
+    fn mcp_factory_union_is_typed_and_provenanced() {
+        let root = workspace_root();
+        let bytes = render_catalog_impl(&root);
+        let fragment: CatalogFragment = serde_json::from_slice(&bytes).expect("catalog JSON");
+        let schema = fragment
+            .schemas
+            .get(&SchemaId::from("ai.filter.http.agentic.mcp"))
+            .expect("MCP schema");
+        let praxis_config_catalog::SchemaKind::OneOf { variants, .. } = &schema.node.kind else {
+            panic!("MCP must expose its two factory shapes as one_of")
+        };
+        assert_eq!(variants.len(), 2);
+        let names: BTreeSet<&str> = variants
+            .iter()
+            .filter_map(|variant| match &variant.kind {
+                praxis_config_catalog::SchemaKind::Object { fields, .. } => {
+                    fields.first().map(|field| field.serialized_name.as_str())
+                },
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains("header_validation"));
+        assert!(names.contains("cache_scope"));
+        assert_eq!(
+            schema.producer.as_ref().map(|p| &p.component),
+            Some(&ProducerComponent::Ai)
+        );
+        assert!(
+            fragment
+                .schemas
+                .get(&SchemaId::from("ai.type.json_value"))
+                .is_some_and(|schema| schema.producer.is_some())
+        );
+    }
+
+    #[test]
+    fn feature_profile_fixture_is_strict() {
+        let profile = feature_profile_from_manifest("[features]\ndefault=[\"apis\"]\napis=[]\nexperimental=[]\n")
+            .expect("valid TOML");
+        assert!(profile.available.contains("apis"));
+        assert!(profile.default_enabled.contains("apis"));
+        assert!(feature_profile_from_manifest("[features\n").is_err());
+    }
+
+    #[test]
+    fn core_artifact_and_ai_fragment_merge() {
+        let root = workspace_root();
+        let core_bytes = fs::read(root.join("../praxis/docs/catalog/config-catalog.json")).expect("Core catalog");
+        let core: CatalogFragment = serde_json::from_slice(&core_bytes).expect("Core JSON");
+        let ai: CatalogFragment = serde_json::from_slice(&render_catalog_impl(&root)).expect("AI JSON");
+        let merged = praxis_config_catalog::merge::merge(core, vec![ai]).expect("Core and AI merge");
+        assert!(!merged.fragment.filters.is_empty());
+        assert!(merged.producers.len() >= 2);
+        assert!(!merged.fragment.roots.is_empty(), "Core roots must survive AI merge");
+        assert!(merged.fragment.filters.windows(2).all(|pair| {
+            (&pair[0].protocol, &pair[0].category, &pair[0].name)
+                <= (&pair[1].protocol, &pair[1].category, &pair[1].name)
+        }));
+        assert!(merged.fragment.filters.iter().all(|filter| filter.producer.is_some()));
+        assert!(merged.fragment.schemas.values().all(|schema| schema.producer.is_some()));
+    }
+
+    #[test]
+    fn incompatible_core_requirement_has_stable_error() {
+        let mut ai = fragment(ProducerComponent::Ai, "praxis-ai", "0.3.0");
+        ai.compatibility.requires_core = Some("^9.0.0".into());
+        let error = praxis_config_catalog::merge::merge(
+            fragment(ProducerComponent::Core, "praxis-proxy-core", "0.5.4"),
+            vec![ai],
+        )
+        .expect_err("incompatible Core requirement must fail closed");
+        assert!(matches!(
+            error,
+            praxis_config_catalog::merge::MergeError::CoreRequirement(_)
+        ));
+    }
+}

--- a/xtask/src/filter_docs.rs
+++ b/xtask/src/filter_docs.rs
@@ -111,23 +111,23 @@ fn collect_stale_doc_paths(root: &Path, docs_dir: &Path, all_filters: &[FilterEn
 // -----------------------------------------------------------------------------
 
 /// A filter with its location metadata for output path construction.
-struct FilterEntry {
+pub(crate) struct FilterEntry {
     /// Crate kind: `"apis"` for provider-specific, `"filters"` for
     /// cross-cutting.
     crate_kind: String,
     /// Category slug (e.g. `anthropic`, `agentic`, `guardrails`).
-    category: String,
+    pub(crate) category: String,
     /// Extracted filter information.
-    filter: FilterInfo,
+    pub(crate) filter: FilterInfo,
 }
 
 /// Information extracted for one filter.
 #[derive(Clone)]
-struct FilterInfo {
+pub(crate) struct FilterInfo {
     /// Filter name as returned by `fn name()` (e.g. `"a2a"`).
-    name: String,
+    pub(crate) name: String,
     /// First paragraph of the filter struct doc comment.
-    description: String,
+    pub(crate) description: String,
     /// First paragraphs from same-name filter variants.
     extra_descriptions: Vec<String>,
     /// Additional notes extracted from config struct docs.
@@ -135,7 +135,27 @@ struct FilterInfo {
     /// Config fields in declaration order.
     fields: Vec<FieldInfo>,
     /// YAML configuration example from doc comments.
-    yaml_examples: Vec<String>,
+    pub(crate) yaml_examples: Vec<String>,
+    /// Raw configuration fields used by the machine-readable catalog.
+    pub(crate) raw_fields: Vec<RawField>,
+    /// Configuration type passed to the filter factory, when discovered.
+    pub(crate) config_type_name: Option<String>,
+    /// Individual factory variants retained for catalog-level unions.
+    pub(crate) variants: Vec<FilterVariant>,
+    /// Parsed source items used to resolve nested configuration types.
+    pub(crate) source_items: ModuleItems,
+    pub(crate) source_path: Option<PathBuf>,
+}
+
+/// One serde shape exposed by a filter factory path.
+#[derive(Clone)]
+pub(crate) struct FilterVariant {
+    /// Rust configuration type name.
+    pub(crate) config_type_name: String,
+    /// Fields in the variant's serde object.
+    pub(crate) raw_fields: Vec<RawField>,
+    /// Source metadata needed to resolve nested types.
+    pub(crate) source_items: ModuleItems,
 }
 
 /// Information extracted for one config field.
@@ -185,32 +205,35 @@ struct FilterAnchor {
 
 /// A parsed config struct with its name and fields.
 #[derive(Clone)]
-struct ConfigStruct {
+pub(crate) struct ConfigStruct {
     /// Struct identifier (e.g. `StaticResponseConfig`).
-    name: String,
+    pub(crate) name: String,
     /// Config struct doc comment.
     doc: String,
     /// Fields in declaration order.
-    fields: Vec<RawField>,
+    pub(crate) fields: Vec<RawField>,
+    /// `#[serde(try_from = "...")]`, when present.
+    pub(crate) try_from: Option<String>,
 }
 
 /// Parsed items accumulated from source files belonging to one filter module.
-struct ModuleItems {
+#[derive(Clone)]
+pub(crate) struct ModuleItems {
     /// Module-level doc comments from files in the filter scope.
     module_docs: Vec<String>,
     /// Local config structs found (with `Deserialize` + `deny_unknown_fields`).
-    configs: Vec<ConfigStruct>,
+    pub(crate) configs: Vec<ConfigStruct>,
     /// Doc comments on public structs and filter implementation structs.
     struct_docs: Vec<String>,
     /// Struct definitions available for nested field rendering.
-    structs: BTreeMap<String, ConfigStruct>,
+    pub(crate) structs: BTreeMap<String, ConfigStruct>,
     /// Enum definitions with `Deserialize` for variant rendering.
-    enums: BTreeMap<String, EnumInfo>,
+    pub(crate) enums: BTreeMap<String, EnumInfo>,
 }
 
 impl ModuleItems {
     /// Create an empty item collection.
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             module_docs: Vec::new(),
             configs: Vec::new(),
@@ -234,23 +257,27 @@ impl ModuleItems {
 
 /// Parsed enum metadata.
 #[derive(Clone)]
-struct EnumInfo {
+pub(crate) struct EnumInfo {
     /// YAML variant names.
-    variants: Vec<String>,
+    pub(crate) variants: Vec<String>,
     /// Whether serde tries variants by shape instead of by variant tag.
-    untagged: bool,
+    pub(crate) untagged: bool,
     /// `#[serde(tag = "...")]` discriminator key name, for internally
     /// tagged enums. `None` for untagged/externally tagged enums.
-    tag: Option<String>,
+    pub(crate) tag: Option<String>,
+    /// `#[serde(content = "...")]` payload key for adjacent tagging.
+    pub(crate) content: Option<String>,
     /// Source shape for each variant.
-    variant_shapes: Vec<EnumVariantShape>,
+    pub(crate) variant_shapes: Vec<EnumVariantShape>,
     /// Named fields from struct-like variants.
-    fields: Vec<RawField>,
+    pub(crate) fields: Vec<RawField>,
+    /// Fields owned by each named variant, retained for catalog rendering.
+    pub(crate) variant_fields: Vec<Vec<RawField>>,
 }
 
 /// Source shape for one enum variant.
 #[derive(Clone)]
-enum EnumVariantShape {
+pub(crate) enum EnumVariantShape {
     /// Unit variant, usually rendered as a scalar YAML value.
     Unit,
     /// Tuple variant with one wrapped type.
@@ -261,26 +288,29 @@ enum EnumVariantShape {
 
 /// A raw field before type rendering.
 #[derive(Clone)]
-struct RawField {
+pub(crate) struct RawField {
     /// Field name.
-    name: String,
+    pub(crate) name: String,
+    pub(crate) aliases: Vec<String>,
     /// Raw type from syn.
-    ty: syn::Type,
+    pub(crate) ty: syn::Type,
     /// Doc comment lines joined.
-    doc: String,
+    pub(crate) doc: String,
     /// Has `#[serde(default)]` or `#[serde(default = "...")]`.
-    has_default: bool,
+    pub(crate) has_default: bool,
+    /// Default function named by `#[serde(default = "...")]`.
+    pub(crate) default_path: Option<String>,
     /// Custom serde deserializer from `#[serde(deserialize_with = "...")]`.
-    deserialize_with: Option<String>,
+    pub(crate) deserialize_with: Option<String>,
     /// Has `#[serde(flatten)]`.
-    flatten: bool,
+    pub(crate) flatten: bool,
     /// Additional requiredness hint from surrounding syntax.
-    requirement_hint: RequirementHint,
+    pub(crate) requirement_hint: RequirementHint,
 }
 
 /// Requiredness hint from the surrounding source shape.
 #[derive(Clone, Copy)]
-enum RequirementHint {
+pub(crate) enum RequirementHint {
     /// Use the field type and serde defaults to infer requiredness.
     Normal,
     /// Field came from one of several struct-like enum variants.
@@ -302,6 +332,15 @@ impl FilterInfo {
         append_unique(&mut self.config_notes, other.config_notes);
         append_unique_fields(&mut self.fields, other.fields);
         append_unique(&mut self.yaml_examples, other.yaml_examples);
+        for variant in other.variants {
+            if !self
+                .variants
+                .iter()
+                .any(|existing| existing.config_type_name == variant.config_type_name)
+            {
+                self.variants.push(variant);
+            }
+        }
     }
 }
 
@@ -310,7 +349,7 @@ impl FilterInfo {
 // -----------------------------------------------------------------------------
 
 /// Parse shared config types that filters may reference from praxis core.
-fn parse_shared_config_items(root: &Path) -> ModuleItems {
+pub(crate) fn parse_shared_config_items(root: &Path) -> ModuleItems {
     let mut items = ModuleItems::new();
     let praxis_root = root.join("../praxis");
     let dirs = if praxis_root.is_dir() {
@@ -339,7 +378,12 @@ fn parse_shared_config_items(root: &Path) -> ModuleItems {
 
 /// Local configuration files whose types are shared by filters in separate
 /// API categories. Paths are relative to the workspace root.
-const LOCAL_SHARED_CONFIG_FILES: &[&str] = &["apis/src/web_search/config.rs", "apis/src/callout_policy.rs"];
+const LOCAL_SHARED_CONFIG_FILES: &[&str] = &[
+    "apis/src/web_search/config.rs",
+    "apis/src/callout_policy.rs",
+    "apis/src/store/postgres.rs",
+    "apis/src/store/pool.rs",
+];
 
 /// Parse local configuration types shared by filters in separate API categories.
 fn parse_local_shared_config(root: &Path, items: &mut ModuleItems) {
@@ -380,7 +424,7 @@ fn resolve_praxis_source_dirs() -> Vec<PathBuf> {
 }
 
 /// Discover all filters across `apis/src/` and `filters/src/`.
-fn discover_all_filters(root: &Path, shared_items: &ModuleItems) -> Vec<FilterEntry> {
+pub(crate) fn discover_all_filters(root: &Path, shared_items: &ModuleItems) -> Vec<FilterEntry> {
     let mut entries = Vec::new();
 
     discover_crate_filters(root, &root.join("apis/src"), "apis", shared_items, &mut entries);
@@ -462,7 +506,8 @@ fn extract_standalone_filter(anchor_path: &Path, crate_kind: &str, shared_items:
     parse_file_items(&file, &mut items);
 
     let anchor = parse_anchor_file(anchor_path)?;
-    let filter = build_filter(&items, &anchor.name, anchor.config_type_name.as_deref());
+    let mut filter = build_filter(&items, &anchor.name, anchor.config_type_name.as_deref());
+    filter.source_path = Some(anchor.file.clone());
     let category = infer_standalone_category(&anchor.name);
     Some(FilterEntry {
         crate_kind: crate_kind.to_owned(),
@@ -505,7 +550,9 @@ fn extract_filters(category_dir: &Path, shared_items: &ModuleItems) -> Vec<Filte
                 };
                 parse_file_items(&file, &mut items);
             }
-            build_filter(&items, &anchor.name, anchor.config_type_name.as_deref())
+            let mut filter = build_filter(&items, &anchor.name, anchor.config_type_name.as_deref());
+            filter.source_path = Some(anchor.file.clone());
+            filter
         })
         .collect();
     merge_filter_variants(filters)
@@ -572,6 +619,53 @@ fn merge_filter_variants(filters: Vec<FilterInfo>) -> Vec<FilterInfo> {
             .or_insert(filter);
     }
     by_name.into_values().collect()
+}
+
+/// Validate factory configuration types before machine-readable generation.
+/// Human documentation intentionally retains its historical merged rendering,
+/// while the catalog must never silently union incompatible serde shapes.
+pub(crate) fn validate_factory_variants(root: &Path, allowed_unions: &[(&str, &str, &str)]) -> Result<(), String> {
+    let mut types = BTreeMap::<String, String>::new();
+    for source_dir in [root.join("apis/src"), root.join("filters/src")] {
+        let (categories, standalone) = classify_src_entries(&source_dir);
+        for directory in categories {
+            for anchor in discover_filter_anchors(&directory) {
+                record_factory_variant(&mut types, &anchor, allowed_unions)?;
+            }
+        }
+        for path in standalone {
+            if let Some(anchor) = parse_anchor_file(&path) {
+                record_factory_variant(&mut types, &anchor, allowed_unions)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn record_factory_variant(
+    types: &mut BTreeMap<String, String>,
+    anchor: &FilterAnchor,
+    allowed_unions: &[(&str, &str, &str)],
+) -> Result<(), String> {
+    let Some(config_type) = anchor.config_type_name.as_deref() else {
+        return Ok(());
+    };
+    if let Some(previous) = types.insert(anchor.name.clone(), config_type.to_owned())
+        && previous != config_type
+    {
+        if allowed_unions.iter().any(|(filter, first, second)| {
+            *filter == anchor.name
+                && ((*first == previous && *second == config_type) || (*first == config_type && *second == previous))
+        }) {
+            types.remove(&anchor.name);
+            return Ok(());
+        }
+        return Err(format!(
+            "catalog_error=incompatible_config_type filter={} first={} second={}",
+            anchor.name, previous, config_type
+        ));
+    }
+    Ok(())
 }
 
 /// Parse a single file to check if it is a filter anchor.
@@ -720,7 +814,7 @@ fn scope_files_recursive(dir: &Path, excluded: &HashSet<&Path>, out: &mut Vec<Pa
 }
 
 /// Recursively collect `.rs` files, skipping test files.
-fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
+pub(crate) fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     collect_rs_files_recursive(dir, &mut files);
     files.sort();
@@ -775,6 +869,7 @@ fn parse_struct(s: &syn::ItemStruct, out: &mut ModuleItems) {
             name: s.ident.to_string(),
             doc: docs.clone(),
             fields,
+            try_from: serde_lit_value_from_attrs(&s.attrs, "try_from"),
         };
         if is_nested_config_struct(s) {
             out.structs.insert(config.name.clone(), config.clone());
@@ -785,6 +880,7 @@ fn parse_struct(s: &syn::ItemStruct, out: &mut ModuleItems) {
                         name: "ClusterTls".to_owned(),
                         doc: config.doc.clone(),
                         fields: config.fields.clone(),
+                        try_from: config.try_from.clone(),
                     },
                 );
             }
@@ -829,6 +925,20 @@ fn build_filter(items: &ModuleItems, name: &str, config_type: Option<&str>) -> F
         config_notes: all_notes,
         fields,
         yaml_examples,
+        raw_fields: config.map_or_else(Vec::new, |c| c.fields.clone()),
+        config_type_name: config_type.map(str::to_owned),
+        variants: config_type
+            .zip(config)
+            .map(|(config_type_name, config)| {
+                vec![FilterVariant {
+                    config_type_name: config_type_name.to_owned(),
+                    raw_fields: config.fields.clone(),
+                    source_items: items.clone(),
+                }]
+            })
+            .unwrap_or_default(),
+        source_items: items.clone(),
+        source_path: None,
     }
 }
 
@@ -1011,8 +1121,10 @@ fn parse_config_fields(s: &syn::ItemStruct) -> Option<Vec<RawField>> {
             .iter()
             .map(|f| RawField {
                 name: serde_field_name(f, rename_all),
+                aliases: serde_aliases(&f.attrs),
                 doc: extract_doc_comment(&f.attrs),
                 has_default: has_serde_default(&f.attrs),
+                default_path: serde_lit_value_from_attrs(&f.attrs, "default"),
                 deserialize_with: serde_deserialize_with(&f.attrs),
                 flatten: has_serde_attr(&f.attrs, "flatten"),
                 requirement_hint: RequirementHint::Normal,
@@ -1066,6 +1178,20 @@ fn serde_field_name(field: &syn::Field, rename_all: Option<&str>) -> String {
         .unwrap_or_default()
 }
 
+fn serde_aliases(attrs: &[syn::Attribute]) -> Vec<String> {
+    attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("serde"))
+        .flat_map(|attr| {
+            let text = quote::quote!(#attr).to_string();
+            text.split("alias = ")
+                .skip(1)
+                .filter_map(|part| part.split('"').nth(1).map(str::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 /// Strip a raw identifier's `r#` prefix (e.g. `r#match` -> `match`), which
 /// `syn::Ident::to_string()` preserves but serde's own field-name
 /// resolution does not -- a raw identifier is only needed to use a
@@ -1101,6 +1227,11 @@ fn serde_deserialize_with(attrs: &[syn::Attribute]) -> Option<String> {
     attrs.iter().find_map(|attr| serde_lit_value(attr, "deserialize_with"))
 }
 
+/// Extract a serde string value from any attribute in a list.
+fn serde_lit_value_from_attrs(attrs: &[syn::Attribute], name: &str) -> Option<String> {
+    attrs.iter().find_map(|attr| serde_lit_value(attr, name))
+}
+
 /// Extract a string-literal serde attribute value.
 fn serde_lit_value(attr: &syn::Attribute, name: &str) -> Option<String> {
     if !attr.path().is_ident("serde") {
@@ -1127,6 +1258,7 @@ fn extract_enum_info(e: &syn::ItemEnum) -> EnumInfo {
     let rename_all = detect_rename_all(&e.attrs);
     let untagged = has_serde_attr(&e.attrs, "untagged");
     let tag = e.attrs.iter().find_map(|attr| serde_lit_value(attr, "tag"));
+    let content = e.attrs.iter().find_map(|attr| serde_lit_value(attr, "content"));
     let variants = e
         .variants
         .iter()
@@ -1139,14 +1271,16 @@ fn extract_enum_info(e: &syn::ItemEnum) -> EnumInfo {
         .collect();
     let variant_shapes = e.variants.iter().map(enum_variant_shape).collect();
     let variant_fields: Vec<Vec<RawField>> = e.variants.iter().map(parse_variant_fields).collect();
-    let fields = flatten_variant_fields_marking_one_of(variant_fields);
+    let fields = flatten_variant_fields_marking_one_of(variant_fields.clone());
 
     EnumInfo {
         variants,
         untagged,
         tag,
+        content,
         variant_shapes,
         fields,
+        variant_fields,
     }
 }
 
@@ -1219,8 +1353,10 @@ fn parse_variant_fields(variant: &syn::Variant) -> Vec<RawField> {
         .iter()
         .map(|f| RawField {
             name: serde_field_name(f, None),
+            aliases: serde_aliases(&f.attrs),
             doc: extract_doc_comment(&f.attrs),
             has_default: has_serde_default(&f.attrs),
+            default_path: serde_lit_value_from_attrs(&f.attrs, "default"),
             deserialize_with: serde_deserialize_with(&f.attrs),
             flatten: has_serde_attr(&f.attrs, "flatten"),
             requirement_hint: RequirementHint::Normal,
@@ -1423,7 +1559,7 @@ fn is_yaml_fence_start(line: &str) -> bool {
 // -----------------------------------------------------------------------------
 
 /// Return whether a type path is `Option<T>`.
-fn is_option_type(ty: &syn::Type) -> bool {
+pub(crate) fn is_option_type(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Path(tp) if tp.path.segments.last().is_some_and(|s| s.ident == "Option"))
 }
 
@@ -1951,12 +2087,25 @@ fn dir_file_name(dir: &Path) -> String {
         .into_owned()
 }
 
-/// Create directories recursively, exiting on failure.
 fn create_dir_all_or_exit(dir: &Path) {
-    if let Err(e) = fs::create_dir_all(dir) {
-        eprintln!("failed to create {}: {e}", dir.display());
+    if let Err(error) = fs::create_dir_all(dir) {
+        eprintln!("failed to create {}: {error}", dir.display());
         std::process::exit(1);
     }
+}
+
+pub(crate) fn type_args(arguments: &syn::PathArguments) -> Vec<&syn::Type> {
+    let syn::PathArguments::AngleBracketed(arguments) = arguments else {
+        return Vec::new();
+    };
+    arguments
+        .args
+        .iter()
+        .filter_map(|argument| match argument {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Write content to a file, exiting on failure.
@@ -1978,7 +2127,7 @@ fn print_relative(root: &Path, path: &Path, action: &str) {
 }
 
 /// Get a path relative to root.
-fn relative_path(root: &Path, path: &Path) -> PathBuf {
+pub(crate) fn relative_path(root: &Path, path: &Path) -> PathBuf {
     path.strip_prefix(root).unwrap_or(path).to_owned()
 }
 
@@ -2311,7 +2460,7 @@ mod tests {
             #[serde(deny_unknown_fields)]
             struct ClusterConfig {
                 /// Cluster name.
-                name: String,
+    pub(crate) name: String,
             }
         ";
         let file: syn::File = syn::parse_str(source).unwrap();
@@ -2499,6 +2648,11 @@ mod tests {
                 config_notes: vec![],
                 fields: vec![],
                 yaml_examples: vec![],
+                raw_fields: vec![],
+                config_type_name: Some("TimeoutConfig".to_owned()),
+                variants: vec![],
+                source_items: ModuleItems::new(),
+                source_path: None,
             },
         }];
         let result = render_reference_index(&entries);
@@ -2733,7 +2887,33 @@ mod tests {
                     required: RequiredKind::Yes,
                 }],
                 yaml_examples: vec!["filter: timeout\ntimeout_ms: 5000".to_owned()],
+                raw_fields: vec![],
+                config_type_name: Some("TimeoutConfig".to_owned()),
+                variants: vec![],
+                source_items: ModuleItems::new(),
+                source_path: None,
             },
         }
+    }
+
+    #[test]
+    fn incompatible_same_name_factory_configs_fail_closed() {
+        let mut types = BTreeMap::new();
+        let first = FilterAnchor {
+            file: PathBuf::from("first.rs"),
+            name: "timeout".to_owned(),
+            config_type_name: Some("TimeoutConfig".to_owned()),
+        };
+        let second = FilterAnchor {
+            file: PathBuf::from("second.rs"),
+            name: "timeout".to_owned(),
+            config_type_name: Some("OtherTimeoutConfig".to_owned()),
+        };
+        record_factory_variant(&mut types, &first, &[]).expect("first variant");
+        let error = record_factory_variant(&mut types, &second, &[])
+            .err()
+            .unwrap_or_default();
+        assert!(error.contains("catalog_error=incompatible_config_type"));
+        assert!(error.contains("filter=timeout"));
     }
 }

--- a/xtask/src/inference_fixtures/tests.rs
+++ b/xtask/src/inference_fixtures/tests.rs
@@ -7,7 +7,6 @@ use std::{
     error::Error as _,
     fmt::Write as _,
     fs,
-    io::{Read as _, Write as _},
     net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     sync::mpsc,
@@ -15,7 +14,6 @@ use std::{
     time::Duration,
 };
 
-use clap::Parser as _;
 use praxis_test_utils::inference_fixture::{
     BodyKind, FixtureProvenance, InferenceProtocol, InferenceScenario, NormalizationMetadata, ProvenanceKind,
     RecordedBody, RecordedExchange, RecordedRequest, RecordedResponse, ScenarioExpectation, ScenarioTurn, WireFixture,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,6 +14,7 @@
 )]
 #![allow(let_underscore_drop, reason = "development tooling")]
 
+mod config_catalog;
 mod debug;
 mod echo;
 mod filter_docs;
@@ -94,6 +95,12 @@ enum Command {
     /// Generate per-filter documentation under `docs/filters/`.
     GenerateFilterDocs(filter_docs::GenerateArgs),
 
+    /// Generate the machine-readable AI configuration catalog.
+    GenerateConfigCatalog(config_catalog::GenerateArgs),
+
+    /// Check that the machine-readable AI configuration catalog is current.
+    LintConfigCatalog(config_catalog::LintArgs),
+
     /// Check that filter doc files are up to date.
     LintFilterDocs(filter_docs::LintArgs),
 
@@ -141,6 +148,8 @@ fn main() {
         Command::MakeReplayFixture(args) => make_replay_fixture::run(args),
         Command::SyncExampleReadme(args) => sync_example_readme::run(&args),
         Command::GenerateFilterDocs(args) => filter_docs::generate(args),
+        Command::GenerateConfigCatalog(args) => config_catalog::generate(args),
+        Command::LintConfigCatalog(args) => config_catalog::lint(args),
         Command::LintFilterDocs(args) => filter_docs::lint(args),
         Command::OpenaiConformance(args) => openai_conformance::run(&args),
         Command::OpenaiConformanceReference(args) => openai_conformance::run_reference(&args),


### PR DESCRIPTION
## Summary

This PR:

* Makes AI praxis consume the core generator for schema
* Commits the initial catalog

The idea behind this is that a UI/playground can use this as a source of truth for supported Praxis configuration, allowing users to have a visual design of their configuration


Depends on https://github.com/praxis-proxy/praxis/pull/1144

This is a WIP

## Related issue

<!-- Contributors must be assigned to the issue before opening a PR. -->

Closes #

## Validation

<!-- List exact commands and any manual or backend-backed proof. -->

- [ ] Unit tests
- [ ] Integration or functional tests
- [ ] `make lint`

## Checklist

- [ ] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [ ] User-facing behavior and generated documentation are updated.
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [ ] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

<!-- If applicable, describe the impact and migration path. -->
