### PR TITLE
fix(rehydrate): remove non-spec history limits from openai_responses_rehydrate

### DIFF
--- a/apis/src/openai/responses/rehydrate/mod.rs
+++ b/apis/src/openai/responses/rehydrate/mod.rs
@@ -34,7 +34,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use praxis_filter::{
-    FilterAction, FilterError, HttpFilter, HttpFilterContext,
+    EmptyFilterConfig, FilterAction, FilterError, HttpFilter, HttpFilterContext,
     body::{BodyAccess, BodyMode, MAX_JSON_BODY_BYTES},
     parse_filter_config,
 };
@@ -48,7 +48,6 @@ use super::{
 };
 use crate::{
     is_event_stream_content_type,
-    json_body::serialized_len,
     store::{ConversationRecord, ResponseRecord, ResponseStoreRegistry},
 };
 
@@ -82,12 +81,7 @@ const PREV_USAGE_TOTAL_KEY: &str = "responses.previous_usage_total_tokens";
 /// ```yaml
 /// filter: openai_responses_rehydrate
 /// ```
-pub struct RehydrateFilter {
-    /// Maximum serialized byte size of stored conversation history.
-    max_history_bytes: usize,
-    /// Optional cap on the number of stored history items.
-    max_history_items: Option<usize>,
-}
+pub struct RehydrateFilter;
 
 impl RehydrateFilter {
     /// Create a filter from YAML config.
@@ -95,25 +89,13 @@ impl RehydrateFilter {
     /// # Errors
     ///
     /// Returns [`FilterError`] if the YAML config contains unknown
-    /// fields, or `max_history_bytes` / `max_history_items` is zero.
+    /// fields.
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
-        let empty = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let cfg = if config.is_null() { &empty } else { config };
-        let validated: RehydrateConfig = parse_filter_config("openai_responses_rehydrate", cfg)?;
-        if validated.max_history_bytes == 0 {
-            return Err(FilterError::from(
-                "openai_responses_rehydrate: max_history_bytes must be greater than 0",
-            ));
-        }
-        if validated.max_history_items == Some(0) {
-            return Err(FilterError::from(
-                "openai_responses_rehydrate: max_history_items must be greater than 0",
-            ));
-        }
-        Ok(Box::new(Self {
-            max_history_bytes: validated.max_history_bytes,
-            max_history_items: validated.max_history_items,
-        }))
+        // The filter has no tunable options. Parsing still runs so that
+        // `deny_unknown_fields` rejects any config keys, including the removed
+        // `max_history_bytes` / `max_history_items` limits.
+        let _: EmptyFilterConfig = parse_filter_config("openai_responses_rehydrate", config)?;
+        Ok(Box::new(Self))
     }
 
     /// Parse body, resolve rehydration source (`previous_response_id` or
@@ -152,12 +134,9 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let stored = match stored_messages_for_response(&record, self.max_history_bytes, self.max_history_items) {
-            Ok(s) => s,
-            Err(action) => return Ok(action),
-        };
         let previous_tools = collect_mcp_tool_listings(&record);
         let previous_usage = record.response_object.get("usage").filter(|u| !u.is_null()).cloned();
+        let stored = stored_messages_for_response(record);
         let state = build_state(parsed_body, stored, previous_tools, previous_usage);
         install_rehydrated_state(ctx, state);
         debug!(previous_response_id = %prev_id, "previous response validated, state populated");
@@ -184,32 +163,12 @@ impl RehydrateFilter {
             Ok(r) => r,
             Err(action) => return Ok(action),
         };
-        let stored = match stored_messages_for_conversation(&record, self.max_history_bytes, self.max_history_items) {
-            Ok(s) => s,
-            Err(action) => return Ok(action),
-        };
+        let stored = stored_messages_for_conversation(record);
         let state = build_state(parsed_body, stored, vec![], None);
         install_rehydrated_state(ctx, state);
         debug!(conversation_id = %conv_id, "conversation rehydrated, state populated");
         Ok(FilterAction::Release)
     }
-}
-
-/// YAML configuration for [`RehydrateFilter`].
-#[derive(serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RehydrateConfig {
-    /// Maximum serialized byte size of stored conversation history. Default: 2,097,152 (2 MiB).
-    #[serde(default = "default_max_history_bytes")]
-    max_history_bytes: usize,
-    /// Optional cap on the number of stored history items.
-    #[serde(default)]
-    max_history_items: Option<usize>,
-}
-
-/// Default maximum byte size for stored conversation history (2 MiB).
-fn default_max_history_bytes() -> usize {
-    2_097_152 // 2 MiB
 }
 
 #[async_trait]
@@ -1130,58 +1089,24 @@ fn is_responses_cancel_path(path: &str) -> bool {
     !response_id.is_empty() && !response_id.contains('/')
 }
 
-/// Reject when `items` exceeds the configured byte-size or item-count cap.
-fn check_history_limits(items: &[Value], max_bytes: usize, max_items: Option<usize>) -> Result<(), FilterAction> {
-    if let Some(max) = max_items {
-        let count = items.len();
-        if count > max {
-            return Err(reject_too_large(&format!(
-                "stored conversation history contains {count} items, \
-                   exceeding the {max} item limit; \
-                   compact or shorten the conversation before continuing"
-            )));
-        }
-    }
-
-    let byte_size = serialized_len(items).unwrap_or(usize::MAX);
-    if byte_size > max_bytes {
-        return Err(reject_too_large(&format!(
-            "stored conversation history is {byte_size} bytes, \
-               exceeding the {max_bytes} byte limit; \
-               compact or shorten the conversation before continuing"
-        )));
-    }
-
-    Ok(())
-}
-
 // -----------------------------------------------------------------------------
 // Stored message extraction
 // -----------------------------------------------------------------------------
 
-/// Stored messages from a response record, checking limits before cloning.
-fn stored_messages_for_response(
-    record: &ResponseRecord,
-    max_bytes: usize,
-    max_items: Option<usize>,
-) -> Result<Vec<Value>, FilterAction> {
-    if let Some(messages) = record.messages.as_array().filter(|a| !a.is_empty()) {
-        check_history_limits(messages, max_bytes, max_items)?;
-        return Ok(messages.clone());
+/// Stored messages from a response record.
+fn stored_messages_for_response(mut record: ResponseRecord) -> Vec<Value> {
+    match std::mem::take(&mut record.messages) {
+        Value::Array(arr) if !arr.is_empty() => arr,
+        _ => reconstruct_messages_from_public_response(record),
     }
-    reconstruct_messages_from_public_response(record, max_bytes, max_items)
 }
 
-/// Stored messages from a conversation record, checking limits before cloning.
-fn stored_messages_for_conversation(
-    record: &ConversationRecord,
-    max_bytes: usize,
-    max_items: Option<usize>,
-) -> Result<Vec<Value>, FilterAction> {
-    let empty: &[Value] = &[];
-    let messages = record.messages.as_array().map_or(empty, Vec::as_slice);
-    check_history_limits(messages, max_bytes, max_items)?;
-    Ok(messages.to_vec())
+/// Stored messages from a conversation record.
+fn stored_messages_for_conversation(record: ConversationRecord) -> Vec<Value> {
+    match record.messages {
+        Value::Array(arr) => arr,
+        _ => vec![],
+    }
 }
 
 /// Fetch the previous response and validate its status in one step.
@@ -1259,29 +1184,28 @@ fn build_state(
 
 /// Return stored history, reconstructing from public fields for
 /// records created before hidden messages were persisted.
-fn reconstruct_messages_from_public_response(
-    record: &ResponseRecord,
-    max_bytes: usize,
-    max_items: Option<usize>,
-) -> Result<Vec<Value>, FilterAction> {
+fn reconstruct_messages_from_public_response(mut record: ResponseRecord) -> Vec<Value> {
     let mut messages = Vec::new();
 
-    append_stored_input_items(&mut messages, record.input.clone());
+    append_stored_input_items(&mut messages, record.input);
 
-    if let Some(output) = record.response_object.get("output").filter(|output| !output.is_null()) {
+    let output = record
+        .response_object
+        .get_mut("output")
+        .map(std::mem::take)
+        .filter(|v| !v.is_null());
+    if let Some(output) = output {
         append_stored_output_items(&mut messages, output);
     }
 
-    check_history_limits(&messages, max_bytes, max_items)?;
-    Ok(messages)
+    messages
 }
 
 /// Append stored response output items to the persisted conversation history.
-fn append_stored_output_items(messages: &mut Vec<Value>, output: &Value) {
-    if let Value::Array(items) = output {
-        messages.extend(items.iter().cloned());
-    } else {
-        messages.push(output.clone());
+fn append_stored_output_items(messages: &mut Vec<Value>, output: Value) {
+    match output {
+        Value::Array(items) => messages.extend(items),
+        other => messages.push(other),
     }
 }
 
@@ -1478,11 +1402,6 @@ fn reject_invalid(message: &str) -> FilterAction {
 /// Build a 500 rejection with a Responses API error body.
 fn reject_server_error(message: &str) -> FilterAction {
     FilterAction::Reject(responses_error_rejection(500, "server_error", message))
-}
-
-/// Build a 413 rejection with a Responses API error body.
-fn reject_too_large(message: &str) -> FilterAction {
-    FilterAction::Reject(responses_error_rejection(413, "invalid_request_error", message))
 }
 
 // -----------------------------------------------------------------------------

--- a/apis/src/openai/responses/rehydrate/tests.rs
+++ b/apis/src/openai/responses/rehydrate/tests.rs
@@ -17,10 +17,7 @@ use crate::{
 };
 
 fn default_filter() -> RehydrateFilter {
-    RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: None,
-    }
+    RehydrateFilter
 }
 
 // -----------------------------------------------------------------------------
@@ -1156,106 +1153,49 @@ fn replay_canonicalizes_defaulted_item_types_and_excludes_unknown_items() {
     );
 }
 
-// -----------------------------------------------------------------------------
-// History Limits
-// -----------------------------------------------------------------------------
+// History limits (max_history_bytes, max_history_items) have been removed.
+// The OpenAI API does not define a total conversation item or byte ceiling;
+// model context overflow is governed by the Responses API `truncation`
+// setting. The fields are no longer accepted at all: configs that still set
+// them fail to build via deny_unknown_fields. See #532.
 
-#[tokio::test]
-async fn rejects_stored_history_exceeding_byte_limit() {
-    let user_content = "A".repeat(500);
-    let assistant_content = "B".repeat(500);
-    let messages = json!([
-        {"role": "user", "content": user_content},
-        {"role": "assistant", "content": assistant_content}
-    ]);
-    let store = MockStore::with_completed_response("resp_big", json!("Hello"), messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        max_history_bytes: 64,
-        max_history_items: None,
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_big"}"#));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(r.status, 413, "should reject with 413 for oversized history");
-            let body_bytes = r.body.unwrap();
-            let body_str = std::str::from_utf8(&body_bytes).unwrap();
-            assert!(
-                body_str.contains("byte limit"),
-                "rejection body should mention byte limit: {body_str}"
-            );
-        },
-        other => panic!("expected Reject, got {other:?}"),
+#[test]
+fn removed_history_limit_fields_rejected() {
+    for field in ["max_history_bytes: 1048576", "max_history_items: 200"] {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(field).unwrap();
+        let result = RehydrateFilter::from_config(&yaml);
+        assert!(
+            result.is_err(),
+            "removed history-limit field should be rejected by deny_unknown_fields: {field}"
+        );
     }
 }
 
 #[tokio::test]
-async fn rejects_stored_history_exceeding_item_limit() {
-    let messages = json!([
-        {"role": "user", "content": "Turn 1"},
-        {"role": "assistant", "content": "Reply 1"},
-        {"role": "user", "content": "Turn 2"},
-        {"role": "assistant", "content": "Reply 2"},
-        {"role": "user", "content": "Turn 3"}
-    ]);
-    let store = MockStore::with_completed_response("resp_many", json!("Hello"), messages);
+async fn large_history_accepted_without_rejection() {
+    let items: Vec<Value> = (0..500)
+        .map(|i| {
+            if i % 2 == 0 {
+                json!({"role": "user", "content": format!("message {i} {}", "x".repeat(200))})
+            } else {
+                json!({"role": "assistant", "content": format!("reply {i} {}", "y".repeat(200))})
+            }
+        })
+        .collect();
+    let store = MockStore::with_completed_response("resp_big", json!("Hello"), Value::Array(items));
     let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(3),
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_many"}"#));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(r.status, 413, "should reject with 413 for too many items");
-            let body_bytes = r.body.unwrap();
-            let body_str = std::str::from_utf8(&body_bytes).unwrap();
-            assert!(
-                body_str.contains("item limit"),
-                "rejection body should mention item limit: {body_str}"
-            );
-        },
-        other => panic!("expected Reject, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn allows_history_within_limits() {
-    let messages = json!([
-        {"role": "user", "content": "Hello"},
-        {"role": "assistant", "content": "Hi"}
-    ]);
-    let store = MockStore::with_completed_response("resp_ok", json!("Hello"), messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(10),
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"Next","previous_response_id":"resp_ok"}"#));
+    let mut body = Some(Bytes::from(r#"{"input":"next","previous_response_id":"resp_big"}"#));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
     assert!(
         matches!(action, FilterAction::Release),
-        "should release when history is within limits"
+        "large history should be accepted without limit enforcement"
     );
 
     let state = ctx
@@ -1263,163 +1203,46 @@ async fn allows_history_within_limits() {
         .get::<ResponsesState>()
         .expect("ResponsesState should be populated");
     assert_eq!(
-        state.messages.len(),
-        3,
-        "messages should contain 2 stored + 1 current input"
+        state.persisted_messages.len(),
+        501,
+        "all 500 stored items plus current input should be preserved"
     );
 }
 
 #[tokio::test]
-async fn from_config_with_custom_limits() {
-    let yaml: serde_yaml::Value = serde_yaml::from_str("max_history_bytes: 2097152\nmax_history_items: 2").unwrap();
-    let filter = RehydrateFilter::from_config(&yaml).unwrap();
-    assert_eq!(filter.name(), "openai_responses_rehydrate");
-
+async fn truncation_setting_preserved_through_rehydration() {
     let messages = json!([
-        {"role": "user", "content": "hello"},
-        {"role": "assistant", "content": "hi"},
-        {"role": "user", "content": "third"}
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"}
     ]);
-    let store = MockStore::with_completed_response("resp_cfg", json!("hello"), messages);
+    let store = MockStore::with_completed_response("resp_trunc", json!("Hello"), messages);
     let registry = setup_registry(store);
 
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry);
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"next","previous_response_id":"resp_cfg"}"#));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(r.status, 413, "configured item limit of 2 should reject 3-item history");
-        },
-        other => panic!("expected Reject for custom max_history_items=2, got {other:?}"),
-    }
-}
-
-#[test]
-fn from_config_rejects_zero_limits() {
-    let yaml = serde_yaml::from_str::<serde_yaml::Value>("max_history_bytes: 0").unwrap();
-    assert!(RehydrateFilter::from_config(&yaml).is_err());
-
-    let yaml = serde_yaml::from_str::<serde_yaml::Value>("max_history_items: 0").unwrap();
-    assert!(RehydrateFilter::from_config(&yaml).is_err());
-}
-
-#[tokio::test]
-async fn rejects_fallback_reconstruction_exceeding_byte_limit() {
-    let large_input = "X".repeat(500);
-    let large_output = json!([
-        {"type": "message", "content": [{"type": "output_text", "text": "Y".repeat(500)}]}
-    ]);
-    let mut records = std::collections::HashMap::new();
-    records.insert(
-        "resp_fallback".to_owned(),
-        ResponseRecord {
-            id: "resp_fallback".to_owned(),
-            tenant_id: "default".to_owned(),
-            created_at: 1000,
-            model: "gpt-4.1".to_owned(),
-            response_object: json!({
-                "id": "resp_fallback",
-                "status": "completed",
-                "output": large_output,
-            }),
-            input: json!(large_input),
-            messages: json!([]),
-        },
-    );
-    let store = MockStore {
-        records,
-        conversations: std::collections::HashMap::new(),
-        should_fail: false,
-    };
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        max_history_bytes: 64,
-        max_history_items: None,
-    };
+    let filter = default_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.extensions.insert(registry.clone());
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_fallback"}"#));
+    let mut body = Some(Bytes::from(
+        r#"{"input":"next","previous_response_id":"resp_trunc","truncation":"auto"}"#,
+    ));
 
     let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(
-                r.status, 413,
-                "fallback reconstruction exceeding byte limit should reject with 413"
-            );
-        },
-        other => panic!("expected Reject for oversized fallback reconstruction, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn rejects_fallback_reconstruction_exceeding_item_limit() {
-    let input = json!([
-        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "a"}]},
-        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "b"}]},
-        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "c"}]}
-    ]);
-    let output = json!([
-        {"type": "message", "content": [{"type": "output_text", "text": "r1"}]},
-        {"type": "message", "content": [{"type": "output_text", "text": "r2"}]}
-    ]);
-    let mut records = std::collections::HashMap::new();
-    records.insert(
-        "resp_items".to_owned(),
-        ResponseRecord {
-            id: "resp_items".to_owned(),
-            tenant_id: "default".to_owned(),
-            created_at: 1000,
-            model: "gpt-4.1".to_owned(),
-            response_object: json!({
-                "id": "resp_items",
-                "status": "completed",
-                "output": output,
-            }),
-            input,
-            messages: json!([]),
-        },
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release with truncation"
     );
-    let store = MockStore {
-        records,
-        conversations: std::collections::HashMap::new(),
-        should_fail: false,
-    };
-    let registry = setup_registry(store);
 
-    let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(3),
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_items"}"#));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(
-                r.status, 413,
-                "fallback reconstruction exceeding item limit should reject with 413"
-            );
-            let body_bytes = r.body.unwrap();
-            let body_str = std::str::from_utf8(&body_bytes).unwrap();
-            assert!(
-                body_str.contains("item limit"),
-                "rejection body should mention item limit: {body_str}"
-            );
-        },
-        other => panic!("expected Reject for oversized fallback reconstruction, got {other:?}"),
-    }
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert!(state.history_rehydrated, "history should be marked as rehydrated");
+    assert_eq!(
+        body.as_ref().unwrap().as_ref(),
+        r#"{"input":"next","previous_response_id":"resp_trunc","truncation":"auto"}"#.as_bytes(),
+        "request body with truncation should not be modified"
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -1733,127 +1556,6 @@ async fn conversation_null_messages_treated_as_empty() {
     );
 }
 
-// -----------------------------------------------------------------------------
-// Conversation History Limits
-// -----------------------------------------------------------------------------
-
-#[tokio::test]
-async fn rejects_conversation_history_exceeding_byte_limit() {
-    let user_content = "A".repeat(500);
-    let assistant_content = "B".repeat(500);
-    let messages = json!([
-        {"role": "user", "content": user_content},
-        {"role": "assistant", "content": assistant_content}
-    ]);
-    let store = MockStore::with_conversation("conv_big", messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        max_history_bytes: 64,
-        max_history_items: None,
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(
-        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_big"}"#,
-    ));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(
-                r.status, 413,
-                "should reject with 413 for oversized conversation history"
-            );
-            let body_bytes = r.body.unwrap();
-            let body_str = std::str::from_utf8(&body_bytes).unwrap();
-            assert!(
-                body_str.contains("byte limit"),
-                "rejection body should mention byte limit: {body_str}"
-            );
-        },
-        other => panic!("expected Reject, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn rejects_conversation_history_exceeding_item_limit() {
-    let messages = json!([
-        {"role": "user", "content": "Turn 1"},
-        {"role": "assistant", "content": "Reply 1"},
-        {"role": "user", "content": "Turn 2"},
-        {"role": "assistant", "content": "Reply 2"},
-        {"role": "user", "content": "Turn 3"}
-    ]);
-    let store = MockStore::with_conversation("conv_many", messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(3),
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(
-        r#"{"model":"gpt-4.1","input":"Hi","conversation":"conv_many"}"#,
-    ));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    match action {
-        FilterAction::Reject(r) => {
-            assert_eq!(r.status, 413, "should reject with 413 for too many conversation items");
-            let body_bytes = r.body.unwrap();
-            let body_str = std::str::from_utf8(&body_bytes).unwrap();
-            assert!(
-                body_str.contains("item limit"),
-                "rejection body should mention item limit: {body_str}"
-            );
-        },
-        other => panic!("expected Reject, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn allows_conversation_history_within_limits() {
-    let messages = json!([
-        {"role": "user", "content": "Hello"},
-        {"role": "assistant", "content": "Hi"}
-    ]);
-    let store = MockStore::with_conversation("conv_ok", messages);
-    let registry = setup_registry(store);
-
-    let filter = RehydrateFilter {
-        max_history_bytes: default_max_history_bytes(),
-        max_history_items: Some(10),
-    };
-    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.extensions.insert(registry.clone());
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
-    let mut body = Some(Bytes::from(
-        r#"{"model":"gpt-4.1","input":"Next","conversation":"conv_ok"}"#,
-    ));
-
-    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
-    assert!(
-        matches!(action, FilterAction::Release),
-        "should release when conversation history is within limits"
-    );
-
-    let state = ctx
-        .extensions
-        .get::<ResponsesState>()
-        .expect("ResponsesState should be populated");
-    assert_eq!(
-        state.messages.len(),
-        3,
-        "messages should contain 2 stored + 1 current input"
-    );
-}
 
 // -----------------------------------------------------------------------------
 // Response-side previous_response_id restore (issue #932)

--- a/docs/filters/openai_responses_rehydrate.md
+++ b/docs/filters/openai_responses_rehydrate.md
@@ -9,13 +9,6 @@ Validates `previous_response_id` by fetching the stored response, confirming its
 
 The request body is **not** modified; downstream filters read from `ResponsesState.messages` instead.
 
-## Configuration
-
-| Field | Type | Required | Description |
-|-------|------|---------|-------------|
-| `max_history_bytes` | integer | no | Maximum serialized byte size of stored conversation history. Default: 2,097,152 (2 MiB). |
-| `max_history_items` | integer | no | Optional cap on the number of stored history items. |
-
 ## Example
 
 ```yaml

--- a/examples/configs/openai/responses/rehydrate.yaml
+++ b/examples/configs/openai/responses/rehydrate.yaml
@@ -50,8 +50,6 @@ filter_chains:
         conversations_table: openai_conversations
 
       - filter: openai_responses_rehydrate
-        # max_history_bytes: 2097152  # 2 MiB (default)
-        # max_history_items: ~        # unlimited (default)
 
       - filter: router
         routes:

--- a/tests/integration/sdk/openai/test_openai_responses_vllm.py
+++ b/tests/integration/sdk/openai/test_openai_responses_vllm.py
@@ -538,6 +538,86 @@ class CompactionHandler(BaseHTTPRequestHandler):
         pass
 
 
+class ResponsesWitnessHandler(BaseHTTPRequestHandler):
+    """Recording shim that sits between Praxis and the native vLLM backend.
+
+    Captures the JSON body of every request the backend receives, then forwards
+    it transparently to real vLLM and streams the response back so the full
+    native Responses pipeline still completes. Tests use the captured bodies to
+    assert on what the proxy actually forwards upstream after its rewrites
+    (rehydration, ``previous_response_id`` stripping, ``truncation`` passthrough).
+    """
+
+    forwarded_bodies: ClassVar[list[dict]] = []
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def _forward(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        if body:
+            try:
+                type(self).forwarded_bodies.append(json.loads(body))
+            except json.JSONDecodeError:
+                pass
+        headers = {
+            k: v
+            for k, v in self.headers.items()
+            if k.lower() not in ("host", "content-length")
+        }
+        url = f"{VLLM_BASE_URL.rstrip('/')}{self.path}"
+        with httpx.Client(timeout=300.0) as client:
+            with client.stream(
+                self.command, url, headers=headers, content=body
+            ) as upstream:
+                self.send_response(upstream.status_code)
+                for key, value in upstream.headers.items():
+                    if key.lower() in (
+                        "transfer-encoding",
+                        "content-length",
+                        "connection",
+                    ):
+                        continue
+                    self.send_header(key, value)
+                self.end_headers()
+                for chunk in upstream.iter_raw():
+                    if chunk:
+                        self.wfile.write(chunk)
+                        self.wfile.flush()
+
+    def do_POST(self):
+        self._forward()
+
+    def do_GET(self):
+        self._forward()
+
+
+def _write_witness_config(
+    praxis_port: int,
+    db_path: str,
+    backend_port: int,
+) -> str:
+    """Patch full-flow.yaml to route the native backend through the shim.
+
+    Identical to :func:`_write_config` except the ``127.0.0.1:3001`` backend is
+    pointed at the recording shim (which forwards to vLLM) instead of vLLM
+    directly, so a test can observe the exact request bodies the backend sees.
+    """
+    with open(CONFIG_PATH) as f:
+        config = f.read()
+
+    config = config.replace("127.0.0.1:8080", f"127.0.0.1:{praxis_port}")
+    config = config.replace("127.0.0.1:3001", f"127.0.0.1:{backend_port}")
+    config = config.replace("127.0.0.1:9999", _ogx_endpoint())
+    config = _patch_store_backend(config, db_path)
+
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    with os.fdopen(fd, "w") as f:
+        f.write(config)
+    return path
+
+
 def _write_agentic_config(
     praxis_port: int,
     db_path: str,
@@ -780,6 +860,69 @@ def compact_proxy(tmp_path_factory, request, compaction_server):
                     file=sys.stderr,
                 )
         os.unlink(config_path)
+
+
+def _witness_proxy_session(tmp_path_factory, request):
+    """Start a proxy whose native backend is a recording shim in front of vLLM.
+
+    Shared generator body for the witness fixtures. Yields ``(client,
+    forwarded_bodies)`` where ``forwarded_bodies`` accumulates the JSON bodies
+    the vLLM Responses backend receives, letting a test assert on the request
+    the proxy actually forwards upstream after its rewrites.
+    """
+    ResponsesWitnessHandler.forwarded_bodies = []
+    forwarded = ResponsesWitnessHandler.forwarded_bodies
+    backend_port = _free_port()
+    server = HTTPServer(("127.0.0.1", backend_port), ResponsesWitnessHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    port = _free_port()
+    db_dir = tmp_path_factory.mktemp("responses-witness")
+    db_path = str(db_dir / "responses.db")
+    config_path = _write_witness_config(port, db_path, backend_port)
+    binary = _find_binary()
+
+    log_path = str(db_dir / "praxis.log")
+    log_file = open(log_path, "w")
+    started = False
+    proc = subprocess.Popen(
+        [binary, "-c", config_path],
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        _wait_for_proxy(port, proc, log_path)
+        started = True
+        client = OpenAI(
+            base_url=f"http://127.0.0.1:{port}/v1",
+            api_key="test",
+            max_retries=0,
+            timeout=300,
+        )
+        yield client, forwarded
+    finally:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        log_file.close()
+        server.shutdown()
+        if not started or request.session.testsfailed > 0:
+            with open(log_path) as f:
+                print(
+                    f"\n=== Witness backend Praxis logs ===\n{f.read()}",
+                    file=sys.stderr,
+                )
+        os.unlink(config_path)
+
+
+@pytest.fixture()
+def witness_backend_client(tmp_path_factory, request):
+    """Function-scoped witness proxy with the stock rehydrate config."""
+    yield from _witness_proxy_session(tmp_path_factory, request)
 
 
 @pytest.fixture(scope="session")
@@ -1158,6 +1301,69 @@ class TestOpenAIResponsesVLLM:
             "client even though it strips the id from the rehydrated upstream "
             f"request; got: {second.previous_response_id!r}"
         )
+
+    def test_truncation_forwarded_to_backend_through_rehydration(
+        self, witness_backend_client
+    ):
+        """Issue #532: the caller's ``truncation`` must reach the native backend
+        on both a fresh turn and a rehydrated continuation.
+
+        The unit test only proves ``truncation`` survives into ``ResponsesState``
+        before the proxy rewrites the outbound body. This drives the full native
+        pipeline against a recording shim in front of vLLM to prove the backend
+        actually *receives* the value on both turns:
+
+        * turn 1 sends ``truncation="auto"`` — forwarded verbatim (no rewrite);
+        * turn 2 rehydrates via ``previous_response_id`` and sends
+          ``truncation="disabled"`` — the proxy replays history into ``input``
+          and strips ``previous_response_id``, but must still forward the
+          caller's ``truncation``.
+
+        Guarding both spec values through the rewrite path is exactly what #532
+        requires: process conversation history without dropping client-supplied
+        request settings.
+        """
+        client, forwarded = witness_backend_client
+
+        before_first = len(forwarded)
+        first = client.responses.create(
+            model=VLLM_MODEL,
+            input="Remember this nonce: TRUNCATE-4821. Acknowledge it. /no_think",
+            temperature=0,
+            truncation="auto",
+            store=True,
+            max_output_tokens=128,
+        )
+        assert first.status == "completed"
+        assert first.truncation == "auto"
+
+        first_seen = forwarded[before_first:]
+        assert first_seen, "backend received no request on the first turn"
+        first_backend = first_seen[-1]
+        assert first_backend.get("truncation") == "auto", first_backend
+
+        before_second = len(forwarded)
+        second = client.responses.create(
+            model=VLLM_MODEL,
+            input="What nonce did I tell you? Repeat it exactly. /no_think",
+            temperature=0,
+            previous_response_id=first.id,
+            truncation="disabled",
+            store=True,
+            max_output_tokens=128,
+        )
+        assert second.status == "completed"
+        assert second.truncation == "disabled"
+
+        second_seen = forwarded[before_second:]
+        assert second_seen, "backend received no request on the rehydrated turn"
+        second_backend = second_seen[-1]
+        # The caller's truncation survives the outbound-body rewrite...
+        assert second_backend.get("truncation") == "disabled", second_backend
+        # ...while previous_response_id is stripped and history is replayed
+        # into `input` instead.
+        assert second_backend.get("previous_response_id") is None, second_backend
+        assert isinstance(second_backend.get("input"), list), second_backend
 
     def test_conversation_context_and_append_back(self, openai_client):
         conversation = openai_client.conversations.create(


### PR DESCRIPTION
## Summary

The `openai_responses_rehydrate` filter enforced Praxis-invented history caps (`max_history_bytes`, default 2 MiB, and optional `max_history_items`) that rejected long-but-valid continuations with a non-spec `413` — the OpenAI Responses API defines no total-history ceiling (context overflow is governed by the request's `truncation` setting, which the proxy already forwards untouched). This removes those caps and their config fields so history rehydrates regardless of size, and switches stored-message extraction to move-by-value (`std::mem::take`) instead of cloning the full history array. Docs and the example config drop the removed fields; the config struct is now `EmptyFilterConfig`, so `deny_unknown_fields` still rejects any stray keys.

## Related issue

Refs #532

This is the no-limits / no-redundant-clone / preserve-`truncation` slice of #532; it does not cover that issue's separate history mutation/storage acceptance criteria.

## Validation

- [x] Unit tests — `cargo test -p praxis-ai-apis --lib rehydrate` → 103 passed (includes `removed_history_limit_fields_rejected`, `large_history_accepted_without_rejection` with a 500-item history, `truncation_setting_preserved_through_rehydration`)
- [x] Integration or functional tests — new SDK test `test_truncation_forwarded_to_backend_through_rehydration` drives the full native pipeline through a recording shim in front of vLLM, proving the backend receives `truncation="auto"` on a fresh turn and `truncation="disabled"` on a rehydrated continuation (with `previous_response_id` stripped and history replayed into `input`); verified against live vLLM (Qwen3-0.6B)
- [x] `make lint` (and `make build`)

## Checklist

- [x] I reviewed every changed line and can explain the change.
- [x] New capabilities include an example config and functional example test.
- [x] User-facing behavior and generated documentation are updated.
- [x] Performance-sensitive changes include appropriate benchmark or load-test evidence.
- [x] Commits are signed and include a `Signed-off-by` trailer.

## Breaking changes

Configs that set `max_history_bytes` or `max_history_items` on `openai_responses_rehydrate` will now fail to parse (rejected by `deny_unknown_fields`). Migration: remove those keys from the filter block — the caps no longer exist and are unnecessary, as history is no longer size-limited.
