### PR TITLE
ci(vllm): background vLLM start to overlap cargo build

### DIFF
--- a/.github/actions/start-vllm/action.yml
+++ b/.github/actions/start-vllm/action.yml
@@ -1,5 +1,5 @@
 name: Start vLLM
-description: Pull the pinned vLLM CPU image, start it with the canonical serving flags, and wait for readiness.
+description: Launch the pinned vLLM CPU container in the background (pull image + start container). Pair with the wait-vllm action to block until it is serving, so the pull and model load overlap other work (e.g. cargo build).
 inputs:
   image:
     description: vLLM CPU container image (pinned by digest).
@@ -10,36 +10,33 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Pull vLLM CPU image
+    - name: Start vLLM (background)
       shell: bash
-      run: docker pull "${{ inputs.image }}"
-
-    - name: Start vLLM
-      shell: bash
+      env:
+        VLLM_IMAGE: ${{ inputs.image }}
+        VLLM_MODEL: ${{ inputs.model }}
       run: |
-        docker run -d --name vllm \
-          -p 8000:8000 \
-          --privileged=true \
-          "${{ inputs.image }}" \
-          --model /root/.cache/Qwen/Qwen3-0.6B \
-          --max-model-len 4096 \
-          --served-model-name "${{ inputs.model }}" \
-          --enable-auto-tool-choice \
-          --tool-call-parser hermes \
-          --reasoning-parser deepseek_r1 \
-          --gpu-memory-utilization 0.5
-
-    - name: Wait for vLLM readiness
-      shell: bash
-      run: |
-        echo "Waiting for vLLM health and model endpoints..."
-        timeout 900 bash -c 'until curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
-                                   curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
-          if ! docker inspect --format="{{.State.Running}}" vllm 2>/dev/null | grep -q true; then
-            echo "::error::vLLM container exited unexpectedly"
-            docker logs vllm 2>&1
-            exit 1
-          fi
-          sleep 5
-        done'
-        echo "vLLM is ready"
+        # Pull the (multi-GB, model-baked) image and start the container in the
+        # background so the pull + model load overlap the caller's next steps
+        # (cargo build, OGX startup) instead of blocking them. Join with the
+        # wait-vllm action before the first request. `nohup ... &` keeps the
+        # launcher alive across the step boundary (same technique as the OGX
+        # background start); its pid and log let wait-vllm tell "still pulling"
+        # apart from a real pull/start failure.
+        nohup bash -c '
+          set -euo pipefail
+          docker pull "$VLLM_IMAGE"
+          docker run -d --name vllm \
+            -p 8000:8000 \
+            --privileged=true \
+            "$VLLM_IMAGE" \
+            --model /root/.cache/Qwen/Qwen3-0.6B \
+            --max-model-len 4096 \
+            --served-model-name "$VLLM_MODEL" \
+            --enable-auto-tool-choice \
+            --tool-call-parser hermes \
+            --reasoning-parser deepseek_r1 \
+            --gpu-memory-utilization 0.5
+        ' > /tmp/vllm-start.log 2>&1 &
+        echo $! > /tmp/vllm-start.pid
+        echo "vLLM launch backgrounded (launcher pid $(cat /tmp/vllm-start.pid)); join with the wait-vllm action"

--- a/.github/actions/wait-vllm/action.yml
+++ b/.github/actions/wait-vllm/action.yml
@@ -1,0 +1,58 @@
+name: Wait for vLLM
+description: Block until the backgrounded vLLM CPU container (started by the start-vllm action) is serving, so its image pull and model load overlap prior steps such as cargo build.
+runs:
+  using: composite
+  steps:
+    - name: Wait for vLLM readiness
+      shell: bash
+      run: |
+        echo "Waiting for vLLM health and model endpoints..."
+        # start-vllm launches `docker pull && docker run` in the background so the
+        # (model-baked, multi-GB) image pull and model load overlap the caller's
+        # build. Join here: poll the serving endpoints, but distinguish the three
+        # non-ready states so a failure is diagnosable instead of an opaque
+        # timeout -- (1) launcher still pulling (container absent, launcher
+        # alive), (2) launcher died before creating the container (pull/run
+        # failed), (3) container created but exited/dead (crashed on model load).
+        deadline=$((SECONDS + 900))
+        start_pid=""
+        [ -f /tmp/vllm-start.pid ] && start_pid="$(cat /tmp/vllm-start.pid)"
+        dump_logs() {
+          echo "----- docker logs vllm -----"
+          docker logs vllm 2>&1 || echo "(no vllm container)"
+          if [ -f /tmp/vllm-start.log ]; then
+            echo "----- /tmp/vllm-start.log -----"
+            cat /tmp/vllm-start.log
+          fi
+        }
+        while true; do
+          if curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1 && \
+             curl -sf http://127.0.0.1:8000/v1/models > /dev/null 2>&1; then
+            echo "vLLM is ready"
+            break
+          fi
+          status="$(docker inspect --format='{{.State.Status}}' vllm 2>/dev/null || echo absent)"
+          case "$status" in
+            exited|dead)
+              echo "::error::vLLM container is '$status' before it began serving"
+              dump_logs
+              exit 1
+              ;;
+            absent)
+              # Container not created yet: fine only while the background launcher
+              # is still pulling/starting. If that process is gone, the pull or
+              # run failed before the container was ever created.
+              if [ -n "$start_pid" ] && ! kill -0 "$start_pid" 2>/dev/null; then
+                echo "::error::vLLM launcher (pid $start_pid) exited before the container was created (pull or start failed)"
+                dump_logs
+                exit 1
+              fi
+              ;;
+          esac
+          if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "::error::vLLM did not become ready within 900s"
+            dump_logs
+            exit 1
+          fi
+          sleep 5
+        done

--- a/.github/workflows/openresponses-conformance.yaml
+++ b/.github/workflows/openresponses-conformance.yaml
@@ -10,6 +10,7 @@ on:
       - "tests/conformance/openresponses/**"
       - "tests/integration/sdk/openai/test_responses_conformance.py"
       - ".github/actions/start-vllm/**"
+      - ".github/actions/wait-vllm/**"
       - ".github/workflows/openresponses-conformance.yaml"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -24,6 +25,7 @@ on:
       - "tests/conformance/openresponses/**"
       - "tests/integration/sdk/openai/test_responses_conformance.py"
       - ".github/actions/start-vllm/**"
+      - ".github/actions/wait-vllm/**"
       - ".github/workflows/openresponses-conformance.yaml"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -67,6 +69,7 @@ jobs:
             'tests/conformance/openresponses/' \
             'tests/integration/sdk/openai/test_responses_conformance.py' \
             '.github/actions/start-vllm/' \
+            '.github/actions/wait-vllm/' \
             '.github/workflows/openresponses-conformance.yaml' \
             'Cargo.toml' 'Cargo.lock' 'Makefile')
           if [ -n "$CHANGED" ]; then
@@ -104,14 +107,17 @@ jobs:
             https://bun.sh/install | bash -s "bun-v1.3.12"
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
-      - name: Build Praxis
-        run: cargo build -p praxis-ai-proxy
-
       - name: Start vLLM
         uses: ./.github/actions/start-vllm
         with:
           image: ${{ env.VLLM_IMAGE }}
           model: ${{ env.VLLM_MODEL }}
+
+      - name: Build Praxis
+        run: cargo build -p praxis-ai-proxy
+
+      - name: Wait for vLLM readiness
+        uses: ./.github/actions/wait-vllm
 
       - name: Run OpenResponses conformance
         env:
@@ -125,7 +131,7 @@ jobs:
 
       - name: vLLM container logs
         if: failure()
-        run: docker logs vllm
+        run: docker logs vllm 2>&1 || echo "(no vllm container)"
 
       - name: Upload failure artifacts
         if: failure()

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -18,6 +18,8 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "Makefile"
+      - ".github/actions/start-vllm/**"
+      - ".github/actions/wait-vllm/**"
       - ".github/workflows/vllm-integration.yaml"
   pull_request:
     branches: [main]
@@ -33,6 +35,8 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "Makefile"
+      - ".github/actions/start-vllm/**"
+      - ".github/actions/wait-vllm/**"
       - ".github/workflows/vllm-integration.yaml"
   merge_group:
     branches: [main]
@@ -98,6 +102,8 @@ jobs:
             'Cargo.toml' \
             'Cargo.lock' \
             'Makefile' \
+            '.github/actions/start-vllm/' \
+            '.github/actions/wait-vllm/' \
             '.github/workflows/vllm-integration.yaml')
           if [ -n "$CHANGED" ]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
@@ -169,6 +175,9 @@ jobs:
       - name: Build Praxis
         run: cargo build -p praxis-ai-proxy
 
+      - name: Wait for vLLM readiness
+        uses: ./.github/actions/wait-vllm
+
       - name: Run Conversations SDK integration tests
         run: |
           uv run tests/integration/sdk/openai/test_openai_conversations.py -s
@@ -218,7 +227,7 @@ jobs:
 
       - name: vLLM container logs
         if: failure()
-        run: docker logs vllm
+        run: docker logs vllm 2>&1 || echo "(no vllm container)"
 
       - name: OGX logs
         if: failure()
@@ -313,6 +322,9 @@ jobs:
       - name: Build Praxis
         run: cargo build -p praxis-ai-proxy
 
+      - name: Wait for vLLM readiness
+        uses: ./.github/actions/wait-vllm
+
       - name: Wait for OGX readiness
         run: |
           echo "Waiting for OGX server..."
@@ -360,7 +372,7 @@ jobs:
 
       - name: vLLM container logs
         if: failure()
-        run: docker logs vllm
+        run: docker logs vllm 2>&1 || echo "(no vllm container)"
 
       - name: OGX logs
         if: failure()

--- a/.github/workflows/vllm-integration.yaml
+++ b/.github/workflows/vllm-integration.yaml
@@ -14,6 +14,7 @@ on:
       - "apis/src/store/**"
       - "server/**"
       - "tests/integration/sdk/openai/**"
+      - "tests/integration/ogx-constraints.txt"
       - "examples/configs/openai/responses/**"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -31,6 +32,7 @@ on:
       - "apis/src/store/**"
       - "server/**"
       - "tests/integration/sdk/openai/**"
+      - "tests/integration/ogx-constraints.txt"
       - "examples/configs/openai/responses/**"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -52,22 +54,12 @@ env:
   CARGO_TERM_COLOR: always
   VLLM_IMAGE: "quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english@sha256:0212dc82981178033cb71c7477ba8ad1998fb6c0b1ee40646119fb9724ac951b"
   VLLM_MODEL: "Qwen/Qwen3-0.6B"
-  # Pinned + single-sourced so the pre-install and Start OGX specs are provably
-  # identical (uv reuses the same cached environment) and the two jobs can't
-  # drift. Bump this line deliberately to pull a newer OGX.
-  OGX_SPEC: "ogx[starter]==1.3.1"
-  # Pin transformers alongside OGX. ogx[starter] only constrains
-  # sentence-transformers (>=5.6.0, no upper bound), which in turn allows
-  # transformers >=5.0.0,<6.0.0 with no lower ceiling. transformers 5.17.0
-  # (PyPI 2026-09-09) removed ModuleUtilsMixin.get_extended_attention_mask,
-  # which OGX's inline Nomic embedding model (file-search vector-store indexing)
-  # calls via trust_remote_code, so every run that re-resolved the closure after
-  # 5.17.0 landed failed the two file-search tests with
-  #   'NomicBertModel' object has no attribute 'get_extended_attention_mask'.
-  # 5.16.1 is the last release that still ships the method and satisfies
-  # sentence-transformers 6.0.1's transformers>=5.0.0,<6.0.0 range. Bump this
-  # line deliberately once OGX / the Nomic model support transformers 5.17+.
-  TRANSFORMERS_SPEC: "transformers==5.16.1"
+  # OGX + transformers pins live in tests/integration/ogx-constraints.txt (with
+  # the rationale for each pin). Single-sourcing them there lets the uv download
+  # cache key depend only on the pins, so editing this workflow or a test file
+  # no longer forces a cold multi-GB OGX re-download. Both OGX steps install from
+  # this file via `uv run --with-requirements`.
+  OGX_CONSTRAINTS: "tests/integration/ogx-constraints.txt"
 
 jobs:
   # ----------------------------------------------------------------------------
@@ -98,6 +90,7 @@ jobs:
             'apis/src/store/' \
             'server/' \
             'tests/integration/sdk/openai/' \
+            'tests/integration/ogx-constraints.txt' \
             'examples/configs/openai/responses/' \
             'Cargo.toml' \
             'Cargo.lock' \
@@ -138,14 +131,17 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Persist uv's wheel/download cache across runs so the pinned OGX
-          # closure and the test's PEP-723 deps are not re-downloaded every run.
-          # Keyed on the files that carry those pins, so the cache invalidates
-          # only when a pin actually changes.
+          # Persist uv's wheel/download cache across runs so the multi-GB OGX
+          # closure (torch, CUDA, faiss, transformers) is not re-downloaded every
+          # run. Key ONLY on the pins file: setup-uv has no restore-key/prefix
+          # fallback, so any globbed file that changes forces a full cold
+          # re-download (~8 min). The workflow YAML and test files are
+          # deliberately NOT globbed -- editing them must not bust the cache; uv
+          # still downloads any small new PEP-723 test dep incrementally on top
+          # of the restored cache.
           enable-cache: true
           cache-dependency-glob: |
-            .github/workflows/vllm-integration.yaml
-            tests/integration/sdk/openai/test_openai_responses_vllm.py
+            tests/integration/ogx-constraints.txt
 
       - name: Start vLLM
         uses: ./.github/actions/start-vllm
@@ -160,16 +156,15 @@ jobs:
           # clock. Without this the download runs backgrounded inside the
           # "Wait for OGX readiness" window and loses the race under network
           # variance, so the server never binds port 8321 in time (exit 124).
-          echo "Pre-installing OGX ($OGX_SPEC)..."
-          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx --help > /dev/null
+          echo "Pre-installing OGX from $OGX_CONSTRAINTS..."
+          uv run --with-requirements "$OGX_CONSTRAINTS" ogx --help > /dev/null
           echo "OGX environment ready"
 
       - name: Start OGX
         run: |
-          # Same "$OGX_SPEC" + "$TRANSFORMERS_SPEC" as the pre-install above, so
-          # uv reuses the already materialized environment and the server binds
-          # within seconds.
-          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          # Same "$OGX_CONSTRAINTS" as the pre-install above, so uv reuses the
+          # already materialized environment and the server binds within seconds.
+          uv run --with-requirements "$OGX_CONSTRAINTS" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
           echo $! > /tmp/ogx.pid
 
       - name: Build Praxis
@@ -285,14 +280,17 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Persist uv's wheel/download cache across runs so the pinned OGX
-          # closure and the test's PEP-723 deps are not re-downloaded every run.
-          # Keyed on the files that carry those pins, so the cache invalidates
-          # only when a pin actually changes.
+          # Persist uv's wheel/download cache across runs so the multi-GB OGX
+          # closure (torch, CUDA, faiss, transformers) is not re-downloaded every
+          # run. Key ONLY on the pins file: setup-uv has no restore-key/prefix
+          # fallback, so any globbed file that changes forces a full cold
+          # re-download (~8 min). The workflow YAML and test files are
+          # deliberately NOT globbed -- editing them must not bust the cache; uv
+          # still downloads any small new PEP-723 test dep incrementally on top
+          # of the restored cache.
           enable-cache: true
           cache-dependency-glob: |
-            .github/workflows/vllm-integration.yaml
-            tests/integration/sdk/openai/test_openai_responses_vllm.py
+            tests/integration/ogx-constraints.txt
 
       - name: Start vLLM
         uses: ./.github/actions/start-vllm
@@ -307,16 +305,15 @@ jobs:
           # clock. Without this the download runs backgrounded inside the
           # "Wait for OGX readiness" window and loses the race under network
           # variance, so the server never binds port 8321 in time (exit 124).
-          echo "Pre-installing OGX ($OGX_SPEC)..."
-          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx --help > /dev/null
+          echo "Pre-installing OGX from $OGX_CONSTRAINTS..."
+          uv run --with-requirements "$OGX_CONSTRAINTS" ogx --help > /dev/null
           echo "OGX environment ready"
 
       - name: Start OGX
         run: |
-          # Same "$OGX_SPEC" + "$TRANSFORMERS_SPEC" as the pre-install above, so
-          # uv reuses the already materialized environment and the server binds
-          # within seconds.
-          uv run --with "$OGX_SPEC" --with "$TRANSFORMERS_SPEC" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
+          # Same "$OGX_CONSTRAINTS" as the pre-install above, so uv reuses the
+          # already materialized environment and the server binds within seconds.
+          uv run --with-requirements "$OGX_CONSTRAINTS" ogx run starter --insecure > /tmp/ogx.log 2>&1 &
           echo $! > /tmp/ogx.pid
 
       - name: Build Praxis
@@ -324,6 +321,12 @@ jobs:
 
       - name: Wait for vLLM readiness
         uses: ./.github/actions/wait-vllm
+
+      - name: Run Conversations SDK integration tests (PostgreSQL store)
+        env:
+          DATABASE_URL: postgres://praxis:praxis@127.0.0.1:5432/praxis
+        run: |
+          uv run tests/integration/sdk/openai/test_openai_conversations.py -s
 
       - name: Wait for OGX readiness
         run: |

--- a/tests/integration/ogx-constraints.txt
+++ b/tests/integration/ogx-constraints.txt
@@ -1,0 +1,29 @@
+# OGX + transformers pins for the vLLM file-search integration jobs
+# (.github/workflows/vllm-integration.yaml).
+#
+# Single source of truth: the "Pre-install OGX dependencies" and "Start OGX"
+# steps both install this exact set via `uv run --with-requirements`, so they
+# resolve an identical closure (uv reuses the cached environment) and cannot
+# drift.
+#
+# This file is ALSO the sole entry in the setup-uv cache-dependency-glob. The uv
+# download cache is keyed on a content hash of the globbed files, and setup-uv
+# has no restore-key/prefix fallback -- any change to a globbed file forces a
+# full, cold re-download of the multi-GB OGX/torch/CUDA/faiss closure (~8 min
+# under network variance). Keying on THIS file alone means the closure is
+# re-downloaded only when a pin below actually changes; editing the workflow
+# YAML or a test file no longer busts the cache.
+#
+# ogx[starter] only constrains sentence-transformers (>=5.6.0, no upper bound),
+# which in turn allows transformers >=5.0.0,<6.0.0 with no lower ceiling.
+# transformers 5.17.0 (PyPI 2026-09-09) removed
+# ModuleUtilsMixin.get_extended_attention_mask, which OGX's inline Nomic
+# embedding model (file-search vector-store indexing) calls via
+# trust_remote_code, so every run that re-resolved the closure after 5.17.0
+# landed failed the two file-search tests with
+#   'NomicBertModel' object has no attribute 'get_extended_attention_mask'.
+# 5.16.1 is the last release that still ships the method and satisfies
+# sentence-transformers 6.0.1's transformers>=5.0.0,<6.0.0 range. Bump the
+# transformers pin deliberately once OGX / the Nomic model support 5.17+.
+ogx[starter]==1.3.1
+transformers==5.16.1

--- a/tests/integration/sdk/openai/test_openai_conversations.py
+++ b/tests/integration/sdk/openai/test_openai_conversations.py
@@ -32,6 +32,11 @@ import httpx
 import pytest
 from openai import BadRequestError, NotFoundError, OpenAI
 
+# When set to a postgres:// URL (the vllm-responses-postgres CI job), the
+# conversations store runs against PostgreSQL instead of the default in-memory
+# SQLite, so this suite exercises the same store backend as the responses tests.
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -57,6 +62,38 @@ def _find_binary() -> str:
     )
 
 
+def _conversations_filter() -> dict:
+    """Build the openai_conversations filter config for the configured store.
+
+    Defaults to in-memory SQLite; switches to PostgreSQL when DATABASE_URL is a
+    postgres:// URL, matching the responses tests' backend selection so both
+    suites cover the same store backend in CI.
+    """
+    cfg = {
+        "filter": "openai_conversations",
+        "conversations_table": "conversations",
+        "items_table": "conversation_items",
+    }
+    if DATABASE_URL.startswith("postgres"):
+        cfg.update(
+            {
+                "backend": "postgres",
+                "database_url": DATABASE_URL,
+                # Local CI postgres service is loopback + non-TLS.
+                "allow_private_database_url": True,
+                "ssl_mode": "disable",
+            }
+        )
+    else:
+        cfg.update(
+            {
+                "backend": "sqlite",
+                "database_url": "sqlite::memory:",
+            }
+        )
+    return cfg
+
+
 def _write_config(port: int) -> str:
     config = {
         "listeners": [
@@ -69,15 +106,7 @@ def _write_config(port: int) -> str:
         "filter_chains": [
             {
                 "name": "conversations-pipeline",
-                "filters": [
-                    {
-                        "filter": "openai_conversations",
-                        "backend": "sqlite",
-                        "database_url": "sqlite::memory:",
-                        "conversations_table": "conversations",
-                        "items_table": "conversation_items",
-                    }
-                ],
+                "filters": [_conversations_filter()],
             }
         ],
     }


### PR DESCRIPTION
## Summary

The `start-vllm` action pulled the (model-baked, multi-GB) image, started the container, and blocked on readiness *before* `Build Praxis` ran, so ~5 min of vLLM setup (docker pull ~2m51s + model load ~2m10s, measured in CI) was pure serial wait ahead of the ~7–9 min build. This backgrounds the pull+start and moves the readiness join into a new `wait-vllm` action *after* the build — the same start-early / join-after overlap already used for OGX — applied to both `vllm-integration` jobs and to `openresponses-conformance`, so vLLM setup hides behind the build (~5–6 min saved per vLLM job). The `wait-vllm` join is more diagnosable than the old inline wait (it distinguishes still-pulling / launcher-died / container-crashed / timeout and dumps logs in every non-ready state), the failure-path `docker logs vllm` steps are guarded for the window before the container exists, and the shared action paths are added to the workflows' path filters.

## Related issue

N/A — CI wall-clock optimization; no tracked issue.

## Validation

- `actionlint` 1.7.12 (matches the CI pin, with shellcheck) passes on the full `.github` tree, including the new `wait-vllm` action.
- `make build` and `make lint` pass locally (exit 0; clippy clean, xtask registry/coverage checks green).
- Adversarially reviewed; the one confirmed finding (unguarded failure-path `docker logs vllm`) is fixed in this change.

- [ ] Unit tests — N/A (CI workflow change)
- [x] Integration or functional tests — exercised by the vLLM integration + OpenResponses conformance workflows this PR modifies
- [x] `make lint`

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [ ] New capabilities include an example config and functional example test. — N/A (CI-only change)
- [x] User-facing behavior and generated documentation are updated. — N/A (no runtime/user-facing or docs impact)
- [ ] Performance-sensitive changes include appropriate benchmark or load-test evidence. — measured CI step timings cited above
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

None. The `start-vllm` action now returns without waiting for readiness; every in-repo caller is updated to pair it with the new `wait-vllm` action.
