### PR TITLE
feat(routing): add static weighted provider selection

### DIFF
--- a/docs/filters/intelligent_route.md
+++ b/docs/filters/intelligent_route.md
@@ -55,6 +55,7 @@ Supports two modes:
 | `candidates[].kind` | `inference_model` \| `mcp_tool` | yes | Capability kind. |
 | `candidates[].name` | string | yes | Capability name (model name, tool name, or agent name). |
 | `candidates[].site` | string | yes | Site that owns this capability. |
+| `candidates[].traffic_weight` | integer | no | Optional bounded weight used only by weighted selection. |
 | `local_site` | string | no | Name of the local site (required in static mode, provided by overlay in overlay mode). |
 | `model_header` | string | no | Header name that carries the model name (default: `X-Model`). |
 | `provider_hop_clusters` | string[] | no | Clusters that terminate the authenticated provider-hop protocol. A selected candidate emits the fixed routing context only when its cluster is present in this allowlist. Each named cluster must use an mTLS-authenticated Praxis provider gateway. Direct API/backend clusters remain absent. |

--- a/filters/src/routing/descriptor.rs
+++ b/filters/src/routing/descriptor.rs
@@ -160,6 +160,10 @@ pub(crate) struct CandidateConfig {
 
     /// Site that owns this capability.
     pub site: String,
+
+    /// Optional bounded weight used only by weighted selection.
+    #[serde(default)]
+    pub traffic_weight: Option<u32>,
 }
 
 /// Default freshness state for candidates.
@@ -213,6 +217,9 @@ pub(crate) struct RouteCandidate {
 
     /// Producer-assigned priority group (lower is preferred).
     pub selection_group: Option<u32>,
+
+    /// Explicit positive traffic weight for weighted selection.
+    pub traffic_weight: Option<u32>,
 
     /// Producer-assigned locality tier (e.g. `"same_region"`).
     pub selection_tier: Option<Arc<str>>,
@@ -303,6 +310,7 @@ pub(crate) fn validate_candidates(raw: Vec<CandidateConfig>) -> Result<Vec<Route
             name: Arc::from(c.name.as_str()),
             rank: None,
             selection_group: None,
+            traffic_weight: c.traffic_weight,
             selection_tier: None,
             site: Arc::from(c.site.as_str()),
             stable_id,
@@ -616,6 +624,7 @@ mod tests {
             kind,
             name: name.to_owned(),
             site: site.to_owned(),
+            traffic_weight: None,
         }
     }
 }

--- a/filters/src/routing/group_index.rs
+++ b/filters/src/routing/group_index.rs
@@ -23,9 +23,22 @@ pub(crate) struct SelectionGroup {
     /// are retained as separate slots, so duplication intentionally acts as a
     /// producer-controlled selection weight.
     pub(crate) candidate_indexes: Vec<usize>,
+    /// Weighted cumulative buckets for this group.
+    pub(crate) weighted_entries: Vec<WeightedEntry>,
+    /// Total positive weight in this group.
+    pub(crate) total_weight: u64,
     /// State belongs to this snapshot and therefore resets only on a real
     /// semantic snapshot replacement.
     pub(crate) next: AtomicUsize,
+}
+
+/// A cumulative weighted-selection bucket.
+#[derive(Debug)]
+pub(crate) struct WeightedEntry {
+    /// Candidate index in the immutable snapshot.
+    pub(crate) candidate_index: usize,
+    /// Exclusive upper bound for the random draw.
+    pub(crate) cumulative_upper_bound: u64,
 }
 
 /// Precomputed capability lookup used by the request path.
@@ -77,6 +90,7 @@ pub(crate) fn build(candidates: &[RouteCandidate]) -> Result<GroupIndex, FilterE
                     .into());
                 }
                 group.candidate_indexes.push(candidate_index);
+                append_weight(group, candidate_index, candidate)?;
                 continue;
             },
             Some(group) if number != group.number.saturating_add(1) => {
@@ -88,15 +102,39 @@ pub(crate) fn build(candidates: &[RouteCandidate]) -> Result<GroupIndex, FilterE
             _ => {},
         }
 
-        groups.push(SelectionGroup {
+        let mut group = SelectionGroup {
             number,
             admission_state: candidate.admission_state,
             candidate_indexes: vec![candidate_index],
+            weighted_entries: Vec::new(),
+            total_weight: 0,
             next: AtomicUsize::new(0),
-        });
+        };
+        append_weight(&mut group, candidate_index, candidate)?;
+        groups.push(group);
     }
 
     Ok(index)
+}
+
+/// Validate and append one candidate's weight to a group.
+fn append_weight(group: &mut SelectionGroup, index: usize, candidate: &RouteCandidate) -> Result<(), FilterError> {
+    let Some(weight) = candidate.traffic_weight else {
+        return Ok(());
+    };
+    if !(1..=1000).contains(&weight) {
+        return Err(format!("routing: candidate {index}: traffic_weight must be between 1 and 1000").into());
+    }
+    let total = group
+        .total_weight
+        .checked_add(u64::from(weight))
+        .ok_or_else(|| FilterError::from("routing: traffic weights overflow"))?;
+    group.total_weight = total;
+    group.weighted_entries.push(WeightedEntry {
+        candidate_index: index,
+        cumulative_upper_bound: total,
+    });
+    Ok(())
 }
 
 #[cfg(test)]
@@ -119,6 +157,7 @@ mod tests {
             name: Arc::from("model"),
             rank: None,
             selection_group: group,
+            traffic_weight: None,
             selection_tier: None,
             site: Arc::from("site"),
             stable_id: Arc::from("stable"),
@@ -149,6 +188,20 @@ mod tests {
         ])
         .unwrap_err();
         assert!(error.to_string().contains("contiguous and monotonic"));
+    }
+
+    #[test]
+    fn direct_capacity_range_is_accepted_and_out_of_range_values_are_rejected() {
+        for weight in [1, 100, 101, 1_000] {
+            let mut value = candidate(Some(0), AdmissionState::NewAndExisting);
+            value.traffic_weight = Some(weight);
+            assert!(build(&[value]).is_ok(), "weight {weight} should be accepted");
+        }
+        for weight in [0, 1_001, u32::MAX] {
+            let mut value = candidate(Some(0), AdmissionState::NewAndExisting);
+            value.traffic_weight = Some(weight);
+            assert!(build(&[value]).is_err(), "weight {weight} should be rejected");
+        }
     }
 
     #[test]

--- a/filters/src/routing/intelligent_route.rs
+++ b/filters/src/routing/intelligent_route.rs
@@ -2729,6 +2729,7 @@ mod tests {
                     kind: CapabilityKind::InferenceModel,
                     name: "llama".to_owned(),
                     site: site1.to_owned(),
+                    traffic_weight: None,
                 },
                 CandidateConfig {
                     cluster: cluster2.to_owned(),
@@ -2737,6 +2738,7 @@ mod tests {
                     kind: CapabilityKind::InferenceModel,
                     name: "llama".to_owned(),
                     site: site2.to_owned(),
+                    traffic_weight: None,
                 },
             ])
             .unwrap(),
@@ -2753,6 +2755,7 @@ mod tests {
                 kind: CapabilityKind::InferenceModel,
                 name: "llama".to_owned(),
                 site: "site-a".to_owned(),
+                traffic_weight: None,
             }])
             .unwrap(),
             Arc::from("site-a"),
@@ -2801,6 +2804,7 @@ mod tests {
                 name: Arc::from("llama"),
                 rank: None,
                 selection_group: None,
+                traffic_weight: None,
                 selection_tier: None,
                 site: Arc::from("s"),
                 stable_id: descriptor::default_stable_id(CapabilityKind::InferenceModel, "llama", "s", cluster),

--- a/filters/src/routing/overlay.rs
+++ b/filters/src/routing/overlay.rs
@@ -527,9 +527,9 @@ impl RouteSnapshot {
             .map_or(PickerPolicy::Deterministic, |policy| policy.mode);
         descriptor::validate_local_site(&envelope.overlay.local_site)?;
         let candidates = overlay_to_candidates(&envelope.overlay)?;
+        validate_selection_mode(&candidates, selection_mode)?;
         let group_index = group_index::build(&candidates)?;
         let generated_at = envelope.overlay.generated_at.map(|s| Arc::from(s.as_str()));
-        validate_selection_mode(&candidates, selection_mode)?;
         warn_if_selection_policy_has_no_groups(selection_mode, &group_index);
 
         Ok(Self {
@@ -555,9 +555,9 @@ impl RouteSnapshot {
             .selection_policy
             .map_or(PickerPolicy::Deterministic, |policy| policy.mode);
         let candidates = overlay_to_candidates(&doc)?;
+        validate_selection_mode(&candidates, selection_mode)?;
         let group_index = group_index::build(&candidates)?;
         let generated_at = doc.generated_at.map(|s| Arc::from(s.as_str()));
-        validate_selection_mode(&candidates, selection_mode)?;
         warn_if_selection_policy_has_no_groups(selection_mode, &group_index);
 
         Ok(Self {
@@ -815,7 +815,8 @@ fn validate_unique_stable_ids(candidates: &[RouteCandidate]) -> Result<(), Filte
 ///
 /// Zips the validated candidate list with the original overlay entries
 /// and sets `admission_state`, `rank`, `selection_group`, `selection_tier`,
-/// and `stable_id`.
+/// and `stable_id`. `traffic_weight` is already copied through the validated
+/// [`CandidateConfig`] path.
 /// Called after [`validate_candidates`] so `deny_unknown_fields` on
 /// [`CandidateConfig`] is never bypassed.
 ///
@@ -831,7 +832,6 @@ pub(super) fn enrich_from_overlay(
         }
         c.rank = oc.rank;
         c.selection_group = oc.selection_group;
-        c.traffic_weight = oc.traffic_weight;
         if let Some(t) = &oc.selection_tier {
             if t.trim().is_empty() || t.len() > 128 {
                 return Err(format!("routing: candidate {i}: selection_tier must be 1-128 non-blank bytes").into());
@@ -2927,6 +2927,16 @@ mod tests {
     fn non_weighted_overlay_rejects_weight_fields() {
         let json = br#"{"local_site":"s","selection_policy":{"mode":"random"},"candidates":[{"kind":"inference_model","name":"m","site":"a","cluster":"a","traffic_weight":10}]}"#;
         assert!(RouteSnapshot::from_overlay(json).is_err());
+    }
+
+    #[test]
+    fn non_weighted_overlay_reports_mode_error_before_weight_range_error() {
+        let json = br#"{"local_site":"s","selection_policy":{"mode":"random"},"candidates":[{"kind":"inference_model","name":"m","site":"a","cluster":"a","traffic_weight":1001}]}"#;
+        let error = RouteSnapshot::from_overlay(json).expect_err("non-weighted mode must reject weights");
+        assert_eq!(
+            error.to_string(),
+            "routing: traffic_weight is only valid with weightedRandom selection"
+        );
     }
 
     /// Poll `predicate` every 20ms until it returns `true` or `timeout` elapses.

--- a/filters/src/routing/overlay.rs
+++ b/filters/src/routing/overlay.rs
@@ -15,6 +15,7 @@
 //! [`ArcSwap`]: arc_swap::ArcSwap
 
 use std::{
+    collections::HashSet,
     fmt::Write as _,
     io::Read as _,
     path::{Path, PathBuf},
@@ -237,6 +238,8 @@ pub(crate) enum PickerPolicy {
     RoundRobin,
     /// Select a candidate uniformly at random from the active group.
     Random,
+    /// Select according to positive candidate traffic weights.
+    WeightedRandom,
 }
 
 impl PickerPolicy {
@@ -246,6 +249,7 @@ impl PickerPolicy {
             Self::Deterministic => "deterministic",
             Self::RoundRobin => "round_robin",
             Self::Random => "random",
+            Self::WeightedRandom => "weighted_random",
         }
     }
 }
@@ -294,6 +298,10 @@ pub(crate) struct OverlayCandidate {
     /// Producer-defined priority group. Lower groups are attempted first.
     #[serde(default)]
     pub(crate) selection_group: Option<u32>,
+
+    /// Optional positive traffic weight.
+    #[serde(default)]
+    pub(crate) traffic_weight: Option<u32>,
 
     /// Producer-assigned locality tier (e.g. `"same_region"`).
     #[serde(default)]
@@ -513,14 +521,15 @@ impl RouteSnapshot {
             validate_expected_scope(expected, &envelope.scope)?;
         }
 
-        descriptor::validate_local_site(&envelope.overlay.local_site)?;
-        let candidates = overlay_to_candidates(&envelope.overlay)?;
-        let group_index = group_index::build(&candidates)?;
-        let generated_at = envelope.overlay.generated_at.map(|s| Arc::from(s.as_str()));
         let selection_mode = envelope
             .overlay
             .selection_policy
             .map_or(PickerPolicy::Deterministic, |policy| policy.mode);
+        descriptor::validate_local_site(&envelope.overlay.local_site)?;
+        let candidates = overlay_to_candidates(&envelope.overlay)?;
+        let group_index = group_index::build(&candidates)?;
+        let generated_at = envelope.overlay.generated_at.map(|s| Arc::from(s.as_str()));
+        validate_selection_mode(&candidates, selection_mode)?;
         warn_if_selection_policy_has_no_groups(selection_mode, &group_index);
 
         Ok(Self {
@@ -542,12 +551,13 @@ impl RouteSnapshot {
             .map_err(|e| FilterError::from(format!("routing: overlay parse error: {e}")))?;
 
         descriptor::validate_local_site(&doc.local_site)?;
-        let candidates = overlay_to_candidates(&doc)?;
-        let group_index = group_index::build(&candidates)?;
-        let generated_at = doc.generated_at.map(|s| Arc::from(s.as_str()));
         let selection_mode = doc
             .selection_policy
             .map_or(PickerPolicy::Deterministic, |policy| policy.mode);
+        let candidates = overlay_to_candidates(&doc)?;
+        let group_index = group_index::build(&candidates)?;
+        let generated_at = doc.generated_at.map(|s| Arc::from(s.as_str()));
+        validate_selection_mode(&candidates, selection_mode)?;
         warn_if_selection_policy_has_no_groups(selection_mode, &group_index);
 
         Ok(Self {
@@ -733,6 +743,23 @@ fn validate_expected_scope(expected: &ExpectedOverlayScope, scope: &ScopeField) 
     Ok(())
 }
 
+/// Enforce the cross-field contract between picker mode and weights.
+fn validate_selection_mode(candidates: &[RouteCandidate], mode: PickerPolicy) -> Result<(), FilterError> {
+    if mode != PickerPolicy::WeightedRandom {
+        if candidates.iter().any(|candidate| candidate.traffic_weight.is_some()) {
+            return Err("routing: traffic_weight is only valid with weightedRandom selection".into());
+        }
+        return Ok(());
+    }
+    if candidates
+        .iter()
+        .any(|candidate| candidate.selection_group.is_none() || candidate.traffic_weight.is_none())
+    {
+        return Err("routing: weightedRandom requires selection_group and traffic_weight on every candidate".into());
+    }
+    Ok(())
+}
+
 // -----------------------------------------------------------------------------
 // Overlay → RouteCandidate conversion
 // -----------------------------------------------------------------------------
@@ -758,13 +785,30 @@ fn overlay_to_candidates(doc: &OverlayDocument) -> Result<Vec<RouteCandidate>, F
                 kind,
                 name: oc.name.clone(),
                 site: oc.site.clone(),
+                traffic_weight: oc.traffic_weight,
             })
         })
         .collect::<Result<Vec<_>, FilterError>>()?;
 
     let mut candidates = descriptor::validate_candidates(raw)?;
     enrich_from_overlay(&mut candidates, &doc.candidates)?;
+    validate_unique_stable_ids(&candidates)?;
     Ok(candidates)
+}
+
+/// Reject effective stable identifiers shared by distinct candidates.
+fn validate_unique_stable_ids(candidates: &[RouteCandidate]) -> Result<(), FilterError> {
+    let mut seen = HashSet::with_capacity(candidates.len());
+    for (index, candidate) in candidates.iter().enumerate() {
+        if !seen.insert(candidate.stable_id.as_ref()) {
+            return Err(format!(
+                "routing: candidate {index}: duplicate stable_id '{}'",
+                candidate.stable_id
+            )
+            .into());
+        }
+    }
+    Ok(())
 }
 
 /// Apply producer-supplied metadata to validated candidates.
@@ -787,6 +831,7 @@ pub(super) fn enrich_from_overlay(
         }
         c.rank = oc.rank;
         c.selection_group = oc.selection_group;
+        c.traffic_weight = oc.traffic_weight;
         if let Some(t) = &oc.selection_tier {
             if t.trim().is_empty() || t.len() > 128 {
                 return Err(format!("routing: candidate {i}: selection_tier must be 1-128 non-blank bytes").into());
@@ -1645,6 +1690,19 @@ mod tests {
         let json = r#"{"local_site":"site-a","candidates":[{"kind":"inference_model","name":"m","site":"s","cluster":"c","fresh":true,"stable_id":"   "}]}"#;
         let result = RouteSnapshot::from_overlay(json.as_bytes());
         assert!(result.is_err(), "whitespace stable_id must be rejected");
+    }
+
+    #[test]
+    fn parse_overlay_duplicate_explicit_stable_id_rejected() {
+        let json = r#"{
+            "local_site": "site-a",
+            "candidates": [
+                {"kind":"inference_model","name":"a","site":"s","cluster":"c","fresh":true,"stable_id":"shared"},
+                {"kind":"inference_model","name":"b","site":"s","cluster":"c","fresh":true,"stable_id":"shared"}
+            ]
+        }"#;
+        let result = RouteSnapshot::from_overlay(json.as_bytes());
+        assert!(result.is_err(), "duplicate explicit stable_id values must be rejected");
     }
 
     #[test]
@@ -2848,6 +2906,28 @@ mod tests {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    #[test]
+    fn weighted_overlay_accepts_positive_group_weights() {
+        let json = br#"{"local_site":"s","selection_policy":{"mode":"weightedRandom"},"candidates":[{"kind":"inference_model","name":"m","site":"a","cluster":"a","selection_group":0,"traffic_weight":70},{"kind":"inference_model","name":"m","site":"b","cluster":"b","selection_group":0,"traffic_weight":30}]}"#;
+        let snapshot = RouteSnapshot::from_overlay(json).expect("valid weighted overlay");
+        assert_eq!(snapshot.selection_mode, PickerPolicy::WeightedRandom);
+        assert_eq!(snapshot.candidates[0].traffic_weight, Some(70));
+    }
+
+    #[test]
+    fn weighted_overlay_rejects_missing_or_out_of_range_weights() {
+        let missing = br#"{"local_site":"s","selection_policy":{"mode":"weightedRandom"},"candidates":[{"kind":"inference_model","name":"m","site":"a","cluster":"a","selection_group":0}]}"#;
+        assert!(RouteSnapshot::from_overlay(missing).is_err());
+        let invalid = br#"{"local_site":"s","selection_policy":{"mode":"weightedRandom"},"candidates":[{"kind":"inference_model","name":"m","site":"a","cluster":"a","selection_group":0,"traffic_weight":0}]}"#;
+        assert!(RouteSnapshot::from_overlay(invalid).is_err());
+    }
+
+    #[test]
+    fn non_weighted_overlay_rejects_weight_fields() {
+        let json = br#"{"local_site":"s","selection_policy":{"mode":"random"},"candidates":[{"kind":"inference_model","name":"m","site":"a","cluster":"a","traffic_weight":10}]}"#;
+        assert!(RouteSnapshot::from_overlay(json).is_err());
+    }
 
     /// Poll `predicate` every 20ms until it returns `true` or `timeout` elapses.
     fn poll_until(timeout: Duration, predicate: impl Fn() -> bool) {

--- a/filters/src/routing/picker.rs
+++ b/filters/src/routing/picker.rs
@@ -50,32 +50,42 @@ fn select_from_group<'a>(
     if group.admission_state != AdmissionState::NewAndExisting {
         return None;
     }
-    let ordinal = choose_ordinal(policy, group.candidate_indexes.len(), &group.next);
-    select_from_group_at(candidates, group, ordinal)
-}
-
-/// Select a specific member of a prevalidated group.
-///
-/// This small ordinal seam keeps policy tests deterministic without changing
-/// production randomness or making the request path injectable at runtime.
-fn select_from_group_at<'a>(
-    candidates: &'a [RouteCandidate],
-    group: &SelectionGroup,
-    ordinal: usize,
-) -> Option<&'a RouteCandidate> {
-    group
-        .candidate_indexes
-        .get(ordinal)
-        .and_then(|&index| candidates.get(index))
+    let index = choose_candidate_index(policy, group, &group.next)?;
+    candidates.get(index)
 }
 
 /// Resolve a policy to an index inside a non-empty selection group.
-fn choose_ordinal(policy: PickerPolicy, len: usize, counter: &AtomicUsize) -> usize {
-    match policy {
-        PickerPolicy::Deterministic => 0,
-        PickerPolicy::RoundRobin => counter.fetch_add(1, Ordering::Relaxed) % len,
-        PickerPolicy::Random => rand::rng().random_range(0..len),
+fn choose_candidate_index(policy: PickerPolicy, group: &SelectionGroup, counter: &AtomicUsize) -> Option<usize> {
+    let len = group.candidate_indexes.len();
+    if len == 0 {
+        return None;
     }
+    match policy {
+        PickerPolicy::Deterministic => group.candidate_indexes.first().copied(),
+        PickerPolicy::RoundRobin => group
+            .candidate_indexes
+            .get(counter.fetch_add(1, Ordering::Relaxed) % len)
+            .copied(),
+        PickerPolicy::Random => group.candidate_indexes.get(rand::rng().random_range(0..len)).copied(),
+        PickerPolicy::WeightedRandom => {
+            if group.total_weight == 0 {
+                return None;
+            }
+            let draw = rand::rng().random_range(0..group.total_weight);
+            weighted_index_for_draw(group, draw)
+        },
+    }
+}
+
+/// Resolve a prevalidated weighted draw to its candidate index.
+fn weighted_index_for_draw(group: &SelectionGroup, draw: u64) -> Option<usize> {
+    if draw >= group.total_weight {
+        return None;
+    }
+    let bucket = group
+        .weighted_entries
+        .partition_point(|entry| entry.cumulative_upper_bound <= draw);
+    group.weighted_entries.get(bucket).map(|entry| entry.candidate_index)
 }
 
 #[cfg(test)]
@@ -86,10 +96,10 @@ mod tests {
     use super::{
         super::{
             descriptor::{AdmissionState, CapabilityKind, RouteCandidate},
-            group_index,
+            group_index::{self, SelectionGroup},
             overlay::PickerPolicy,
         },
-        choose_ordinal, select_candidate,
+        choose_candidate_index, select_candidate, weighted_index_for_draw,
     };
 
     fn candidate(cluster: &str, group: Option<u32>, admission: AdmissionState) -> RouteCandidate {
@@ -102,6 +112,7 @@ mod tests {
             name: Arc::from("model"),
             rank: None,
             selection_group: group,
+            traffic_weight: None,
             selection_tier: None,
             site: Arc::from("site"),
             stable_id: Arc::from(cluster),
@@ -232,8 +243,50 @@ mod tests {
     #[test]
     fn round_robin_counter_wraps_without_leaving_group() {
         let counter = AtomicUsize::new(usize::MAX);
-        assert_eq!(choose_ordinal(PickerPolicy::RoundRobin, 2, &counter), usize::MAX % 2);
-        assert_eq!(choose_ordinal(PickerPolicy::RoundRobin, 2, &counter), 0);
+        let group = SelectionGroup {
+            number: 0,
+            admission_state: AdmissionState::NewAndExisting,
+            candidate_indexes: vec![0, 1],
+            weighted_entries: Vec::new(),
+            total_weight: 0,
+            next: AtomicUsize::new(0),
+        };
+        assert_eq!(
+            choose_candidate_index(PickerPolicy::RoundRobin, &group, &counter),
+            Some(usize::MAX % 2)
+        );
+        assert_eq!(
+            choose_candidate_index(PickerPolicy::RoundRobin, &group, &counter),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn weighted_draw_boundaries_are_proportional_and_exclusive() {
+        let mut candidates = vec![
+            candidate("a", Some(0), AdmissionState::NewAndExisting),
+            candidate("b", Some(0), AdmissionState::NewAndExisting),
+        ];
+        candidates.first_mut().unwrap().traffic_weight = Some(70);
+        candidates.get_mut(1).unwrap().traffic_weight = Some(30);
+        let groups = group_index::build(&candidates).unwrap();
+        let group = groups
+            .get(&CapabilityKind::InferenceModel)
+            .and_then(|by_name| by_name.get("model"))
+            .and_then(|groups| groups.first())
+            .unwrap();
+
+        assert_eq!(weighted_index_for_draw(group, 0), Some(0));
+        assert_eq!(weighted_index_for_draw(group, 69), Some(0));
+        assert_eq!(weighted_index_for_draw(group, 70), Some(1));
+        assert_eq!(weighted_index_for_draw(group, 99), Some(1));
+        assert_eq!(weighted_index_for_draw(group, 100), None);
+        let counts = (0..group.total_weight).fold([0_u64; 2], |mut counts, draw| {
+            let index = weighted_index_for_draw(group, draw).unwrap();
+            *counts.get_mut(index).unwrap() += 1;
+            counts
+        });
+        assert_eq!(counts, [70, 30]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add opt-in static weighted provider selection to the Praxis AI routing overlay.

- add `weightedRandom` selection within the first viable selection group
- accept explicit per-candidate `traffic_weight` values from `1..=1000`
- preserve eligibility, group precedence, and session-affinity behavior
- validate that weights are present only for weighted selection
- reject missing, zero, oversized, or conflicting weighted configuration
- reject duplicate effective stable IDs
- use checked cumulative `u64` weight bounds and an unbiased random draw
- preserve the existing empty-overlay last-known-good behavior

This is static configuration, not metric-driven routing. Grid determines candidate eligibility and grouping before Praxis performs the weighted draw.

## Why

Grid can determine that several providers are equally eligible while those providers have different configured capacities. Existing deterministic, round-robin, and random selection cannot express that capacity ratio. This change lets a trusted routing overlay ask Praxis to distribute new requests proportionally within the first eligible group, without weakening health, policy, locality, admission, or affinity precedence.

Keeping the weighted draw in Praxis also keeps request selection local to the gateway's accepted in-memory snapshot. Requests do not wait for Grid, Kubernetes, metrics collection, or a cross-site control-plane call.

## Related issue

Closes #1042

## API

```yaml
selection_policy:
  mode: weightedRandom
candidates:
  - cluster: provider-a
    selection_group: 0
    traffic_weight: 50
  - cluster: provider-b
    selection_group: 0
    traffic_weight: 30
```

Weights are relative. `50/30/20` and `5/3/2` express the same intended proportions.

## Dependency

The companion [praxis-proxy/grid#142](https://github.com/praxis-proxy/grid/pull/142) change is merged. It publishes validated direct weights in the same `1..=1000` range, propagates provider capacity across sites, and provides the Helm-backed Kind qualification. This AI support must be available before a Grid configuration enables `weightedRandom`.

## Validation

- [x] Unit tests
- [x] Integration or functional tests
- [x] `make lint`

Completed validation:

- AI workspace tests: passed
- focused routing tests: 378 passed
- Clippy with warnings denied: passed
- documentation and lint checks: passed
- two companion Grid Kind qualifications passed all baseline, changed-weight, equal-weight, convergence, attribution, gateway-stability, and cleanup assertions
- follow-up overlay validation: 111 tests passed

The final review also removed an unrelated change that would have accepted empty overlays. The follow-up patch improves validation errors and removes a redundant weight assignment without changing the validated weight contract.

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

The weighted overlay is produced by Grid and is covered by Grid's Helm-backed static-weighted qualification. This AI PR documents the overlay fields, but it does not yet add a standalone `examples/configs/` entry and corresponding AI functional example test.

## Compatibility

The feature is opt-in. Existing deterministic, round-robin, and random configurations do not receive weight fields and retain their current behavior.

## Breaking changes

None. Existing selection modes and overlays without weighted fields retain their current behavior.
