### PR TITLE
feat(routing): authorize providers by resource identity

### DIFF
--- a/docs/architecture/opentelemetry.md
+++ b/docs/architecture/opentelemetry.md
@@ -32,6 +32,8 @@ successfully served the request. It contains:
   route.
 - `provider.route.candidate_id`: the edge-selected candidate ID that was
   validated and resolved.
+- `provider.route.provider_ref.name` and `provider.route.provider_ref.site`:
+  the trusted Grid provider identity when the overlay supplied one.
 - `overlay.revision`: present only when the edge supplied a serving overlay
   revision that passed syntax and trust-boundary validation. It is
   correlation evidence only, not a provider-local config revision and not an

--- a/docs/filters/provider_route.md
+++ b/docs/filters/provider_route.md
@@ -18,7 +18,10 @@ These names are AI-owned rather than Praxis-reserved because Praxis intentionall
 | `provider_id` | string | yes | Provider-owned identifier used for observability and demo attribution. |
 | `model_header` | string | no | Header populated by an inference parser with the requested model. |
 | `routes` | ProviderRouteConfig[] | yes | Exact provider-local candidate mappings. |
-| `routes[].candidate_id` | string | yes | Stable candidate ID selected by the edge `intelligent_route`. |
+| `routes[].candidate_id` | string | no | Stable candidate ID selected by the edge `intelligent_route`. Mutually exclusive with `provider_ref`; this selector remains the backward-compatible form for existing configurations. |
+| `routes[].provider_ref` | ProviderRefConfig | no | Trusted human-readable provider identity selected by Grid. The name is scoped by site because remote Grid sites may reuse provider names. Mutually exclusive with `candidate_id`. |
+| `routes[].provider_ref.name` | string | yes | `InferenceProvider.metadata.name`. |
+| `routes[].provider_ref.site` | string | yes | Site that owns the provider candidate. |
 | `routes[].cluster` | string | yes | Provider-local backend cluster. |
 | `routes[].credential` | CandidateCredential | no | Optional provider-local credential reference for the final API hop. |
 | `routes[].credential.strategy` | string | yes | Injection strategy. |

--- a/examples/configs/provider-route.yaml
+++ b/examples/configs/provider-route.yaml
@@ -31,12 +31,17 @@ filter_chains:
         header: X-Model
 
       # Exact local policy mapping. This is not another routing engine.
+      # provider_ref is the trusted Grid identity; provider_ref.site scopes
+      # the name for multi-site overlays. candidate_id: <stable_id> remains
+      # supported for legacy configurations.
       - filter: provider_route
         provider_id: site-us-west
         model_header: X-Model
         emit_demo_attribution: true
         routes:
-          - candidate_id: inference_model/mock-model/site-us-west/provider-us-west
+          - provider_ref:
+              name: mock-model-provider
+              site: site-us-west
             model: mock-model
             paths:
               - /v1/chat/completions

--- a/filters/src/opentelemetry.rs
+++ b/filters/src/opentelemetry.rs
@@ -34,6 +34,10 @@ struct RoutingSelection<'a> {
     site: &'a str,
     /// Stable identifier assigned to the selected provider.
     stable_id: &'a str,
+    /// Trusted provider reference name, when supplied by Grid.
+    provider_ref_name: Option<&'a str>,
+    /// Trusted provider reference site, when supplied by Grid.
+    provider_ref_site: Option<&'a str>,
     /// Producer-assigned selection tier, when available.
     tier: Option<&'a str>,
 }
@@ -56,6 +60,8 @@ impl<'a> RoutingSelection<'a> {
             revision: semantic_revision.map(AsRef::as_ref),
             site: candidate.site.as_ref(),
             stable_id: candidate.stable_id.as_ref(),
+            provider_ref_name: candidate.provider_ref.as_ref().map(|r| r.name.as_ref()),
+            provider_ref_site: candidate.provider_ref.as_ref().map(|r| r.site.as_ref()),
             tier: candidate.selection_tier.as_deref(),
         }
     }
@@ -73,6 +79,10 @@ struct ProviderRouteSelection<'a> {
     candidate_id: &'a str,
     /// Edge serving-overlay revision, when supplied and validated.
     revision: Option<&'a str>,
+    /// Trusted provider reference name, when supplied by the edge.
+    provider_ref_name: Option<&'a str>,
+    /// Trusted provider reference site, when supplied by the edge.
+    provider_ref_site: Option<&'a str>,
 }
 
 impl<'a> ProviderRouteSelection<'a> {
@@ -84,6 +94,8 @@ impl<'a> ProviderRouteSelection<'a> {
         model: &'a Arc<str>,
         candidate_id: &'a str,
         revision: Option<&'a str>,
+        provider_ref_name: Option<&'a str>,
+        provider_ref_site: Option<&'a str>,
     ) -> Self {
         Self {
             provider_id: provider_id.as_ref(),
@@ -91,6 +103,8 @@ impl<'a> ProviderRouteSelection<'a> {
             model: model.as_ref(),
             candidate_id,
             revision,
+            provider_ref_name,
+            provider_ref_site,
         }
     }
 }
@@ -112,6 +126,8 @@ pub(crate) fn record_routing_selection(
         "selected.cluster" = selection.cluster,
         "selected.site" = selection.site,
         "selected.stable_id" = selection.stable_id,
+        "selected.provider_ref.name" = Empty,
+        "selected.provider_ref.site" = Empty,
         "routing.admission_state" = selection.admission_state,
         "routing.kind" = selection.kind,
         "routing.local_site" = selection.local_site,
@@ -127,6 +143,12 @@ pub(crate) fn record_routing_selection(
     }
     if let Some(revision) = selection.revision {
         span.record("overlay.revision", revision);
+    }
+    if let Some(provider_ref_name) = selection.provider_ref_name {
+        span.record("selected.provider_ref.name", provider_ref_name);
+    }
+    if let Some(provider_ref_site) = selection.provider_ref_site {
+        span.record("selected.provider_ref.site", provider_ref_site);
     }
     let _entered = span.enter();
 }
@@ -150,18 +172,36 @@ pub(crate) fn record_provider_route_selection(
     model: &Arc<str>,
     candidate_id: &str,
     overlay_revision: Option<&str>,
+    provider_ref_name: Option<&str>,
+    provider_ref_site: Option<&str>,
 ) {
-    let selection = ProviderRouteSelection::new(provider_id, cluster, model, candidate_id, overlay_revision);
+    let selection = ProviderRouteSelection::new(
+        provider_id,
+        cluster,
+        model,
+        candidate_id,
+        overlay_revision,
+        provider_ref_name,
+        provider_ref_site,
+    );
     let span = tracing::info_span!(
         "provider.route",
         "provider.id" = selection.provider_id,
         "provider.backend.cluster" = selection.cluster,
         "provider.route.model" = selection.model,
         "provider.route.candidate_id" = selection.candidate_id,
+        "provider.route.provider_ref.name" = Empty,
+        "provider.route.provider_ref.site" = Empty,
         "overlay.revision" = Empty,
     );
     if let Some(revision) = selection.revision {
         span.record("overlay.revision", revision);
+    }
+    if let Some(provider_ref_name) = selection.provider_ref_name {
+        span.record("provider.route.provider_ref.name", provider_ref_name);
+    }
+    if let Some(provider_ref_site) = selection.provider_ref_site {
+        span.record("provider.route.provider_ref.site", provider_ref_site);
     }
     let _entered = span.enter();
 }
@@ -229,7 +269,15 @@ mod tests {
 
         // Keep a smoke assertion around the tracing macro in addition to the
         // projection contract above.
-        record_provider_route_selection(&provider_id, &cluster, &model, "candidate-a", Some("revision-a"));
+        record_provider_route_selection(
+            &provider_id,
+            &cluster,
+            &model,
+            "candidate-a",
+            Some("revision-a"),
+            Some("provider-a"),
+            Some("site-a"),
+        );
     }
 
     #[test]
@@ -252,6 +300,7 @@ mod tests {
             admission_state: AdmissionState::NewAndExisting,
             cluster: Arc::from("provider-a"),
             credential: None,
+            provider_ref: None,
             fresh: true,
             kind: CapabilityKind::InferenceModel,
             name: Arc::from("model-a"),

--- a/filters/src/routing/descriptor.rs
+++ b/filters/src/routing/descriptor.rs
@@ -162,6 +162,16 @@ pub(crate) struct CandidateConfig {
     pub site: String,
 }
 
+/// Trusted provider identity projected from the Grid routing overlay.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct ProviderRef {
+    /// `InferenceProvider.metadata.name`.
+    pub name: Arc<str>,
+
+    /// Site that owns the provider candidate.
+    pub site: Arc<str>,
+}
+
 /// Default freshness state for candidates.
 fn default_fresh() -> bool {
     true
@@ -190,6 +200,9 @@ pub(crate) struct RouteCandidate {
 
     /// Optional final-hop credential reference.
     pub credential: Option<CandidateCredential>,
+
+    /// Trusted provider identity from the selected overlay candidate.
+    pub provider_ref: Option<ProviderRef>,
 
     /// Whether this candidate is fresh. Preserved from overlay/static config;
     /// the configuration producer owns freshness ordering.
@@ -298,6 +311,7 @@ pub(crate) fn validate_candidates(raw: Vec<CandidateConfig>) -> Result<Vec<Route
             admission_state: AdmissionState::default(),
             cluster: Arc::from(c.cluster.as_str()),
             credential: c.credential,
+            provider_ref: None,
             fresh: c.fresh,
             kind: c.kind,
             name: Arc::from(c.name.as_str()),

--- a/filters/src/routing/group_index.rs
+++ b/filters/src/routing/group_index.rs
@@ -114,6 +114,7 @@ mod tests {
             admission_state,
             cluster: Arc::from("cluster"),
             credential: None,
+            provider_ref: None,
             fresh: true,
             kind: CapabilityKind::InferenceModel,
             name: Arc::from("model"),

--- a/filters/src/routing/intelligent_route.rs
+++ b/filters/src/routing/intelligent_route.rs
@@ -20,7 +20,10 @@
 //! group.
 //! The filter does not recompute source geography, load, or scoring.
 //!
-//! No request-time metrics or control-plane lookups are performed.
+//! No request-time metrics or control-plane lookups are performed. Overlay
+//! candidates may carry a trusted `provider_ref`; when a provider hop is
+//! configured, its name and site are forwarded alongside the stable ID using
+//! AI-owned peer headers generated after candidate selection.
 
 use std::{
     collections::BTreeSet,
@@ -39,10 +42,10 @@ use serde::Deserialize;
 use super::{
     descriptor::{self, AdmissionState, CandidateConfig, CapabilityKind, RouteCandidate},
     metadata::{
-        OVERLAY_REVISION_HEADER, PROVIDER_HOP_REQUEST_ID_HEADER, ROUTE_ADMISSION_STATE, ROUTE_CLUSTER, ROUTE_KIND,
-        ROUTE_LOCAL_SITE, ROUTE_NAME, ROUTE_PROVIDER_HOP_REQUEST_ID, ROUTE_RANK, ROUTE_SELECTION_GROUP,
-        ROUTE_SELECTION_MODE, ROUTE_SELECTION_TIER, ROUTE_SITE, ROUTE_STABLE_ID, SELECTED_CANDIDATE_HEADER,
-        set_credential_metadata,
+        OVERLAY_REVISION_HEADER, PROVIDER_HOP_REQUEST_ID_HEADER, PROVIDER_REF_NAME_HEADER, PROVIDER_REF_SITE_HEADER,
+        ROUTE_ADMISSION_STATE, ROUTE_CLUSTER, ROUTE_KIND, ROUTE_LOCAL_SITE, ROUTE_NAME, ROUTE_PROVIDER_HOP_REQUEST_ID,
+        ROUTE_PROVIDER_REF_NAME, ROUTE_PROVIDER_REF_SITE, ROUTE_RANK, ROUTE_SELECTION_GROUP, ROUTE_SELECTION_MODE,
+        ROUTE_SELECTION_TIER, ROUTE_SITE, ROUTE_STABLE_ID, SELECTED_CANDIDATE_HEADER, set_credential_metadata,
     },
     overlay::{self, ExpectedOverlayScope, OverlayReloadHandle, PickerPolicy, RouteSnapshot},
     picker,
@@ -646,6 +649,10 @@ impl HttpFilter for IntelligentRouteFilter {
             .push(HeaderName::from_static(PROVIDER_HOP_REQUEST_ID_HEADER));
         ctx.request_headers_to_remove
             .push(HeaderName::from_static(OVERLAY_REVISION_HEADER));
+        ctx.request_headers_to_remove
+            .push(HeaderName::from_static(PROVIDER_REF_NAME_HEADER));
+        ctx.request_headers_to_remove
+            .push(HeaderName::from_static(PROVIDER_REF_SITE_HEADER));
 
         if ctx.cluster.is_some() {
             tracing::debug!("intelligent_route: cluster already set; preserving");
@@ -954,6 +961,10 @@ fn record_route_decision(ctx: &mut HttpFilterContext<'_>, local_site: &Arc<str>,
     ctx.set_metadata(ROUTE_NAME, &*candidate.name);
     ctx.set_metadata(ROUTE_SITE, &*candidate.site);
     ctx.set_metadata(ROUTE_STABLE_ID, &*candidate.stable_id);
+    if let Some(provider_ref) = &candidate.provider_ref {
+        ctx.set_metadata(ROUTE_PROVIDER_REF_NAME, &*provider_ref.name);
+        ctx.set_metadata(ROUTE_PROVIDER_REF_SITE, &*provider_ref.site);
+    }
     if let Some(rank) = candidate.rank {
         ctx.set_metadata(ROUTE_RANK, rank.to_string());
     }
@@ -1005,6 +1016,18 @@ fn write_provider_context(
         HeaderName::from_static(PROVIDER_HOP_REQUEST_ID_HEADER),
         request_id_value,
     ));
+    if let Some(provider_ref) = &candidate.provider_ref {
+        let provider_name = HeaderValue::from_str(&provider_ref.name).map_err(|error| {
+            FilterError::from(format!("intelligent_route: invalid provider reference name: {error}"))
+        })?;
+        let provider_site = HeaderValue::from_str(&provider_ref.site).map_err(|error| {
+            FilterError::from(format!("intelligent_route: invalid provider reference site: {error}"))
+        })?;
+        ctx.request_headers_to_set
+            .push((HeaderName::from_static(PROVIDER_REF_NAME_HEADER), provider_name));
+        ctx.request_headers_to_set
+            .push((HeaderName::from_static(PROVIDER_REF_SITE_HEADER), provider_site));
+    }
     if let Some(rev) = semantic_revision {
         let rev_value = HeaderValue::from_str(rev).map_err(|error| {
             FilterError::from(format!("intelligent_route: invalid serving overlay revision: {error}"))
@@ -2804,6 +2827,7 @@ mod tests {
                 selection_tier: None,
                 site: Arc::from("s"),
                 stable_id: descriptor::default_stable_id(CapabilityKind::InferenceModel, "llama", "s", cluster),
+                provider_ref: None,
             });
         }
         RouteSnapshot::from_static(route_candidates, Arc::from("site-a"))

--- a/filters/src/routing/metadata.rs
+++ b/filters/src/routing/metadata.rs
@@ -21,6 +21,12 @@ pub(crate) const PROVIDER_HOP_REQUEST_ID_HEADER: &str = "x-ai-routing-request-id
 /// Serving overlay revision forwarded from the edge gateway.
 pub(crate) const OVERLAY_REVISION_HEADER: &str = "x-ai-routing-revision";
 
+/// Trusted provider name forwarded from the selected Grid candidate.
+pub(crate) const PROVIDER_REF_NAME_HEADER: &str = "x-ai-routing-provider-name";
+
+/// Trusted provider site scope forwarded from the selected Grid candidate.
+pub(crate) const PROVIDER_REF_SITE_HEADER: &str = "x-ai-routing-provider-site";
+
 /// Provider identity header added only for backend/demo capture.
 pub(crate) const PROVIDER_ATTRIBUTION_HEADER: &str = "x-ai-provider-attribution";
 
@@ -58,11 +64,19 @@ pub(crate) const ROUTE_SELECTION_TIER: &str = "intelligent_route.selection_tier"
 pub(crate) const ROUTE_SITE: &str = "intelligent_route.site";
 /// Stable identifier for the selected candidate.
 pub(crate) const ROUTE_STABLE_ID: &str = "intelligent_route.stable_id";
+/// Trusted provider name of the selected candidate.
+pub(crate) const ROUTE_PROVIDER_REF_NAME: &str = "intelligent_route.provider_ref.name";
+/// Trusted provider site of the selected candidate.
+pub(crate) const ROUTE_PROVIDER_REF_SITE: &str = "intelligent_route.provider_ref.site";
 /// Hop request ID forwarded to the provider gateway.
 pub(crate) const ROUTE_PROVIDER_HOP_REQUEST_ID: &str = "intelligent_route.provider_hop_request_id";
 
 /// Candidate ID validated by `provider_route`.
 pub(crate) const PROVIDER_ROUTE_CANDIDATE_ID: &str = "provider_route.candidate_id";
+/// Provider reference name validated by `provider_route`.
+pub(crate) const PROVIDER_ROUTE_PROVIDER_REF_NAME: &str = "provider_route.provider_ref.name";
+/// Provider reference site validated by `provider_route`.
+pub(crate) const PROVIDER_ROUTE_PROVIDER_REF_SITE: &str = "provider_route.provider_ref.site";
 /// Provider-local backend cluster.
 pub(crate) const PROVIDER_ROUTE_CLUSTER: &str = "provider_route.cluster";
 /// Model validated by `provider_route`.

--- a/filters/src/routing/overlay.rs
+++ b/filters/src/routing/overlay.rs
@@ -31,7 +31,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    descriptor::{self, AdmissionState, CandidateConfig, CapabilityKind, RouteCandidate},
+    descriptor::{self, AdmissionState, CandidateConfig, CapabilityKind, ProviderRef, RouteCandidate},
     group_index::{self, GroupIndex},
     metadata::{CandidateCredential, CredentialRef},
 };
@@ -277,6 +277,10 @@ pub(crate) struct OverlayCandidate {
     #[serde(default)]
     credential: Option<OverlayCredential>,
 
+    /// Trusted provider identity projected by Grid.
+    #[serde(default)]
+    provider_ref: Option<OverlayProviderRef>,
+
     /// Whether this candidate is considered fresh by the configuration producer.
     #[serde(default = "default_fresh")]
     pub(crate) fresh: bool,
@@ -305,6 +309,17 @@ pub(crate) struct OverlayCandidate {
     /// Deterministic identifier assigned by the configuration producer.
     #[serde(default)]
     pub(crate) stable_id: Option<String>,
+}
+
+/// Provider identity in the Grid overlay.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OverlayProviderRef {
+    /// `InferenceProvider` resource name.
+    name: String,
+
+    /// Site that owns the provider.
+    site: String,
 }
 
 /// Default freshness for overlay candidates.
@@ -800,6 +815,26 @@ pub(super) fn enrich_from_overlay(
                 );
             }
             c.stable_id = Arc::from(id.as_str());
+        }
+        c.provider_ref = oc.provider_ref.as_ref().map(|provider_ref| ProviderRef {
+            name: Arc::from(provider_ref.name.as_str()),
+            site: Arc::from(provider_ref.site.as_str()),
+        });
+        if let Some(provider_ref) = &c.provider_ref {
+            validate_overlay_provider_ref(i, provider_ref)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validate the trusted provider identity before it can cross the provider hop.
+fn validate_overlay_provider_ref(index: usize, provider_ref: &ProviderRef) -> Result<(), FilterError> {
+    for (field, value) in [("name", &provider_ref.name), ("site", &provider_ref.site)] {
+        if value.trim().is_empty() || value.len() > 256 || value.parse::<http::HeaderValue>().is_err() {
+            return Err(format!(
+                "routing: candidate {index}: provider_ref.{field} must be a valid 1-256 byte header value"
+            )
+            .into());
         }
     }
     Ok(())
@@ -1488,6 +1523,26 @@ mod tests {
         assert_eq!(snap.candidates.len(), 1);
         assert_eq!(&*snap.candidates[0].name, "llama-3-70b");
         assert_eq!(&*snap.local_site, "us-east-1");
+    }
+
+    #[test]
+    fn snapshot_preserves_trusted_provider_reference() {
+        let json = r#"{
+            "local_site": "site-a",
+            "candidates": [{
+                "kind": "inference_model",
+                "name": "qwen3",
+                "site": "site-b",
+                "cluster": "provider-b",
+                "fresh": true,
+                "stable_id": "stable-qwen3",
+                "provider_ref": {"name": "qwen3-ifc1", "site": "site-b"}
+            }]
+        }"#;
+        let snap = RouteSnapshot::from_overlay(json.as_bytes()).unwrap();
+        let provider_ref = snap.candidates[0].provider_ref.as_ref().unwrap();
+        assert_eq!(&*provider_ref.name, "qwen3-ifc1");
+        assert_eq!(&*provider_ref.site, "site-b");
     }
 
     // -------------------------------------------------------------------------

--- a/filters/src/routing/picker.rs
+++ b/filters/src/routing/picker.rs
@@ -97,6 +97,7 @@ mod tests {
             admission_state: admission,
             cluster: Arc::from(cluster),
             credential: None,
+            provider_ref: None,
             fresh: true,
             kind: CapabilityKind::InferenceModel,
             name: Arc::from("model"),

--- a/filters/src/routing/provider_route.rs
+++ b/filters/src/routing/provider_route.rs
@@ -26,9 +26,11 @@ use super::{
     metadata::{
         CandidateCredential, OVERLAY_REVISION_HEADER, PROVIDER_ATTRIBUTION_HEADER,
         PROVIDER_ATTRIBUTION_RESPONSE_HEADER, PROVIDER_HOP_REQUEST_ID_HEADER, PROVIDER_INFERENCE_RESPONSE_HEADER,
-        PROVIDER_OVERLAY_REVISION_HEADER, PROVIDER_REQUEST_ID_HEADER, PROVIDER_ROUTE_CANDIDATE_ID,
-        PROVIDER_ROUTE_CLUSTER, PROVIDER_ROUTE_MODEL, PROVIDER_ROUTE_OVERLAY_REVISION, PROVIDER_ROUTE_PROVIDER_ID,
-        PROVIDER_ROUTE_REQUEST_ID, SELECTED_CANDIDATE_HEADER, set_credential_metadata,
+        PROVIDER_OVERLAY_REVISION_HEADER, PROVIDER_REF_NAME_HEADER, PROVIDER_REF_SITE_HEADER,
+        PROVIDER_REQUEST_ID_HEADER, PROVIDER_ROUTE_CANDIDATE_ID, PROVIDER_ROUTE_CLUSTER, PROVIDER_ROUTE_MODEL,
+        PROVIDER_ROUTE_OVERLAY_REVISION, PROVIDER_ROUTE_PROVIDER_ID, PROVIDER_ROUTE_PROVIDER_REF_NAME,
+        PROVIDER_ROUTE_PROVIDER_REF_SITE, PROVIDER_ROUTE_REQUEST_ID, SELECTED_CANDIDATE_HEADER,
+        set_credential_metadata,
     },
 };
 
@@ -67,7 +69,15 @@ struct ProviderRouteFilterConfig {
 #[serde(deny_unknown_fields)]
 struct ProviderRouteConfig {
     /// Stable candidate ID selected by the edge `intelligent_route`.
-    candidate_id: String,
+    ///
+    /// Mutually exclusive with `provider_ref`; this selector remains the
+    /// backward-compatible form for existing configurations.
+    candidate_id: Option<String>,
+
+    /// Trusted human-readable provider identity selected by Grid. The name is
+    /// scoped by site because remote Grid sites may reuse provider names.
+    /// Mutually exclusive with `candidate_id`.
+    provider_ref: Option<ProviderRefConfig>,
 
     /// Provider-local backend cluster.
     cluster: String,
@@ -82,13 +92,24 @@ struct ProviderRouteConfig {
     paths: Vec<String>,
 }
 
+/// Provider identity selector in provider-gateway configuration.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProviderRefConfig {
+    /// `InferenceProvider.metadata.name`.
+    name: String,
+
+    /// Site that owns the provider candidate.
+    site: String,
+}
+
 /// Returns the default model header name (`X-Model`).
 fn default_model_header() -> String {
     "X-Model".to_owned()
 }
 
 /// Resolved route entry for a single candidate.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 struct ProviderRoute {
     /// Backend cluster name.
     cluster: Arc<str>,
@@ -98,6 +119,39 @@ struct ProviderRoute {
     model: Arc<str>,
     /// Accepted request paths.
     paths: Vec<Arc<str>>,
+}
+
+/// Reject a provider-boundary request with a diagnostic that identifies the
+/// failed trusted selector without exposing credentials.
+fn reject_provider_request(reason: &'static str) -> FilterAction {
+    tracing::warn!(reason, "provider_route: provider authorization rejected");
+    FilterAction::Reject(Rejection::status(403))
+}
+
+/// Require stable-ID and provider-reference selectors to resolve identically
+/// when both are present on a trusted provider hop.
+fn routes_equivalent(left: &ProviderRoute, right: &ProviderRoute) -> bool {
+    left == right
+}
+
+/// Explicit provider-route selectors. Keeping the maps separate prevents a
+/// candidate name from being guessed to be either a stable ID or a provider
+/// resource name.
+#[derive(Debug, Default)]
+struct ProviderRoutes {
+    /// Routes keyed by trusted provider reference.
+    provider_refs: HashMap<ProviderRefKey, ProviderRoute>,
+    /// Routes keyed by legacy stable candidate ID.
+    stable_ids: HashMap<Arc<str>, ProviderRoute>,
+}
+
+/// Namespaced provider identity used by the trusted overlay handoff.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ProviderRefKey {
+    /// Human-readable `InferenceProvider` name.
+    name: Arc<str>,
+    /// Grid site scope for the provider name.
+    site: Arc<str>,
 }
 
 /// Exact provider-local mapping from an authenticated intelligent routing
@@ -130,7 +184,7 @@ pub struct ProviderRouteFilter {
     /// Prevalidated provider attribution header.
     provider_id_header: HeaderValue,
     /// Candidate-to-route map.
-    routes: HashMap<Arc<str>, ProviderRoute>,
+    routes: ProviderRoutes,
 }
 
 impl ProviderRouteFilter {
@@ -164,25 +218,53 @@ impl ProviderRouteFilter {
 }
 
 /// Validate and resolve the configured provider-local candidate routes.
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps selector validation and map construction together"
+)]
 fn build_routes(
     route_configs: Vec<ProviderRouteConfig>,
     emit_demo_attribution: bool,
-) -> Result<HashMap<Arc<str>, ProviderRoute>, FilterError> {
-    let mut routes = HashMap::with_capacity(route_configs.len());
+) -> Result<ProviderRoutes, FilterError> {
+    let mut routes = ProviderRoutes {
+        provider_refs: HashMap::new(),
+        stable_ids: HashMap::with_capacity(route_configs.len()),
+    };
     for route in route_configs {
         validate_route(&route)?;
         if emit_demo_attribution {
             validate_attribution_cluster(&route.cluster)?;
         }
-        let candidate_id: Arc<str> = Arc::from(route.candidate_id.as_str());
         let provider_route = ProviderRoute {
             cluster: Arc::from(route.cluster.as_str()),
             credential: route.credential,
             model: Arc::from(route.model.as_str()),
             paths: route.paths.into_iter().map(Arc::from).collect(),
         };
-        if routes.insert(candidate_id, provider_route).is_some() {
-            return Err("provider_route: duplicate candidate_id".into());
+        match (route.candidate_id, route.provider_ref) {
+            (Some(candidate_id), None) => {
+                let candidate_id: Arc<str> = Arc::from(candidate_id.as_str());
+                if routes.stable_ids.insert(candidate_id, provider_route).is_some() {
+                    return Err("provider_route: duplicate candidate_id".into());
+                }
+            },
+            (None, Some(provider_ref)) => {
+                validate_value("provider_ref.name", &provider_ref.name)?;
+                validate_value("provider_ref.site", &provider_ref.site)?;
+                let key = ProviderRefKey {
+                    name: Arc::from(provider_ref.name.as_str()),
+                    site: Arc::from(provider_ref.site.as_str()),
+                };
+                if routes.provider_refs.insert(key, provider_route).is_some() {
+                    return Err("provider_route: duplicate provider_ref".into());
+                }
+            },
+            (Some(_), Some(_)) => {
+                return Err("provider_route: candidate_id and provider_ref are mutually exclusive".into());
+            },
+            (None, None) => {
+                return Err("provider_route: exactly one of candidate_id or provider_ref is required".into());
+            },
         }
     }
     Ok(routes)
@@ -216,20 +298,41 @@ impl HttpFilter for ProviderRouteFilter {
         strip_edge_headers(ctx);
 
         let Some(candidate_id) = request_header(ctx, SELECTED_CANDIDATE_HEADER).map(str::to_owned) else {
-            return Ok(FilterAction::Reject(Rejection::status(403)));
+            return Ok(reject_provider_request("missing trusted stable candidate ID"));
         };
         let Some(request_id) = request_header(ctx, PROVIDER_HOP_REQUEST_ID_HEADER).map(str::to_owned) else {
-            return Ok(FilterAction::Reject(Rejection::status(403)));
+            return Ok(reject_provider_request("missing trusted provider-hop request ID"));
         };
         let overlay_revision = match peer_overlay_revision(ctx) {
             Ok(revision) => revision.map(str::to_owned),
-            Err(InvalidPeerOverlayRevision) => return Ok(FilterAction::Reject(Rejection::status(403))),
+            Err(InvalidPeerOverlayRevision) => return Ok(reject_provider_request("invalid trusted overlay revision")),
         };
         let Some(model) = request_header_by_name(ctx, &self.model_header).map(str::to_owned) else {
             return Ok(FilterAction::Reject(Rejection::status(400)));
         };
-        let Some(route) = self.routes.get(candidate_id.as_str()) else {
-            return Ok(FilterAction::Reject(Rejection::status(403)));
+        let stable_route = self.routes.stable_ids.get(candidate_id.as_str());
+        let provider_name = request_header(ctx, PROVIDER_REF_NAME_HEADER).map(str::to_owned);
+        let provider_site = request_header(ctx, PROVIDER_REF_SITE_HEADER).map(str::to_owned);
+        let provider_ref_key = match (provider_name.as_deref(), provider_site.as_deref()) {
+            (Some(name), Some(site)) => Some(ProviderRefKey {
+                name: Arc::from(name),
+                site: Arc::from(site),
+            }),
+            (None, None) => None,
+            _ => return Ok(reject_provider_request("incomplete trusted provider reference")),
+        };
+        let provider_route = provider_ref_key
+            .as_ref()
+            .and_then(|provider_ref| self.routes.provider_refs.get(provider_ref));
+        let route = match (stable_route, provider_route) {
+            (Some(stable), Some(provider)) if !routes_equivalent(stable, provider) => {
+                return Ok(reject_provider_request(
+                    "stable ID and provider reference select different routes",
+                ));
+            },
+            (Some(stable), _) => stable,
+            (None, Some(provider)) => provider,
+            (None, None) => return Ok(reject_provider_request("unknown stable ID or provider reference")),
         };
         if route.model.as_ref() != model || !route.paths.iter().any(|path| path.as_ref() == ctx.request.uri.path()) {
             return Ok(FilterAction::Reject(Rejection::status(404)));
@@ -241,6 +344,13 @@ impl HttpFilter for ProviderRouteFilter {
         ctx.set_metadata(PROVIDER_ROUTE_MODEL, &model);
         ctx.set_metadata(PROVIDER_ROUTE_PROVIDER_ID, &*self.provider_id);
         ctx.set_metadata(PROVIDER_ROUTE_REQUEST_ID, &request_id);
+        let validated_provider_ref = provider_route
+            .zip(provider_ref_key.as_ref())
+            .map(|(_, provider_ref)| provider_ref);
+        if let Some(provider_ref) = validated_provider_ref {
+            ctx.set_metadata(PROVIDER_ROUTE_PROVIDER_REF_NAME, &*provider_ref.name);
+            ctx.set_metadata(PROVIDER_ROUTE_PROVIDER_REF_SITE, &*provider_ref.site);
+        }
         if let Some(revision) = &overlay_revision {
             ctx.set_metadata(PROVIDER_ROUTE_OVERLAY_REVISION, revision);
         }
@@ -254,6 +364,8 @@ impl HttpFilter for ProviderRouteFilter {
             &route.model,
             &candidate_id,
             overlay_revision.as_deref(),
+            validated_provider_ref.map(|provider_ref| provider_ref.name.as_ref()),
+            validated_provider_ref.map(|provider_ref| provider_ref.site.as_ref()),
         );
 
         Ok(FilterAction::Continue)
@@ -298,6 +410,10 @@ fn strip_edge_headers(ctx: &mut HttpFilterContext<'_>) {
         .push(HeaderName::from_static(PROVIDER_HOP_REQUEST_ID_HEADER));
     ctx.request_headers_to_remove
         .push(HeaderName::from_static(OVERLAY_REVISION_HEADER));
+    ctx.request_headers_to_remove
+        .push(HeaderName::from_static(PROVIDER_REF_NAME_HEADER));
+    ctx.request_headers_to_remove
+        .push(HeaderName::from_static(PROVIDER_REF_SITE_HEADER));
     ctx.request_headers_to_remove
         .push(HeaderName::from_static(PROVIDER_REQUEST_ID_HEADER));
     ctx.request_headers_to_remove
@@ -367,7 +483,9 @@ fn request_header_by_name<'a>(ctx: &'a HttpFilterContext<'_>, name: &HeaderName)
 
 /// Validate all fields of a single route entry.
 fn validate_route(route: &ProviderRouteConfig) -> Result<(), FilterError> {
-    validate_value("candidate_id", &route.candidate_id)?;
+    if let Some(candidate_id) = &route.candidate_id {
+        validate_value("candidate_id", candidate_id)?;
+    }
     validate_value("cluster", &route.cluster)?;
     validate_value("model", &route.model)?;
     if route.paths.is_empty() || route.paths.len() > MAX_PATHS_PER_ROUTE {
@@ -763,6 +881,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn provider_reference_authorizes_with_trusted_overlay_identity() {
+        let config = serde_yaml::from_str(
+            "provider_id: test-provider\n\
+             routes:\n\
+             \x20 - provider_ref:\n\
+             \x20     name: qwen3-ifc1\n\
+             \x20     site: site-a\n\
+             \x20   cluster: mock-backend\n\
+             \x20   model: sim-model-v1\n\
+             \x20   paths: [/v1/chat/completions]\n",
+        )
+        .unwrap();
+        let filter = ProviderRouteFilter::from_config(&config).unwrap();
+        let mut request = request_with_peer_context("/v1/chat/completions", "stable-a", "req-1", "sim-model-v1");
+        request.headers.insert(
+            HeaderName::from_static(PROVIDER_REF_NAME_HEADER),
+            HeaderValue::from_static("qwen3-ifc1"),
+        );
+        request.headers.insert(
+            HeaderName::from_static(PROVIDER_REF_SITE_HEADER),
+            HeaderValue::from_static("site-a"),
+        );
+        let mut ctx = test_utils::make_filter_context(&request);
+
+        assert!(matches!(
+            filter.on_request(&mut ctx).await.unwrap(),
+            FilterAction::Continue
+        ));
+        assert_eq!(ctx.get_metadata(PROVIDER_ROUTE_PROVIDER_REF_NAME), Some("qwen3-ifc1"));
+        assert_eq!(ctx.get_metadata(PROVIDER_ROUTE_PROVIDER_REF_SITE), Some("site-a"));
+        assert!(
+            ctx.request_headers_to_remove
+                .contains(&HeaderName::from_static(PROVIDER_REF_NAME_HEADER))
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_stable_id_does_not_attribute_an_unresolved_provider_reference() {
+        let filter = make_filter("abc123");
+        let mut request = request_with_peer_context("/v1/chat/completions", "abc123", "req-1", "sim-model-v1");
+        request.headers.insert(
+            HeaderName::from_static(PROVIDER_REF_NAME_HEADER),
+            HeaderValue::from_static("unconfigured-provider"),
+        );
+        request.headers.insert(
+            HeaderName::from_static(PROVIDER_REF_SITE_HEADER),
+            HeaderValue::from_static("site-a"),
+        );
+        let mut ctx = test_utils::make_filter_context(&request);
+
+        assert!(matches!(
+            filter.on_request(&mut ctx).await.unwrap(),
+            FilterAction::Continue
+        ));
+        assert_eq!(ctx.get_metadata(PROVIDER_ROUTE_PROVIDER_REF_NAME), None);
+        assert_eq!(ctx.get_metadata(PROVIDER_ROUTE_PROVIDER_REF_SITE), None);
+    }
+
+    #[tokio::test]
+    async fn provider_reference_wrong_site_is_denied() {
+        let config = serde_yaml::from_str(
+            "provider_id: test-provider\n\
+             routes:\n\
+             \x20 - provider_ref:\n\
+             \x20     name: qwen3-ifc1\n\
+             \x20     site: site-a\n\
+             \x20   cluster: mock-backend\n\
+             \x20   model: sim-model-v1\n\
+             \x20   paths: [/v1/chat/completions]\n",
+        )
+        .unwrap();
+        let filter = ProviderRouteFilter::from_config(&config).unwrap();
+        let mut request = request_with_peer_context("/v1/chat/completions", "unknown", "req-1", "sim-model-v1");
+        request.headers.insert(
+            HeaderName::from_static(PROVIDER_REF_NAME_HEADER),
+            HeaderValue::from_static("qwen3-ifc1"),
+        );
+        request.headers.insert(
+            HeaderName::from_static(PROVIDER_REF_SITE_HEADER),
+            HeaderValue::from_static("site-b"),
+        );
+        let mut ctx = test_utils::make_filter_context(&request);
+
+        assert!(matches!(filter.on_request(&mut ctx).await.unwrap(), FilterAction::Reject(r) if r.status == 403));
+    }
+
+    #[tokio::test]
     async fn distinct_candidates_resolve_independent_cluster_metadata() {
         let f = ProviderRouteFilter::from_config(&two_route_config()).unwrap();
         let req_a = request_with_peer_context("/v1/chat/completions", "abc123", "req-1", "sim-model-v1");
@@ -1007,6 +1212,20 @@ mod tests {
         let val: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
         let result = ProviderRouteFilter::from_config(&val);
         assert!(result.is_err(), "duplicate candidate_id must be rejected");
+    }
+
+    #[test]
+    fn conflicting_selectors_rejected() {
+        let yaml = "provider_id: p\nroutes:\n  - candidate_id: a\n    provider_ref: {name: p, site: s}\n    model: m\n    paths: [/x]\n    cluster: c\n";
+        let val: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        assert!(ProviderRouteFilter::from_config(&val).is_err());
+    }
+
+    #[test]
+    fn duplicate_provider_reference_rejected() {
+        let yaml = "provider_id: p\nroutes:\n  - provider_ref: {name: p, site: s}\n    model: m\n    paths: [/x]\n    cluster: c\n  - provider_ref: {name: p, site: s}\n    model: m\n    paths: [/y]\n    cluster: c2\n";
+        let val: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        assert!(ProviderRouteFilter::from_config(&val).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Allow `provider_route` authorization rules to select a trusted candidate by the trusted Grid provider resource identity instead of requiring operators to copy an opaque generated stable ID.

This is the Praxis AI half of praxis-proxy/grid#132. The companion Grid change publishes `provider_ref.name` and `provider_ref.site` from reconciled `InferenceProvider` state.

## API

Provider routes may use either the existing stable-ID selector:

```yaml
- candidate_id: f91111ba
  cluster: qwen-backend
  model: qwen3
  paths: [/v1/chat/completions]
```

or a site-scoped provider reference:

```yaml
- provider_ref:
    name: qwen3-ifc1
    site: site-a
  cluster: qwen-backend
  model: qwen3
  paths: [/v1/chat/completions]
```

The selectors are mutually exclusive in configuration. Stable IDs remain the internal routing and affinity identity.

## Trust and authorization

- `intelligent_route` reads provider identity only from a validated routing overlay.
- Client-supplied provider-reference headers are removed before trusted values are written for a provider hop.
- `provider_route` matches the site-scoped `(name, site)` pair against its configured route table.
- Missing, incomplete, unknown, duplicate, conflicting, or wrong-site selectors fail closed.
- Same-named providers at different sites cannot cross-authorize.
- Provider-reference headers are consumed at the provider boundary and are not forwarded to the backend.
- Telemetry records provider identity only when that reference resolved through the configured provider route; an unresolved reference accompanying a valid legacy stable ID is not attributed.

## Compatibility

Existing `candidate_id` configurations continue to work. Candidates without `provider_ref` continue to parse, and static non-overlay candidates do not synthesize a trusted provider identity.

## Validation

- Provider-route focused tests: 40 passed.
- Overlay focused tests: 107 passed in the implementation validation.
- AI workspace tests, documentation, lint, formatting, generated filter documentation, and consistency checks passed.
- Focused post-review Clippy passed with warnings denied.
- `git diff --check` passed.

The Kind qualification is intentionally delegated and has not yet run. The companion Grid PR carries the coordinated overlay contract and qualification context.
